### PR TITLE
refactor: 将格式转换逻辑从 Adapter 移至 Executor 层

### DIFF
--- a/internal/adapter/provider/antigravity/adapter.go
+++ b/internal/adapter/provider/antigravity/adapter.go
@@ -49,8 +49,9 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 }
 
 func (a *AntigravityAdapter) SupportedClientTypes() []domain.ClientType {
-	// Antigravity natively supports Claude, OpenAI, and Gemini by converting to Gemini/v1internal API
-	return []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeGemini}
+	// Antigravity natively supports Claude and Gemini by converting to Gemini/v1internal API
+	// OpenAI requests will be converted to Claude format by Executor before reaching this adapter
+	return []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeGemini}
 }
 
 func (a *AntigravityAdapter) Execute(ctx context.Context, w http.ResponseWriter, req *http.Request, provider *domain.Provider) error {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -11,26 +11,31 @@ import (
 type contextKey string
 
 const (
-	CtxKeyClientType      contextKey = "client_type"
-	CtxKeySessionID       contextKey = "session_id"
-	CtxKeyProjectID       contextKey = "project_id"
-	CtxKeyRequestModel    contextKey = "request_model"
-	CtxKeyMappedModel     contextKey = "mapped_model"
-	CtxKeyResponseModel   contextKey = "response_model"
-	CtxKeyProxyRequest    contextKey = "proxy_request"
-	CtxKeyRequestBody     contextKey = "request_body"
-	CtxKeyUpstreamAttempt contextKey = "upstream_attempt"
-	CtxKeyRequestHeaders  contextKey = "request_headers"
-	CtxKeyRequestURI      contextKey = "request_uri"
-	CtxKeyBroadcaster     contextKey = "broadcaster"
-	CtxKeyIsStream        contextKey = "is_stream"
-	CtxKeyAPITokenID      contextKey = "api_token_id"
-	CtxKeyEventChan       contextKey = "event_chan"
+	CtxKeyClientType         contextKey = "client_type"
+	CtxKeyOriginalClientType contextKey = "original_client_type" // Original client type before format conversion
+	CtxKeySessionID          contextKey = "session_id"
+	CtxKeyProjectID          contextKey = "project_id"
+	CtxKeyRequestModel       contextKey = "request_model"
+	CtxKeyMappedModel        contextKey = "mapped_model"
+	CtxKeyResponseModel      contextKey = "response_model"
+	CtxKeyProxyRequest       contextKey = "proxy_request"
+	CtxKeyRequestBody        contextKey = "request_body"
+	CtxKeyUpstreamAttempt    contextKey = "upstream_attempt"
+	CtxKeyRequestHeaders     contextKey = "request_headers"
+	CtxKeyRequestURI         contextKey = "request_uri"
+	CtxKeyBroadcaster        contextKey = "broadcaster"
+	CtxKeyIsStream           contextKey = "is_stream"
+	CtxKeyAPITokenID         contextKey = "api_token_id"
+	CtxKeyEventChan          contextKey = "event_chan"
 )
 
 // Setters
 func WithClientType(ctx context.Context, ct domain.ClientType) context.Context {
 	return context.WithValue(ctx, CtxKeyClientType, ct)
+}
+
+func WithOriginalClientType(ctx context.Context, ct domain.ClientType) context.Context {
+	return context.WithValue(ctx, CtxKeyOriginalClientType, ct)
 }
 
 func WithSessionID(ctx context.Context, sid string) context.Context {
@@ -76,6 +81,13 @@ func WithRequestURI(ctx context.Context, uri string) context.Context {
 // Getters
 func GetClientType(ctx context.Context) domain.ClientType {
 	if v, ok := ctx.Value(CtxKeyClientType).(domain.ClientType); ok {
+		return v
+	}
+	return ""
+}
+
+func GetOriginalClientType(ctx context.Context) domain.ClientType {
+	if v, ok := ctx.Value(CtxKeyOriginalClientType).(domain.ClientType); ok {
 		return v
 	}
 	return ""

--- a/internal/executor/converting_writer.go
+++ b/internal/executor/converting_writer.go
@@ -1,0 +1,214 @@
+package executor
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// URL path mappings for different client types
+var clientTypeURLPaths = map[domain.ClientType]string{
+	domain.ClientTypeClaude: "/v1/messages",
+	domain.ClientTypeOpenAI: "/v1/chat/completions",
+	// Gemini uses dynamic paths with model names, handled separately
+}
+
+// ConvertRequestURI converts the request URI from one client type to another
+func ConvertRequestURI(originalURI string, fromType, toType domain.ClientType) string {
+	if fromType == toType {
+		return originalURI
+	}
+
+	// Get the target path for the destination type
+	targetPath, ok := clientTypeURLPaths[toType]
+	if !ok {
+		// For Gemini or unknown types, return original
+		return originalURI
+	}
+
+	// Check if the original URI matches a known pattern and replace it
+	for _, knownPath := range clientTypeURLPaths {
+		if strings.HasPrefix(originalURI, knownPath) {
+			// Replace the path prefix, preserving query string if any
+			suffix := strings.TrimPrefix(originalURI, knownPath)
+			return targetPath + suffix
+		}
+	}
+
+	// If no known pattern matched, return target path
+	// This handles cases where the original path doesn't match expected patterns
+	return targetPath
+}
+
+// ConvertingResponseWriter wraps http.ResponseWriter to convert response format
+// It converts responses from provider's format (targetType) back to client's format (originalType)
+type ConvertingResponseWriter struct {
+	underlying   http.ResponseWriter
+	converter    *converter.Registry
+	originalType domain.ClientType // Client's original format
+	targetType   domain.ClientType // Provider's format
+	isStream     bool
+	statusCode   int
+	headers      http.Header
+	buffer       bytes.Buffer      // Buffer for non-streaming responses
+	streamState  *converter.TransformState
+	headersSent  bool
+}
+
+// NewConvertingResponseWriter creates a new ConvertingResponseWriter
+func NewConvertingResponseWriter(
+	w http.ResponseWriter,
+	conv *converter.Registry,
+	originalType, targetType domain.ClientType,
+	isStream bool,
+) *ConvertingResponseWriter {
+	return &ConvertingResponseWriter{
+		underlying:   w,
+		converter:    conv,
+		originalType: originalType,
+		targetType:   targetType,
+		isStream:     isStream,
+		statusCode:   http.StatusOK,
+		headers:      make(http.Header),
+		streamState:  converter.NewTransformState(),
+	}
+}
+
+// Header returns the header map
+func (c *ConvertingResponseWriter) Header() http.Header {
+	return c.underlying.Header()
+}
+
+// WriteHeader captures the status code
+func (c *ConvertingResponseWriter) WriteHeader(code int) {
+	c.statusCode = code
+	if c.isStream {
+		// For streaming, write headers immediately
+		c.underlying.WriteHeader(code)
+		c.headersSent = true
+	}
+	// For non-streaming, defer header writing until we have the converted response
+}
+
+// Write handles response body conversion
+func (c *ConvertingResponseWriter) Write(b []byte) (int, error) {
+	if c.isStream {
+		return c.writeStream(b)
+	}
+	// For non-streaming, buffer the response
+	return c.buffer.Write(b)
+}
+
+// writeStream handles streaming response conversion
+func (c *ConvertingResponseWriter) writeStream(b []byte) (int, error) {
+	// Convert the chunk
+	converted, err := c.converter.TransformStreamChunk(c.targetType, c.originalType, b, c.streamState)
+	if err != nil {
+		// On conversion error, pass through original data
+		return c.underlying.Write(b)
+	}
+
+	if len(converted) > 0 {
+		_, writeErr := c.underlying.Write(converted)
+		if writeErr != nil {
+			return 0, writeErr
+		}
+	}
+
+	return len(b), nil
+}
+
+// Flush implements http.Flusher for streaming support
+func (c *ConvertingResponseWriter) Flush() {
+	if f, ok := c.underlying.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Finalize converts and writes buffered non-streaming response
+// Must be called after adapter completes for non-streaming responses
+func (c *ConvertingResponseWriter) Finalize() error {
+	if c.isStream {
+		return nil // Streaming responses are already written
+	}
+
+	body := c.buffer.Bytes()
+
+	// Convert the response
+	converted, err := c.converter.TransformResponse(c.targetType, c.originalType, body)
+	if err != nil {
+		// On conversion error, use original body
+		converted = body
+	}
+
+	// Update Content-Type header based on original client type
+	c.updateContentType()
+
+	// Write headers and body
+	if !c.headersSent {
+		c.underlying.WriteHeader(c.statusCode)
+		c.headersSent = true
+	}
+	_, writeErr := c.underlying.Write(converted)
+	return writeErr
+}
+
+// updateContentType sets the Content-Type header based on client type
+func (c *ConvertingResponseWriter) updateContentType() {
+	switch c.originalType {
+	case domain.ClientTypeClaude:
+		c.underlying.Header().Set("Content-Type", "application/json")
+	case domain.ClientTypeOpenAI:
+		c.underlying.Header().Set("Content-Type", "application/json")
+	case domain.ClientTypeGemini:
+		c.underlying.Header().Set("Content-Type", "application/json")
+	}
+}
+
+// StatusCode returns the captured status code
+func (c *ConvertingResponseWriter) StatusCode() int {
+	return c.statusCode
+}
+
+// Body returns the buffered response body (for non-streaming)
+func (c *ConvertingResponseWriter) Body() string {
+	return c.buffer.String()
+}
+
+// NeedsConversion returns true if format conversion is needed
+func NeedsConversion(originalType, targetType domain.ClientType) bool {
+	return originalType != targetType && originalType != "" && targetType != ""
+}
+
+// GetPreferredTargetType returns the best target type for conversion
+// Prefers Claude as it has the richest format support
+func GetPreferredTargetType(supportedTypes []domain.ClientType, originalType domain.ClientType) domain.ClientType {
+	// If original type is supported, no conversion needed
+	for _, t := range supportedTypes {
+		if t == originalType {
+			return originalType
+		}
+	}
+
+	// Prefer Claude as target (richest format)
+	for _, t := range supportedTypes {
+		if t == domain.ClientTypeClaude {
+			return t
+		}
+	}
+
+	// Fall back to first supported type
+	if len(supportedTypes) > 0 {
+		return supportedTypes[0]
+	}
+
+	return originalType
+}
+
+// IsSSELine checks if a line is an SSE data line
+func IsSSELine(line string) bool {
+	return strings.HasPrefix(line, "data: ")
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -501,10 +501,10 @@ func (s *AdminService) GetLogs(limit int) (*LogsResult, error) {
 func (s *AdminService) autoSetSupportedClientTypes(provider *domain.Provider) {
 	switch provider.Type {
 	case "antigravity":
-		// Antigravity natively supports Claude, OpenAI, and Gemini
+		// Antigravity natively supports Claude and Gemini
+		// OpenAI requests will be converted to Claude format by Executor
 		provider.SupportedClientTypes = []domain.ClientType{
 			domain.ClientTypeClaude,
-			domain.ClientTypeOpenAI,
 			domain.ClientTypeGemini,
 		}
 	case "kiro":


### PR DESCRIPTION
## Summary
- 将请求/响应格式转换职责从各 Provider Adapter 集中到 Executor 层，提高代码可维护性
- 新增 `ConvertingResponseWriter` 统一处理流式/非流式响应的格式转换
- 简化 `CustomAdapter`，移除其格式转换逻辑，使 Adapter 只负责请求代理
- 更新 `AntigravityAdapter` 支持的客户端类型（OpenAI 请求现由 Executor 自动转换为 Claude 格式）
- 新增 `OriginalClientType` 上下文字段以追踪原始客户端类型
- 优化事件处理为实时模式，提升请求信息的可见性

## Test plan
- [ ] 测试 Claude 格式请求直接代理到 Claude Provider
- [ ] 测试 OpenAI 格式请求自动转换为 Claude 格式后代理
- [ ] 测试 Gemini 格式请求的处理
- [ ] 验证流式响应的格式转换正确性
- [ ] 验证非流式响应的格式转换正确性
- [ ] 确认请求日志中的 RequestInfo 实时显示正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 引入了自动格式转换功能，支持不同客户端类型之间的无缝转换
  * OpenAI 请求现已自动转换为 Claude 格式进行处理
  * 增强的流式响应处理能力，确保实时数据传输的稳定性

* **改进**
  * 优化了请求/响应处理流程
  * 改进了对多种客户端类型的支持机制

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->