### PR TITLE
fix: 修复 Docker 构建时 wailsjs 模块缺失问题

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
 		rollupOptions: {
 			external: [
 				"@wailsio/runtime",
+				// Wails 生成的绑定只在桌面模式下存在，Docker 构建时需要排除
+				/^@\/wailsjs\/.*/,
 			],
 		},
 	},


### PR DESCRIPTION
### **User description**
## Summary
- 将 `@/wailsjs/*` 路径添加到 Vite rollupOptions.external
- 修复 Docker 构建时因缺少 Wails 生成的绑定文件导致的构建失败

## 问题原因
Docker 构建环境中没有 Wails，因此不会生成 `wailsjs` 目录。但 Vite 在分析 `wails-transport.ts` 时会尝试解析其中的 `@/wailsjs/go/desktop/DesktopApp` 导入，导致构建失败。

## 解决方案
将 wailsjs 相关路径标记为 external，让 Rollup 跳过这些模块的解析。由于 Docker 环境只使用 HTTP transport，不需要 Wails transport，所以这不会影响运行时功能。

## Test plan
- [x] 本地 `docker build .` 测试通过
- [ ] GitHub Actions Docker 构建测试


___

### **PR Type**
bug_fix


___

### **Description**
- Fix Docker build failure due to missing wailsjs

- Mark wailsjs paths as external in Vite config


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Build"] -- "fails due to missing" --> B["wailsjs module"]
  B -- "fixed by marking" --> C["wailsjs paths as external"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Update Vite configuration for Docker builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

web/vite.config.ts

<ul><li>Added wailsjs paths to external<br> <li> Prevent Vite from resolving wailsjs in Docker</ul>


</details>


  </td>
  <td><a href="https://github.com/awsl-project/maxx/pull/36/files#diff-9430906049744cbbfe5d0b382b2466843a42cfebf755ff86fec850b0712258ef">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

