### PR TITLE
Fix infinite re-render loop in virtualized requests list

### DIFF
--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -83,6 +83,7 @@ export function RequestsPage() {
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
   const [rowHeight, setRowHeight] = useState(DEFAULT_ROW_HEIGHT);
+  const rowHeightRef = useRef(DEFAULT_ROW_HEIGHT);
   const rowMeasureObserver = useRef<ResizeObserver | null>(null);
 
   const handleContainerRef = useCallback((node: HTMLDivElement | null) => {
@@ -248,7 +249,8 @@ export function RequestsPage() {
 
     const updateHeight = () => {
       const nextHeight = node.getBoundingClientRect().height;
-      if (nextHeight > 0 && Math.abs(nextHeight - rowHeight) > 0.5) {
+      if (nextHeight > 0 && Math.abs(nextHeight - rowHeightRef.current) > 0.5) {
+        rowHeightRef.current = nextHeight;
         setRowHeight(nextHeight);
       }
     };
@@ -264,7 +266,7 @@ export function RequestsPage() {
       observer.observe(node);
       rowMeasureObserver.current = observer;
     }
-  }, [rowHeight]);
+  }, []);
 
   return (
     <div className="flex flex-col h-full bg-background">


### PR DESCRIPTION
## Summary
- `handleRowMeasure` 的 `useCallback` 依赖了 `rowHeight` state，导致循环：`rowHeight` 变化 → callback 重建 → ref 重新触发 → `setRowHeight` → `rowHeight` 变化 → 无限循环
- 引入 `rowHeightRef` 保存当前行高用于比较，使 callback 依赖数组为空 `[]`，打破循环

## Test Plan
- [ ] 打开 requests 页面，确认无 React error #185 (Maximum update depth exceeded)
- [ ] 滚动列表正常，虚拟化生效
- [ ] 浏览器窗口缩放后行高自适应正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化**
  * 改进了行高跟踪机制，提升了布局渲染效率。
  * 优化了高度测量和布局观察器初始化流程，减少了不必要的重新计算。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->