### PR TITLE
fix: 修复 macOS 客户端无法退出的问题

### DIFF
--- a/internal/desktop/launcher.go
+++ b/internal/desktop/launcher.go
@@ -395,16 +395,7 @@ func (a *LauncherApp) DomReady(ctx context.Context) {
 }
 
 // BeforeClose Wails 关闭前回调
-func (a *LauncherApp) BeforeClose(ctx context.Context) bool {
-	log.Println("[Launcher] Window close requested - hiding window to tray")
-
-	// 隐藏窗口到托盘，不退出应用
-	// 服务器继续在后台运行
-	runtime.WindowHide(ctx)
-
-	// 返回 true 阻止窗口关闭（实际上已经隐藏了）
-	return true
-}
+// 由平台特定文件实现：launcher_windows.go 和 launcher_other.go
 
 // GetConfig 获取当前配置（暴露给前端）
 func (a *LauncherApp) GetConfig() DesktopConfig {

--- a/internal/desktop/launcher_other.go
+++ b/internal/desktop/launcher_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package desktop
+
+import (
+	"context"
+	"log"
+)
+
+// BeforeClose 非 Windows: 允许正常退出
+func (a *LauncherApp) BeforeClose(ctx context.Context) bool {
+	log.Println("[Launcher] Window close requested")
+	return false
+}

--- a/internal/desktop/launcher_windows.go
+++ b/internal/desktop/launcher_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package desktop
+
+import (
+	"context"
+	"log"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// BeforeClose Windows: 隐藏到托盘，不退出
+func (a *LauncherApp) BeforeClose(ctx context.Context) bool {
+	log.Println("[Launcher] Window close requested - hiding to tray")
+	runtime.WindowHide(ctx)
+	return true
+}


### PR DESCRIPTION
BeforeClose 返回 false 允许正常关闭窗口

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了窗口关闭行为 - 关闭应用窗口现在会正常退出应用程序。之前关闭窗口会将应用最小化到系统托盘并继续后台运行。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->