### PR TITLE
feat: 添加 hidden 属性隐藏 Kiro provider 入口

### DIFF
--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import {
   quickTemplates,
+  PROVIDER_TYPE_CONFIGS,
   type ProviderFormData,
 } from '../types'
 import { Button } from '@/components/ui'
@@ -29,6 +30,10 @@ export function SelectTypeStep({
   onSkipToConfig,
   onBack,
 }: SelectTypeStepProps) {
+  // 计算可见的 provider 数量
+  const visibleProviderCount = Object.values(PROVIDER_TYPE_CONFIGS).filter(c => !c.hidden).length
+  const gridCols = visibleProviderCount <= 2 ? 'md:grid-cols-2' : 'md:grid-cols-3'
+
   return (
     <div className="flex flex-col h-full">
       <div className="px-6 h-[73px] flex items-center gap-4  border-b border-border bg-card">
@@ -52,7 +57,7 @@ export function SelectTypeStep({
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
               1. Choose Service Provider
             </h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-start">
+            <div className={`grid grid-cols-1 ${gridCols} gap-4 items-start`}>
               <Button
                 onClick={() => onSelectType('antigravity')}
                 variant="ghost"
@@ -82,6 +87,7 @@ export function SelectTypeStep({
                 </div>
               </Button>
 
+              {!PROVIDER_TYPE_CONFIGS.kiro.hidden && (
               <Button
                 onClick={() => onSelectType('kiro')}
                 variant="ghost"
@@ -110,6 +116,7 @@ export function SelectTypeStep({
                   )}
                 </div>
               </Button>
+              )}
 
               <Button
                 onClick={() => onSelectType('custom')}

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -19,6 +19,8 @@ export interface ProviderTypeConfig {
   isAccountBased: boolean;
   // 获取显示信息的函数
   getDisplayInfo: (provider: Provider) => string;
+  // 是否在创建流程中隐藏
+  hidden?: boolean;
 }
 
 // Provider 类型配置表
@@ -38,6 +40,7 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
     color: getProviderColorVar('kiro'),
     isAccountBased: true,
     getDisplayInfo: (p) => p.config?.kiro?.email || 'Kiro Account',
+    hidden: true,
   },
   custom: {
     key: 'custom',


### PR DESCRIPTION
## Summary
- 在 ProviderTypeConfig 接口中添加 hidden 属性
- 设置 kiro.hidden = true 暂时隐藏入口
- 在 select-type-step 中根据 hidden 属性控制显示
- 网格布局根据可见 provider 数量自适应（2个时用2列，3个时用3列）

## Test plan
- [ ] 验证添加 Provider 页面只显示 Antigravity 和 Custom 两个选项
- [ ] 验证两个选项占满整行宽度
- [ ] 将 kiro.hidden 改为 false 后验证 Kiro 选项正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **用户界面改进**
  * 提供程序选择网格布局现在根据可见提供程序数量动态调整列数，改善了响应式设计。
  * 隐藏了特定提供程序选项。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->