### PR TITLE
fix: hide Codex sort button on claude/gemini pages

### DIFF
--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -161,9 +161,10 @@ export function ClientRoutesPage() {
               </div>
 
               {/* Sort Buttons - Only show when viewing Global routes */}
-              {selectedProjectId === '0' && (hasAntigravityRoutes || hasCodexRoutes) && (
+              {selectedProjectId === '0' && (
                 <div className="flex items-center gap-2">
-                  {hasAntigravityRoutes && (
+                  {/* Only show Antigravity sort button for antigravity client type */}
+                  {hasAntigravityRoutes && activeClientType === 'antigravity' && (
                     <Button
                       variant="outline"
                       size="sm"
@@ -176,7 +177,8 @@ export function ClientRoutesPage() {
                       {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
                     </Button>
                   )}
-                  {hasCodexRoutes && (
+                  {/* Only show Codex sort button for codex client type */}
+                  {hasCodexRoutes && activeClientType === 'codex' && (
                     <Button
                       variant="outline"
                       size="sm"


### PR DESCRIPTION
## Fixes
- #198: "一键排序 Codex" button incorrectly appears on claude and gemini pages

## Changes
- Only show Antigravity sort button for antigravity client type
- Only show Codex sort button for codex client type

Co-authored-by: longxiazy <longxiazy@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **功能改进**
  * 全局路由现在始终显示排序按钮容器，无需特定路由类型存在。
  * Antigravity 和 Codex 排序按钮现在根据活跃客户端类型进行适当的条件控制，提高了界面逻辑的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->