### PR TITLE
fix: 统一项目详情返回按钮样式

### DIFF
--- a/web/src/pages/projects/detail.tsx
+++ b/web/src/pages/projects/detail.tsx
@@ -4,9 +4,9 @@ import { Button, Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/u
 import { useProject, useDeleteProject, projectKeys } from '@/hooks/queries';
 import {
   ArrowLeft,
+  ChevronLeft,
   Trash2,
   Loader2,
-  FolderKanban,
   LayoutGrid,
   Route,
   Users,
@@ -67,21 +67,11 @@ export function ProjectDetailPage() {
     <div className="flex flex-col h-full bg-background">
       {/* Header */}
       <PageHeader
-        icon={FolderKanban}
-        iconClassName="text-purple-500"
+        icon={<ChevronLeft className="cursor-pointer" onClick={() => navigate('/projects')} />}
         title={project.name}
         description={project.slug}
         actions={
           <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate('/projects')}
-              className="h-8 px-3"
-            >
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              {t('common.back')}
-            </Button>
             <Button
               variant="destructive"
               size="sm"


### PR DESCRIPTION
## 变更
- 项目详情顶部返回按钮复用左侧图标样式，移除右侧返回按钮

## 验证
- 未运行（UI 变更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 优化了项目详情页的返回导航交互方式。
  * 简化了页面头部操作栏布局，提升用户界面整洁度，移除冗余操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->