### PR TITLE
chore(web): pin web engines.node to 22.11.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.7.0",
   "engines": {
-    "node": ">=22.11.0 <23"
+    "node": "22.11.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- pin @web/package.json engines.node to 22.11.0 to match .nvmrc/.node-version
- avoid minor version drift (e.g., 22.12/22.13) during installs

## Testing
- not run (metadata only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项**
  * Node.js 引擎版本要求已更新为 22.11.0（精确版本指定）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->