### PR TITLE
feat: 支持手动粘贴回调 URL 完成 Codex OAuth 认证

### DIFF
--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -490,6 +490,17 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async exchangeCodexOAuthCallback(
+    code: string,
+    state: string,
+  ): Promise<import('./types').CodexOAuthResult> {
+    const { data } = await axios.post<import('./types').CodexOAuthResult>(
+      '/api/codex/oauth/exchange',
+      { code, state },
+    );
+    return data;
+  }
+
   async refreshCodexProviderInfo(providerId: number): Promise<CodexTokenValidationResult> {
     const { data } = await axios.post<CodexTokenValidationResult>(
       `/api/codex/provider/${providerId}/refresh`,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -36,6 +36,7 @@ import type {
   CodexTokenValidationResult,
   CodexUsageResponse,
   CodexQuotaData,
+  CodexOAuthResult,
   AuthStatus,
   AuthVerifyResult,
   APIToken,
@@ -156,6 +157,7 @@ export interface Transport {
   // ===== Codex API =====
   validateCodexToken(refreshToken: string): Promise<CodexTokenValidationResult>;
   startCodexOAuth(): Promise<{ authURL: string; state: string }>;
+  exchangeCodexOAuthCallback(code: string, state: string): Promise<CodexOAuthResult>;
   refreshCodexProviderInfo(providerId: number): Promise<CodexTokenValidationResult>;
   getCodexProviderUsage(providerId: number): Promise<CodexUsageResponse>;
   getCodexBatchQuotas(): Promise<Record<number, CodexQuotaData>>;


### PR DESCRIPTION
## Summary
- 添加 `POST /codex/oauth/exchange` 端点，允许前端直接提交 `code` 和 `state` 参数完成 token 交换
- 前端 OAuth 等待状态下添加"复制 Auth URL"按钮和"粘贴回调 URL"输入框
- 关闭弹窗后保持 OAuth 会话状态，用户可以继续使用手动方式完成认证
- 解决生产环境中用户浏览器无法访问服务器上 `localhost:1455` 的问题

## 使用流程
1. 点击 "Sign in with OpenAI" 启动 OAuth 流程
2. 如果弹窗无法正常工作或 localhost:1455 不可访问：
   - 点击 "Copy Auth URL" 复制认证链接
   - 在本地浏览器中打开该链接完成 OpenAI 登录
   - 登录后浏览器会跳转到 `http://localhost:1455/auth/callback?code=xxx&state=xxx`（会显示错误页面）
   - 复制浏览器地址栏中的完整 URL
   - 粘贴到回调 URL 输入框中
   - 点击 "Submit Callback URL" 完成认证

## Test plan
- [ ] 测试正常 OAuth 弹窗流程仍然正常工作
- [ ] 测试关闭弹窗后状态保持，可以继续粘贴回调 URL
- [ ] 测试复制 Auth URL 功能
- [ ] 测试粘贴无效 URL 时显示错误提示
- [ ] 测试粘贴 state 不匹配的 URL 时显示错误提示
- [ ] 测试手动提交回调 URL 成功完成认证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

**新功能**
* 增加了手动 OAuth 回调流程，用户可通过粘贴回调 URL 完成令牌交换
* 优化了 OAuth 授权 URL 的一键复制功能
* 改进了 OAuth 弹窗关闭后的流程处理，支持继续手动完成认证

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->