### PR TITLE
refactor: 简化数据保留设置，仅保留 request_retention_days

### DIFF
--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	defaultRequestRetentionDays = 0  // 0 表示默认不清理
-	defaultStatsRetentionDays   = 0  // 0 表示默认不清理
+	defaultRequestRetentionDays = 7 // 默认保留 7 天
 )
 
 // BackgroundTaskDeps 后台任务依赖

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -361,9 +361,7 @@ type SystemSetting struct {
 // 系统设置 Key 常量
 const (
 	SettingKeyProxyPort            = "proxy_port"             // 代理服务器端口，默认 9880
-	SettingKeyRequestRetentionDays = "request_retention_days" // 请求记录保留天数，默认 7 天，0 表示不按天数清理
-	SettingKeyRequestMaxCount      = "request_max_count"      // 请求记录最大条数，默认 10000，0 表示不按条数清理
-	SettingKeyStatsRetentionDays   = "stats_retention_days"   // 统计数据保留天数，默认 30 天，0 表示不清理
+	SettingKeyRequestRetentionDays = "request_retention_days" // 请求记录保留天数，默认 7 天，0 表示不清理
 )
 
 // Antigravity 模型配额

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -309,10 +309,8 @@
     "matchPattern": "匹配模式",
     "targetModel": "目标模型",
     "dataRetention": "数据保留",
-    "requestRetentionDays": "请求记录",
+    "requestRetentionDays": "请求记录保留天数",
     "requestRetentionDaysDesc": "超过此天数的请求记录将被自动清理，0 表示不清理",
-    "statsRetentionDays": "统计数据",
-    "statsRetentionDaysDesc": "超过此天数的统计数据将被自动清理，0 表示不清理",
     "retentionDaysHint": "0 表示不清理"
   },
   "modelMappings": {

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -99,19 +99,16 @@ function DataRetentionSection() {
   const { t } = useTranslation();
 
   const requestRetentionDays = settings?.request_retention_days ?? '7';
-  const statsRetentionDays = settings?.stats_retention_days ?? '30';
 
   const [requestDraft, setRequestDraft] = useState('');
-  const [statsDraft, setStatsDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     if (!isLoading && !initialized) {
       setRequestDraft(requestRetentionDays);
-      setStatsDraft(statsRetentionDays);
       setInitialized(true);
     }
-  }, [isLoading, initialized, requestRetentionDays, statsRetentionDays]);
+  }, [isLoading, initialized, requestRetentionDays]);
 
   useEffect(() => {
     if (initialized) {
@@ -119,30 +116,15 @@ function DataRetentionSection() {
     }
   }, [requestRetentionDays, initialized]);
 
-  useEffect(() => {
-    if (initialized) {
-      setStatsDraft(statsRetentionDays);
-    }
-  }, [statsRetentionDays, initialized]);
-
-  const hasChanges =
-    initialized && (requestDraft !== requestRetentionDays || statsDraft !== statsRetentionDays);
+  const hasChanges = initialized && requestDraft !== requestRetentionDays;
 
   const handleSave = async () => {
     const requestNum = parseInt(requestDraft, 10);
-    const statsNum = parseInt(statsDraft, 10);
 
     if (!isNaN(requestNum) && requestNum >= 0 && requestDraft !== requestRetentionDays) {
       await updateSetting.mutateAsync({
         key: 'request_retention_days',
         value: requestDraft,
-      });
-    }
-
-    if (!isNaN(statsNum) && statsNum >= 0 && statsDraft !== statsRetentionDays) {
-      await updateSetting.mutateAsync({
-        key: 'stats_retention_days',
-        value: statsDraft,
       });
     }
   };
@@ -166,35 +148,19 @@ function DataRetentionSection() {
         </div>
       </CardHeader>
       <CardContent className="p-6">
-        <div className="grid grid-cols-2 gap-6">
-          <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-muted-foreground shrink-0">
-              {t('settings.requestRetentionDays')}
-            </label>
-            <Input
-              type="number"
-              value={requestDraft}
-              onChange={(e) => setRequestDraft(e.target.value)}
-              className="w-24"
-              min={0}
-              disabled={updateSetting.isPending}
-            />
-            <span className="text-xs text-muted-foreground">{t('common.days')}</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <label className="text-sm font-medium text-muted-foreground shrink-0">
-              {t('settings.statsRetentionDays')}
-            </label>
-            <Input
-              type="number"
-              value={statsDraft}
-              onChange={(e) => setStatsDraft(e.target.value)}
-              className="w-24"
-              min={0}
-              disabled={updateSetting.isPending}
-            />
-            <span className="text-xs text-muted-foreground">{t('common.days')}</span>
-          </div>
+        <div className="flex items-center gap-3">
+          <label className="text-sm font-medium text-muted-foreground shrink-0">
+            {t('settings.requestRetentionDays')}
+          </label>
+          <Input
+            type="number"
+            value={requestDraft}
+            onChange={(e) => setRequestDraft(e.target.value)}
+            className="w-24"
+            min={0}
+            disabled={updateSetting.isPending}
+          />
+          <span className="text-xs text-muted-foreground">{t('common.days')}</span>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- 移除 `stats_retention_days` 和 `request_max_count` 配置（未实现的功能）
- 统计数据清理保持原有硬编码逻辑（分钟级保留1天，小时级保留1月）
- 前端 UI 仅保留请求记录保留天数配置
- 后端默认值改为 7 天

## Test plan
- [ ] 验证设置页面只显示请求记录保留天数配置
- [ ] 验证修改保留天数后能正确保存
- [ ] 验证后端清理任务按配置的天数清理请求记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **默认设置更新**
  * 请求记录默认保留期限已调整为7天
  * 移除了统计数据保留天数相关配置选项
  * 优化了设置界面，简化了数据保留管理功能

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->