### PR TITLE
feat: 优化 Antigravity Quota 批量查询与 UI 布局

### DIFF
--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/pages/client-routes/components/provider-row';
 import type { ProviderConfigItem } from '@/pages/client-routes/types';
 import { Button } from '../ui';
+import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 
 interface ClientTypeRoutesContentProps {
   clientType: ClientType;
@@ -212,11 +213,12 @@ export function ClientTypeRoutesContent({
   }
 
   return (
-    <div className="flex flex-col h-full px-6">
-      <div className="flex-1 overflow-y-auto px-lg py-6">
-        <div className="mx-auto max-w-[1400px] space-y-6">
-          {/* Routes List */}
-          {items.length > 0 ? (
+    <AntigravityQuotasProvider>
+      <div className="flex flex-col h-full px-6">
+        <div className="flex-1 overflow-y-auto px-lg py-6">
+          <div className="mx-auto max-w-[1400px] space-y-6">
+            {/* Routes List */}
+            {items.length > 0 ? (
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
@@ -342,5 +344,6 @@ export function ClientTypeRoutesContent({
         </div>
       </div>
     </div>
+  </AntigravityQuotasProvider>
   );
 }

--- a/web/src/contexts/antigravity-quotas-context.tsx
+++ b/web/src/contexts/antigravity-quotas-context.tsx
@@ -1,0 +1,49 @@
+/**
+ * Antigravity Quotas Context
+ * 提供批量获取的 Antigravity 配额数据，减少重复请求
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+import type { AntigravityQuotaData } from '@/lib/transport';
+import { useAntigravityBatchQuotas } from '@/hooks/queries';
+
+interface AntigravityQuotasContextValue {
+  quotas: Record<number, AntigravityQuotaData> | undefined;
+  isLoading: boolean;
+  getQuotaForProvider: (providerId: number) => AntigravityQuotaData | undefined;
+}
+
+const AntigravityQuotasContext = createContext<AntigravityQuotasContextValue | null>(null);
+
+interface AntigravityQuotasProviderProps {
+  children: ReactNode;
+  enabled?: boolean;
+}
+
+export function AntigravityQuotasProvider({ children, enabled = true }: AntigravityQuotasProviderProps) {
+  const { data: quotas, isLoading } = useAntigravityBatchQuotas(enabled);
+
+  const getQuotaForProvider = (providerId: number): AntigravityQuotaData | undefined => {
+    return quotas?.[providerId];
+  };
+
+  return (
+    <AntigravityQuotasContext.Provider value={{ quotas, isLoading, getQuotaForProvider }}>
+      {children}
+    </AntigravityQuotasContext.Provider>
+  );
+}
+
+export function useAntigravityQuotasContext() {
+  const context = useContext(AntigravityQuotasContext);
+  if (!context) {
+    throw new Error('useAntigravityQuotasContext must be used within AntigravityQuotasProvider');
+  }
+  return context;
+}
+
+// 可选的 hook，用于在没有 Provider 时不抛出错误
+export function useAntigravityQuotaFromContext(providerId: number): AntigravityQuotaData | undefined {
+  const context = useContext(AntigravityQuotasContext);
+  return context?.getQuotaForProvider(providerId);
+}

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -13,6 +13,7 @@ export {
   useProviderStats,
   useAllProviderStats,
   useAntigravityQuota,
+  useAntigravityBatchQuotas,
   useKiroQuota,
 } from './use-providers';
 

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -101,9 +101,21 @@ export function useAntigravityQuota(providerId: number, enabled = true) {
     queryKey: [...providerKeys.all, 'antigravity-quota', providerId],
     queryFn: () => getTransport().getAntigravityProviderQuota(providerId, false),
     enabled: enabled && providerId > 0,
-    // 每 60 秒刷新一次
-    refetchInterval: 60000,
-    staleTime: 30000,
+    // 每 10 分钟刷新一次
+    refetchInterval: 600000,
+    staleTime: 600000,
+  });
+}
+
+// 批量获取所有 Antigravity Provider 额度
+export function useAntigravityBatchQuotas(enabled = true) {
+  return useQuery({
+    queryKey: [...providerKeys.all, 'antigravity-batch-quotas'],
+    queryFn: () => getTransport().getAntigravityBatchQuotas(),
+    enabled,
+    // 每 10 分钟刷新一次
+    refetchInterval: 600000,
+    staleTime: 600000,
   });
 }
 
@@ -113,8 +125,8 @@ export function useKiroQuota(providerId: number, enabled = true) {
     queryKey: [...providerKeys.all, 'kiro-quota', providerId],
     queryFn: () => getTransport().getKiroProviderQuota(providerId),
     enabled: enabled && providerId > 0,
-    // 每 60 秒刷新一次
-    refetchInterval: 60000,
-    staleTime: 30000,
+    // 每 10 分钟刷新一次
+    refetchInterval: 600000,
+    staleTime: 600000,
   });
 }

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -378,6 +378,13 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async getAntigravityBatchQuotas(): Promise<Record<number, AntigravityQuotaData>> {
+    const { data } = await axios.get<{ quotas: Record<number, AntigravityQuotaData> }>(
+      '/api/antigravity/providers/quotas',
+    );
+    return data.quotas;
+  }
+
   async startAntigravityOAuth(): Promise<{ authURL: string; state: string }> {
     const { data } = await axios.post<{ authURL: string; state: string }>(
       '/api/antigravity/oauth/start',

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -44,6 +44,7 @@ export type {
   AntigravityUserInfo,
   AntigravityModelQuota,
   AntigravityQuotaData,
+  AntigravityBatchQuotaResult,
   AntigravityTokenValidationResult,
   AntigravityBatchValidationResult,
   AntigravityOAuthResult,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -123,6 +123,7 @@ export interface Transport {
     providerId: number,
     forceRefresh?: boolean,
   ): Promise<AntigravityQuotaData>;
+  getAntigravityBatchQuotas(): Promise<Record<number, AntigravityQuotaData>>;
   startAntigravityOAuth(): Promise<{ authURL: string; state: string }>;
 
   // ===== Model Mapping API =====

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -339,6 +339,11 @@ export interface AntigravityQuotaData {
   subscriptionTier: string; // FREE/PRO/ULTRA
 }
 
+// 批量配额查询结果
+export interface AntigravityBatchQuotaResult {
+  quotas: Record<number, AntigravityQuotaData>; // providerId -> quota
+}
+
 export interface AntigravityTokenValidationResult {
   valid: boolean;
   error?: string;

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { PageHeader } from '@/components/layout/page-header';
 import { PROVIDER_TYPE_CONFIGS, type ProviderTypeKey } from './types';
 import { useState } from 'react';
+import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 
 export function ProvidersPage() {
   const { t } = useTranslation();
@@ -158,39 +159,41 @@ export function ProvidersPage() {
               </Button>
             </div>
           ) : (
-            <div className="space-y-8">
-              {/* 动态渲染各类型分组 */}
-              {(Object.keys(PROVIDER_TYPE_CONFIGS) as ProviderTypeKey[]).map((typeKey) => {
-                const typeProviders = groupedProviders[typeKey];
-                if (typeProviders.length === 0) return null;
+            <AntigravityQuotasProvider>
+              <div className="space-y-8">
+                {/* 动态渲染各类型分组 */}
+                {(Object.keys(PROVIDER_TYPE_CONFIGS) as ProviderTypeKey[]).map((typeKey) => {
+                  const typeProviders = groupedProviders[typeKey];
+                  if (typeProviders.length === 0) return null;
 
-                const config = PROVIDER_TYPE_CONFIGS[typeKey];
-                const TypeIcon = config.icon;
+                  const config = PROVIDER_TYPE_CONFIGS[typeKey];
+                  const TypeIcon = config.icon;
 
-                return (
-                  <section key={typeKey} className="space-y-3">
-                    <div className="flex items-center gap-2 px-1">
-                      <TypeIcon size={16} style={{ color: config.color }} />
-                      <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                        {config.label}
-                      </h3>
-                      <div className="h-px flex-1 bg-border/50 ml-2" />
-                    </div>
-                    <div className="space-y-3">
-                      {typeProviders.map((provider) => (
-                        <ProviderRow
-                          key={provider.id}
-                          provider={provider}
-                          stats={providerStats[provider.id]}
-                          streamingCount={countsByProvider.get(provider.id) || 0}
-                          onClick={() => navigate(`/providers/${provider.id}/edit`)}
-                        />
-                      ))}
-                    </div>
-                  </section>
-                );
-              })}
-            </div>
+                  return (
+                    <section key={typeKey} className="space-y-3">
+                      <div className="flex items-center gap-2 px-1">
+                        <TypeIcon size={16} style={{ color: config.color }} />
+                        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                          {config.label}
+                        </h3>
+                        <div className="h-px flex-1 bg-border/50 ml-2" />
+                      </div>
+                      <div className="space-y-3">
+                        {typeProviders.map((provider) => (
+                          <ProviderRow
+                            key={provider.id}
+                            provider={provider}
+                            stats={providerStats[provider.id]}
+                            streamingCount={countsByProvider.get(provider.id) || 0}
+                            onClick={() => navigate(`/providers/${provider.id}/edit`)}
+                          />
+                        ))}
+                      </div>
+                    </section>
+                  );
+                })}
+              </div>
+            </AntigravityQuotasProvider>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- 新增批量获取配额 API: `GET /antigravity/providers/quotas`，减少 N 个单独请求为 1 个批量请求
- 缓存时间从 5 分钟延长到 10 分钟，减少不必要的 API 调用
- 创建 `AntigravityQuotasProvider` 上下文实现懒加载，只有进入相关页面才发起请求
- 优化 provider-row 布局:
  - 移除左侧类型图标，改为显示 Clients 图标（居中）
  - Antigravity provider 移除邮箱显示，只显示 Claude 余额进度条

## Test plan

- [ ] 验证 Providers 页面加载时只发起一个批量配额请求
- [ ] 验证 Client Routes 页面加载时只发起一个批量配额请求
- [ ] 验证 Claude 余额进度条正确显示在左侧
- [ ] 验证 Clients 图标在左侧居中显示
- [ ] 验证非 Antigravity provider（如 Kiro、Custom）仍显示邮箱/endpoint 信息
- [ ] 验证缓存 10 分钟内不会重复请求

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加了批量获取Antigravity提供商配额的功能
  * 优化了配额缓存机制，将有效期从5分钟延长至10分钟

* **改进**
  * 重新设计了提供商信息展示，新增支持的客户端类型集群显示
  * 改进了配额进度条的可视化效果，提供更清晰的动态显示

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->