### PR TITLE
Add GPT-5.4 model pricing and test cases

### DIFF
--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -116,6 +116,15 @@ func TestCalculator_Calculate(t *testing.T) {
 			wantZero: false,
 		},
 		{
+			name:  "gpt-5.4 basic",
+			model: "gpt-5.4",
+			metrics: &usage.Metrics{
+				InputTokens:  50_000,
+				OutputTokens: 5_000,
+			},
+			wantZero: false,
+		},
+		{
 			name:  "gemini-2.5-pro basic",
 			model: "gemini-2.5-pro",
 			metrics: &usage.Metrics{
@@ -216,6 +225,7 @@ func TestPriceTable_Get_PrefixMatch(t *testing.T) {
 		{"gpt-5.1-codex", true},
 		{"gpt-5.2", true},
 		{"gpt-5.3", true},
+		{"gpt-5.4", true},
 		{"gemini-2.5-pro", true},
 		{"gemini-2.5-flash", true},
 		{"gemini-3-pro-preview", true},

--- a/internal/pricing/default_prices.go
+++ b/internal/pricing/default_prices.go
@@ -276,6 +276,14 @@ func initDefaultPrices() *PriceTable {
 		CacheReadPriceMicro: 175_000,    // $0.175/M
 	})
 
+	// gpt-5.4: input=$2.50, cache_read=$0.25, output=$15
+	pt.Set(&ModelPricing{
+		ModelID:             "gpt-5.4",
+		InputPriceMicro:     2_500_000,  // $2.50/M
+		OutputPriceMicro:    15_000_000, // $15.00/M
+		CacheReadPriceMicro: 250_000,    // $0.25/M
+	})
+
 	// ========== GPT-4o 系列 ==========
 	// gpt-4o: input=$2.50, output=$10, cache_read=$1.25
 	pt.Set(&ModelPricing{


### PR DESCRIPTION
This pull request adds support for the new `gpt-5.4` model to the pricing calculator, including its pricing details and relevant test coverage. The changes ensure that the calculator recognizes `gpt-5.4` and applies the correct pricing.

**Support for new model:**

* Added pricing details for `gpt-5.4` to the `PriceTable` in `default_prices.go`, specifying input, output, and cache read prices.

**Test coverage:**

* Added a test case for `gpt-5.4` in `TestCalculator_Calculate` to verify calculation logic for the new model.
* Updated prefix match tests in `TestPriceTable_Get_PrefixMatch` to include `gpt-5.4`, ensuring the model is recognized by prefix matching logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加对 GPT-5.4 模型的支持并配置完整定价：输入 $2.50/百万 tokens，输出 $15.00/百万 tokens，缓存读取 $0.25/百万 tokens。

* **测试**
  * 添加覆盖 GPT-5.4 的定价与计费测试用例，验证在典型输入/输出容量下产生非零费用并确保前缀匹配查找生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->