### PR TITLE
feat: 统一请求响应详情显示规格

### DIFF
--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -789,6 +789,8 @@ export interface BackupRoutingStrategy {
 
 export interface BackupAPIToken {
   name: string;
+  token?: string; // plaintext token for backup/restore
+  tokenPrefix?: string; // display prefix
   description: string;
   projectSlug: string;
   isEnabled: boolean;


### PR DESCRIPTION
## 摘要
- 引入 `shouldClearRequestDetail()` 条件判断，统一控制请求/响应详情的存储逻辑

## 变更内容
- 请求详情（RequestInfo）记录增加条件判断
- 成功响应详情（ResponseInfo）记录增加条件判断
- 失败响应详情（ResponseInfo）记录增加条件判断
- 实时事件处理中的详情记录增加条件判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新增功能**
  * 扩展了备份 API 令牌的公共接口，新增两个可选字段用于存储令牌明文和其显示前缀。
* **改进**
  * 请求/响应详细信息的保留行为已改为可配置：系统根据保留设置有条件地保留或清除请求与响应的头部、URI 和正文，实时事件与历史记录展示会遵循该策略。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->