### PR TITLE
fix: resolve #298 - 服务请求长上下文需智能压缩以降低 Codex 客户端持续重试

### DIFF
--- a/internal/handler/codex_context_compact.go
+++ b/internal/handler/codex_context_compact.go
@@ -160,6 +160,7 @@ func trimCodexItemText(item interface{}, maxChars int) interface{} {
 	if !ok {
 		return item
 	}
+	m = deepCopyJSONObject(m)
 
 	if content, ok := m["content"].(string); ok {
 		if compacted, changed := compactLongString(content, maxChars); changed {
@@ -208,27 +209,69 @@ func compactNestedStrings(value interface{}, maxChars int) (interface{}, bool) {
 		}
 		return v, false
 	case map[string]interface{}:
-		changed := false
+		var copied map[string]interface{}
 		for key, raw := range v {
 			compacted, partChanged := compactNestedStrings(raw, maxChars)
-			if partChanged {
-				changed = true
-				v[key] = compacted
+			if !partChanged {
+				continue
 			}
+			if copied == nil {
+				copied = make(map[string]interface{}, len(v))
+				for k, vv := range v {
+					copied[k] = vv
+				}
+			}
+			copied[key] = compacted
 		}
-		return v, changed
+		if copied == nil {
+			return v, false
+		}
+		return copied, true
 	case []interface{}:
-		changed := false
+		var copied []interface{}
 		for i := range v {
 			compacted, partChanged := compactNestedStrings(v[i], maxChars)
-			if partChanged {
-				changed = true
-				v[i] = compacted
+			if !partChanged {
+				continue
 			}
+			if copied == nil {
+				copied = append([]interface{}(nil), v...)
+			}
+			copied[i] = compacted
 		}
-		return v, changed
+		if copied == nil {
+			return v, false
+		}
+		return copied, true
 	default:
 		return value, false
+	}
+}
+
+func deepCopyJSONObject(src map[string]interface{}) map[string]interface{} {
+	dst := make(map[string]interface{}, len(src))
+	for key, value := range src {
+		dst[key] = deepCopyJSONValue(value)
+	}
+	return dst
+}
+
+func deepCopyJSONArray(src []interface{}) []interface{} {
+	dst := make([]interface{}, len(src))
+	for i, value := range src {
+		dst[i] = deepCopyJSONValue(value)
+	}
+	return dst
+}
+
+func deepCopyJSONValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return deepCopyJSONObject(v)
+	case []interface{}:
+		return deepCopyJSONArray(v)
+	default:
+		return v
 	}
 }
 

--- a/internal/handler/codex_context_compact_test.go
+++ b/internal/handler/codex_context_compact_test.go
@@ -218,4 +218,52 @@ func TestTrimCodexItemText_CompactsArgumentsField(t *testing.T) {
 	if !strings.Contains(nestedText, "[maxx] ... earlier context omitted ...") {
 		t.Fatalf("expected nested argument text to be compacted")
 	}
+
+	originalArgs, _ := item["arguments"].(map[string]interface{})
+	originalQuery, _ := originalArgs["query"].(string)
+	if strings.Contains(originalQuery, "[maxx] ... earlier context omitted ...") {
+		t.Fatalf("expected original query argument to remain unchanged")
+	}
+	originalNested, _ := originalArgs["nested"].([]interface{})
+	originalNestedMap, _ := originalNested[0].(map[string]interface{})
+	originalNestedText, _ := originalNestedMap["text"].(string)
+	if strings.Contains(originalNestedText, "[maxx] ... earlier context omitted ...") {
+		t.Fatalf("expected original nested argument text to remain unchanged")
+	}
+}
+
+func TestCompactNestedStrings_DoesNotMutateInput(t *testing.T) {
+	value := map[string]interface{}{
+		"query": strings.Repeat("Q", 20000),
+		"nested": []interface{}{
+			map[string]interface{}{
+				"text": strings.Repeat("N", 18000),
+			},
+		},
+	}
+
+	compacted, changed := compactNestedStrings(value, codexCompactMaxTextChars)
+	if !changed {
+		t.Fatalf("expected nested strings to be compacted")
+	}
+
+	compactedMap, ok := compacted.(map[string]interface{})
+	if !ok {
+		t.Fatalf("compacted value type = %T, want map", compacted)
+	}
+	compactedQuery, _ := compactedMap["query"].(string)
+	if !strings.Contains(compactedQuery, "[maxx] ... earlier context omitted ...") {
+		t.Fatalf("expected compacted query to contain marker")
+	}
+
+	originalQuery, _ := value["query"].(string)
+	if strings.Contains(originalQuery, "[maxx] ... earlier context omitted ...") {
+		t.Fatalf("expected original query to remain unchanged")
+	}
+	originalNested, _ := value["nested"].([]interface{})
+	originalNestedMap, _ := originalNested[0].(map[string]interface{})
+	originalNestedText, _ := originalNestedMap["text"].(string)
+	if strings.Contains(originalNestedText, "[maxx] ... earlier context omitted ...") {
+		t.Fatalf("expected original nested text to remain unchanged")
+	}
 }

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -289,7 +289,7 @@ func normalizeOpenAIChatCompletionsPayload(body []byte) ([]byte, bool) {
 }
 
 func isCodexCompactionEligiblePath(path string) bool {
-	return path == "/responses" || path == "/v1/responses"
+	return path == "/responses"
 }
 
 // Helper functions

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -33,7 +33,7 @@ func TestIsCodexCompactionEligiblePath(t *testing.T) {
 		want bool
 	}{
 		{path: "/responses", want: true},
-		{path: "/v1/responses", want: true},
+		{path: "/v1/responses", want: false},
 		{path: "/v1/chat/completions", want: false},
 		{path: "/messages", want: false},
 	}


### PR DESCRIPTION
Closes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 自动对较大请求的上下文进行压缩：在保留关键片段的同时插入省略标记以缩短内容并减小请求体大小。

* **测试**
  * 新增多种场景测试，验证长文本、消息序列及嵌套结构的压缩行为及不改变原始输入的要求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->