### PR TITLE
fix: 未开启admin密码时隐藏用户管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ codex
 
 | Variable | Description |
 |----------|-------------|
-| `MAXX_ADMIN_PASSWORD` | Enable admin authentication with JWT |
+| `MAXX_ADMIN_PASSWORD` | Enable admin authentication with JWT. Default username: `admin`, password: the value of this variable |
 | `MAXX_DSN` | Database connection string |
 | `MAXX_DATA_DIR` | Custom data directory path |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -241,7 +241,7 @@ codex
 
 | 变量 | 说明 |
 |------|------|
-| `MAXX_ADMIN_PASSWORD` | 启用管理员 JWT 认证 |
+| `MAXX_ADMIN_PASSWORD` | 启用管理员 JWT 认证。默认用户名：`admin`，密码为该变量的值 |
 | `MAXX_DSN` | 数据库连接字符串 |
 | `MAXX_DATA_DIR` | 自定义数据目录路径 |
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ import { AuthProvider, useAuth } from '@/lib/auth-context';
 
 function AppRoutes() {
   const { t } = useTranslation();
-  const { isAuthenticated, isLoading, login, user } = useAuth();
+  const { isAuthenticated, isLoading, authEnabled, login, user } = useAuth();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -78,7 +78,7 @@ function AppRoutes() {
           <Route path="routing-strategies" element={<RoutingStrategiesPage />} />
           <Route path="stats" element={<StatsPage />} />
           <Route path="settings" element={<SettingsPage />} />
-          {isAdmin && <Route path="users" element={<UsersPage />} />}
+          {isAdmin && authEnabled && <Route path="users" element={<UsersPage />} />}
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -112,6 +112,7 @@ export const sidebarConfig: SidebarConfig = {
           icon: UserCog,
           labelKey: 'nav.users',
           adminOnly: true,
+          authOnly: true,
         },
       ],
     },

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -64,7 +64,7 @@ function MenuItemRenderer({ item }: { item: MenuItem }) {
  */
 export function SidebarRenderer({ config }: SidebarRendererProps) {
   const { t } = useTranslation();
-  const { user } = useAuth();
+  const { user, authEnabled } = useAuth();
   const isAdmin = !user || user.role === 'admin';
 
   return (
@@ -72,6 +72,9 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
       {config.sections.map((section) => {
         const filteredItems = section.items.filter((item) => {
           if (item.type === 'standard' && item.adminOnly && !isAdmin) {
+            return false;
+          }
+          if (item.type === 'standard' && item.authOnly && !authEnabled) {
             return false;
           }
           return true;

--- a/web/src/types/sidebar.ts
+++ b/web/src/types/sidebar.ts
@@ -11,6 +11,7 @@ export interface StandardMenuItem {
   labelKey: string;
   activeMatch?: 'exact' | 'startsWith'; // Default: 'startsWith'
   adminOnly?: boolean; // Only show for admin role
+  authOnly?: boolean; // Only show when auth is enabled
 }
 
 /**


### PR DESCRIPTION
## Summary
- 未设置 `MAXX_ADMIN_PASSWORD` 时，隐藏侧边栏「用户管理」菜单项和对应路由
- 新增 `authOnly` 属性用于标记仅在认证启用时显示的菜单项
- 文档补充 `MAXX_ADMIN_PASSWORD` 的默认用户名和密码说明

## Test plan
- [ ] 不设置 `MAXX_ADMIN_PASSWORD` 启动，确认侧边栏无「用户管理」入口
- [ ] 不设置 `MAXX_ADMIN_PASSWORD` 启动，确认直接访问 `/users` 路由 404
- [ ] 设置 `MAXX_ADMIN_PASSWORD` 启动，确认「用户管理」正常显示和访问

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新了管理员认证密码环境变量说明，明确默认用户名为 admin，且管理员密码即为该环境变量的值。

* **功能改进**
  * 强化了用户管理入口的访问控制：当认证未启用时，用户管理菜单项和对应路由将被隐藏。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->