### PR TITLE
docs: 修复 Codex CLI auth.json 配置字段名

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Create or edit `~/.codex/auth.json`:
 ```json
 {
   "maxx": {
-    "api_key": "maxx_your_token_here"
+    "OPENAI_API_KEY": "maxx_your_token_here"
   }
 }
 ```
@@ -205,12 +205,12 @@ codex
 <summary>🔐 Token Authentication</summary>
 
 **When Token Authentication is Enabled:**
-- Configure `api_key` in `auth.json` with a token created in the 'API Tokens' page (format: `maxx_xxx`)
+- Configure `OPENAI_API_KEY` in `auth.json` with a token created in the 'API Tokens' page (format: `maxx_xxx`)
 - Codex CLI will automatically add the `Authorization: Bearer <token>` header to requests
 - maxx will validate the token before processing requests
 
 **When Token Authentication is Disabled:**
-- You can set `api_key` in `auth.json` to any value (e.g., `"dummy"`)
+- You can set `OPENAI_API_KEY` in `auth.json` to any value (e.g., `"dummy"`)
 - maxx will not validate the token
 - Suitable for internal networks or testing scenarios
 - ⚠️ **Warning:** Disabling token authentication reduces security

--- a/README_CN.md
+++ b/README_CN.md
@@ -186,7 +186,7 @@ stream_idle_timeout_ms = 300000
 ```json
 {
   "maxx": {
-    "api_key": "maxx_your_token_here"
+    "OPENAI_API_KEY": "maxx_your_token_here"
   }
 }
 ```
@@ -205,12 +205,12 @@ codex
 <summary>🔐 Token 认证说明</summary>
 
 **开启 Token 认证时：**
-- 在 `auth.json` 中配置 `api_key` 为在「API 令牌」页面创建的 Token（格式：`maxx_xxx`）
+- 在 `auth.json` 中配置 `OPENAI_API_KEY` 为在「API 令牌」页面创建的 Token（格式：`maxx_xxx`）
 - Codex CLI 会自动在请求头中添加 `Authorization: Bearer <token>`
 - maxx 会在处理请求前验证 Token
 
 **关闭 Token 认证时：**
-- 可以在 `auth.json` 中将 `api_key` 设置为任意值（如 `"dummy"`）
+- 可以在 `auth.json` 中将 `OPENAI_API_KEY` 设置为任意值（如 `"dummy"`）
 - maxx 不会验证 Token
 - 适用于内网环境或测试场景
 - ⚠️ **警告：** 关闭 Token 认证会降低安全性

--- a/web/src/pages/documentation/index.tsx
+++ b/web/src/pages/documentation/index.tsx
@@ -296,7 +296,7 @@ stream_idle_timeout_ms = 300000`}
               <CodeBlock
                 code={`{
   "maxx": {
-    "api_key": "maxx_your_token_here"
+    "OPENAI_API_KEY": "maxx_your_token_here"
   }
 }`}
                 id="codex-auth"


### PR DESCRIPTION
## Summary
- 将 Codex CLI `auth.json` 文档中的 `api_key` 修正为 `OPENAI_API_KEY`
- 涉及 README.md、README_CN.md 和前端文档页面

## Test plan
- [ ] 确认 README.md 中 auth.json 示例使用 `OPENAI_API_KEY`
- [ ] 确认 README_CN.md 中 auth.json 示例使用 `OPENAI_API_KEY`
- [ ] 确认前端文档页面显示正确的字段名

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了文档和代码示例中的API密钥配置命名，统一使用标准的API密钥环境变量名称，确保用户参考文档时获得一致的配置指导。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->