### PR TITLE
fix: 修复codex配置与复制

### DIFF
--- a/web/src/lib/codex-config.ts
+++ b/web/src/lib/codex-config.ts
@@ -69,9 +69,7 @@ request_max_retries = 4
 stream_max_retries = 10
 stream_idle_timeout_ms = 300000`;
 
-  const authJson = `{
-  "OPENAI_API_KEY": "${token}"
-}`;
+  const authJson = JSON.stringify({ OPENAI_API_KEY: token }, null, 2);
 
   const combined = `# ~/.codex/config.toml
 ${configToml}

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -241,11 +241,20 @@ export function APITokensPage() {
   };
 
   const handleCopyCodexSection = async (section: 'configToml' | 'authJson', content: string) => {
-    await navigator.clipboard.writeText(content);
-    setCopiedCodexSection(section);
-    setTimeout(() => {
-      setCopiedCodexSection((current) => (current === section ? null : current));
-    }, 2000);
+    if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      console.error('Clipboard API is not available.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopiedCodexSection(section);
+      setTimeout(() => {
+        setCopiedCodexSection((current) => (current === section ? null : current));
+      }, 2000);
+    } catch (error) {
+      console.error('Failed to copy Codex config section.', error);
+    }
   };
 
   const getCodexCheckHint = (checkKey: string) => {


### PR DESCRIPTION
## 变更
- 使用 JSON.stringify 生成 auth.json，保证 token 转义
- 复制 Codex 配置时增加剪贴板可用性检查与错误处理

## 验证
- 未运行测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 增强了 API 令牌复制流程的稳定性，增加剪贴板可用性检查与错误处理，避免在不支持或异常环境中导致失败。
* **Refactor**
  * 优化了配置内容的生成方式，提高一致性与维护性，用户可见行为保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->