### PR TITLE
Harden request detail privacy and WS auth

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -353,18 +353,18 @@ type ProxyUpstreamAttempt struct {
 
 // AttemptCostData contains minimal data needed for cost recalculation
 type AttemptCostData struct {
-	ID               uint64
-	ProxyRequestID   uint64
-	ResponseModel    string
-	MappedModel      string
-	RequestModel     string
-	InputTokenCount  uint64
-	OutputTokenCount uint64
-	CacheReadCount   uint64
-	CacheWriteCount  uint64
+	ID                uint64
+	ProxyRequestID    uint64
+	ResponseModel     string
+	MappedModel       string
+	RequestModel      string
+	InputTokenCount   uint64
+	OutputTokenCount  uint64
+	CacheReadCount    uint64
+	CacheWriteCount   uint64
 	Cache5mWriteCount uint64
 	Cache1hWriteCount uint64
-	Cost             uint64
+	Cost              uint64
 }
 
 // 重试配置
@@ -442,7 +442,7 @@ type SystemSetting struct {
 const (
 	SettingKeyProxyPort                     = "proxy_port"                       // 代理服务器端口，默认 9880
 	SettingKeyRequestRetentionHours         = "request_retention_hours"          // 请求记录保留小时数，默认 168 小时（7天），0 表示不清理
-	SettingKeyRequestDetailRetentionSeconds = "request_detail_retention_seconds" // 请求详情保留秒数，-1=永久保存(默认)，0=不保存，>0=保留秒数
+	SettingKeyRequestDetailRetentionSeconds = "request_detail_retention_seconds" // 请求详情保留秒数，-1=永久保存，0=不保存(默认)，>0=保留秒数
 	SettingKeyTimezone                      = "timezone"                         // 时区设置，默认 Asia/Shanghai
 	SettingKeyQuotaRefreshInterval          = "quota_refresh_interval"           // Antigravity 配额刷新间隔（分钟），0 表示禁用
 	SettingKeyAutoSortAntigravity           = "auto_sort_antigravity"            // 是否自动排序 Antigravity 路由，"true" 或 "false"
@@ -564,10 +564,10 @@ type ProviderStats struct {
 	ProviderID uint64 `json:"providerID"`
 
 	// 请求统计
-	TotalRequests     uint64  `json:"totalRequests"`
+	TotalRequests      uint64  `json:"totalRequests"`
 	SuccessfulRequests uint64  `json:"successfulRequests"`
-	FailedRequests    uint64  `json:"failedRequests"`
-	SuccessRate       float64 `json:"successRate"` // 0-100
+	FailedRequests     uint64  `json:"failedRequests"`
+	SuccessRate        float64 `json:"successRate"` // 0-100
 
 	// 活动请求（正在处理中）
 	ActiveRequests uint64 `json:"activeRequests"`

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -730,7 +730,7 @@ export class HttpTransport implements Transport {
     }
 
     this.connectPromise = new Promise((resolve, reject) => {
-      this.ws = new WebSocket(this.config.wsURL);
+      this.ws = new WebSocket(this.buildWsUrl());
 
       this.ws.onopen = () => {
         const isReconnect = this.reconnectAttempts > 0;
@@ -781,6 +781,21 @@ export class HttpTransport implements Transport {
 
   isConnected(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private buildWsUrl(): string {
+    if (!this.authToken) {
+      return this.config.wsURL;
+    }
+
+    try {
+      const url = new URL(this.config.wsURL, window.location.href);
+      url.searchParams.set('token', this.authToken);
+      return url.toString();
+    } catch {
+      const separator = this.config.wsURL.includes('?') ? '&' : '?';
+      return `${this.config.wsURL}${separator}token=${encodeURIComponent(this.authToken)}`;
+    }
   }
 
   private scheduleReconnect(): void {

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -277,7 +277,7 @@ function DataRetentionSection() {
   const { t } = useTranslation();
 
   const requestRetentionHours = settings?.request_retention_hours ?? '168';
-  const requestDetailRetentionSeconds = settings?.request_detail_retention_seconds ?? '-1';
+  const requestDetailRetentionSeconds = settings?.request_detail_retention_seconds ?? '0';
 
   const [requestDraft, setRequestDraft] = useState('');
   const [detailDraft, setDetailDraft] = useState('');


### PR DESCRIPTION
## Summary\n- Default request detail retention to 0 (do not persist request/response bodies)\n- Sanitize sensitive headers before persisting or broadcasting\n- Require admin JWT for WebSocket connections; enforce same-origin\n- Frontend WS connects with token when authenticated\n\n## Testing\n- pnpm install\n- pnpm build\n- go test ./...\n\n## Notes\nInitial go test failed before web build due to missing web/dist; passed after pnpm build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为 WebSocket 连接增加令牌认证支持
  * 添加请求/响应详情数据保留控制功能

* **安全改进**
  * 加强 WebSocket 来源验证
  * 实现敏感请求头信息的数据清理

* **变更**
  * 调整请求详情保留的默认行为

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->