### PR TITLE
fix: 修复热力图显示问题并优化 WebSocket 数据刷新

### DIFF
--- a/internal/event/broadcaster.go
+++ b/internal/event/broadcaster.go
@@ -8,7 +8,6 @@ type Broadcaster interface {
 	BroadcastProxyRequest(req *domain.ProxyRequest)
 	BroadcastProxyUpstreamAttempt(attempt *domain.ProxyUpstreamAttempt)
 	BroadcastLog(message string)
-	BroadcastStats(stats interface{})
 	BroadcastMessage(messageType string, data interface{})
 }
 
@@ -18,5 +17,4 @@ type NopBroadcaster struct{}
 func (n *NopBroadcaster) BroadcastProxyRequest(req *domain.ProxyRequest)                {}
 func (n *NopBroadcaster) BroadcastProxyUpstreamAttempt(attempt *domain.ProxyUpstreamAttempt) {}
 func (n *NopBroadcaster) BroadcastLog(message string)                                   {}
-func (n *NopBroadcaster) BroadcastStats(stats interface{})                              {}
 func (n *NopBroadcaster) BroadcastMessage(messageType string, data interface{})         {}

--- a/internal/event/wails_broadcaster_desktop.go
+++ b/internal/event/wails_broadcaster_desktop.go
@@ -71,14 +71,6 @@ func (w *WailsBroadcaster) BroadcastLog(message string) {
 	w.emitWailsEvent("log_message", message)
 }
 
-// BroadcastStats broadcasts stats update
-func (w *WailsBroadcaster) BroadcastStats(stats interface{}) {
-	if w.inner != nil {
-		w.inner.BroadcastStats(stats)
-	}
-	w.emitWailsEvent("stats_update", stats)
-}
-
 // BroadcastMessage broadcasts a custom message
 func (w *WailsBroadcaster) BroadcastMessage(messageType string, data interface{}) {
 	if w.inner != nil {

--- a/internal/event/wails_broadcaster_http.go
+++ b/internal/event/wails_broadcaster_http.go
@@ -52,13 +52,6 @@ func (w *WailsBroadcaster) BroadcastLog(message string) {
 	}
 }
 
-// BroadcastStats broadcasts stats update
-func (w *WailsBroadcaster) BroadcastStats(stats interface{}) {
-	if w.inner != nil {
-		w.inner.BroadcastStats(stats)
-	}
-}
-
 // BroadcastMessage broadcasts a custom message
 func (w *WailsBroadcaster) BroadcastMessage(messageType string, data interface{}) {
 	if w.inner != nil {

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -20,7 +20,7 @@ var upgrader = websocket.Upgrader{
 }
 
 type WSMessage struct {
-	Type string      `json:"type"` // "proxy_request_update", "stats_update"
+	Type string      `json:"type"` // "proxy_request_update", "proxy_upstream_attempt_update", etc.
 	Data interface{} `json:"data"`
 }
 
@@ -91,13 +91,6 @@ func (h *WebSocketHub) BroadcastProxyUpstreamAttempt(attempt *domain.ProxyUpstre
 	h.broadcast <- WSMessage{
 		Type: "proxy_upstream_attempt_update",
 		Data: attempt,
-	}
-}
-
-func (h *WebSocketHub) BroadcastStats(stats interface{}) {
-	h.broadcast <- WSMessage{
-		Type: "stats_update",
-		Data: stats,
 	}
 }
 

--- a/web/src/hooks/queries/use-dashboard-stats.ts
+++ b/web/src/hooks/queries/use-dashboard-stats.ts
@@ -62,7 +62,7 @@ export function useDashboardData() {
     queryKey: ['dashboard'],
     queryFn: () => getTransport().getDashboardData(),
     staleTime: 5 * 1000, // 5 seconds
-    refetchInterval: 5 * 1000, // 每 5 秒自动刷新
+    // 不再轮询，改为通过 WebSocket 事件触发刷新 (useProxyRequestUpdates)
     refetchOnWindowFocus: false,
   });
 }

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -79,8 +79,7 @@ export function useProviderStats(clientType?: string, projectId?: number) {
   return useQuery({
     queryKey: [...providerKeys.stats(), clientType, projectId],
     queryFn: () => getTransport().getProviderStats(clientType, projectId),
-    // 每 30 秒刷新一次
-    refetchInterval: 30000,
+    // 不再轮询，改为通过 WebSocket 事件触发刷新 (useProxyRequestUpdates)
     enabled: !!clientType, // 只在有 clientType 时才查询
   });
 }
@@ -90,8 +89,7 @@ export function useAllProviderStats() {
   return useQuery({
     queryKey: [...providerKeys.stats(), 'all'],
     queryFn: () => getTransport().getProviderStats(),
-    // 每 30 秒刷新一次
-    refetchInterval: 30000,
+    // 不再轮询，改为通过 WebSocket 事件触发刷新 (useProxyRequestUpdates)
   });
 }
 

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -98,6 +98,19 @@ export function useProxyRequestUpdates() {
         if (isNewRequest) {
           queryClient.setQueryData<number>(['requestsCount'], (old) => (old ?? 0) + 1);
         }
+
+        // 请求完成或失败时刷新相关数据
+        if (updatedRequest.status === 'COMPLETED' || updatedRequest.status === 'FAILED') {
+          // 刷新 dashboard 数据
+          queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+          // 刷新 provider stats（因为统计数据变化了）
+          queryClient.invalidateQueries({ queryKey: ['providers', 'stats'] });
+        }
+
+        // 请求失败时还需要刷新 cooldowns（可能触发了冷却）
+        if (updatedRequest.status === 'FAILED') {
+          queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
+        }
       },
     );
 

--- a/web/src/hooks/use-cooldowns.ts
+++ b/web/src/hooks/use-cooldowns.ts
@@ -13,7 +13,7 @@ export function useCooldowns() {
   } = useQuery({
     queryKey: ['cooldowns'],
     queryFn: () => getTransport().getCooldowns(),
-    refetchInterval: 5000, // Refetch every 5 seconds from server
+    // 不再轮询，改为通过 WebSocket 事件触发刷新 (useProxyRequestUpdates)
     staleTime: 3000,
   });
 


### PR DESCRIPTION
## Summary
- 修复热力图未正确补全日期的问题，现在始终显示 53 周（约一年）
- 移除前端轮询，改用 WebSocket 事件触发数据刷新
- 清理未使用的 `BroadcastStats` / `stats_update` 死代码

## 改动详情

### 热力图修复
- 前端：始终从 53 周前开始显示，无论数据何时开始都能填满
- 后端：只返回 `count > 0` 的日期，减少数据传输
- 正确处理今日数据的实时更新（今日条目可能不在历史查询中）

### WebSocket 数据刷新
- 请求完成/失败时自动刷新：`dashboard`、`provider stats`
- 请求失败时额外刷新：`cooldowns`（可能触发冷却）
- 移除的轮询：`dashboard` (5s)、`cooldowns` (5s)、`provider stats` (30s)
- 保留轮询：Antigravity/Kiro 配额 (10min) - 外部 API 不受代理请求影响

## Test plan
- [ ] 验证热力图正确显示 53 周数据
- [ ] 验证新请求完成后 dashboard 自动刷新
- [ ] 验证请求失败后 cooldowns 自动刷新
- [ ] 验证侧边栏活动请求数正确更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 活动热力图现已显示固定的 53 周时间窗口
  * 用 WebSocket 实时事件驱动替代定期数据轮询，提升性能和更新实时性
  * 请求完成或失败时自动刷新相关数据缓存

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->