### PR TITLE
fix: resolve log mutex deadlock causing API hang

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -33,6 +33,7 @@ type Executor struct {
 	converter        *converter.Registry
 	engine           *flow.Engine
 	middlewares      []flow.HandlerFunc
+	cooldownSem      chan struct{} // semaphore to limit concurrent cooldown update goroutines
 }
 
 // NewExecutor creates a new executor
@@ -63,6 +64,7 @@ func NewExecutor(
 		statsAggregator:  statsAggregator,
 		converter:        converter.GetGlobalRegistry(),
 		engine:           flow.NewEngine(),
+		cooldownSem:      make(chan struct{}, 10),
 	}
 }
 
@@ -224,9 +226,14 @@ func (e *Executor) handleCooldown(proxyErr *domain.ProxyError, provider *domain.
 	// Otherwise, cooldown duration is calculated based on policy and failure count
 	cooldown.Default().RecordFailure(provider.ID, selectedClientType, reason, explicitUntil)
 
-	// If there's an async update channel, listen for updates
+	// If there's an async update channel, listen for updates (bounded by semaphore)
 	if proxyErr.CooldownUpdateChan != nil {
-		go e.handleAsyncCooldownUpdate(proxyErr.CooldownUpdateChan, provider, selectedClientType)
+		select {
+		case e.cooldownSem <- struct{}{}:
+			go e.handleAsyncCooldownUpdate(proxyErr.CooldownUpdateChan, provider, selectedClientType)
+		default:
+			// Semaphore full, skip async cooldown update to prevent goroutine leak
+		}
 	}
 }
 
@@ -250,6 +257,7 @@ func mapRateLimitTypeToReason(rateLimitType string) cooldown.CooldownReason {
 
 // handleAsyncCooldownUpdate listens for async cooldown updates from providers
 func (e *Executor) handleAsyncCooldownUpdate(updateChan chan time.Time, provider *domain.Provider, clientType string) {
+	defer func() { <-e.cooldownSem }()
 	select {
 	case newCooldownTime := <-updateChan:
 		if !newCooldownTime.IsZero() {

--- a/internal/handler/websocket.go
+++ b/internal/handler/websocket.go
@@ -82,16 +82,11 @@ func (h *WebSocketHub) tryEnqueueBroadcast(msg WSMessage, meta string) {
 	select {
 	case h.broadcast <- msg:
 	default:
-		dropped := h.broadcastDroppedTotal.Add(1)
-		// 避免日志刷屏：首次 + 每100次打印一次，确保可观测性但不拖慢热路径。
-		if dropped == 1 || dropped%100 == 0 {
-			meta = strings.TrimSpace(meta)
-			if meta != "" {
-				log.Printf("[WebSocket] drop broadcast message type=%s %s dropped_total=%d", msg.Type, meta, dropped)
-			} else {
-				log.Printf("[WebSocket] drop broadcast message type=%s dropped_total=%d", msg.Type, dropped)
-			}
-		}
+		// Only increment counter; do NOT call log.Printf here.
+		// This function is called from within WebSocketLogWriter.Write(),
+		// which is invoked by log.Printf while holding the log mutex.
+		// Calling log.Printf again would deadlock (sync.Mutex is not reentrant).
+		h.broadcastDroppedTotal.Add(1)
 	}
 }
 

--- a/internal/handler/websocket_test.go
+++ b/internal/handler/websocket_test.go
@@ -1,11 +1,11 @@
 package handler
 
 import (
-	"bytes"
 	"encoding/json"
+	"io"
 	"log"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
 )
@@ -84,42 +84,66 @@ func TestWebSocketHub_BroadcastProxyUpstreamAttempt_SendsSnapshot(t *testing.T) 
 	}
 }
 
-func TestWebSocketHub_BroadcastProxyRequest_LogsWhenDropped(t *testing.T) {
+func TestWebSocketHub_BroadcastDrop_IncrementsCounter(t *testing.T) {
 	hub := &WebSocketHub{
 		broadcast: make(chan WSMessage, 1),
 	}
 	hub.broadcast <- WSMessage{Type: "dummy", Data: nil}
 
-	var buf bytes.Buffer
-	oldOutput := log.Writer()
-	oldFlags := log.Flags()
-	oldPrefix := log.Prefix()
-	log.SetOutput(&buf)
-	log.SetFlags(0)
-	log.SetPrefix("")
-	defer func() {
-		log.SetOutput(oldOutput)
-		log.SetFlags(oldFlags)
-		log.SetPrefix(oldPrefix)
-	}()
+	before := hub.broadcastDroppedTotal.Load()
 
 	req := &domain.ProxyRequest{
 		ID:        1,
 		RequestID: "req_1",
 		Status:    "IN_PROGRESS",
 	}
-
 	hub.BroadcastProxyRequest(req)
 
-	out := buf.String()
-	if !strings.Contains(out, "drop") && !strings.Contains(out, "丢弃") {
-		t.Fatalf("expected drop log, got: %q", out)
+	after := hub.broadcastDroppedTotal.Load()
+	if after != before+1 {
+		t.Fatalf("expected drop counter to increment from %d to %d, got %d", before, before+1, after)
 	}
-	if !strings.Contains(out, "proxy_request_update") {
-		t.Fatalf("expected message type in log, got: %q", out)
+}
+
+func TestWebSocketLogWriter_NoDeadlockOnFullChannel(t *testing.T) {
+	// Create hub WITHOUT starting run() goroutine, so channel stays full
+	hub := &WebSocketHub{
+		broadcast: make(chan WSMessage, 100),
 	}
-	if !strings.Contains(out, "req_1") {
-		t.Fatalf("expected requestID in log, got: %q", out)
+
+	// Fill broadcast channel completely
+	for i := 0; i < 100; i++ {
+		hub.broadcast <- WSMessage{Type: "fill", Data: i}
+	}
+
+	// Create WebSocketLogWriter pointing to this hub
+	writer := NewWebSocketLogWriter(hub, io.Discard, "")
+
+	// Redirect log output through WebSocketLogWriter
+	oldOutput := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(writer)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(oldOutput)
+		log.SetFlags(oldFlags)
+	}()
+
+	// log.Printf path: holds log mutex → WebSocketLogWriter.Write
+	//   → BroadcastLog → tryEnqueueBroadcast → channel full → default branch
+	// Before fix: default branch called log.Printf → re-acquire log mutex → DEADLOCK
+	// After fix:  default branch only increments counter → no deadlock
+	done := make(chan struct{})
+	go func() {
+		log.Printf("this must not deadlock")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// No deadlock
+	case <-time.After(2 * time.Second):
+		t.Fatal("Deadlock: log.Printf hung because tryEnqueueBroadcast called log.Printf while log mutex was held")
 	}
 }
 

--- a/internal/repository/sqlite/db_test.go
+++ b/internal/repository/sqlite/db_test.go
@@ -1,0 +1,17 @@
+package sqlite
+
+import (
+	"testing"
+)
+
+func TestDBDialectorName(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	if db.Dialector() != "sqlite" {
+		t.Fatalf("Expected dialector 'sqlite', got %q", db.Dialector())
+	}
+}

--- a/tests/e2e/db_stability_test.go
+++ b/tests/e2e/db_stability_test.go
@@ -1,0 +1,165 @@
+package e2e_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDBStability_BurstConcurrentRequests(t *testing.T) {
+	env := NewTestEnv(t)
+
+	// Create some test data first
+	provider := map[string]any{
+		"name":    "stability-test-provider",
+		"type":    "openai",
+		"baseURL": "https://api.example.com",
+		"apiKey":  "sk-test",
+		"models":  []string{"gpt-4"},
+	}
+	resp := env.AdminPost("/api/admin/providers", provider)
+	AssertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	// Burst of concurrent reads
+	const numRequests = 50
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	var failCount atomic.Int32
+
+	wg.Add(numRequests)
+	for i := 0; i < numRequests; i++ {
+		go func() {
+			defer wg.Done()
+			r := env.AdminGet("/api/admin/providers")
+			if r.StatusCode == http.StatusOK {
+				successCount.Add(1)
+			} else {
+				failCount.Add(1)
+			}
+			r.Body.Close()
+		}()
+	}
+	wg.Wait()
+
+	if failCount.Load() > 0 {
+		t.Fatalf("Expected all %d requests to succeed, but %d failed", numRequests, failCount.Load())
+	}
+	if successCount.Load() != numRequests {
+		t.Fatalf("Expected %d successful requests, got %d", numRequests, successCount.Load())
+	}
+}
+
+func TestDBStability_HealthCheckUnderLoad(t *testing.T) {
+	env := NewTestEnv(t)
+
+	// Start background load using direct HTTP requests (not t.Fatal-based helpers)
+	const numWorkers = 5
+	const requestsPerWorker = 10
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < requestsPerWorker; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				body := fmt.Sprintf(`{"name":"load-%d-%d","type":"openai","baseURL":"https://api.example.com","apiKey":"sk-test","models":["gpt-4"]}`, idx, j)
+				req, err := http.NewRequest(http.MethodPost, env.URL("/api/admin/providers"), bytes.NewBufferString(body))
+				if err != nil {
+					continue
+				}
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+env.Token)
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					continue // ignore connection errors in load goroutines
+				}
+				resp.Body.Close()
+			}
+		}(i)
+	}
+
+	// While load is running, verify health check always responds
+	const numHealthChecks = 10
+	var healthSuccess atomic.Int32
+
+	for i := 0; i < numHealthChecks; i++ {
+		resp, err := http.Get(env.URL("/health"))
+		if err == nil && resp.StatusCode == http.StatusOK {
+			healthSuccess.Add(1)
+			resp.Body.Close()
+		} else if resp != nil {
+			resp.Body.Close()
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	if healthSuccess.Load() != numHealthChecks {
+		t.Fatalf("Health check failed under load: %d/%d succeeded", healthSuccess.Load(), numHealthChecks)
+	}
+}
+
+func TestDBStability_ConcurrentReadsAndWrites(t *testing.T) {
+	env := NewTestEnv(t)
+
+	const numWriters = 10
+	const numReaders = 20
+	var wg sync.WaitGroup
+	var writeSuccess atomic.Int32
+	var readSuccess atomic.Int32
+
+	// Writers
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			provider := map[string]any{
+				"name":    fmt.Sprintf("rw-provider-%d", idx),
+				"type":    "openai",
+				"baseURL": fmt.Sprintf("https://api%d.example.com", idx),
+				"apiKey":  fmt.Sprintf("sk-test-%d", idx),
+				"models":  []string{"gpt-4"},
+			}
+			r := env.AdminPost("/api/admin/providers", provider)
+			if r.StatusCode == http.StatusCreated {
+				writeSuccess.Add(1)
+			}
+			r.Body.Close()
+		}(i)
+	}
+
+	// Readers (concurrent with writers)
+	wg.Add(numReaders)
+	for i := 0; i < numReaders; i++ {
+		go func() {
+			defer wg.Done()
+			r := env.AdminGet("/api/admin/providers")
+			if r.StatusCode == http.StatusOK {
+				readSuccess.Add(1)
+			}
+			r.Body.Close()
+		}()
+	}
+
+	wg.Wait()
+
+	if writeSuccess.Load() != numWriters {
+		t.Fatalf("Expected all %d writes to succeed, got %d", numWriters, writeSuccess.Load())
+	}
+	if readSuccess.Load() != numReaders {
+		t.Fatalf("Expected all %d reads to succeed, got %d", numReaders, readSuccess.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- Fix deadlock in `tryEnqueueBroadcast`: removed `log.Printf` from the drop path, which was called from within `WebSocketLogWriter.Write()` (already inside `log.Printf` holding the log mutex). Go's `sync.Mutex` is not reentrant, causing permanent deadlock.
- Add semaphore (`cooldownSem`) to bound concurrent `handleAsyncCooldownUpdate` goroutines to 10, preventing unbounded goroutine spawning on 429 errors.

## Root Cause

```
log.Printf() → log.mu.Lock() [acquired]
  → WebSocketLogWriter.Write()
    → hub.BroadcastLog()
      → tryEnqueueBroadcast()
        → channel full → default branch
          → log.Printf() → log.mu.Lock() [DEADLOCK]
```

All handlers using `LoggingMiddleware` hang (`/`, `/api/*`). `/health` is unaffected because `LoggingMiddleware` skips it.

## Test plan

- [x] `TestWebSocketLogWriter_NoDeadlockOnFullChannel` — directly reproduces the deadlock scenario
- [x] `TestWebSocketHub_BroadcastDrop_IncrementsCounter` — verifies drop counter still works
- [x] All existing WebSocket, handler, and e2e tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了并发处理中的潜在死锁问题
  * 优化了并发更新的资源管理，防止goroutine泄漏

* **Tests**
  * 新增数据库稳定性测试
  * 新增并发操作场景验证

<!-- end of auto-generated comment: release notes by coderabbit.ai -->