### PR TITLE
fix: defer state updates to prevent React #185

### DIFF
--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -82,6 +82,7 @@ export function RequestsPage() {
   // Status 过滤器
   const [selectedStatus, setSelectedStatus] = useState<string | undefined>(undefined);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const containerReadyRef = useRef(false);
   const [containerReady, setContainerReady] = useState(false);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(0);
@@ -89,9 +90,18 @@ export function RequestsPage() {
   const rowHeightRef = useRef(DEFAULT_ROW_HEIGHT);
   const rowMeasureObserver = useRef<ResizeObserver | null>(null);
 
+  // Lazy initialization to prevent re-render during initial mount
   const handleContainerRef = useCallback((node: HTMLDivElement | null) => {
     scrollContainerRef.current = node;
-    setContainerReady(!!node);
+    if (node && !containerReadyRef.current) {
+      containerReadyRef.current = true;
+      // Use requestAnimationFrame to defer the state update to avoid React #185
+      requestAnimationFrame(() => {
+        setContainerReady(true);
+      });
+    } else if (!node) {
+      containerReadyRef.current = false;
+    }
   }, []);
 
   const currentCursor = cursors[pageIndex];
@@ -249,11 +259,17 @@ export function RequestsPage() {
       return;
     }
 
+    // Skip if already measuring this node
+    if (rowMeasureObserver.current?.element === node) return;
+
     const updateHeight = () => {
       const nextHeight = node.getBoundingClientRect().height;
       if (nextHeight > 0 && Math.abs(nextHeight - rowHeightRef.current) > 0.5) {
         rowHeightRef.current = nextHeight;
-        setRowHeight(nextHeight);
+        // Defer state update to avoid React #185
+        requestAnimationFrame(() => {
+          setRowHeight(nextHeight);
+        });
       }
     };
 


### PR DESCRIPTION
## Fixes
- #197: requests page blank and React #185 error with multiple users

## Changes
- handleContainerRef: use requestAnimationFrame to defer setContainerReady(true) and prevent React #185
- handleRowMeasure: add node dedup check and defer setRowHeight with requestAnimationFrame

Co-authored-by: longxiazy <longxiazy@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 优化了页面渲染逻辑，减少了不必要的重新渲染，提升应用响应速度
  * 改进了测量和更新机制，降低了性能开销，使用户交互更加流畅

<!-- end of auto-generated comment: release notes by coderabbit.ai -->