### PR TITLE
fix: 移除版本号显示中重复的 v 前缀

### DIFF
--- a/web/src/components/layout/sidebar-nav.tsx
+++ b/web/src/components/layout/sidebar-nav.tsx
@@ -91,7 +91,7 @@ function RequestsNavItem() {
 export function SidebarNav() {
   const { t } = useTranslation()
   const { data: proxyStatus } = useProxyStatus()
-  const versionDisplay = proxyStatus?.version ? `v${proxyStatus.version}` : '...'
+  const versionDisplay = proxyStatus?.version ?? '...'
   return (
     <Sidebar collapsible="icon">
       <SidebarHeader>


### PR DESCRIPTION
## Summary
- 后端版本号已包含 v 前缀，前端不应再添加
- 修复显示 vv0.5.6 的问题

## Test plan
- [ ] 检查前端版本号显示正确

🤖 Generated with Claude Code