### PR TITLE
feat: 为 Provider 添加 SupportModels 模型过滤功能

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -96,6 +96,11 @@ type Provider struct {
 
 	// 支持的 Client
 	SupportedClientTypes []ClientType `json:"supportedClientTypes"`
+
+	// 支持的模型列表（通配符模式）
+	// 如果配置了，在 Route 匹配时会检查前置映射后的模型是否在支持列表中
+	// 空数组表示支持所有模型
+	SupportModels []string `json:"supportModels,omitempty"`
 }
 
 type Project struct {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -166,7 +166,12 @@ func (e *Executor) Execute(ctx context.Context, w http.ResponseWriter, req *http
 	}
 
 	// Match routes
-	routes, err := e.router.Match(clientType, projectID)
+	routes, err := e.router.Match(&router.MatchContext{
+		ClientType:   clientType,
+		ProjectID:    projectID,
+		RequestModel: requestModel,
+		APITokenID:   apiTokenID,
+	})
 	if err != nil {
 		proxyReq.Status = "FAILED"
 		proxyReq.Error = "no routes available"
@@ -258,6 +263,7 @@ func (e *Executor) Execute(ctx context.Context, w http.ResponseWriter, req *http
 		}
 
 		// Determine model mapping
+		// Model mapping is done in Executor after Router has filtered by SupportModels
 		clientType := ctxutil.GetClientType(ctx)
 		mappedModel := e.mapModel(requestModel, matchedRoute.Route, matchedRoute.Provider, clientType, projectID, apiTokenID)
 		ctx = ctxutil.WithMappedModel(ctx, mappedModel)

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -118,6 +118,7 @@ type Provider struct {
 	Name                 string `gorm:"not null"`
 	Config               string `gorm:"type:longtext"`
 	SupportedClientTypes string `gorm:"type:text"`
+	SupportModels        string `gorm:"type:text"`
 }
 
 func (Provider) TableName() string { return "providers" }

--- a/internal/repository/sqlite/provider.go
+++ b/internal/repository/sqlite/provider.go
@@ -84,6 +84,7 @@ func (r *ProviderRepository) toModel(p *domain.Provider) *Provider {
 		Name:                 p.Name,
 		Config:               toJSON(p.Config),
 		SupportedClientTypes: toJSON(p.SupportedClientTypes),
+		SupportModels:        toJSON(p.SupportModels),
 	}
 }
 
@@ -98,5 +99,6 @@ func (r *ProviderRepository) toDomain(m *Provider) *domain.Provider {
 		Name:                 m.Name,
 		Config:               fromJSON[*domain.ProviderConfig](m.Config),
 		SupportedClientTypes: fromJSON[[]domain.ClientType](m.SupportedClientTypes),
+		SupportModels:        fromJSON[[]string](m.SupportModels),
 	}
 }

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -49,6 +49,7 @@ export interface Provider {
   logo?: string; // Logo URL or data URI
   config: ProviderConfig | null;
   supportedClientTypes: ClientType[];
+  supportModels?: string[]; // 支持的模型列表（通配符模式），空数组表示支持所有模型
 }
 
 // supportedClientTypes 可选，后端会根据 provider type 自动设置
@@ -57,6 +58,7 @@ export type CreateProviderData = Omit<
   'id' | 'createdAt' | 'updatedAt' | 'supportedClientTypes'
 > & {
   supportedClientTypes?: ClientType[];
+  supportModels?: string[];
 };
 
 // ===== Project =====


### PR DESCRIPTION
## Summary
- 新增 `Provider.SupportModels` 字段，支持通配符模式匹配（如 `claude-*`、`gemini-2.5-*`）
- Router 在路由匹配阶段用原始 `requestModel` 检查 `SupportModels`，跳过不支持该模型的 Provider
- 模型映射在 Executor 阶段执行，确保只对通过检查的 Provider 进行映射计算

## Changes
- `internal/domain/model.go`: 添加 `SupportModels []string` 字段
- `internal/repository/sqlite/`: 更新 SQLite 模型和序列化逻辑
- `internal/router/router.go`: 添加 `isModelSupported()` 方法和 SupportModels 检查逻辑
- `internal/executor/executor.go`: 更新注释说明映射时机
- `web/src/pages/providers/`: 新增 ProviderSupportModels 组件用于 UI 配置

## Test plan
- [ ] 配置 Provider 的 SupportModels 为 `claude-*`
- [ ] 请求 `claude-3-opus` → 应该匹配成功
- [ ] 请求 `gemini-2.5-pro` → 应该跳过该 Provider
- [ ] 不配置 SupportModels → 所有模型都应该支持

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了针对供应商的模型级别支持筛选功能。用户现在可以指定每个供应商支持的具体模型，增强了路由匹配的灵活性和精确度。支持通配符模式配置，空数组表示支持所有模型。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->