### PR TITLE
feat: 添加请求记录自动清理功能

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -354,6 +354,8 @@ const (
 	SettingKeyProxyPort               = "proxy_port"                 // 代理服务器端口，默认 9880
 	SettingKeyAntigravityModelMapping = "antigravity_model_mapping"  // Antigravity 全局模型映射 (JSON)
 	SettingKeyKiroModelMapping        = "kiro_model_mapping"         // Kiro 全局模型映射 (JSON)
+	SettingKeyRequestRetentionDays    = "request_retention_days"     // 请求记录保留天数，默认 7 天，0 表示不按天数清理
+	SettingKeyRequestMaxCount         = "request_max_count"          // 请求记录最大条数，默认 10000，0 表示不按条数清理
 )
 
 // Antigravity 模型配额

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -1,6 +1,10 @@
 package repository
 
-import "github.com/awsl-project/maxx/internal/domain"
+import (
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
 
 type ProviderRepository interface {
 	Create(provider *domain.Provider) error
@@ -70,6 +74,10 @@ type ProxyRequestRepository interface {
 	// MarkStaleAsFailed marks all IN_PROGRESS/PENDING requests from other instances as FAILED
 	// Also marks requests that have been IN_PROGRESS for too long (> 30 minutes) as timed out
 	MarkStaleAsFailed(currentInstanceID string) (int64, error)
+	// DeleteOlderThan 删除指定时间之前的请求记录
+	DeleteOlderThan(before time.Time) (int64, error)
+	// DeleteExceedingCount 删除超出指定条数的旧记录
+	DeleteExceedingCount(maxCount int64) (int64, error)
 }
 
 type ProxyUpstreamAttemptRepository interface {

--- a/internal/repository/sqlite/db.go
+++ b/internal/repository/sqlite/db.go
@@ -34,6 +34,11 @@ func (d *DB) Close() error {
 	return d.db.Close()
 }
 
+// Exec 执行 SQL 语句
+func (d *DB) Exec(query string, args ...interface{}) (sql.Result, error) {
+	return d.db.Exec(query, args...)
+}
+
 func (d *DB) migrate() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS providers (

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -287,3 +287,106 @@ func (r *ProxyRequestRepository) UpdateProjectIDBySessionID(sessionID string, pr
 	}
 	return result.RowsAffected()
 }
+
+// DeleteOlderThan 删除指定时间之前的请求记录
+// 同时删除关联的 proxy_upstream_attempts 记录
+func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error) {
+	// 先删除关联的 attempts
+	_, err := r.db.db.Exec(
+		`DELETE FROM proxy_upstream_attempts WHERE proxy_request_id IN (
+			SELECT id FROM proxy_requests WHERE created_at < ?
+		)`,
+		before,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	// 再删除 requests
+	result, err := r.db.db.Exec(
+		`DELETE FROM proxy_requests WHERE created_at < ?`,
+		before,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	// 更新计数缓存
+	if affected > 0 {
+		atomic.AddInt64(&r.count, -affected)
+	}
+
+	return affected, nil
+}
+
+// DeleteExceedingCount 删除超出指定条数的旧记录（分批处理）
+// 保留最新的 maxCount 条记录，删除其余的
+func (r *ProxyRequestRepository) DeleteExceedingCount(maxCount int64) (int64, error) {
+	const batchSize int64 = 1000 // 每批删除 1000 条
+
+	var totalDeleted int64
+	for {
+		currentCount := atomic.LoadInt64(&r.count)
+		if currentCount <= maxCount {
+			break
+		}
+
+		// 每次最多删除 batchSize 条
+		toDelete := currentCount - maxCount
+		if toDelete > batchSize {
+			toDelete = batchSize
+		}
+
+		deleted, err := r.deleteBatch(toDelete)
+		if err != nil {
+			return totalDeleted, err
+		}
+		if deleted == 0 {
+			break
+		}
+		totalDeleted += deleted
+	}
+	return totalDeleted, nil
+}
+
+// deleteBatch 删除指定数量的最旧记录
+func (r *ProxyRequestRepository) deleteBatch(count int64) (int64, error) {
+	// 先删除关联的 attempts
+	_, err := r.db.db.Exec(
+		`DELETE FROM proxy_upstream_attempts WHERE proxy_request_id IN (
+			SELECT id FROM proxy_requests ORDER BY id ASC LIMIT ?
+		)`,
+		count,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	// 删除最旧的记录
+	result, err := r.db.db.Exec(
+		`DELETE FROM proxy_requests WHERE id IN (
+			SELECT id FROM proxy_requests ORDER BY id ASC LIMIT ?
+		)`,
+		count,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+
+	// 更新计数缓存
+	if affected > 0 {
+		atomic.AddInt64(&r.count, -affected)
+	}
+
+	return affected, nil
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -301,7 +301,13 @@
     "resetToPreset": "Reset to Preset",
     "modelMappingDesc": "Model name mapping rules, matched in order (higher priority first). Supports wildcard *, e.g., *sonnet* matches all sonnet variants",
     "matchPattern": "Match Pattern",
-    "targetModel": "Target Model"
+    "targetModel": "Target Model",
+    "requestCleanup": "Request Cleanup",
+    "requestCleanupDesc": "Automatically clean up old request records to reduce database size. Cleanup runs hourly.",
+    "retentionDays": "Retention Days",
+    "retentionDaysHint": "0 = no cleanup by days",
+    "maxCount": "Max Records",
+    "maxCountHint": "0 = no cleanup by count"
   },
   "clientRoutes": {
     "claude": "Claude",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -301,7 +301,13 @@
     "resetToPreset": "重置为预设",
     "modelMappingDesc": "模型名映射规则，按顺序匹配（越靠前优先级越高）。支持通配符 *，例如 *sonnet* 匹配所有 sonnet 变体",
     "matchPattern": "匹配模式",
-    "targetModel": "目标模型"
+    "targetModel": "目标模型",
+    "requestCleanup": "请求记录清理",
+    "requestCleanupDesc": "自动清理旧的请求记录以减少数据库大小。每小时执行一次清理。",
+    "retentionDays": "保留天数",
+    "retentionDaysHint": "0 = 不按天数清理",
+    "maxCount": "最大条数",
+    "maxCountHint": "0 = 不按条数清理"
   },
   "clientRoutes": {
     "claude": "Claude",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -1,4 +1,4 @@
-import { Settings, Moon, Sun, Monitor, Laptop, FolderOpen, Zap, Plus, Trash2, ArrowRight, RotateCcw, GripVertical, Languages } from 'lucide-react'
+import { Settings, Moon, Sun, Monitor, Laptop, FolderOpen, Zap, Plus, Trash2, ArrowRight, RotateCcw, GripVertical, Languages, Database } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
@@ -39,6 +39,7 @@ export function SettingsPage() {
           <AppearanceSection />
           <LanguageSection />
           <ForceProjectSection />
+          <RequestCleanupSection />
           <AntigravityModelMappingSection />
         </div>
       </div>
@@ -194,6 +195,85 @@ function ForceProjectSection() {
             <span className="text-xs text-muted-foreground">{t('settings.waitTimeoutRange')}</span>
           </div>
         )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function RequestCleanupSection() {
+  const { data: settings, isLoading } = useSettings()
+  const updateSetting = useUpdateSetting()
+  const { t } = useTranslation()
+
+  const retentionDays = settings?.request_retention_days || '7'
+  const maxCount = settings?.request_max_count || '10000'
+
+  const handleRetentionDaysChange = async (value: string) => {
+    const numValue = parseInt(value, 10)
+    if (numValue >= 0 && numValue <= 365) {
+      await updateSetting.mutateAsync({
+        key: 'request_retention_days',
+        value: value,
+      })
+    }
+  }
+
+  const handleMaxCountChange = async (value: string) => {
+    const numValue = parseInt(value, 10)
+    if (numValue >= 0 && numValue <= 1000000) {
+      await updateSetting.mutateAsync({
+        key: 'request_max_count',
+        value: value,
+      })
+    }
+  }
+
+  if (isLoading) return null
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Database className="h-4 w-4 text-muted-foreground" />
+          {t('settings.requestCleanup')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        <p className="text-xs text-muted-foreground">
+          {t('settings.requestCleanupDesc')}
+        </p>
+
+        <div className="flex items-center gap-6">
+          <label className="text-sm font-medium text-muted-foreground w-32 shrink-0">
+            {t('settings.retentionDays')}
+          </label>
+          <Input
+            type="number"
+            value={retentionDays}
+            onChange={e => handleRetentionDaysChange(e.target.value)}
+            className="w-24"
+            min={0}
+            max={365}
+            disabled={updateSetting.isPending}
+          />
+          <span className="text-xs text-muted-foreground">{t('settings.retentionDaysHint')}</span>
+        </div>
+
+        <div className="flex items-center gap-6">
+          <label className="text-sm font-medium text-muted-foreground w-32 shrink-0">
+            {t('settings.maxCount')}
+          </label>
+          <Input
+            type="number"
+            value={maxCount}
+            onChange={e => handleMaxCountChange(e.target.value)}
+            className="w-24"
+            min={0}
+            max={1000000}
+            disabled={updateSetting.isPending}
+          />
+          <span className="text-xs text-muted-foreground">{t('settings.maxCountHint')}</span>
+        </div>
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
- 支持按保留天数清理（默认 7 天）
- 支持按最大条数清理（默认 10000 条）
- 分批删除避免锁表，每批 1000 条
- 使用增量 VACUUM 优化数据库压缩
- 添加前端设置页面配置清理策略

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 自动请求记录清理：系统每小时自动清理过期的请求记录，支持按保留天数和最大记录数清理，帮助减少数据库占用空间。
* 新增清理配置设置：允许用户自定义保留天数（默认7天）和最大记录数（默认10,000），通过新的设置页面直观管理。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->