### PR TITLE
fix: 确保关闭窗口时 HTTP 服务器正确停止

### DIFF
--- a/internal/desktop/launcher.go
+++ b/internal/desktop/launcher.go
@@ -379,6 +379,15 @@ func (a *LauncherApp) DomReady(ctx context.Context) {
 // BeforeClose Wails 关闭前回调
 func (a *LauncherApp) BeforeClose(ctx context.Context) bool {
 	log.Println("[Launcher] Window close requested")
+
+	// 先停止 HTTP 服务器，确保端口被释放
+	if a.server != nil && a.server.IsRunning() {
+		log.Println("[Launcher] Stopping HTTP server before close...")
+		if err := a.server.Stop(ctx); err != nil {
+			log.Printf("[Launcher] Failed to stop server in BeforeClose: %v", err)
+		}
+	}
+
 	// 允许关闭
 	return false
 }


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Ensure HTTP server stops on window close

- Shorten graceful shutdown timeout to 3 seconds

- Add forced close logic on timeout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Window Close Requested"] -- "Stop HTTP Server" --> B["HTTP Server Stopped"]
  B -- "Graceful Shutdown" --> C["Timeout Occurs"]
  C -- "Force Close" --> D["Port Released"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Modify HTTP server shutdown behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/core/server.go

<ul><li>Shortened shutdown timeout to 3 seconds<br> <li> Added forced close logic on shutdown failure</ul>


</details>


  </td>
  <td><a href="https://github.com/awsl-project/maxx/pull/47/files#diff-2df0abb67b731220c5bf854d6717ddfa1320f0e264cac61cd274e6d8bb6c914e">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>launcher.go</strong><dd><code>Ensure server stops before window close</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/desktop/launcher.go

- Stop HTTP server before closing window
- Log failure to stop server


</details>


  </td>
  <td><a href="https://github.com/awsl-project/maxx/pull/47/files#diff-f39a208f48f877c31cd245dd4b88728c3d15c58e4e825723d86f76882ef8ab56">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

