### PR TITLE
feat: 在 Dashboard Today Requests 显示活跃请求数

### DIFF
--- a/web/src/pages/overview.tsx
+++ b/web/src/pages/overview.tsx
@@ -129,6 +129,8 @@ function StatCard({
   trend,
   icon: Icon,
   iconClassName,
+  badge,
+  badgeColor = '#3b82f6',
 }: {
   title: string;
   value: string;
@@ -136,7 +138,11 @@ function StatCard({
   trend?: number;
   icon: React.ElementType;
   iconClassName?: string;
+  badge?: number;
+  badgeColor?: string;
 }) {
+  const showBadge = badge !== undefined && badge > 0;
+
   return (
     <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
       <CardContent className="p-4">
@@ -155,8 +161,24 @@ function StatCard({
               {trend !== undefined && <TrendIndicator value={trend} />}
             </div>
           </div>
-          <div className={cn('p-2.5 rounded-xl bg-muted', iconClassName)}>
-            <Icon className="h-5 w-5" />
+          <div
+            className={cn(
+              'w-10 h-10 rounded-xl bg-muted flex items-center justify-center box-border border-2 border-transparent transition-shadow duration-300',
+              showBadge && 'animate-pulse-soft',
+              iconClassName
+            )}
+            style={showBadge ? {
+              borderColor: badgeColor,
+              boxShadow: `0 0 10px ${badgeColor}60`,
+            } : undefined}
+          >
+            {showBadge ? (
+              <span className="text-lg font-extrabold">
+                {badge > 99 ? '99+' : badge}
+              </span>
+            ) : (
+              <Icon className="h-5 w-5" />
+            )}
           </div>
         </div>
       </CardContent>
@@ -183,7 +205,14 @@ export function OverviewPage() {
   // 启用请求实时更新
   useProxyRequestUpdates();
 
-  const recentRequests = requestsData?.items ?? [];
+  const recentRequests = useMemo(() => requestsData?.items ?? [], [requestsData?.items]);
+
+  // 计算正在进行中的请求数量
+  const activeRequestsCount = useMemo(() => {
+    return recentRequests.filter(
+      (req) => req.status !== 'COMPLETED' && req.status !== 'FAILED'
+    ).length;
+  }, [recentRequests]);
 
   // 计算 Provider 使用分布
   const providerDistribution = useMemo(() => {
@@ -282,6 +311,7 @@ export function OverviewPage() {
               trend={summary?.requestsChange}
               icon={Activity}
               iconClassName="text-blue-600 dark:text-blue-400"
+              badge={activeRequestsCount}
             />
             <StatCard
               title={t('dashboard.todayTokens')}


### PR DESCRIPTION
## Summary
- 当有正在进行中的请求时，Today Requests 卡片右上角的图标变成当前活跃请求数量
- 添加发光边框和脉冲动画效果（与 sidebar StreamingBadge 风格一致）
- 修复 recentRequests 的 useMemo 依赖警告

## Test plan
- [ ] 发起请求时检查 Dashboard Today Requests 卡片右上角是否显示活跃数量
- [ ] 确认动画效果正常（脉冲 + 发光边框）
- [ ] 请求完成后确认数字消失、图标恢复

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
- 仪表板统计卡片新增活动徽章功能，可展示请求数量（超过99条显示为"99+"）
- 实时展示今日活跃请求计数
- 新增脉动动画、动态边框和发光效果的视觉增强

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->