### PR TITLE
fix(web): docs URL follows current protocol

### DIFF
--- a/web/src/pages/documentation/index.tsx
+++ b/web/src/pages/documentation/index.tsx
@@ -13,6 +13,16 @@ interface CodeBlockProps {
   onCopy: (text: string, id: string) => void;
 }
 
+function buildBaseUrl(address: string): string {
+  const trimmedAddress = address.trim().replace(/\/+$/, '');
+  if (/^https?:\/\//i.test(trimmedAddress)) {
+    return trimmedAddress;
+  }
+  const protocol =
+    typeof window !== 'undefined' && window.location.protocol === 'https:' ? 'https' : 'http';
+  return `${protocol}://${trimmedAddress}`;
+}
+
 function CodeBlock({ code, id, copiedCode, onCopy }: CodeBlockProps) {
   return (
     <div className="relative group">
@@ -59,7 +69,7 @@ function DocumentationSection() {
   const [copiedCode, setCopiedCode] = useState<string | null>(null);
   const { data: proxyStatus } = useProxyStatus();
   const proxyAddress = proxyStatus?.address ?? 'localhost:9880';
-  const baseUrl = `http://${proxyAddress}`;
+  const baseUrl = buildBaseUrl(proxyAddress);
 
   const copyToClipboard = (text: string, id: string) => {
     navigator.clipboard.writeText(text);


### PR DESCRIPTION
## Summary
- fix documentation page base URL generation
- use current page protocol (http/https) instead of hardcoded http
- preserve existing protocol when proxy address already includes one

## Verification
- pnpm -C web typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化了网址处理方式，现可正确识别和处理 HTTP/HTTPS 协议，同时改进了相对与绝对地址的处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->