### PR TITLE
feat: 提升自定义提供商克隆体验

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "common": {
     "save": "Save",
     "cancel": "Cancel",
@@ -918,6 +918,10 @@
     "createError": "Failed to create provider. Please check your connection and try again.",
     "updateError": "Failed to update provider. Please check your connection and try again.",
     "saveChanges": "Save Changes",
+    "clone": "Clone",
+    "cloning": "Cloning...",
+    "cloneSuffix": " (Copy)",
+    "cloneSuccess": "Cloned \"{{name}}\" successfully.",
     "delete": "Delete",
     "cancel": "Cancel",
     "none": "None",
@@ -1083,3 +1087,4 @@
     "emptyHint": "No model mappings configured. Add mappings to transform request models before sending to upstream."
   }
 }
+

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -918,6 +918,10 @@
     "createError": "创建提供商失败。请检查您的连接并重试。",
     "updateError": "更新提供商失败。请检查您的连接并重试。",
     "saveChanges": "保存更改",
+    "clone": "克隆",
+    "cloning": "克隆中...",
+    "cloneSuffix": "（副本）",
+    "cloneSuccess": "已成功克隆「{{name}}」。",
     "delete": "删除",
     "cancel": "取消",
     "none": "无",
@@ -1082,3 +1086,4 @@
     "emptyHint": "暂无模型映射。添加映射以在发送到上游前转换请求模型。"
   }
 }
+


### PR DESCRIPTION
## 概要
- 自定义提供商编辑页新增克隆按钮，复用创建接口复制配置
- 克隆后复制模型映射并提示成功，自动返回提供商列表

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
- 添加提供商克隆功能，用户可在编辑界面克隆现有提供商并自动为其重命名
- 克隆操作保留提供商的关键配置和模型映射设置
- 克隆成功时显示确认提示信息，支持英文和中文
<!-- end of auto-generated comment: release notes by coderabbit.ai -->