### PR TITLE
fix: 恢复设置页面的数据保留配置

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -281,6 +281,7 @@
   "settings": {
     "title": "Settings",
     "description": "Configure your maxx instance",
+    "general": "General",
     "appearance": "Appearance",
     "themePreference": "Theme Preference",
     "theme": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -281,6 +281,7 @@
   "settings": {
     "title": "设置",
     "description": "配置您的 Maxx 实例",
+    "general": "通用",
     "appearance": "外观",
     "themePreference": "主题偏好",
     "theme": {

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -1,4 +1,5 @@
-import { Settings, Moon, Sun, Monitor, Laptop, FolderOpen, Languages } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { Settings, Moon, Sun, Monitor, Laptop, FolderOpen, Database } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useTheme } from '@/components/theme-provider'
 import {
@@ -29,8 +30,8 @@ export function SettingsPage() {
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="space-y-6">
-          <AppearanceSection />
-          <LanguageSection />
+          <GeneralSection />
+          <DataRetentionSection />
           <ForceProjectSection />
         </div>
       </div>
@@ -38,9 +39,9 @@ export function SettingsPage() {
   )
 }
 
-function AppearanceSection() {
+function GeneralSection() {
   const { theme, setTheme } = useTheme()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
     { value: 'light', label: t('settings.theme.light'), icon: Sun },
@@ -48,15 +49,20 @@ function AppearanceSection() {
     { value: 'system', label: t('settings.theme.system'), icon: Laptop },
   ]
 
+  const languages = [
+    { value: 'en', label: t('settings.languages.en') },
+    { value: 'zh', label: t('settings.languages.zh') },
+  ]
+
   return (
     <Card className="border-border bg-card">
       <CardHeader className="border-b border-border py-4">
         <CardTitle className="text-base font-medium flex items-center gap-2">
           <Monitor className="h-4 w-4 text-muted-foreground" />
-          {t('settings.appearance')}
+          {t('settings.general')}
         </CardTitle>
       </CardHeader>
-      <CardContent className="p-6">
+      <CardContent className="p-6 space-y-4">
         <div className="flex items-center gap-6">
           <label className="text-sm font-medium text-muted-foreground w-40 shrink-0">
             {t('settings.themePreference')}
@@ -74,28 +80,6 @@ function AppearanceSection() {
             ))}
           </div>
         </div>
-      </CardContent>
-    </Card>
-  )
-}
-
-function LanguageSection() {
-  const { t, i18n } = useTranslation()
-
-  const languages = [
-    { value: 'en', label: t('settings.languages.en') },
-    { value: 'zh', label: t('settings.languages.zh') },
-  ]
-
-  return (
-    <Card className="border-border bg-card">
-      <CardHeader className="border-b border-border py-4">
-        <CardTitle className="text-base font-medium flex items-center gap-2">
-          <Languages className="h-4 w-4 text-muted-foreground" />
-          {t('settings.language')}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="p-6">
         <div className="flex items-center gap-6">
           <label className="text-sm font-medium text-muted-foreground w-40 shrink-0">
             {t('settings.languagePreference')}
@@ -110,6 +94,117 @@ function LanguageSection() {
                 <span className="text-sm font-medium">{label}</span>
               </Button>
             ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function DataRetentionSection() {
+  const { data: settings, isLoading } = useSettings()
+  const updateSetting = useUpdateSetting()
+  const { t } = useTranslation()
+
+  const requestRetentionDays = settings?.request_retention_days ?? '7'
+  const statsRetentionDays = settings?.stats_retention_days ?? '30'
+
+  const [requestDraft, setRequestDraft] = useState('')
+  const [statsDraft, setStatsDraft] = useState('')
+  const [initialized, setInitialized] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading && !initialized) {
+      setRequestDraft(requestRetentionDays)
+      setStatsDraft(statsRetentionDays)
+      setInitialized(true)
+    }
+  }, [isLoading, initialized, requestRetentionDays, statsRetentionDays])
+
+  useEffect(() => {
+    if (initialized) {
+      setRequestDraft(requestRetentionDays)
+    }
+  }, [requestRetentionDays, initialized])
+
+  useEffect(() => {
+    if (initialized) {
+      setStatsDraft(statsRetentionDays)
+    }
+  }, [statsRetentionDays, initialized])
+
+  const hasChanges = initialized && (requestDraft !== requestRetentionDays || statsDraft !== statsRetentionDays)
+
+  const handleSave = async () => {
+    const requestNum = parseInt(requestDraft, 10)
+    const statsNum = parseInt(statsDraft, 10)
+
+    if (!isNaN(requestNum) && requestNum >= 0 && requestDraft !== requestRetentionDays) {
+      await updateSetting.mutateAsync({
+        key: 'request_retention_days',
+        value: requestDraft,
+      })
+    }
+
+    if (!isNaN(statsNum) && statsNum >= 0 && statsDraft !== statsRetentionDays) {
+      await updateSetting.mutateAsync({
+        key: 'stats_retention_days',
+        value: statsDraft,
+      })
+    }
+  }
+
+  if (isLoading || !initialized) return null
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-base font-medium flex items-center gap-2">
+              <Database className="h-4 w-4 text-muted-foreground" />
+              {t('settings.dataRetention')}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">{t('settings.retentionDaysHint')}</p>
+          </div>
+          <Button
+            onClick={handleSave}
+            disabled={!hasChanges || updateSetting.isPending}
+            size="sm"
+          >
+            {updateSetting.isPending ? t('common.saving') : t('common.save')}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6">
+        <div className="grid grid-cols-2 gap-6">
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-medium text-muted-foreground shrink-0">
+              {t('settings.requestRetentionDays')}
+            </label>
+            <Input
+              type="number"
+              value={requestDraft}
+              onChange={e => setRequestDraft(e.target.value)}
+              className="w-24"
+              min={0}
+              disabled={updateSetting.isPending}
+            />
+            <span className="text-xs text-muted-foreground">{t('common.days')}</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-medium text-muted-foreground shrink-0">
+              {t('settings.statsRetentionDays')}
+            </label>
+            <Input
+              type="number"
+              value={statsDraft}
+              onChange={e => setStatsDraft(e.target.value)}
+              className="w-24"
+              min={0}
+              disabled={updateSetting.isPending}
+            />
+            <span className="text-xs text-muted-foreground">{t('common.days')}</span>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- 恢复 DataRetentionSection 组件（在之前的重构中丢失）
- 合并外观和语言设置到通用设置卡片
- 添加 settings.general i18n 文本

## Test plan
- [ ] 验证设置页面正常显示数据保留配置
- [ ] 验证请求记录和统计数据的保留天数可以正常修改
- [ ] 验证通用设置卡片包含主题和语言选项

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加数据保留设置，用户可配置请求与统计数据的保留天数。
  * 新增“通用”翻译条目（中/英文），界面中显示为“通用”。

* **重构**
  * 设置页布局调整：将“外观”项重命名为“通用”，移除语言选择区域并引入新的数据保留设置模块。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->