### PR TITLE
refactor: 将请求记录保留配置从天改为小时粒度

### DIFF
--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultRequestRetentionDays = 7 // 默认保留 7 天
+	defaultRequestRetentionHours = 168 // 默认保留 168 小时（7天）
 )
 
 // BackgroundTaskDeps 后台任务依赖
@@ -105,22 +105,22 @@ func (d *BackgroundTaskDeps) runCleanupTasks() {
 
 // cleanupOldRequests 清理过期的请求记录
 func (d *BackgroundTaskDeps) cleanupOldRequests() {
-	retentionDays := defaultRequestRetentionDays
+	retentionHours := defaultRequestRetentionHours
 
-	if val, err := d.Settings.Get(domain.SettingKeyRequestRetentionDays); err == nil && val != "" {
-		if days, err := strconv.Atoi(val); err == nil {
-			retentionDays = days
+	if val, err := d.Settings.Get(domain.SettingKeyRequestRetentionHours); err == nil && val != "" {
+		if hours, err := strconv.Atoi(val); err == nil {
+			retentionHours = hours
 		}
 	}
 
-	if retentionDays <= 0 {
+	if retentionHours <= 0 {
 		return // 0 表示不清理
 	}
 
-	before := time.Now().AddDate(0, 0, -retentionDays)
+	before := time.Now().Add(-time.Duration(retentionHours) * time.Hour)
 	if deleted, err := d.ProxyRequest.DeleteOlderThan(before); err != nil {
 		log.Printf("[Task] Failed to delete old requests: %v", err)
 	} else if deleted > 0 {
-		log.Printf("[Task] Deleted %d requests older than %d days", deleted, retentionDays)
+		log.Printf("[Task] Deleted %d requests older than %d hours", deleted, retentionHours)
 	}
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -360,8 +360,8 @@ type SystemSetting struct {
 
 // 系统设置 Key 常量
 const (
-	SettingKeyProxyPort            = "proxy_port"             // 代理服务器端口，默认 9880
-	SettingKeyRequestRetentionDays = "request_retention_days" // 请求记录保留天数，默认 7 天，0 表示不清理
+	SettingKeyProxyPort             = "proxy_port"              // 代理服务器端口，默认 9880
+	SettingKeyRequestRetentionHours = "request_retention_hours" // 请求记录保留小时数，默认 168 小时（7天），0 表示不清理
 )
 
 // Antigravity 模型配额

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -34,6 +34,7 @@
     "updating": "Updating...",
     "day": "day",
     "days": "days",
+    "hours": "hours",
     "global": "Global",
     "initFailed": "Failed to Initialize"
   },
@@ -309,11 +310,9 @@
     "matchPattern": "Match Pattern",
     "targetModel": "Target Model",
     "dataRetention": "Data Retention",
-    "requestRetentionDays": "Requests",
-    "requestRetentionDaysDesc": "Requests older than this will be automatically cleaned up, 0 means no cleanup",
-    "statsRetentionDays": "Statistics",
-    "statsRetentionDaysDesc": "Statistics older than this will be automatically cleaned up, 0 means no cleanup",
-    "retentionDaysHint": "0 = no cleanup"
+    "requestRetentionHours": "Request Retention",
+    "requestRetentionHoursDesc": "Requests older than this will be automatically cleaned up, 0 means no cleanup",
+    "retentionHoursHint": "0 = no cleanup"
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -34,6 +34,7 @@
     "updating": "更新中...",
     "day": "天",
     "days": "天",
+    "hours": "小时",
     "global": "全局",
     "initFailed": "初始化失败"
   },
@@ -309,9 +310,9 @@
     "matchPattern": "匹配模式",
     "targetModel": "目标模型",
     "dataRetention": "数据保留",
-    "requestRetentionDays": "请求记录保留天数",
-    "requestRetentionDaysDesc": "超过此天数的请求记录将被自动清理，0 表示不清理",
-    "retentionDaysHint": "0 表示不清理"
+    "requestRetentionHours": "请求记录保留时间",
+    "requestRetentionHoursDesc": "超过此时间的请求记录将被自动清理，0 表示不清理",
+    "retentionHoursHint": "0 表示不清理"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -98,32 +98,32 @@ function DataRetentionSection() {
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
 
-  const requestRetentionDays = settings?.request_retention_days ?? '7';
+  const requestRetentionHours = settings?.request_retention_hours ?? '168';
 
   const [requestDraft, setRequestDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     if (!isLoading && !initialized) {
-      setRequestDraft(requestRetentionDays);
+      setRequestDraft(requestRetentionHours);
       setInitialized(true);
     }
-  }, [isLoading, initialized, requestRetentionDays]);
+  }, [isLoading, initialized, requestRetentionHours]);
 
   useEffect(() => {
     if (initialized) {
-      setRequestDraft(requestRetentionDays);
+      setRequestDraft(requestRetentionHours);
     }
-  }, [requestRetentionDays, initialized]);
+  }, [requestRetentionHours, initialized]);
 
-  const hasChanges = initialized && requestDraft !== requestRetentionDays;
+  const hasChanges = initialized && requestDraft !== requestRetentionHours;
 
   const handleSave = async () => {
     const requestNum = parseInt(requestDraft, 10);
 
-    if (!isNaN(requestNum) && requestNum >= 0 && requestDraft !== requestRetentionDays) {
+    if (!isNaN(requestNum) && requestNum >= 0 && requestDraft !== requestRetentionHours) {
       await updateSetting.mutateAsync({
-        key: 'request_retention_days',
+        key: 'request_retention_hours',
         value: requestDraft,
       });
     }
@@ -140,7 +140,7 @@ function DataRetentionSection() {
               <Database className="h-4 w-4 text-muted-foreground" />
               {t('settings.dataRetention')}
             </CardTitle>
-            <p className="text-xs text-muted-foreground mt-1">{t('settings.retentionDaysHint')}</p>
+            <p className="text-xs text-muted-foreground mt-1">{t('settings.retentionHoursHint')}</p>
           </div>
           <Button onClick={handleSave} disabled={!hasChanges || updateSetting.isPending} size="sm">
             {updateSetting.isPending ? t('common.saving') : t('common.save')}
@@ -150,7 +150,7 @@ function DataRetentionSection() {
       <CardContent className="p-6">
         <div className="flex items-center gap-3">
           <label className="text-sm font-medium text-muted-foreground shrink-0">
-            {t('settings.requestRetentionDays')}
+            {t('settings.requestRetentionHours')}
           </label>
           <Input
             type="number"
@@ -160,7 +160,7 @@ function DataRetentionSection() {
             min={0}
             disabled={updateSetting.isPending}
           />
-          <span className="text-xs text-muted-foreground">{t('common.days')}</span>
+          <span className="text-xs text-muted-foreground">{t('common.hours')}</span>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- 后端: `SettingKeyRequestRetentionDays` → `SettingKeyRequestRetentionHours`
- 后端: 默认值改为 168 小时（7天）
- 后端: 清理逻辑使用小时计算
- 前端: UI 配置改为小时
- 移除未使用的 `stats_retention_days` 和 `request_max_count` 配置

## Test plan
- [ ] 验证设置页面显示小时配置
- [ ] 验证修改保留小时数后能正确保存
- [ ] 验证后端清理任务按配置的小时数清理请求记录

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **Refactor**
  * 数据保留配置已更新为基于小时的单位制，默认保留时间为 168 小时（等同于原来的 7 天）。
  * 同步更新了设置页面中的配置标签、提示信息和中英文本地化内容，确保用户界面与新的时间单位一致。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->