### PR TITLE
fix: 修复 Dockerfile TARGETARCH 变量位置

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,8 +1,9 @@
 # CI Dockerfile - frontend and backend are pre-built by GitHub Actions
 
-ARG TARGETARCH
-
 FROM alpine:latest
+
+# TARGETARCH is automatically set by Docker Buildx (amd64, arm64, etc.)
+ARG TARGETARCH
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
## Summary
- 将 `ARG TARGETARCH` 移到 `FROM` 之后
- 修复 Docker 构建时找不到 `maxx-linux-` 文件的问题

## 原因
Docker 中 `ARG` 在 `FROM` 之前声明时，只能用于 `FROM` 指令本身。要在构建阶段使用，必须在 `FROM` 之后重新声明。

## Test plan
- [ ] 触发 tag 构建验证 workflow 正常运行

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂务**
  * 优化了Docker构建配置，调整了构建参数的声明位置，以改进镜像构建流程的兼容性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->