### PR TITLE
fix: 简化 GetLatestHour 时间解析，截取前19字符忽略时区

### DIFF
--- a/internal/repository/sqlite/usage_stats.go
+++ b/internal/repository/sqlite/usage_stats.go
@@ -256,16 +256,14 @@ func (r *UsageStatsRepository) GetLatestHour() (*time.Time, error) {
 		return nil, nil
 	}
 
-	// 尝试多种格式解析
-	hour, err := time.Parse(time.RFC3339, *hourStr)
+	// 截取前 19 个字符 "2006-01-02 15:04:05" 来解析，忽略后面的时区信息
+	str := *hourStr
+	if len(str) >= 19 {
+		str = str[:19]
+	}
+	hour, err := time.Parse("2006-01-02 15:04:05", str)
 	if err != nil {
-		hour, err = time.Parse("2006-01-02 15:04:05", *hourStr)
-		if err != nil {
-			hour, err = time.Parse("2006-01-02 15", *hourStr)
-			if err != nil {
-				return nil, err
-			}
-		}
+		return nil, err
 	}
 	return &hour, nil
 }


### PR DESCRIPTION
## Summary
- 修复 `GetLatestHour` 函数解析时间格式失败的问题
- 截取时间字符串前19个字符 (`2006-01-02 15:04:05`) 进行解析，忽略后面的时区和 monotonic clock 信息
- 兼容本地数据库格式 (`2026-01-17 02:00:00 +0800 CST`) 和线上数据库格式 (`2026-01-16 11:38:13.562611352 +0000 UTC m=+679.832423366`)

## Test plan
- [x] 本地测试解析多种时间格式
- [ ] 部署后验证聚合任务正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 改进了内部时间戳解析逻辑，优化了错误处理机制，提升系统稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->