### PR TITLE
feat: add OpenAI to default client types for Custom Provider

### DIFF
--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -143,6 +143,7 @@ export type ClientConfig = {
 
 export const defaultClients: ClientConfig[] = [
   { id: 'claude', name: 'Claude', enabled: true, urlOverride: '' },
+  { id: 'openai', name: 'OpenAI', enabled: false, urlOverride: '' },
   { id: 'codex', name: 'Codex', enabled: false, urlOverride: '' },
   { id: 'gemini', name: 'Gemini', enabled: false, urlOverride: '' },
 ];


### PR DESCRIPTION
## Summary
- 在 Custom Provider 的默认客户端类型列表中添加 OpenAI 选项
- 修复前端配置中缺失 OpenAI 客户端类型的问题，使用户可以在创建 Custom Provider 时启用 OpenAI 原生透传支持

## Test plan
- [ ] 创建新的 Custom Provider，验证 OpenAI 选项出现在客户端类型列表中
- [ ] 启用 OpenAI 并配置 Endpoint Override，验证保存成功
- [ ] 发送 OpenAI 格式请求 (`/v1/chat/completions`)，验证透传正常工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了 OpenAI 客户端配置选项，初始状态为禁用。用户现可在提供商设置中访问此选项。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->