### PR TITLE
feat: Custom Provider 对 Claude 请求使用 CLI 风格头部

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/awsl-project/maxx
 go 1.25
 
 require (
+	github.com/andybalholm/brotli v1.2.0
 	github.com/bytedance/sonic v1.14.2
 	github.com/getlantern/systray v1.2.2
 	github.com/glebarez/sqlite v1.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/klauspost/compress v1.18.3
 	github.com/wailsapp/wails/v2 v2.11.0
 	golang.org/x/sync v0.19.0
 	gorm.io/driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
@@ -63,6 +65,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/labstack/echo/v4 v4.13.3 h1:pwhpCPrTl5qry5HRdM5FwdXnhXSLSY+WE+YQSeCaafY=
@@ -131,6 +135,8 @@ github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhw
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
 github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
 github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670 h1:18EFjUmQOcUvxNYSkA6jO9VAiXCnxFY6NyDX0bHDmkU=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/internal/adapter/provider/custom/claude_headers.go
+++ b/internal/adapter/provider/custom/claude_headers.go
@@ -1,0 +1,59 @@
+package custom
+
+import (
+	"net/http"
+	"strings"
+)
+
+const (
+	anthropicVersion   = "2023-06-01"
+	anthropicBetaFlags = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+	claudeUserAgent    = "claude-cli/1.0.83 (external, cli)"
+)
+
+// applyClaudeHeaders sets Claude API request headers, mimicking the official CLI
+func applyClaudeHeaders(req *http.Request, apiKey string, stream bool) {
+	// 1. Authentication header (only set if apiKey is provided)
+	if apiKey != "" {
+		if isAnthropicAPI(req.URL.String()) {
+			req.Header.Del("Authorization")
+			req.Header.Set("x-api-key", apiKey)
+		} else {
+			req.Header.Del("x-api-key")
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+	}
+
+	// 2. Core headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Anthropic-Version", anthropicVersion)
+	req.Header.Set("Anthropic-Beta", anthropicBetaFlags)
+	req.Header.Set("Anthropic-Dangerous-Direct-Browser-Access", "true")
+
+	// 3. Stainless headers (mimics official Node.js SDK)
+	req.Header.Set("X-App", "cli")
+	req.Header.Set("X-Stainless-Helper-Method", "stream")
+	req.Header.Set("X-Stainless-Retry-Count", "0")
+	req.Header.Set("X-Stainless-Runtime-Version", "v24.3.0")
+	req.Header.Set("X-Stainless-Package-Version", "0.55.1")
+	req.Header.Set("X-Stainless-Runtime", "node")
+	req.Header.Set("X-Stainless-Lang", "js")
+	req.Header.Set("X-Stainless-Arch", "arm64")
+	req.Header.Set("X-Stainless-Os", "MacOS")
+	req.Header.Set("X-Stainless-Timeout", "60")
+	req.Header.Set("User-Agent", claudeUserAgent)
+
+	// 4. Connection and encoding
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
+}
+
+func isAnthropicAPI(url string) bool {
+	return strings.Contains(url, "api.anthropic.com")
+}

--- a/internal/adapter/provider/custom/decompression.go
+++ b/internal/adapter/provider/custom/decompression.go
@@ -1,0 +1,57 @@
+package custom
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
+)
+
+// nopCloser wraps a reader and makes Close() a no-op
+// Used to prevent double-closing when decompressResponse returns resp.Body directly
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+// decompressResponse returns a reader that decompresses the response body
+// based on the Content-Encoding header.
+// The returned reader's Close() does NOT close the underlying resp.Body -
+// the caller is responsible for closing resp.Body separately.
+func decompressResponse(resp *http.Response) (io.ReadCloser, error) {
+	encoding := resp.Header.Get("Content-Encoding")
+	if encoding == "" {
+		// Wrap in nopCloser to prevent double-close when caller defers reader.Close()
+		// while resp.Body.Close() is also deferred elsewhere
+		return nopCloser{resp.Body}, nil
+	}
+
+	for _, enc := range strings.Split(encoding, ",") {
+		enc = strings.TrimSpace(strings.ToLower(enc))
+		switch enc {
+		case "gzip":
+			// gzip.Reader.Close() does NOT close the underlying reader
+			return gzip.NewReader(resp.Body)
+		case "deflate":
+			// flate.Reader.Close() does NOT close the underlying reader
+			return flate.NewReader(resp.Body), nil
+		case "br":
+			// brotli.Reader has no Close method, wrap with nopCloser
+			return nopCloser{brotli.NewReader(resp.Body)}, nil
+		case "zstd":
+			// zstd decoder.Close() does NOT close the underlying reader
+			decoder, err := zstd.NewReader(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			return decoder.IOReadCloser(), nil
+		}
+	}
+	// Unknown encoding, wrap in nopCloser
+	return nopCloser{resp.Body}, nil
+}


### PR DESCRIPTION
## Summary

- Custom Provider 对 Claude API 的请求从透传方式改为主动设置伪装头部，模拟官方 Claude CLI 行为
- 新增响应解压缩支持（gzip、deflate、br、zstd）
- 修复响应头部处理，避免客户端二次解压

## Changes

| 文件 | 说明 |
|------|------|
| `claude_headers.go` | 新增 - 设置 Anthropic-Version、Anthropic-Beta、X-Stainless-* 等伪装头部 |
| `decompression.go` | 新增 - 支持多种压缩格式的响应解压 |
| `adapter.go` | 修改 - Claude 类型使用专用头部处理，其他类型保持透传 |
| `go.mod` / `go.sum` | 新增 brotli/zstd 依赖 |

## Test plan

- [ ] 使用 Claude Code CLI 连接到 Custom Provider
- [ ] 检查上游请求的 headers 是否包含伪装头部（通过 EventChannel 的 RequestInfo）
- [ ] 验证流式响应正常工作
- [ ] 测试压缩响应的解压缩

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 改进Claude API集成，优化请求头处理和API交互

* **改进**
  * 添加HTTP响应解压缩支持，提升响应处理效率
  * 优化流式响应处理，改进数据传输稳定性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->