### PR TITLE
feat: 添加客户端类型标签的国际化支持

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -56,6 +56,12 @@
     "clear": "Clear",
     "unknown": "Unknown"
   },
+  "clientTypes": {
+    "claude": "Claude",
+    "openai": "OpenAI",
+    "codex": "Codex",
+    "gemini": "Gemini"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "documentation": "Docs",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -56,6 +56,12 @@
     "clear": "清除",
     "unknown": "未知"
   },
+  "clientTypes": {
+    "claude": "Claude",
+    "openai": "OpenAI",
+    "codex": "Codex",
+    "gemini": "Gemini"
+  },
   "nav": {
     "dashboard": "仪表板",
     "documentation": "文档",

--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -223,25 +223,27 @@ export function ClientRoutesPage() {
           return (
             <TabsContent key={project.id} value={String(project.id)} className="flex-1 min-h-0 overflow-hidden m-0 flex flex-col">
               {/* Custom Routes Toggle Bar */}
-              <div className="h-12 px-6 border-b border-border bg-card flex items-center justify-between shrink-0">
-                <div className="flex items-center gap-3">
+              <div className="min-h-12 px-6 py-2 border-b border-border bg-card flex items-center justify-between gap-4 shrink-0">
+                <div className="flex flex-1 min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
                   <p className="text-sm font-medium">{t('routes.customRoutes')}</p>
                   {isCustomRoutesEnabled && (
                     <span className="text-xs px-2 py-0.5 bg-green-500/10 text-green-600 dark:text-green-400 rounded-full">
                       {t('common.enabled')}
                     </span>
                   )}
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground min-w-0 flex-1 break-words">
                     {isCustomRoutesEnabled
                       ? t('routes.usingProjectRoutes')
                       : t('routes.usingGlobalRoutes')}
                   </p>
                 </div>
-                <Switch
-                  checked={isCustomRoutesEnabled}
-                  onCheckedChange={(checked) => handleToggleCustomRoutes(project.id, checked)}
-                  disabled={updateProject.isPending}
-                />
+                <div className="shrink-0 self-center">
+                  <Switch
+                    checked={isCustomRoutesEnabled}
+                    onCheckedChange={(checked) => handleToggleCustomRoutes(project.id, checked)}
+                    disabled={updateProject.isPending}
+                  />
+                </div>
               </div>
 
               {/* Content Area */}

--- a/web/src/pages/projects/tabs/routes.tsx
+++ b/web/src/pages/projects/tabs/routes.tsx
@@ -6,7 +6,7 @@
 import { useState, useMemo } from 'react';
 import { useRoutes, useUpdateProject, projectKeys } from '@/hooks/queries';
 import { useStreamingRequests } from '@/hooks/use-streaming';
-import { ClientIcon, getClientName, getClientColor } from '@/components/icons/client-icons';
+import { ClientIcon, getClientColor } from '@/components/icons/client-icons';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui';
 import type { Project, ClientType, Route } from '@/lib/transport';
@@ -14,6 +14,7 @@ import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { useQueryClient } from '@tanstack/react-query';
 import { ClientTypeRoutesContent } from '@/components/routes/ClientTypeRoutesContent';
 import { useTranslation } from 'react-i18next';
+import { getClientTypeLabel } from '../utils';
 
 // 支持的客户端类型列表
 const CLIENT_TYPES: ClientType[] = ['claude', 'openai', 'codex', 'gemini'];
@@ -39,14 +40,15 @@ function ProjectClientTypeWrapper({
   projectRoutes,
 }: ProjectClientTypeWrapperProps) {
   const { t } = useTranslation();
+  const clientLabel = getClientTypeLabel(t, clientType);
   return (
     <div className="flex flex-col h-full">
       {/* Header with Toggle */}
-      <div className="flex items-center justify-between px-lg py-4 border-b border-border bg-card">
+      <div className="flex items-center justify-between px-lg p-4 border-b border-border bg-card">
         <div className="flex items-center gap-4">
           <ClientIcon type={clientType} size={32} />
           <div>
-            <h2 className="text-lg font-semibold text-foreground">{getClientName(clientType)}</h2>
+            <h2 className="text-lg font-semibold text-foreground">{clientLabel}</h2>
             <p className="text-xs text-muted-foreground">
               {isCustomRoutesEnabled
                 ? t('routes.routesConfigured', {
@@ -74,7 +76,7 @@ function ProjectClientTypeWrapper({
             </h3>
             <p className="text-sm text-text-secondary leading-relaxed">
               {t('routes.usingGlobalRoutesDesc', {
-                client: getClientName(clientType),
+                client: clientLabel,
               })}
             </p>
           </div>
@@ -175,6 +177,7 @@ export function RoutesTab({ project }: RoutesTabProps) {
           const routeCount = getRouteCount(clientType);
           const streamingCount = getStreamingCount(clientType);
           const color = getClientColor(clientType);
+          const clientLabel = getClientTypeLabel(t, clientType);
 
           return (
             <button
@@ -188,7 +191,7 @@ export function RoutesTab({ project }: RoutesTabProps) {
               )}
             >
               <ClientIcon type={clientType} size={16} />
-              <span className="text-sm font-medium">{getClientName(clientType)}</span>
+              <span className="text-sm font-medium">{clientLabel}</span>
               {routeCount > 0 && (
                 <span className="text-[10px] font-mono text-muted-foreground">{routeCount}</span>
               )}

--- a/web/src/pages/projects/tabs/sessions.tsx
+++ b/web/src/pages/projects/tabs/sessions.tsx
@@ -12,6 +12,7 @@ import { useSessions } from '@/hooks/queries';
 import type { Project } from '@/lib/transport';
 import { Loader2, Users } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { getClientTypeLabel } from '../utils';
 
 interface SessionsTabProps {
   project: Project;
@@ -61,7 +62,7 @@ export function SessionsTab({ project }: SessionsTabProps) {
                   </TableCell>
                   <TableCell>
                     <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-accent/10 text-accent">
-                      {session.clientType}
+                      {getClientTypeLabel(t, session.clientType)}
                     </span>
                   </TableCell>
                   <TableCell className="text-muted-foreground text-xs">

--- a/web/src/pages/projects/utils.ts
+++ b/web/src/pages/projects/utils.ts
@@ -1,0 +1,18 @@
+import type { TFunction } from 'i18next';
+import type { ClientType } from '@/lib/transport';
+
+const clientTypeKeyMap: Record<ClientType, string> = {
+  claude: 'claude',
+  openai: 'openai',
+  codex: 'codex',
+  gemini: 'gemini',
+};
+
+export function getClientTypeLabel(t: TFunction, clientType: ClientType): string {
+  const key = clientTypeKeyMap[clientType];
+  if (!key) {
+    return clientType;
+  }
+
+  return t(`clientTypes.${key}`);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了客户端类型的多语言支持，包括 Claude、OpenAI、Codex 和 Gemini 的本地化标签。

* **改进**
  * 优化了自定义路由切换栏的布局，提升了响应式设计效果。
  * 统一使用本地化的客户端类型标签来改善用户界面的一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->