### PR TITLE
feat: 添加一键排序 Antigravity 路由功能

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -368,9 +368,11 @@ type SystemSetting struct {
 
 // 系统设置 Key 常量
 const (
-	SettingKeyProxyPort             = "proxy_port"              // 代理服务器端口，默认 9880
-	SettingKeyRequestRetentionHours = "request_retention_hours" // 请求记录保留小时数，默认 168 小时（7天），0 表示不清理
-	SettingKeyTimezone              = "timezone"                // 时区设置，默认 Asia/Shanghai
+	SettingKeyProxyPort              = "proxy_port"               // 代理服务器端口，默认 9880
+	SettingKeyRequestRetentionHours  = "request_retention_hours"  // 请求记录保留小时数，默认 168 小时（7天），0 表示不清理
+	SettingKeyTimezone               = "timezone"                 // 时区设置，默认 Asia/Shanghai
+	SettingKeyQuotaRefreshInterval   = "quota_refresh_interval"   // Antigravity 配额刷新间隔（分钟），0 表示禁用
+	SettingKeyAutoSortAntigravity    = "auto_sort_antigravity"    // 是否自动排序 Antigravity 路由，"true" 或 "false"
 )
 
 // Antigravity 模型配额

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -78,6 +78,8 @@ type ProxyRequestRepository interface {
 	MarkStaleAsFailed(currentInstanceID string) (int64, error)
 	// DeleteOlderThan 删除指定时间之前的请求记录
 	DeleteOlderThan(before time.Time) (int64, error)
+	// HasRecentRequests 检查指定时间之后是否有请求记录
+	HasRecentRequests(since time.Time) (bool, error)
 }
 
 type ProxyUpstreamAttemptRepository interface {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -187,6 +187,16 @@ func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error
 	return affected, nil
 }
 
+// HasRecentRequests 检查指定时间之后是否有请求记录
+func (r *ProxyRequestRepository) HasRecentRequests(since time.Time) (bool, error) {
+	sinceTs := toTimestamp(since)
+	var count int64
+	if err := r.db.gorm.Model(&ProxyRequest{}).Where("created_at >= ?", sinceTs).Limit(1).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (r *ProxyRequestRepository) toModel(p *domain.ProxyRequest) *ProxyRequest {
 	return &ProxyRequest{
 		BaseModel: BaseModel{

--- a/internal/service/antigravity_task.go
+++ b/internal/service/antigravity_task.go
@@ -1,0 +1,418 @@
+package service
+
+import (
+	"context"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider/antigravity"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/event"
+	"github.com/awsl-project/maxx/internal/repository"
+)
+
+const (
+	defaultQuotaRefreshInterval = 0 // 默认不自动刷新
+)
+
+// AntigravityTaskService handles periodic quota refresh and auto-sorting
+type AntigravityTaskService struct {
+	providerRepo repository.ProviderRepository
+	routeRepo    repository.RouteRepository
+	quotaRepo    repository.AntigravityQuotaRepository
+	settingRepo  repository.SystemSettingRepository
+	requestRepo  repository.ProxyRequestRepository
+	broadcaster  event.Broadcaster
+}
+
+// NewAntigravityTaskService creates a new AntigravityTaskService
+func NewAntigravityTaskService(
+	providerRepo repository.ProviderRepository,
+	routeRepo repository.RouteRepository,
+	quotaRepo repository.AntigravityQuotaRepository,
+	settingRepo repository.SystemSettingRepository,
+	requestRepo repository.ProxyRequestRepository,
+	broadcaster event.Broadcaster,
+) *AntigravityTaskService {
+	return &AntigravityTaskService{
+		providerRepo: providerRepo,
+		routeRepo:    routeRepo,
+		quotaRepo:    quotaRepo,
+		settingRepo:  settingRepo,
+		requestRepo:  requestRepo,
+		broadcaster:  broadcaster,
+	}
+}
+
+// GetRefreshInterval returns the configured refresh interval in minutes (0 = disabled)
+func (s *AntigravityTaskService) GetRefreshInterval() int {
+	val, err := s.settingRepo.Get(domain.SettingKeyQuotaRefreshInterval)
+	if err != nil || val == "" {
+		return defaultQuotaRefreshInterval
+	}
+	interval, err := strconv.Atoi(val)
+	if err != nil {
+		return defaultQuotaRefreshInterval
+	}
+	return interval
+}
+
+// RefreshQuotas refreshes all Antigravity quotas (for periodic auto-refresh)
+// Returns true if quotas were refreshed
+// Skips refresh if no requests in the last 10 minutes
+func (s *AntigravityTaskService) RefreshQuotas(ctx context.Context) bool {
+	// Check if there were any requests in the last 10 minutes
+	since := time.Now().Add(-10 * time.Minute)
+	hasRecent, err := s.requestRepo.HasRecentRequests(since)
+	if err != nil {
+		log.Printf("[AntigravityTask] Failed to check recent requests: %v", err)
+		// Continue with refresh on error
+	} else if !hasRecent {
+		log.Printf("[AntigravityTask] No requests in the last 10 minutes, skipping quota refresh")
+		return false
+	}
+
+	// Refresh quotas
+	refreshed := s.refreshAllQuotas(ctx)
+	if refreshed {
+		// Broadcast quota updated message
+		s.broadcaster.BroadcastMessage("quota_updated", nil)
+
+		// Check if auto-sort is enabled
+		autoSortEnabled := s.isAutoSortEnabled()
+		log.Printf("[AntigravityTask] Auto-sort enabled: %v", autoSortEnabled)
+		if autoSortEnabled {
+			s.autoSortAntigravityRoutes(ctx)
+		}
+	}
+
+	return refreshed
+}
+
+// ForceRefreshQuotas forces a refresh of all Antigravity quotas
+func (s *AntigravityTaskService) ForceRefreshQuotas(ctx context.Context) bool {
+	refreshed := s.refreshAllQuotas(ctx)
+	if refreshed {
+		// Broadcast quota updated message
+		s.broadcaster.BroadcastMessage("quota_updated", nil)
+
+		// Check if auto-sort is enabled
+		autoSortEnabled := s.isAutoSortEnabled()
+		log.Printf("[AntigravityTask] Auto-sort enabled: %v", autoSortEnabled)
+		if autoSortEnabled {
+			s.autoSortAntigravityRoutes(ctx)
+		}
+	}
+	return refreshed
+}
+
+// SortRoutes manually sorts Antigravity routes by resetTime
+func (s *AntigravityTaskService) SortRoutes(ctx context.Context) {
+	s.autoSortAntigravityRoutes(ctx)
+}
+
+// refreshAllQuotas refreshes quotas for all Antigravity providers
+func (s *AntigravityTaskService) refreshAllQuotas(ctx context.Context) bool {
+	providers, err := s.providerRepo.List()
+	if err != nil {
+		log.Printf("[AntigravityTask] Failed to list providers: %v", err)
+		return false
+	}
+
+	refreshedCount := 0
+	for _, provider := range providers {
+		if provider.Type != "antigravity" || provider.Config == nil || provider.Config.Antigravity == nil {
+			continue
+		}
+
+		config := provider.Config.Antigravity
+		if config.RefreshToken == "" {
+			continue
+		}
+
+		// Fetch quota from API
+		quota, err := antigravity.FetchQuotaForProvider(ctx, config.RefreshToken, config.ProjectID)
+		if err != nil {
+			log.Printf("[AntigravityTask] Failed to fetch quota for provider %d: %v", provider.ID, err)
+			continue
+		}
+
+		// Save to database
+		s.saveQuotaToDB(config.Email, config.ProjectID, quota)
+		refreshedCount++
+	}
+
+	if refreshedCount > 0 {
+		log.Printf("[AntigravityTask] Refreshed quotas for %d providers", refreshedCount)
+		return true
+	}
+
+	return false
+}
+
+// saveQuotaToDB saves quota to database
+func (s *AntigravityTaskService) saveQuotaToDB(email, projectID string, quota *antigravity.QuotaData) {
+	if s.quotaRepo == nil || email == "" {
+		return
+	}
+
+	var models []domain.AntigravityModelQuota
+	var subscriptionTier string
+	var isForbidden bool
+
+	if quota != nil {
+		models = make([]domain.AntigravityModelQuota, len(quota.Models))
+		for i, m := range quota.Models {
+			models[i] = domain.AntigravityModelQuota{
+				Name:       m.Name,
+				Percentage: m.Percentage,
+				ResetTime:  m.ResetTime,
+			}
+		}
+		subscriptionTier = quota.SubscriptionTier
+		isForbidden = quota.IsForbidden
+	}
+
+	// Try to preserve existing user info
+	var name, picture string
+	if existing, _ := s.quotaRepo.GetByEmail(email); existing != nil {
+		name = existing.Name
+		picture = existing.Picture
+	}
+
+	domainQuota := &domain.AntigravityQuota{
+		Email:            email,
+		Name:             name,
+		Picture:          picture,
+		GCPProjectID:     projectID,
+		SubscriptionTier: subscriptionTier,
+		IsForbidden:      isForbidden,
+		Models:           models,
+	}
+
+	s.quotaRepo.Upsert(domainQuota)
+}
+
+// isAutoSortEnabled checks if auto-sort is enabled in settings
+func (s *AntigravityTaskService) isAutoSortEnabled() bool {
+	val, err := s.settingRepo.Get(domain.SettingKeyAutoSortAntigravity)
+	if err != nil {
+		return false
+	}
+	return val == "true"
+}
+
+// autoSortAntigravityRoutes sorts Antigravity routes by resetTime for all scopes
+func (s *AntigravityTaskService) autoSortAntigravityRoutes(ctx context.Context) {
+	log.Printf("[AntigravityTask] Starting auto-sort")
+
+	routes, err := s.routeRepo.List()
+	if err != nil {
+		log.Printf("[AntigravityTask] Failed to list routes: %v", err)
+		return
+	}
+
+	providers, err := s.providerRepo.List()
+	if err != nil {
+		log.Printf("[AntigravityTask] Failed to list providers: %v", err)
+		return
+	}
+
+	// Build provider map
+	providerMap := make(map[uint64]*domain.Provider)
+	antigravityCount := 0
+	for _, p := range providers {
+		providerMap[p.ID] = p
+		if p.Type == "antigravity" {
+			antigravityCount++
+		}
+	}
+	log.Printf("[AntigravityTask] Found %d Antigravity providers, %d total routes", antigravityCount, len(routes))
+
+	// Get all quotas
+	quotas, err := s.quotaRepo.List()
+	if err != nil {
+		log.Printf("[AntigravityTask] Failed to list quotas: %v", err)
+		return
+	}
+	log.Printf("[AntigravityTask] Found %d quotas in database", len(quotas))
+
+	// Build email to quota map
+	quotaByEmail := make(map[string]*domain.AntigravityQuota)
+	for _, q := range quotas {
+		quotaByEmail[q.Email] = q
+	}
+
+	// Collect all unique (clientType, projectID) combinations
+	type scope struct {
+		clientType domain.ClientType
+		projectID  uint64
+	}
+	scopes := make(map[scope]bool)
+	for _, r := range routes {
+		scopes[scope{r.ClientType, r.ProjectID}] = true
+	}
+
+	// Process each scope
+	var allUpdates []domain.RoutePositionUpdate
+	for sc := range scopes {
+		updates := s.sortAntigravityRoutesForScope(routes, providerMap, quotaByEmail, sc.clientType, sc.projectID)
+		allUpdates = append(allUpdates, updates...)
+	}
+
+	if len(allUpdates) > 0 {
+		if err := s.routeRepo.BatchUpdatePositions(allUpdates); err != nil {
+			log.Printf("[AntigravityTask] Failed to update route positions: %v", err)
+			return
+		}
+		log.Printf("[AntigravityTask] Auto-sorted %d routes", len(allUpdates))
+
+		// Broadcast routes updated
+		s.broadcaster.BroadcastMessage("routes_updated", nil)
+	}
+}
+
+// sortAntigravityRoutesForScope sorts Antigravity routes within a scope
+func (s *AntigravityTaskService) sortAntigravityRoutesForScope(
+	routes []*domain.Route,
+	providerMap map[uint64]*domain.Provider,
+	quotaByEmail map[string]*domain.AntigravityQuota,
+	clientType domain.ClientType,
+	projectID uint64,
+) []domain.RoutePositionUpdate {
+	// Filter routes for this scope and sort by position
+	var scopeRoutes []*domain.Route
+	for _, r := range routes {
+		if r.ClientType == clientType && r.ProjectID == projectID {
+			scopeRoutes = append(scopeRoutes, r)
+		}
+	}
+
+	if len(scopeRoutes) == 0 {
+		return nil
+	}
+
+	// Sort by current position
+	sort.Slice(scopeRoutes, func(i, j int) bool {
+		return scopeRoutes[i].Position < scopeRoutes[j].Position
+	})
+
+	// Collect Antigravity routes and their indices
+	type antigravityRoute struct {
+		route     *domain.Route
+		index     int
+		resetTime *time.Time
+	}
+	var antigravityRoutes []antigravityRoute
+
+	for i, r := range scopeRoutes {
+		provider := providerMap[r.ProviderID]
+		if provider == nil || provider.Type != "antigravity" {
+			continue
+		}
+
+		// Get resetTime from quota
+		var resetTime *time.Time
+		if provider.Config != nil && provider.Config.Antigravity != nil {
+			email := provider.Config.Antigravity.Email
+			if quota := quotaByEmail[email]; quota != nil {
+				resetTime = s.getClaudeResetTime(quota)
+			}
+		}
+
+		antigravityRoutes = append(antigravityRoutes, antigravityRoute{
+			route:     r,
+			index:     i,
+			resetTime: resetTime,
+		})
+	}
+
+	if len(antigravityRoutes) <= 1 {
+		return nil
+	}
+
+	// Save original order before sorting
+	originalOrder := make([]uint64, len(antigravityRoutes))
+	for i, ar := range antigravityRoutes {
+		originalOrder[i] = ar.route.ID
+	}
+
+	// Sort Antigravity routes by resetTime (earliest first)
+	sort.Slice(antigravityRoutes, func(i, j int) bool {
+		a, b := antigravityRoutes[i].resetTime, antigravityRoutes[j].resetTime
+		if a == nil && b == nil {
+			return false
+		}
+		if a == nil {
+			return false // nil goes to end
+		}
+		if b == nil {
+			return true
+		}
+		return a.Before(*b)
+	})
+
+	// Check if order changed
+	needsReorder := false
+	for i, ar := range antigravityRoutes {
+		if ar.route.ID != originalOrder[i] {
+			needsReorder = true
+			break
+		}
+	}
+
+	if !needsReorder {
+		return nil
+	}
+
+	// Build new route order: place sorted Antigravity routes back into their original positions
+	newScopeRoutes := make([]*domain.Route, len(scopeRoutes))
+	copy(newScopeRoutes, scopeRoutes)
+
+	// Get original Antigravity indices
+	originalIndices := make([]int, len(antigravityRoutes))
+	for i, ar := range antigravityRoutes {
+		originalIndices[i] = ar.index
+	}
+	sort.Ints(originalIndices)
+
+	// Place sorted routes into original positions
+	for i, idx := range originalIndices {
+		newScopeRoutes[idx] = antigravityRoutes[i].route
+	}
+
+	// Generate position updates
+	var updates []domain.RoutePositionUpdate
+	for i, r := range newScopeRoutes {
+		newPosition := i + 1
+		if r.Position != newPosition {
+			updates = append(updates, domain.RoutePositionUpdate{
+				ID:       r.ID,
+				Position: newPosition,
+			})
+		}
+	}
+
+	return updates
+}
+
+// getClaudeResetTime extracts Claude model reset time from quota
+func (s *AntigravityTaskService) getClaudeResetTime(quota *domain.AntigravityQuota) *time.Time {
+	if quota == nil || quota.IsForbidden || len(quota.Models) == 0 {
+		return nil
+	}
+
+	for _, m := range quota.Models {
+		// Use case-insensitive matching for model name
+		if strings.Contains(strings.ToLower(m.Name), "claude") {
+			t, err := time.Parse(time.RFC3339, m.ResetTime)
+			if err == nil {
+				return &t
+			}
+		}
+	}
+	return nil
+}

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -401,6 +401,13 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async refreshAntigravityQuotas(): Promise<{ success: boolean; refreshed: number }> {
+    const { data } = await axios.post<{ success: boolean; refreshed: number }>(
+      '/api/antigravity/refresh-quotas',
+    );
+    return data;
+  }
+
   // ===== Model Mapping API =====
 
   async getModelMappings(): Promise<ModelMapping[]> {

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -130,6 +130,7 @@ export interface Transport {
   ): Promise<AntigravityQuotaData>;
   getAntigravityBatchQuotas(): Promise<Record<number, AntigravityQuotaData>>;
   startAntigravityOAuth(): Promise<{ authURL: string; state: string }>;
+  refreshAntigravityQuotas(): Promise<{ success: boolean; refreshed: number }>;
 
   // ===== Model Mapping API =====
   getModelMappings(): Promise<ModelMapping[]>;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -161,7 +161,8 @@
     "noProvidersHint": "Click \"Add Provider\" to create one",
     "importProviders": "Import Providers",
     "exportProviders": "Export Providers",
-    "importCompleted": "Import completed: {{imported}} imported, {{skipped}} skipped"
+    "importCompleted": "Import completed: {{imported}} imported, {{skipped}} skipped",
+    "refreshQuotas": "Refresh quotas for all Antigravity providers"
   },
   "projects": {
     "title": "Projects",
@@ -360,7 +361,14 @@
     "updated": "Updated",
     "importWarnings": "Warnings",
     "importErrors": "Errors",
-    "backupContainsSensitive": "Backup file contains sensitive information (API keys, etc.), keep it safe"
+    "backupContainsSensitive": "Backup file contains sensitive information (API keys, etc.), keep it safe",
+    "antigravity": "Antigravity Settings",
+    "antigravityDesc": "Configure automatic quota refresh and route sorting for Antigravity providers",
+    "quotaRefreshInterval": "Quota Refresh Interval",
+    "quotaRefreshIntervalDesc": "How often to automatically refresh Antigravity quotas (0 = disabled)",
+    "minutes": "minutes",
+    "autoSortAntigravity": "Auto-Sort Routes",
+    "autoSortAntigravityDesc": "Automatically sort Antigravity routes by Claude model reset time (earliest first) after quota refresh"
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -161,7 +161,8 @@
     "noProvidersHint": "点击「添加提供商」创建一个",
     "importProviders": "导入提供商",
     "exportProviders": "导出提供商",
-    "importCompleted": "导入完成：{{imported}} 个已导入，{{skipped}} 个已跳过"
+    "importCompleted": "导入完成：{{imported}} 个已导入，{{skipped}} 个已跳过",
+    "refreshQuotas": "刷新所有 Antigravity 的额度"
   },
   "projects": {
     "title": "项目",
@@ -360,7 +361,14 @@
     "updated": "已更新",
     "importWarnings": "警告",
     "importErrors": "错误",
-    "backupContainsSensitive": "备份文件包含敏感信息（API 密钥等），请妥善保管"
+    "backupContainsSensitive": "备份文件包含敏感信息（API 密钥等），请妥善保管",
+    "antigravity": "Antigravity 设置",
+    "antigravityDesc": "配置 Antigravity 账号的自动配额刷新和路由排序",
+    "quotaRefreshInterval": "配额刷新间隔",
+    "quotaRefreshIntervalDesc": "自动刷新 Antigravity 配额的频率（0 = 禁用）",
+    "minutes": "分钟",
+    "autoSortAntigravity": "自动排序路由",
+    "autoSortAntigravityDesc": "配额刷新后自动按 Claude 模型重置时间排序 Antigravity 路由（最早重置的优先）"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -42,13 +42,27 @@ interface ProviderRowProps {
 // 获取 Claude 模型额度百分比和重置时间
 function getClaudeQuotaInfo(
   quota: AntigravityQuotaData | undefined,
-): { percentage: number; resetTime: string } | null {
+): { percentage: number; resetTime: string; lastUpdated: number } | null {
   if (!quota || quota.isForbidden || !quota.models) return null;
-  const claudeModel = quota.models.find((m) => m.name.includes('claude'));
+  const claudeModel = quota.models.find((m) => m.name.toLowerCase().includes('claude'));
   if (!claudeModel) return null;
   return {
     percentage: claudeModel.percentage,
     resetTime: claudeModel.resetTime,
+    lastUpdated: quota.lastUpdated,
+  };
+}
+
+// 获取 Image 模型额度百分比
+function getImageQuotaInfo(
+  quota: AntigravityQuotaData | undefined,
+): { percentage: number; resetTime: string } | null {
+  if (!quota || quota.isForbidden || !quota.models) return null;
+  const imageModel = quota.models.find((m) => m.name.toLowerCase().includes('image'));
+  if (!imageModel) return null;
+  return {
+    percentage: imageModel.percentage,
+    resetTime: imageModel.resetTime,
   };
 }
 
@@ -75,6 +89,21 @@ function formatResetTime(resetTime: string, t: (key: string) => string): string 
   } catch {
     return '-';
   }
+}
+
+// 格式化 lastUpdated 为相对时间
+function formatLastUpdated(timestamp: number): string {
+  if (!timestamp) return '';
+  const now = Date.now();
+  const diff = now - timestamp * 1000;
+  const minutes = Math.floor(diff / (1000 * 60));
+
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
 }
 
 // 格式化 Kiro 重置天数
@@ -120,6 +149,7 @@ export function ProviderRow({ provider, stats, streamingCount, onClick }: Provid
   // 从批量查询上下文获取 Antigravity 额度
   const antigravityQuota = useAntigravityQuotaFromContext(provider.id);
   const claudeInfo = isAntigravity ? getClaudeQuotaInfo(antigravityQuota) : null;
+  const imageInfo = isAntigravity ? getImageQuotaInfo(antigravityQuota) : null;
 
   // 仅为 Kiro provider 获取额度
   const { data: kiroQuota } = useKiroQuota(provider.id, isKiro);
@@ -181,28 +211,63 @@ export function ProviderRow({ provider, stats, streamingCount, onClick }: Provid
           <h3 className="text-[15px] font-bold text-foreground truncate">{provider.name}</h3>
         </div>
         <div className="flex items-center gap-3">
-          {/* 对于 Antigravity，显示 Claude Quota；对于其他类型，显示邮箱/endpoint */}
-          {isAntigravity && claudeInfo ? (
-            <div className="flex items-center gap-2 shrink-0">
-              <span className="text-[9px] font-black text-muted-foreground/60 uppercase">
-                Claude
-              </span>
-              <div className="w-20 h-1.5 bg-muted rounded-full overflow-hidden border border-border/50">
-                <div
-                  className={cn(
-                    'h-full rounded-full transition-all duration-1000',
-                    claudeInfo.percentage >= 50
-                      ? 'bg-emerald-500'
-                      : claudeInfo.percentage >= 20
-                        ? 'bg-amber-500'
-                        : 'bg-red-500',
-                  )}
-                  style={{ width: `${claudeInfo.percentage}%` }}
-                />
-              </div>
-              <span className="text-[9px] font-mono text-muted-foreground/60">
-                {formatResetTime(claudeInfo.resetTime, t)}
-              </span>
+          {/* 对于 Antigravity，显示 Claude 和 Imagen Quota；对于其他类型，显示邮箱/endpoint */}
+          {isAntigravity && (claudeInfo || imageInfo) ? (
+            <div className="flex items-center gap-3 shrink-0">
+              {/* Claude Quota */}
+              {claudeInfo && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] font-black text-muted-foreground/60 uppercase">
+                    Claude
+                  </span>
+                  <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden border border-border/50">
+                    <div
+                      className={cn(
+                        'h-full rounded-full transition-all duration-1000',
+                        claudeInfo.percentage >= 50
+                          ? 'bg-emerald-500'
+                          : claudeInfo.percentage >= 20
+                            ? 'bg-amber-500'
+                            : 'bg-red-500',
+                      )}
+                      style={{ width: `${claudeInfo.percentage}%` }}
+                    />
+                  </div>
+                  <span className="text-[9px] font-mono text-muted-foreground/60">
+                    {formatResetTime(claudeInfo.resetTime, t)}
+                  </span>
+                </div>
+              )}
+              {/* Image Quota */}
+              {imageInfo && (
+                <div className="flex items-center gap-1.5">
+                  <span className="text-[9px] font-black text-muted-foreground/60 uppercase">
+                    Image
+                  </span>
+                  <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden border border-border/50">
+                    <div
+                      className={cn(
+                        'h-full rounded-full transition-all duration-1000',
+                        imageInfo.percentage >= 50
+                          ? 'bg-emerald-500'
+                          : imageInfo.percentage >= 20
+                            ? 'bg-amber-500'
+                            : 'bg-red-500',
+                      )}
+                      style={{ width: `${imageInfo.percentage}%` }}
+                    />
+                  </div>
+                  <span className="text-[9px] font-mono text-muted-foreground/60">
+                    {formatResetTime(imageInfo.resetTime, t)}
+                  </span>
+                </div>
+              )}
+              {/* Last Updated */}
+              {claudeInfo && (
+                <span className="text-[8px] font-mono text-muted-foreground/40" title="Last updated">
+                  @{formatLastUpdated(claudeInfo.lastUpdated)}
+                </span>
+              )}
             </div>
           ) : (
             <div


### PR DESCRIPTION
## Summary
- 在 Routes 页面添加"一键排序 Antigravity"按钮
- 根据 Claude 模型的重刷时间 (resetTime) 对 Antigravity 类型的路由进行排序，越早重刷的排在前面
- 排序只影响 Antigravity 路由之间的顺序，非 Antigravity 路由位置保持不变

## Test plan
- [ ] 在 Routes 页面添加多个 Antigravity 类型的 Provider 路由
- [ ] 确认"一键排序 Antigravity"按钮显示
- [ ] 点击按钮后，Antigravity 路由按 resetTime 从早到晚排序
- [ ] 确认非 Antigravity 路由位置不受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“一键排序 Antigravity”按钮，按 Claude 重置时间整理路由并支持即时列表更新（失败回滚）。
  * 新增手动“刷新配额”操作，可触发 Antigravity 配额刷新并显示进行状态。

* **设置**
  * 添加 Antigravity 配置：配额刷新间隔与自动排序开关，支持保存生效。

* **界面**
  * 提示和列表增强：并排展示 Claude 与 Image 配额、“最后更新时间”及提供者元信息。  

* **国际化**
  * 补充中/英文相关文案。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->