### PR TITLE
fix: hide Codex sort button on wrong pages

### DIFF
--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -160,8 +160,10 @@ export function ClientRoutesPage() {
                 </div>
               </div>
 
-              {/* Sort Buttons - Only show when viewing Global routes */}
-              {selectedProjectId === '0' && (
+              {/* Sort Buttons - Only show when viewing Global routes and on appropriate pages */}
+              {selectedProjectId === '0' &&
+                ((hasAntigravityRoutes && activeClientType === 'antigravity') ||
+                  (hasCodexRoutes && activeClientType === 'codex')) && (
                 <div className="flex items-center gap-2">
                   {/* Only show Antigravity sort button for antigravity client type */}
                   {hasAntigravityRoutes && activeClientType === 'antigravity' && (


### PR DESCRIPTION
## Fixes
- #198: "一键排序 Codex" button incorrectly appears on claude and gemini pages

## Changes
- Only show Antigravity sort button for antigravity client type
- Only show Codex sort button for codex client type

Co-authored-by: longxiazy <longxiazy@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了全局路由排序界面的可见性：仅在查看“全局”路由且当前客户端类型与某类路由匹配时才显示整体排序容器，且针对不同路由类型（Antigravity / Codex）的排序按钮仅在对应路由存在且为活跃客户端时显示，从而避免了不相关按钮的混淆。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->