### PR TITLE
feat: 在 Antigravity 和 Codex 详情页添加 token 复制功能

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -204,6 +204,7 @@
     "supportedClients": "Supported Clients",
     "enabled": "Enabled",
     "noClientsConfigured": "No clients configured",
+    "refreshToken": "Refresh Token",
     "supportModels": {
       "title": "Supported Models",
       "desc": "Configure which models this provider supports. If empty, all models are supported. Supports wildcards like claude-* or gemini-*.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -204,6 +204,7 @@
     "supportedClients": "支持的客户端",
     "enabled": "已启用",
     "noClientsConfigured": "未配置客户端",
+    "refreshToken": "刷新令牌",
     "supportModels": {
       "title": "支持的模型",
       "desc": "配置此提供商支持的模型。如果为空，则支持所有模型。支持通配符，如 claude-* 或 gemini-*。",

--- a/web/src/pages/providers/components/antigravity-provider-view.tsx
+++ b/web/src/pages/providers/components/antigravity-provider-view.tsx
@@ -10,6 +10,8 @@ import {
   Plus,
   ArrowRight,
   Zap,
+  Copy,
+  Check,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ClientIcon } from '@/components/icons/client-icons';
@@ -270,6 +272,19 @@ export function AntigravityProviderView({
   const [quota, setQuota] = useState<AntigravityQuotaData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
+
+  const handleCopyToken = async () => {
+    const token = provider.config?.antigravity?.refreshToken;
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {
+      // Failed to copy
+    }
+  };
 
   const fetchQuota = async (forceRefresh = false) => {
     setLoading(true);
@@ -352,6 +367,25 @@ export function AntigravityProviderView({
                   {provider.config?.antigravity?.endpoint || '-'}
                 </div>
               </div>
+              {provider.config?.antigravity?.refreshToken && (
+                <div>
+                  <div className="text-xs text-muted-foreground uppercase tracking-wider font-semibold mb-1.5">
+                    {t('providers.refreshToken')}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="font-mono text-sm text-foreground bg-card px-2 py-1 rounded border border-border/50 flex-1 truncate">
+                      {provider.config.antigravity.refreshToken.slice(0, 20)}...
+                    </div>
+                    <button
+                      onClick={handleCopyToken}
+                      className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                      title={t('common.copy')}
+                    >
+                      {tokenCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/web/src/pages/providers/components/codex-provider-view.tsx
+++ b/web/src/pages/providers/components/codex-provider-view.tsx
@@ -14,6 +14,8 @@ import {
   Zap,
   AlertCircle,
   Gauge,
+  Copy,
+  Check,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -325,8 +327,21 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
   const [usage, setUsage] = useState<CodexUsageResponse | null>(null);
   const [usageLoading, setUsageLoading] = useState(false);
   const [usageError, setUsageError] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
 
   const config = provider.config?.codex;
+
+  const handleCopyToken = async () => {
+    const token = config?.refreshToken;
+    if (!token) return;
+    try {
+      await navigator.clipboard.writeText(token);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {
+      // Failed to copy
+    }
+  };
 
   // 从 React Query 缓存获取配额数据（不会自动请求 API，因为 staleTime 设置为 Infinity）
   const { data: batchQuotas } = useCodexBatchQuotas(true);
@@ -441,6 +456,26 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
                 </div>
               )}
             </div>
+
+            {config?.refreshToken && (
+              <div className="mt-6 pt-6 border-t border-border/50">
+                <div className="text-xs text-muted-foreground uppercase tracking-wider font-semibold mb-1.5">
+                  {t('providers.refreshToken')}
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="font-mono text-sm text-foreground bg-card px-2 py-1 rounded border border-border/50 flex-1 truncate">
+                    {config.refreshToken.slice(0, 30)}...
+                  </div>
+                  <button
+                    onClick={handleCopyToken}
+                    className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                    title={t('common.copy')}
+                  >
+                    {tokenCopied ? <Check size={16} className="text-green-500" /> : <Copy size={16} />}
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Subscription Section */}


### PR DESCRIPTION
## Summary
- 在 Antigravity 详情页添加 refreshToken 展示和复制按钮
- 在 Codex 详情页添加 refreshToken 展示和复制按钮
- 添加中英文翻译支持

## Test plan
- [ ] 打开 Antigravity Provider 详情页，验证 token 显示和复制功能
- [ ] 打开 Codex Provider 详情页，验证 token 显示和复制功能
- [ ] 点击复制按钮，确认图标变为绿色对勾后恢复
- [ ] 粘贴验证复制的内容正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为多个提供商的刷新令牌添加了复制到剪贴板功能，用户可快速复制令牌供使用。

* **本地化**
  * 新增英文和中文翻译字符串，用于支持刷新令牌相关功能的多语言显示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->