### PR TITLE
fix: 内网/客户端场景下跳过用户认证体系

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -324,14 +324,20 @@ func main() {
 		r, // Router implements ProviderAdapterRefresher interface
 	)
 
-	// Ensure an active admin user exists (panic on failure since all operations require auth)
-	if err := core.SeedDefaultAdmin(userRepo); err != nil {
-		log.Fatalf("Failed to seed default admin: %v", err)
-	}
+	// Determine if authentication is enabled based on MAXX_ADMIN_PASSWORD
+	authEnabled := os.Getenv(handler.AdminPasswordEnvKey) != ""
+	var authMiddleware *handler.AuthMiddleware
 
-	// Create auth middleware
-	authMiddleware := handler.NewAuthMiddleware(settingRepo)
-	log.Println("Admin API authentication is enabled (multi-user mode)")
+	if authEnabled {
+		// Ensure an active admin user exists (panic on failure since all operations require auth)
+		if err := core.SeedDefaultAdmin(userRepo); err != nil {
+			log.Fatalf("Failed to seed default admin: %v", err)
+		}
+		authMiddleware = handler.NewAuthMiddleware(settingRepo)
+		log.Println("Admin API authentication is enabled (multi-user mode)")
+	} else {
+		log.Println("Admin API authentication is disabled (no MAXX_ADMIN_PASSWORD set)")
+	}
 
 	// Create token auth middleware
 	tokenAuthMiddleware := handler.NewTokenAuthMiddleware(cachedAPITokenRepo, settingRepo)
@@ -347,7 +353,7 @@ func main() {
 	proxyHandler.SetRequestTracker(requestTracker)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
 	adminHandler.SetUserRepo(userRepo)
-	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo)
+	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, authEnabled)
 	antigravityHandler := handler.NewAntigravityHandler(adminService, antigravityQuotaRepo, wsHub)
 	antigravityHandler.SetTaskService(antigravityTaskSvc)
 	kiroHandler := handler.NewKiroHandler(adminService)
@@ -366,7 +372,11 @@ func main() {
 	mux.Handle("/api/admin/auth/", http.StripPrefix("/api", authHandler))
 
 	// Admin API routes with authentication middleware
-	mux.Handle("/api/admin/", http.StripPrefix("/api", authMiddleware.Wrap(adminHandler)))
+	if authMiddleware != nil {
+		mux.Handle("/api/admin/", http.StripPrefix("/api", authMiddleware.Wrap(adminHandler)))
+	} else {
+		mux.Handle("/api/admin/", http.StripPrefix("/api", handler.NoAuthMiddleware(adminHandler)))
+	}
 
 	// Other API routes (no authentication required)
 	mux.Handle("/api/antigravity/", http.StripPrefix("/api", antigravityHandler))

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -361,8 +361,18 @@ func InitializeServerComponents(
 	)
 
 	log.Printf("[Core] Creating auth middleware and handler")
-	authMiddleware := handler.NewAuthMiddleware(repos.SettingRepo)
-	authHandler := handler.NewAuthHandler(authMiddleware, repos.UserRepo, repos.TenantRepo)
+	authEnabled := os.Getenv(handler.AdminPasswordEnvKey) != ""
+	var authMiddleware *handler.AuthMiddleware
+	if authEnabled {
+		if err := SeedDefaultAdmin(repos.UserRepo); err != nil {
+			return nil, fmt.Errorf("failed to seed default admin: %w", err)
+		}
+		authMiddleware = handler.NewAuthMiddleware(repos.SettingRepo)
+		log.Println("Admin API authentication is enabled (multi-user mode)")
+	} else {
+		log.Println("Admin API authentication is disabled (no MAXX_ADMIN_PASSWORD set)")
+	}
+	authHandler := handler.NewAuthHandler(authMiddleware, repos.UserRepo, repos.TenantRepo, authEnabled)
 
 	log.Printf("[Core] Creating handlers")
 	tokenAuthMiddleware := handler.NewTokenAuthMiddleware(repos.CachedAPITokenRepo, repos.SettingRepo)

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -79,7 +79,7 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	if s.config.AuthMiddleware != nil {
 		mux.Handle("/api/admin/", http.StripPrefix("/api", s.config.AuthMiddleware.Wrap(components.AdminHandler)))
 	} else {
-		mux.Handle("/api/admin/", http.StripPrefix("/api", components.AdminHandler))
+		mux.Handle("/api/admin/", http.StripPrefix("/api", handler.NoAuthMiddleware(components.AdminHandler)))
 	}
 	mux.Handle("/api/antigravity/", http.StripPrefix("/api", components.AntigravityHandler))
 	mux.Handle("/api/kiro/", http.StripPrefix("/api", components.KiroHandler))

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -134,6 +134,17 @@ func (m *AuthMiddleware) Wrap(next http.Handler) http.Handler {
 	})
 }
 
+// NoAuthMiddleware injects default tenant/user context when authentication is disabled.
+// Used in single-user / intranet mode where MAXX_ADMIN_PASSWORD is not set.
+func NoAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := maxxctx.WithTenantID(r.Context(), domain.DefaultTenantID)
+		ctx = maxxctx.WithUserID(ctx, domain.DefaultUserID)
+		ctx = maxxctx.WithUserRole(ctx, string(domain.UserRoleAdmin))
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 func writeUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -17,14 +17,16 @@ type AuthHandler struct {
 	authMiddleware *AuthMiddleware
 	userRepo       repository.UserRepository
 	tenantRepo     repository.TenantRepository
+	authEnabled    bool
 }
 
 // NewAuthHandler creates a new auth handler
-func NewAuthHandler(authMiddleware *AuthMiddleware, userRepo repository.UserRepository, tenantRepo repository.TenantRepository) *AuthHandler {
+func NewAuthHandler(authMiddleware *AuthMiddleware, userRepo repository.UserRepository, tenantRepo repository.TenantRepository, authEnabled bool) *AuthHandler {
 	return &AuthHandler{
 		authMiddleware: authMiddleware,
 		userRepo:       userRepo,
 		tenantRepo:     tenantRepo,
+		authEnabled:    authEnabled,
 	}
 }
 
@@ -330,7 +332,7 @@ func (h *AuthHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result := map[string]any{
-		"authEnabled": true,
+		"authEnabled": h.authEnabled,
 	}
 
 	// If authenticated, return user info

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -55,6 +55,18 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
         setAuthEnabled(status.authEnabled);
 
+        // If auth is disabled, auto-authenticate as admin
+        if (!status.authEnabled) {
+          setIsAuthenticated(true);
+          setUser({
+            id: 1,
+            username: 'admin',
+            tenantID: 1,
+            role: 'admin',
+          });
+          return;
+        }
+
         if (savedToken) {
           try {
             await transport.getProxyStatus();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加可选的管理员认证模式：可通过环境变量启用或禁用管理员认证。
  * 认证禁用时，前端自动以管理员身份登录，无需手动认证。
  * 认证启用时，支持默认管理员用户初始化以便首次登录。
  * 状态接口会反映当前是否启用认证，启动日志会提示认证状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->