### PR TITLE
fix: token 校验支持多种 header 格式作为兜底

### DIFF
--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -76,7 +76,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Token authentication (needs clientType to determine which header to extract from)
+	// Token authentication (uses clientType for primary header, with fallback)
 	var apiToken *domain.APIToken
 	var apiTokenID uint64
 	if h.tokenAuth != nil {


### PR DESCRIPTION
- 优先使用 clientType 对应的 header 提取 token
- 兜底依次尝试 Authorization: Bearer、x-api-key、x-goog-api-key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug修复**
  * 优化令牌认证机制：现在根据客户端类型优先使用相应的认证标头，主要选项不可用时自动回退到其他标准标头，提升了兼容性和认证可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->