### PR TITLE
fix: pin Go version to 1.25 in Dockerfile for sonic compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG VITE_COMMIT=unknown
 RUN VITE_COMMIT=${VITE_COMMIT} pnpm build
 
 # Stage 2: Build backend
-FROM golang:alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 
 # Install build dependencies
 RUN apk add --no-cache git


### PR DESCRIPTION
## Problem
`golang:alpine` now pulls Go 1.26, which is incompatible with `bytedance/sonic v1.14.2` (supports Go 1.18~1.25 only).

The build fails with:
```
undefined: GoMapIterator
```

## Solution
Pin the Go version to `1.25-alpine` in Dockerfile to ensure compatibility with sonic library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂务**
  * 后端构建环境已更新至最新的Go运行时版本，以改进性能和安全性支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->