### PR TITLE
feat: 添加 CooldownsProvider 上下文减少重复 API 请求

### DIFF
--- a/web/src/components/cooldown-details-dialog.tsx
+++ b/web/src/components/cooldown-details-dialog.tsx
@@ -17,7 +17,7 @@ import {
   Activity,
 } from 'lucide-react';
 import type { Cooldown } from '@/lib/transport/types';
-import { useCooldowns } from '@/hooks/use-cooldowns';
+import { useCooldownsContext } from '@/contexts/cooldowns-context';
 
 interface CooldownDetailsDialogProps {
   cooldown: Cooldown | null;
@@ -93,7 +93,7 @@ export function CooldownDetailsDialog({
   const { t, i18n } = useTranslation();
   const REASON_INFO = getReasonInfo(t);
   // 获取 formatRemaining 函数用于实时倒计时
-  const { formatRemaining } = useCooldowns();
+  const { formatRemaining } = useCooldownsContext();
 
   // 计算初始倒计时值
   const getInitialCountdown = useCallback(() => {

--- a/web/src/components/provider-details-dialog.tsx
+++ b/web/src/components/provider-details-dialog.tsx
@@ -23,7 +23,7 @@ import {
 } from 'lucide-react';
 import type { Cooldown, ProviderStats, ClientType } from '@/lib/transport/types';
 import type { ProviderConfigItem } from '@/pages/client-routes/types';
-import { useCooldowns } from '@/hooks/use-cooldowns';
+import { useCooldownsContext } from '@/contexts/cooldowns-context';
 import { Button, Switch } from '@/components/ui';
 import { getProviderColor, type ProviderType } from '@/lib/theme';
 import { cn } from '@/lib/utils';
@@ -145,7 +145,7 @@ export function ProviderDetailsDialog({
 }: ProviderDetailsDialogProps) {
   const { t, i18n } = useTranslation();
   const REASON_INFO = getReasonInfo(t);
-  const { formatRemaining } = useCooldowns();
+  const { formatRemaining } = useCooldownsContext();
 
   // 计算初始倒计时值
   const getInitialCountdown = useCallback(() => {

--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -44,6 +44,7 @@ import {
 import type { ProviderConfigItem } from '@/pages/client-routes/types';
 import { Button } from '../ui';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
+import { CooldownsProvider } from '@/contexts/cooldowns-context';
 
 interface ClientTypeRoutesContentProps {
   clientType: ClientType;
@@ -51,7 +52,19 @@ interface ClientTypeRoutesContentProps {
   searchQuery?: string; // Optional search query from parent
 }
 
-export function ClientTypeRoutesContent({
+// Wrapper component that provides the AntigravityQuotasProvider and CooldownsProvider
+export function ClientTypeRoutesContent(props: ClientTypeRoutesContentProps) {
+  return (
+    <AntigravityQuotasProvider>
+      <CooldownsProvider>
+        <ClientTypeRoutesContentInner {...props} />
+      </CooldownsProvider>
+    </AntigravityQuotasProvider>
+  );
+}
+
+// Inner component that can access the contexts
+function ClientTypeRoutesContentInner({
   clientType,
   projectID,
   searchQuery = '',
@@ -237,10 +250,9 @@ export function ClientTypeRoutesContent({
   }
 
   return (
-    <AntigravityQuotasProvider>
-      <div className="flex flex-col h-full px-6">
-        <div className="flex-1 overflow-y-auto px-lg py-6">
-          <div className="mx-auto max-w-[1400px] space-y-6">
+    <div className="flex flex-col h-full px-6">
+      <div className="flex-1 overflow-y-auto px-lg py-6">
+        <div className="mx-auto max-w-[1400px] space-y-6">
             {/* Routes List */}
             {items.length > 0 ? (
               <DndContext
@@ -366,9 +378,8 @@ export function ClientTypeRoutesContent({
                 </div>
               </div>
             )}
-          </div>
         </div>
       </div>
-    </AntigravityQuotasProvider>
+    </div>
   );
 }

--- a/web/src/contexts/cooldowns-context.tsx
+++ b/web/src/contexts/cooldowns-context.tsx
@@ -1,0 +1,179 @@
+/**
+ * Cooldowns Context
+ * 提供共享的 Cooldowns 数据，减少重复请求
+ */
+
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
+import { getTransport } from '@/lib/transport';
+import type { Cooldown } from '@/lib/transport';
+
+interface CooldownsContextValue {
+  cooldowns: Cooldown[];
+  isLoading: boolean;
+  getCooldownForProvider: (providerId: number, clientType?: string) => Cooldown | undefined;
+  isProviderInCooldown: (providerId: number, clientType?: string) => boolean;
+  getRemainingSeconds: (cooldown: Cooldown) => number;
+  formatRemaining: (cooldown: Cooldown) => string;
+  clearCooldown: (providerId: number) => void;
+  isClearingCooldown: boolean;
+}
+
+const CooldownsContext = createContext<CooldownsContextValue | null>(null);
+
+interface CooldownsProviderProps {
+  children: ReactNode;
+}
+
+export function CooldownsProvider({ children }: CooldownsProviderProps) {
+  const queryClient = useQueryClient();
+  // Force re-render counter to trigger updates when cooldowns expire
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const {
+    data: cooldowns = [],
+    isLoading,
+  } = useQuery({
+    queryKey: ['cooldowns'],
+    queryFn: () => getTransport().getCooldowns(),
+    staleTime: 5000,
+  });
+
+  // Subscribe to cooldown_update WebSocket event
+  useEffect(() => {
+    const transport = getTransport();
+    const unsubscribe = transport.subscribe('cooldown_update', () => {
+      queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [queryClient]);
+
+  // Mutation for clearing cooldown
+  const clearCooldownMutation = useMutation({
+    mutationFn: (providerId: number) => getTransport().clearCooldown(providerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
+    },
+  });
+
+  // Setup timeouts for each cooldown to force re-render when they expire
+  useEffect(() => {
+    if (cooldowns.length === 0) {
+      return;
+    }
+
+    const timeouts: number[] = [];
+
+    cooldowns.forEach((cooldown) => {
+      const until = new Date(cooldown.untilTime).getTime();
+      const now = Date.now();
+      const delay = until - now;
+
+      if (delay > 0) {
+        const timeout = setTimeout(() => {
+          setRefreshKey((prev) => prev + 1);
+        }, delay + 100);
+        timeouts.push(timeout);
+      }
+    });
+
+    return () => {
+      timeouts.forEach((timeout) => clearTimeout(timeout));
+    };
+  }, [cooldowns]);
+
+  const getCooldownForProvider = useCallback((providerId: number, clientType?: string) => {
+    return cooldowns.find((cd: Cooldown) => {
+      const matchesProvider = cd.providerID === providerId;
+      const matchesClientType =
+        cd.clientType === '' ||
+        cd.clientType === 'all' ||
+        (clientType && cd.clientType === clientType);
+
+      if (!matchesProvider || !matchesClientType) {
+        return false;
+      }
+
+      const untilTime =
+        cd.untilTime || ((cd as unknown as Record<string, unknown>).until as string);
+      if (!untilTime) {
+        return false;
+      }
+      const until = new Date(untilTime).getTime();
+      const now = Date.now();
+      return until > now;
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cooldowns, refreshKey]);
+
+  const isProviderInCooldown = useCallback((providerId: number, clientType?: string) => {
+    return !!getCooldownForProvider(providerId, clientType);
+  }, [getCooldownForProvider]);
+
+  const getRemainingSeconds = useCallback((cooldown: Cooldown) => {
+    const untilTime =
+      cooldown.untilTime || ((cooldown as unknown as Record<string, unknown>).until as string);
+    if (!untilTime) return 0;
+
+    const until = new Date(untilTime);
+    const now = new Date();
+    const diff = until.getTime() - now.getTime();
+    return Math.max(0, Math.floor(diff / 1000));
+  }, []);
+
+  const formatRemaining = useCallback((cooldown: Cooldown) => {
+    const seconds = getRemainingSeconds(cooldown);
+
+    if (Number.isNaN(seconds) || seconds === 0) return 'Expired';
+
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hours > 0) {
+      return `${String(hours).padStart(2, '0')}h ${String(minutes).padStart(2, '0')}m ${String(secs).padStart(2, '0')}s`;
+    } else if (minutes > 0) {
+      return `${String(minutes).padStart(2, '0')}m ${String(secs).padStart(2, '0')}s`;
+    } else {
+      return `${String(secs).padStart(2, '0')}s`;
+    }
+  }, [getRemainingSeconds]);
+
+  const clearCooldown = useCallback((providerId: number) => {
+    clearCooldownMutation.mutate(providerId);
+  }, [clearCooldownMutation]);
+
+  return (
+    <CooldownsContext.Provider
+      value={{
+        cooldowns,
+        isLoading,
+        getCooldownForProvider,
+        isProviderInCooldown,
+        getRemainingSeconds,
+        formatRemaining,
+        clearCooldown,
+        isClearingCooldown: clearCooldownMutation.isPending,
+      }}
+    >
+      {children}
+    </CooldownsContext.Provider>
+  );
+}
+
+export function useCooldownsContext() {
+  const context = useContext(CooldownsContext);
+  if (!context) {
+    throw new Error('useCooldownsContext must be used within CooldownsProvider');
+  }
+  return context;
+}
+
+// Optional hook that doesn't throw when used outside provider
+export function useCooldownFromContext(providerId: number, clientType?: string): Cooldown | undefined {
+  const context = useContext(CooldownsContext);
+  return context?.getCooldownForProvider(providerId, clientType);
+}

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 import type { ClientType, ProviderStats, AntigravityQuotaData } from '@/lib/transport';
 import type { ProviderConfigItem } from '../types';
 import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-context';
-import { useCooldowns } from '@/hooks/use-cooldowns';
+import { useCooldownsContext } from '@/contexts/cooldowns-context';
 import { ProviderDetailsDialog } from '@/components/provider-details-dialog';
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -60,7 +60,7 @@ export function SortableProviderRow({
   onDelete,
 }: SortableProviderRowProps) {
   const [showDetailsDialog, setShowDetailsDialog] = useState(false);
-  const { getCooldownForProvider, clearCooldown, isClearingCooldown } = useCooldowns();
+  const { getCooldownForProvider, clearCooldown, isClearingCooldown } = useCooldownsContext();
   const cooldown = getCooldownForProvider(item.provider.id, clientType);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -206,7 +206,7 @@ export function ProviderRowContent({
   const claudeInfo = isAntigravity ? getClaudeQuotaInfo(quota) : null;
 
   // 获取 cooldown 状态
-  const { getCooldownForProvider, formatRemaining, getRemainingSeconds } = useCooldowns();
+  const { getCooldownForProvider, formatRemaining, getRemainingSeconds } = useCooldownsContext();
   const cooldown = getCooldownForProvider(provider.id, clientType);
   const isInCooldown = isInCooldownProp ?? !!cooldown;
 


### PR DESCRIPTION
## Summary
- 创建 `CooldownsProvider` 上下文共享 cooldowns 数据
- 更新 `ClientTypeRoutesContent` 包装 `CooldownsProvider`
- 更新 `provider-row` 使用 `useCooldownsContext()`
- 更新 dialog 组件使用 `useCooldownsContext()`

## Problem
在 Routes 页面，每个 provider row 组件都独立调用 `useCooldowns()` hook，导致多个组件同时发起 `/api/admin/cooldowns` 请求，造成不必要的重复请求。

## Solution
创建 `CooldownsProvider` 上下文，在 `ClientTypeRoutesContent` 外层包装，让所有子组件共享同一份 cooldowns 数据，显著减少 API 请求数量。

## Test plan
- [ ] 验证 Routes 页面加载时只发起一次 cooldowns 请求
- [ ] 验证 cooldown 状态正常显示和更新
- [ ] 验证清除 cooldown 功能正常工作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

**重构**
* 优化了冷却时间状态管理架构，引入集中式上下文系统
* 增强了实时更新机制，通过WebSocket事件驱动的缓存失效提升数据同步效率
* 改进了组件间冷却时间数据的共享模式，实现更高效的状态流转

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->