### PR TITLE
fix: 修复 SQLite WAL 模式参数格式

### DIFF
--- a/internal/repository/sqlite/db.go
+++ b/internal/repository/sqlite/db.go
@@ -60,7 +60,7 @@ func NewDBWithDSN(dsn string) (*DB, error) {
 		sqlitePath := strings.TrimPrefix(dsn, "sqlite://")
 		// Add SQLite options for WAL mode and busy timeout
 		if !strings.Contains(sqlitePath, "?") {
-			sqlitePath += "?_journal_mode=WAL&_busy_timeout=30000"
+			sqlitePath += "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(30000)"
 		}
 		dialector = sqlite.Open(sqlitePath)
 		dialectorName = "sqlite"


### PR DESCRIPTION
glebarez/sqlite 库使用 _pragma=name(value) 格式而非 _name=value

- 旧: ?_journal_mode=WAL&_busy_timeout=30000
- 新: ?_pragma=journal_mode(WAL)&_pragma=busy_timeout(30000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **优化改进**
  * 改进了SQLite数据库连接配置的处理方式，提升了数据库性能和稳定性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->