### PR TITLE
feat: 添加 SQLite 数据库支持的后台任务清理功能

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -245,6 +245,7 @@ func main() {
 
 	// Start background tasks
 	core.StartBackgroundTasks(core.BackgroundTaskDeps{
+		DB:                 db,
 		UsageStats:         usageStatsRepo,
 		ProxyRequest:       proxyRequestRepo,
 		AttemptRepo:        attemptRepo,


### PR DESCRIPTION
# 背景/动机
当前请求日志清理会删除历史请求记录，但 SQLite 在删除后不会自动收缩数据库文件；同时 WAL 文件也可能持续增长。长期运行场景下，磁盘占用可能不收敛并带来碎片/性能波动。
因此在“请求日志保留清理”完成后，增加一次可控的 SQLite 维护流程，尽量回收空间并控制 WAL 体积。

# 变更点
- `cmd/maxx/main.go`
  - 向 `core.StartBackgroundTasks` 注入 `DB: db`，便于后台任务在需要时执行数据库维护。
- `internal/core/task.go`
  - 在请求日志清理（`DeleteOlderThan`）成功后，若当前 dialector 为 SQLite 且确实删除了记录，则 best-effort 执行：
    - `PRAGMA wal_checkpoint(TRUNCATE)`
    - `VACUUM`
  - 增加节流：最多每 1 小时执行一次维护（避免频繁 VACUUM 的 IO/锁开销）。
  - 增加互斥：维护进行中禁止并发触发，避免竞态窗口导致并发 VACUUM。
  - 
# 行为变化
- 仅 SQLite 生效：`d.DB != nil && d.DB.Dialector() == "sqlite"` 才会执行维护；MySQL/Postgres 等不受影响。
- best-effort：checkpoint/VACUUM 失败只记录日志，不影响请求日志清理主流程与其他后台任务。
- 无 schema 变更。
 风险 & 注意点
- SQLite 的 `VACUUM` 可能引发短时 IO/锁竞争（SQLite 机制决定），但已通过：
  - 1 小时节流降低触发频率；
  - 互斥避免并发维护；
  - best-effort（失败不影响业务）降低可用性风险。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了数据库后台维护机制，确保定期清理和优化数据库性能。

* **Performance**
  * 添加了自动数据库清理功能，包括智能限流控制，防止维护任务过度消耗系统资源。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->