### PR TITLE
:bug: :zap: Fix API token backup/restore and add cache preload

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -167,6 +167,9 @@ func main() {
 	if err := cachedProjectRepo.Load(); err != nil {
 		log.Printf("Warning: Failed to load projects cache: %v", err)
 	}
+	if err := cachedAPITokenRepo.Load(); err != nil {
+		log.Printf("Warning: Failed to load API tokens cache: %v", err)
+	}
 	if err := cachedModelMappingRepo.Load(); err != nil {
 		log.Printf("Warning: Failed to load model mappings cache: %v", err)
 	}

--- a/internal/domain/backup.go
+++ b/internal/domain/backup.go
@@ -15,14 +15,14 @@ type BackupFile struct {
 
 // BackupData contains all exportable entities
 type BackupData struct {
-	SystemSettings    []BackupSystemSetting    `json:"systemSettings,omitempty"`
-	Providers         []BackupProvider         `json:"providers,omitempty"`
-	Projects          []BackupProject          `json:"projects,omitempty"`
-	RetryConfigs      []BackupRetryConfig      `json:"retryConfigs,omitempty"`
-	Routes            []BackupRoute            `json:"routes,omitempty"`
-	RoutingStrategies []BackupRoutingStrategy  `json:"routingStrategies,omitempty"`
-	APITokens         []BackupAPIToken         `json:"apiTokens,omitempty"`
-	ModelMappings     []BackupModelMapping     `json:"modelMappings,omitempty"`
+	SystemSettings    []BackupSystemSetting   `json:"systemSettings,omitempty"`
+	Providers         []BackupProvider        `json:"providers,omitempty"`
+	Projects          []BackupProject         `json:"projects,omitempty"`
+	RetryConfigs      []BackupRetryConfig     `json:"retryConfigs,omitempty"`
+	Routes            []BackupRoute           `json:"routes,omitempty"`
+	RoutingStrategies []BackupRoutingStrategy `json:"routingStrategies,omitempty"`
+	APITokens         []BackupAPIToken        `json:"apiTokens,omitempty"`
+	ModelMappings     []BackupModelMapping    `json:"modelMappings,omitempty"`
 }
 
 // BackupSystemSetting represents a system setting for backup
@@ -49,19 +49,19 @@ type BackupProject struct {
 
 // BackupRetryConfig represents a retry config for backup
 type BackupRetryConfig struct {
-	Name              string        `json:"name"`
-	IsDefault         bool          `json:"isDefault"`
-	MaxRetries        int           `json:"maxRetries"`
-	InitialIntervalMs int64         `json:"initialIntervalMs"`
-	BackoffRate       float64       `json:"backoffRate"`
-	MaxIntervalMs     int64         `json:"maxIntervalMs"`
+	Name              string  `json:"name"`
+	IsDefault         bool    `json:"isDefault"`
+	MaxRetries        int     `json:"maxRetries"`
+	InitialIntervalMs int64   `json:"initialIntervalMs"`
+	BackoffRate       float64 `json:"backoffRate"`
+	MaxIntervalMs     int64   `json:"maxIntervalMs"`
 }
 
 // BackupRoute represents a route for backup (using names instead of IDs)
 type BackupRoute struct {
 	IsEnabled       bool       `json:"isEnabled"`
 	IsNative        bool       `json:"isNative"`
-	ProjectSlug     string     `json:"projectSlug"`     // empty = global
+	ProjectSlug     string     `json:"projectSlug"` // empty = global
 	ClientType      ClientType `json:"clientType"`
 	ProviderName    string     `json:"providerName"`
 	Position        int        `json:"position"`
@@ -75,9 +75,11 @@ type BackupRoutingStrategy struct {
 	Config      *RoutingStrategyConfig `json:"config,omitempty"`
 }
 
-// BackupAPIToken represents an API token for backup (token value not exported)
+// BackupAPIToken represents an API token for backup
 type BackupAPIToken struct {
 	Name        string     `json:"name"`
+	Token       string     `json:"token,omitempty"`       // plaintext token for import
+	TokenPrefix string     `json:"tokenPrefix,omitempty"` // display prefix
 	Description string     `json:"description"`
 	ProjectSlug string     `json:"projectSlug"` // empty = global
 	IsEnabled   bool       `json:"isEnabled"`
@@ -122,9 +124,9 @@ type ImportResult struct {
 // NewImportResult creates a new ImportResult with initialized fields
 func NewImportResult() *ImportResult {
 	return &ImportResult{
-		Success: true,
-		Summary: make(map[string]ImportSummary),
-		Errors:  []string{},
+		Success:  true,
+		Summary:  make(map[string]ImportSummary),
+		Errors:   []string{},
 		Warnings: []string{},
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
  * API 令牌现在在备份和恢复过程中得到保留，恢复时系统优先重用已导出的令牌值，避免不必要的重新生成
  * 增强了备份和导入功能，完整支持令牌数据的保存与恢复，同时保持对旧版备份的向后兼容性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->