### PR TITLE
fix: 修复 GitHub Release 缺少 tag 的问题

### DIFF
--- a/.github/workflows/ci-wails-build.yml
+++ b/.github/workflows/ci-wails-build.yml
@@ -363,6 +363,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: release-assets/*
           body_path: /tmp/release_body.md
           draft: false


### PR DESCRIPTION
### **User description**
## Summary
- 为 `softprops/action-gh-release` 添加 `tag_name: ${{ inputs.tag || github.ref_name }}` 参数
- 当通过 `workflow_call` 调用时，`github.ref` 不是 tag，需要明确指定

## Test plan
- [ ] 验证通过 release workflow 触发时能正常创建 Release


___

### **PR Type**
bug_fix


___

### **Description**
- Add `tag_name` parameter for GitHub Release

- Fix issue with missing tag during workflow_call


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Add tag_name parameter"] -- "Fixes" --> B["GitHub Release action"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-wails-build.yml</strong><dd><code>Update GitHub Release action configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-wails-build.yml

<ul><li>Added <code>tag_name</code> parameter to action<br> <li> Ensures tag is set during workflow_call</ul>


</details>


  </td>
  <td><a href="https://github.com/awsl-project/maxx/pull/32/files#diff-c22534eb7f16b41130a6219271d41dfee399a1142115ed77e8a1115523778e7d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

