### PR TITLE
feat: 前端版本号改为显示后端版本

### DIFF
--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository"
+	"github.com/awsl-project/maxx/internal/version"
 )
 
 // ProviderAdapterRefresher is an interface for refreshing provider adapters
@@ -428,6 +429,8 @@ type ProxyStatus struct {
 	Running bool   `json:"running"`
 	Address string `json:"address"`
 	Port    int    `json:"port"`
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
 }
 
 func (s *AdminService) GetProxyStatus(r *http.Request) *ProxyStatus {
@@ -470,6 +473,8 @@ func (s *AdminService) GetProxyStatus(r *http.Request) *ProxyStatus {
 		Running: true,
 		Address: displayAddr,
 		Port:    port,
+		Version: version.Version,
+		Commit:  version.Commit,
 	}
 }
 

--- a/web/src/components/layout/sidebar-nav.tsx
+++ b/web/src/components/layout/sidebar-nav.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 import { StreamingBadge } from '@/components/ui/streaming-badge'
 import { useStreamingRequests } from '@/hooks/use-streaming'
+import { useProxyStatus } from '@/hooks/queries'
 import {
   Sidebar,
   SidebarContent,
@@ -89,7 +90,8 @@ function RequestsNavItem() {
 
 export function SidebarNav() {
   const { t } = useTranslation()
-  const versionDisplay = `v${__APP_VERSION__}`
+  const { data: proxyStatus } = useProxyStatus()
+  const versionDisplay = proxyStatus?.version ? `v${proxyStatus.version}` : '...'
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader>

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -284,6 +284,8 @@ export interface ProxyStatus {
   running: boolean;
   address: string;
   port: number;
+  version: string;
+  commit: string;
 }
 
 // ===== Provider Stats =====


### PR DESCRIPTION
## Summary
- 在 ProxyStatus 结构体中添加 version 和 commit 字段
- GetProxyStatus API 返回后端版本信息
- 前端 sidebar 从 proxy-status API 获取版本号显示

## Test plan
- [ ] 启动后端服务，验证 `/api/admin/proxy-status` 返回 version 和 commit 字段
- [ ] 检查前端 sidebar 底部显示的版本号与后端一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 添加了代理服务器版本和提交信息的显示功能，应用界面现在动态展示代理状态的版本信息

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->