### PR TITLE
fix: resolve #341-普通用户不显示「用户管理」Tab及页面，并做好路由鉴权拦截

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,11 +23,12 @@ import { StatsPage } from '@/pages/stats';
 import { ModelMappingsPage } from '@/pages/model-mappings';
 import { ModelPricesPage } from '@/pages/model-prices';
 import { UsersPage } from '@/pages/users';
+import { AdminRoute } from '@/components/auth/admin-route';
 import { AuthProvider, useAuth } from '@/lib/auth-context';
 
 function AppRoutes() {
   const { t } = useTranslation();
-  const { isAuthenticated, isLoading, authEnabled, login, user } = useAuth();
+  const { isAuthenticated, isLoading, login } = useAuth();
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -53,8 +54,6 @@ function AppRoutes() {
     return <LoginPage onSuccess={login} />;
   }
 
-  const isAdmin = !user || user.role === 'admin';
-
   return (
     <BrowserRouter>
       <Routes>
@@ -78,7 +77,14 @@ function AppRoutes() {
           <Route path="routing-strategies" element={<RoutingStrategiesPage />} />
           <Route path="stats" element={<StatsPage />} />
           <Route path="settings" element={<SettingsPage />} />
-          {isAdmin && authEnabled && <Route path="users" element={<UsersPage />} />}
+          <Route
+            path="users"
+            element={
+              <AdminRoute>
+                <UsersPage />
+              </AdminRoute>
+            }
+          />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/src/components/auth/admin-route.tsx
+++ b/web/src/components/auth/admin-route.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/lib/auth-context';
+
+interface AdminRouteProps {
+  children: ReactNode;
+}
+
+export function AdminRoute({ children }: AdminRouteProps) {
+  const { t } = useTranslation();
+  const { authEnabled, user, isLoading } = useAuth();
+
+  if (isLoading || (authEnabled && !user)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <span className="text-muted-foreground">{t('common.loading')}</span>
+      </div>
+    );
+  }
+
+  if (authEnabled && user.role !== 'admin') {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
Summary

  - 新增 AdminRoute 组件：在鉴权加载/用户未就绪时展示加载态，非管理员跳转到首页
  - 将 UsersPage 路由统一改为使用 AdminRoute 包裹，移除 App.tsx 里内联的管理员判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了用户管理页面的访问权限控制机制，确保仅拥有管理员权限的用户可以访问该页面

* **Improvements**
  * 改进了路由守卫的实现方式，增强了身份验证流程的安全性和可靠性，并优化了加载状态的处理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->