### PR TITLE
fix: 修复 pnpm/action-setup 找不到版本的问题

### DIFF
--- a/.github/workflows/ci-wails-build.yml
+++ b/.github/workflows/ci-wails-build.yml
@@ -34,6 +34,8 @@ jobs:
           node-version: '22'
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
@@ -103,6 +105,8 @@ jobs:
           node-version: '22'
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
@@ -174,6 +178,8 @@ jobs:
             libwebkit2gtk-4.0-dev
 
       - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest


### PR DESCRIPTION
### **User description**
## Summary
- 为 pnpm/action-setup 添加 `package_json_file: web/package.json` 参数
- 因为 `packageManager` 字段在 `web/package.json` 中，而不是项目根目录

## Test plan
- [ ] 验证 CI workflow 正常运行


___

### **PR Type**
enhancement


___

### **Description**
- Add `package_json_file` parameter for pnpm/action-setup

- Specify path to `web/package.json`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add package_json_file parameter"] --> B["Specify web/package.json"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-wails-build.yml</strong><dd><code>Update pnpm/action-setup configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-wails-build.yml

- Added `package_json_file` parameter
- Points to `web/package.json`


</details>


  </td>
  <td><a href="https://github.com/awsl-project/maxx/pull/31/files#diff-c22534eb7f16b41130a6219271d41dfee399a1142115ed77e8a1115523778e7d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

