### PR TITLE
fix: 修复 MySQL TEXT 列大小限制导致的数据插入失败问题

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"time"
 
@@ -102,7 +103,9 @@ func (e *Executor) Execute(ctx context.Context, w http.ResponseWriter, req *http
 		Body:    string(requestBody),
 	}
 
-	_ = e.proxyRequestRepo.Create(proxyReq)
+	if err := e.proxyRequestRepo.Create(proxyReq); err != nil {
+		log.Printf("[Executor] Failed to create proxy request: %v", err)
+	}
 
 	// Broadcast the new request immediately
 	if e.broadcaster != nil {
@@ -278,7 +281,9 @@ func (e *Executor) Execute(ctx context.Context, w http.ResponseWriter, req *http
 				RequestModel:   requestModel,
 				MappedModel:    mappedModel,
 			}
-			_ = e.attemptRepo.Create(attemptRecord)
+			if err := e.attemptRepo.Create(attemptRecord); err != nil {
+				log.Printf("[Executor] Failed to create attempt record: %v", err)
+			}
 			currentAttempt = attemptRecord
 
 			// Increment attempt count when creating a new attempt

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -18,19 +18,7 @@ type Migration struct {
 
 // 所有迁移按版本号注册
 // 注意：GORM AutoMigrate 会自动处理新增列，这里只需要处理特殊情况（重命名、数据迁移等）
-var migrations = []Migration{
-	// 示例迁移：如果需要重命名列，可以这样写
-	// {
-	// 	Version:     1,
-	// 	Description: "rename old_column to new_column",
-	// 	Up: func(db *gorm.DB) error {
-	// 		if db.Migrator().HasColumn(&SomeModel{}, "old_column") {
-	// 			return db.Migrator().RenameColumn(&SomeModel{}, "old_column", "new_column")
-	// 		}
-	// 		return nil
-	// 	},
-	// },
-}
+var migrations = []Migration{}
 
 // RunMigrations 运行所有待执行的迁移
 func (d *DB) RunMigrations() error {

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -116,7 +116,7 @@ type Provider struct {
 	SoftDeleteModel
 	Type                 string `gorm:"not null"`
 	Name                 string `gorm:"not null"`
-	Config               string `gorm:"type:text"`
+	Config               string `gorm:"type:longtext"`
 	SupportedClientTypes string `gorm:"type:text"`
 }
 
@@ -221,7 +221,7 @@ type AntigravityQuota struct {
 	IsForbidden      int    `gorm:"default:0"`
 	Models           string `gorm:"type:text"`
 	Name             string `gorm:"default:''"`
-	Picture          string `gorm:"type:text"`
+	Picture          string `gorm:"type:longtext"`
 	GCPProjectID     string `gorm:"column:gcp_project_id;default:''"`
 }
 
@@ -242,9 +242,9 @@ type ProxyRequest struct {
 	EndTime                     int64  `gorm:"default:0"`
 	DurationMs                  int64  `gorm:"default:0"`
 	Status                      string `gorm:"type:text"`
-	RequestInfo                 string `gorm:"type:text"`
-	ResponseInfo                string `gorm:"type:text"`
-	Error                       string `gorm:"type:text"`
+	RequestInfo                 string `gorm:"type:longtext"`
+	ResponseInfo                string `gorm:"type:longtext"`
+	Error                       string `gorm:"type:longtext"`
 	ProxyUpstreamAttemptCount   uint64 `gorm:"default:0"`
 	FinalProxyUpstreamAttemptID uint64 `gorm:"default:0"`
 	InputTokenCount             uint64 `gorm:"default:0"`
@@ -269,8 +269,8 @@ type ProxyUpstreamAttempt struct {
 	BaseModel
 	Status            string `gorm:"type:text"`
 	ProxyRequestID    uint64 `gorm:"index"`
-	RequestInfo       string `gorm:"type:text"`
-	ResponseInfo      string `gorm:"type:text"`
+	RequestInfo       string `gorm:"type:longtext"`
+	ResponseInfo      string `gorm:"type:longtext"`
 	RouteID           uint64
 	ProviderID        uint64
 	InputTokenCount   uint64 `gorm:"default:0"`
@@ -294,7 +294,7 @@ func (ProxyUpstreamAttempt) TableName() string { return "proxy_upstream_attempts
 // SystemSetting model
 type SystemSetting struct {
 	Key       string `gorm:"column:setting_key;type:varchar(255);primaryKey"`
-	Value     string `gorm:"not null"`
+	Value     string `gorm:"type:longtext;not null"`
 	CreatedAt int64  `gorm:"not null"`
 	UpdatedAt int64  `gorm:"not null"`
 }


### PR DESCRIPTION
## Summary
- 将多个 TEXT 类型的列改为 LONGTEXT 以支持更大的数据存储（MySQL TEXT 限制为 64KB，LONGTEXT 支持 4GB）
- 添加 ProxyRequest 和 ProxyUpstreamAttempt 创建失败时的错误日志
- 清理 migrations.go 中的示例注释

## 修改的列
| 表 | 列 |
|---|---|
| `providers` | `config` |
| `proxy_requests` | `request_info` |
| `proxy_requests` | `response_info` |
| `proxy_requests` | `error` |
| `proxy_upstream_attempts` | `request_info` |
| `proxy_upstream_attempts` | `response_info` |
| `antigravity_quotas` | `picture` |
| `system_settings` | `value` |

## 问题原因
使用 MySQL 时，当请求体较大（超过 64KB）时，会出现以下错误：
```
[Executor] Failed to create proxy request: Error 1406 (22001): Data too long for column 'request_info' at row 1
```

## Test plan
- [ ] 删除 MySQL 数据库后重新启动应用，验证表结构正确创建
- [ ] 发送大请求体的代理请求，验证 ProxyRequest 记录正常创建
- [ ] SQLite 模式下功能正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 增强了错误处理机制，提升系统稳定性。

* **功能改进**
  * 扩展了系统对更大数据容量的支持，包括供应商配置、图片、请求/响应信息、错误日志及系统设置等字段。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->