### PR TITLE
feat: Web端支持重启服务器

### DIFF
--- a/internal/desktop/launcher.go
+++ b/internal/desktop/launcher.go
@@ -206,6 +206,11 @@ func (a *LauncherApp) startServerAsync() {
 	}
 	a.components = components
 
+	// Allow Web admin endpoint to trigger desktop restart
+	if components.AdminHandler != nil {
+		components.AdminHandler.SetRestartFunc(a.RestartServer)
+	}
+
 	// 设置 Wails context 用于事件广播
 	if components.WailsBroadcaster != nil {
 		components.WailsBroadcaster.SetContext(a.ctx)

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -323,6 +323,12 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  // ===== System API =====
+
+  async restartServer(): Promise<void> {
+    await this.client.post('/restart');
+  }
+
   // ===== Provider Stats API =====
 
   async getProviderStats(

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -117,6 +117,9 @@ export interface Transport {
   // ===== Proxy Status API =====
   getProxyStatus(): Promise<ProxyStatus>;
 
+  // ===== System API =====
+  restartServer(): Promise<void>;
+
   // ===== Provider Stats API =====
   getProviderStats(clientType?: string, projectId?: number): Promise<Record<number, ProviderStats>>;
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -83,6 +83,9 @@
     "account": "Account",
     "notifications": "Notifications",
     "theme": "Theme",
+    "restartServer": "Restart Server",
+    "restartServerConfirm": "Restart the server? Active connections may be briefly interrupted.",
+    "restartServerFailed": "Restart failed. Please check the server status.",
     "language": "Language",
     "logout": "Log out"
   },

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -83,6 +83,9 @@
     "account": "账户",
     "notifications": "通知",
     "theme": "主题",
+    "restartServer": "重启服务器",
+    "restartServerConfirm": "确定重启服务器？当前连接可能会短暂中断。",
+    "restartServerFailed": "重启失败，请检查服务状态。",
     "language": "语言",
     "logout": "退出登录"
   },


### PR DESCRIPTION
## Summary
- Web端菜单接入 /api/admin/restart 触发自我重启
- 后端绑定 restart 回调并实现优雅停机后拉起新进程
- 桌面端接通 restart 回调

## Testing
- 未运行（UI/接口变更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在用户菜单中新增"重启服务器"选项，允许管理员快速重启服务器
  * 重启前显示确认对话框，提醒用户活跃连接可能会被短暂中断
  * 增强服务器优雅关闭机制，确保完整清理资源
  * 支持英文和中文界面提示
<!-- end of auto-generated comment: release notes by coderabbit.ai -->