### PR TITLE
feat: add eye icon to toggle provider key/token visibility

### DIFF
--- a/web/src/components/ui/chart.tsx
+++ b/web/src/components/ui/chart.tsx
@@ -182,7 +182,7 @@ function ChartTooltipContent({
 
             return (
               <div
-                key={item.dataKey}
+                key={item.dataKey as string}
                 className={cn(
                   '[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5',
                   indicator === 'dot' && 'items-center',

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -27,6 +27,8 @@
     "refresh": "Refresh",
     "copy": "Copy",
     "copied": "Copied",
+    "show": "Show",
+    "hide": "Hide",
     "saving": "Saving...",
     "saved": "Saved",
     "clientType": "Client Type",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -27,6 +27,8 @@
     "refresh": "刷新",
     "copy": "复制",
     "copied": "已复制",
+    "show": "显示",
+    "hide": "隐藏",
     "saving": "保存中...",
     "saved": "已保存",
     "clientType": "客户端类型",

--- a/web/src/pages/providers/components/antigravity-provider-view.tsx
+++ b/web/src/pages/providers/components/antigravity-provider-view.tsx
@@ -12,6 +12,8 @@ import {
   Zap,
   Copy,
   Check,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ClientIcon } from '@/components/icons/client-icons';
@@ -276,6 +278,7 @@ export function AntigravityProviderView({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tokenCopied, setTokenCopied] = useState(false);
+  const [showToken, setShowToken] = useState(false);
   const updateProvider = useUpdateProvider();
 
   const [useCLIProxyAPI, setUseCLIProxyAPI] = useState(
@@ -441,8 +444,15 @@ export function AntigravityProviderView({
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="font-mono text-sm text-foreground bg-card px-2 py-1 rounded border border-border/50 flex-1 truncate">
-                      {provider.config.antigravity.refreshToken.slice(0, 20)}...
+                      {showToken ? provider.config.antigravity.refreshToken : `${provider.config.antigravity.refreshToken.slice(0, 20)}...`}
                     </div>
+                    <button
+                      onClick={() => setShowToken(!showToken)}
+                      className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                      title={showToken ? t('common.hide') : t('common.show')}
+                    >
+                      {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
                     <button
                       onClick={handleCopyToken}
                       className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"

--- a/web/src/pages/providers/components/claude-provider-view.tsx
+++ b/web/src/pages/providers/components/claude-provider-view.tsx
@@ -13,6 +13,8 @@ import {
   AlertCircle,
   Copy,
   Check,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -218,6 +220,7 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tokenCopied, setTokenCopied] = useState(false);
+  const [showToken, setShowToken] = useState(false);
 
   const config = provider.config?.claude;
   const updateProvider = useUpdateProvider();
@@ -329,8 +332,15 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="font-mono text-sm text-foreground bg-card px-2 py-1 rounded border border-border/50 flex-1 truncate">
-                      {config.refreshToken.slice(0, 30)}...
+                      {showToken ? config.refreshToken : `${config.refreshToken.slice(0, 30)}...`}
                     </div>
+                    <button
+                      onClick={() => setShowToken(!showToken)}
+                      className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                      title={showToken ? t('common.hide') : t('common.show')}
+                    >
+                      {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
                     <button
                       onClick={handleCopyToken}
                       className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"

--- a/web/src/pages/providers/components/codex-provider-view.tsx
+++ b/web/src/pages/providers/components/codex-provider-view.tsx
@@ -16,6 +16,8 @@ import {
   Gauge,
   Copy,
   Check,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
@@ -347,6 +349,7 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
   const [usageLoading, setUsageLoading] = useState(false);
   const [usageError, setUsageError] = useState<string | null>(null);
   const [tokenCopied, setTokenCopied] = useState(false);
+  const [showToken, setShowToken] = useState(false);
 
   const config = provider.config?.codex;
   const updateProvider = useUpdateProvider();
@@ -602,8 +605,15 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
                   </div>
                   <div className="flex items-center gap-2">
                     <div className="font-mono text-sm text-foreground bg-card px-2 py-1 rounded border border-border/50 flex-1 truncate">
-                      {config.refreshToken.slice(0, 30)}...
+                      {showToken ? config.refreshToken : `${config.refreshToken.slice(0, 30)}...`}
                     </div>
+                    <button
+                      onClick={() => setShowToken(!showToken)}
+                      className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                      title={showToken ? t('common.hide') : t('common.show')}
+                    >
+                      {showToken ? <EyeOff size={16} /> : <Eye size={16} />}
+                    </button>
                     <button
                       onClick={handleCopyToken}
                       className="p-1.5 rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -1,4 +1,5 @@
-import { Globe, ChevronLeft, Key, Check, Plus, Trash2, ArrowRight } from 'lucide-react';
+import { useState } from 'react';
+import { Globe, ChevronLeft, Key, Check, Plus, Trash2, ArrowRight, Eye, EyeOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
 import type { ClientType, CreateProviderData } from '@/lib/transport';
@@ -12,6 +13,7 @@ import { useProviderForm } from '../context/provider-form-context';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
 
 export function CustomConfigStep() {
+  const [showApiKey, setShowApiKey] = useState(false);
   const { t } = useTranslation();
   const {
     formData,
@@ -174,13 +176,23 @@ export function CustomConfigStep() {
                       <span>{t('provider.apiKey')}</span>
                     </div>
                   </label>
-                  <Input
-                    type="password"
-                    value={formData.apiKey}
-                    onChange={(e) => updateFormData({ apiKey: e.target.value })}
-                    placeholder={t('provider.keyPlaceholder')}
-                    className="w-full"
-                  />
+                  <div className="relative">
+                    <Input
+                      type={showApiKey ? 'text' : 'password'}
+                      value={formData.apiKey}
+                      onChange={(e) => updateFormData({ apiKey: e.target.value })}
+                      placeholder={t('provider.keyPlaceholder')}
+                      className="w-full pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      tabIndex={-1}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -10,6 +10,8 @@ import {
   ArrowRight,
   Zap,
   Filter,
+  Eye,
+  EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -304,6 +306,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     });
   };
 
+  const [showApiKey, setShowApiKey] = useState(false);
   const [formData, setFormData] = useState<EditFormData>({
     name: provider.name,
     baseURL: provider.config?.custom?.baseURL || '',
@@ -660,13 +663,23 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                       <span>{t('provider.apiKeyEdit')}</span>
                     </div>
                   </label>
-                  <Input
-                    type="password"
-                    value={formData.apiKey}
-                    onChange={(e) => setFormData((prev) => ({ ...prev, apiKey: e.target.value }))}
-                    placeholder={t('provider.keyPlaceholder')}
-                    className="w-full"
-                  />
+                  <div className="relative">
+                    <Input
+                      type={showApiKey ? 'text' : 'password'}
+                      value={formData.apiKey}
+                      onChange={(e) => setFormData((prev) => ({ ...prev, apiKey: e.target.value }))}
+                      placeholder={t('provider.keyPlaceholder')}
+                      className="w-full pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      tabIndex={-1}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Add Eye/EyeOff toggle icons to reveal or hide sensitive credentials across all provider views
- Claude, Codex, Antigravity provider refresh tokens: click eye to show full token (default: truncated with `...`)
- Custom provider create/edit: click eye to toggle API key between password dots and plaintext
- Add `common.show` / `common.hide` i18n keys (en + zh)
- Fix pre-existing TS2322 in `chart.tsx` (`dataKey` type cast)

## Test plan
- [x] Docker build + Playwright E2E verified with screenshots
- [ ] Verify eye toggle works on Claude/Codex/Antigravity provider detail pages
- [ ] Verify eye toggle works on custom provider create and edit pages
- [ ] Verify i18n tooltip text shows correctly in EN and ZH

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* 添加了令牌和API密钥的可见性切换功能。用户现在可以在多个提供商配置页面中，点击按钮来显示或隐藏完整的敏感信息，平衡安全性与可用性。

## 国际化
* 为英文和中文语言包添加了"显示"和"隐藏"本地化字符串条目，以支持新的可见性切换功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->