### PR TITLE
feat: 优化 Activity Heatmap 的 hover 效果

### DIFF
--- a/web/src/components/ui/activity-heatmap.tsx
+++ b/web/src/components/ui/activity-heatmap.tsx
@@ -213,7 +213,7 @@ export function ActivityHeatmap({
                           )}
                         />
                       </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={8}>
+                      <TooltipContent side="top" sideOffset={8} className="pointer-events-none">
                         <div className="flex flex-col gap-0.5">
                           <span className="font-semibold">{formatDate(day.date)}</span>
                           <span className="tabular-nums">


### PR DESCRIPTION
## Summary
- 使用共享 `TooltipProvider` 并设置 `closeDelay={100}`，避免鼠标在格子间移动时 tooltip 快速消失再出现的闪烁问题
- 使用 `box-shadow` 替代 `scale` 放大效果，避免边缘抖动问题
- 改进 tooltip 样式：增加 `sideOffset`、加粗日期、数字使用 `tabular-nums` 等宽对齐

## Test plan
- [ ] 在 Dashboard 页面查看 Activity Heatmap
- [ ] 鼠标快速在格子间滑动，验证 tooltip 不再闪烁
- [ ] 鼠标在格子边缘 hover，验证不再抖动
- [ ] 检查 tooltip 内容和样式是否正确显示