### PR TITLE
PR #252 优化

### DIFF
--- a/internal/codexutil/normalize.go
+++ b/internal/codexutil/normalize.go
@@ -1,0 +1,43 @@
+package codexutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func NormalizeCodexInput(body []byte) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body
+	}
+
+	for i, item := range input.Array() {
+		itemType := item.Get("type").String()
+		if itemType != "message" {
+			if item.Get("role").Exists() {
+				body, _ = sjson.DeleteBytes(body, fmt.Sprintf("input.%d.role", i))
+			}
+		}
+		if itemType == "function_call" {
+			id := strings.TrimSpace(item.Get("id").String())
+			switch {
+			case strings.HasPrefix(id, "fc_"):
+			case id == "":
+				body, _ = sjson.SetBytes(body, fmt.Sprintf("input.%d.id", i), "fc_"+uuid.NewString())
+			default:
+				body, _ = sjson.SetBytes(body, fmt.Sprintf("input.%d.id", i), "fc_"+id)
+			}
+		}
+		if itemType == "function_call_output" {
+			if !item.Get("output").Exists() {
+				body, _ = sjson.SetBytes(body, fmt.Sprintf("input.%d.output", i), "")
+			}
+		}
+	}
+
+	return body
+}


### PR DESCRIPTION
 Summary:
  - Added internal/codexutil/normalize.go with shared input normalization (role
  cleanup, function_call id prefixing with fc_, uuid fallback, output defaulting).
  - Wired both Codex adapters to use the shared helper and removed duplicated logic.
  - Updated TestApplyCodexRequestTuning to cover fc_ prefixing, generated IDs, and
  defaulted function_call_output output.
  - Verified Store remains json:"store,omitempty".

  Test:
  - go test ./internal/adapter/provider/codex -run TestApplyCodexRequestTuning

  Files touched:
  - internal/codexutil/normalize.go
  - internal/adapter/provider/cliproxyapi_codex/adapter.go
  - internal/adapter/provider/codex/adapter.go
  - internal/adapter/provider/codex/adapter_test.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **重构**
  * 整合了有效负载规范化逻辑至统一工具函数，改善了代码组织和可维护性。

* **测试**
  * 增强了测试覆盖范围，包含更复杂的输入有效负载和ID前缀验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->