### PR TITLE
fix: separate Codex quotas by account identity

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -651,7 +651,7 @@ type CodexRateLimitInfo struct {
 	SecondaryWindow *CodexQuotaWindow `json:"secondaryWindow,omitempty"`
 }
 
-// Codex 账户配额（基于邮箱存储）
+// Codex 账户配额（优先按 account_id 区分，回退到 email）
 type CodexQuota struct {
 	ID        uint64    `json:"id"`
 	CreatedAt time.Time `json:"createdAt"`
@@ -663,7 +663,10 @@ type CodexQuota struct {
 	// 所属租户
 	TenantID uint64 `json:"tenantID"`
 
-	// 邮箱作为唯一标识
+	// 配额身份键：优先 account:<account_id>，否则 email:<email>
+	IdentityKey string `json:"identityKey"`
+
+	// 邮箱（展示和回退匹配用）
 	Email string `json:"email"`
 
 	// 账户 ID
@@ -683,6 +686,18 @@ type CodexQuota struct {
 
 	// 代码审查限流
 	CodeReviewWindow *CodexQuotaWindow `json:"codeReviewWindow,omitempty"`
+}
+
+func CodexQuotaIdentityKey(email, accountID string) string {
+	accountID = strings.TrimSpace(accountID)
+	if accountID != "" {
+		return "account:" + accountID
+	}
+	email = strings.TrimSpace(email)
+	if email != "" {
+		return "email:" + email
+	}
+	return ""
 }
 
 // Provider 统计信息

--- a/internal/handler/codex.go
+++ b/internal/handler/codex.go
@@ -603,10 +603,11 @@ func (h *CodexHandler) GetBatchQuotas(ctx context.Context) (*CodexBatchQuotaResu
 
 		config := provider.Config.Codex
 		email := config.Email
+		identityKey := domain.CodexQuotaIdentityKey(config.Email, config.AccountID)
 
 		// 优先从数据库获取缓存的配额（无论是否过期）
-		if email != "" && h.quotaRepo != nil {
-			cachedQuota, err := h.quotaRepo.GetByEmail(tenantID, email)
+		if identityKey != "" && h.quotaRepo != nil {
+			cachedQuota, err := h.quotaRepo.GetByIdentityKey(tenantID, identityKey)
 			if err == nil && cachedQuota != nil {
 				result.Quotas[provider.ID] = h.domainQuotaToResponse(cachedQuota)
 				continue
@@ -680,11 +681,12 @@ func (h *CodexHandler) isTokenExpired(expiresAt string) bool {
 
 // saveQuotaToDB saves Codex quota to database
 func (h *CodexHandler) saveQuotaToDB(email, accountID, planType string, usage *codex.CodexUsageResponse, isForbidden bool) {
-	if h.quotaRepo == nil || email == "" {
+	if h.quotaRepo == nil || domain.CodexQuotaIdentityKey(email, accountID) == "" {
 		return
 	}
 
 	quota := &domain.CodexQuota{
+		IdentityKey: domain.CodexQuotaIdentityKey(email, accountID),
 		Email:       email,
 		AccountID:   accountID,
 		PlanType:    planType,

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -191,8 +191,10 @@ type AntigravityQuotaRepository interface {
 }
 
 type CodexQuotaRepository interface {
-	// Upsert 更新或插入配额（基于邮箱）
+	// Upsert 更新或插入配额（优先基于 identityKey，其次回退邮箱）
 	Upsert(quota *domain.CodexQuota) error
+	// GetByIdentityKey 根据身份键获取配额
+	GetByIdentityKey(tenantID uint64, identityKey string) (*domain.CodexQuota, error)
 	// GetByEmail 根据邮箱获取配额
 	GetByEmail(tenantID uint64, email string) (*domain.CodexQuota, error)
 	// List 获取所有配额

--- a/internal/repository/sqlite/codex_quota.go
+++ b/internal/repository/sqlite/codex_quota.go
@@ -17,19 +17,27 @@ func NewCodexQuotaRepository(d *DB) *CodexQuotaRepository {
 
 func (r *CodexQuotaRepository) Upsert(quota *domain.CodexQuota) error {
 	now := time.Now()
+	identityKey := domain.CodexQuotaIdentityKey(quota.Email, quota.AccountID)
+	quota.IdentityKey = identityKey
 
-	// Try to update first
-	result := tenantScope(r.db.gorm.Model(&CodexQuota{}), quota.TenantID).
-		Where("email = ? AND deleted_at = 0", quota.Email).
-		Updates(map[string]any{
-			"updated_at":          toTimestamp(now),
-			"account_id":          quota.AccountID,
-			"plan_type":           quota.PlanType,
-			"is_forbidden":        quota.IsForbidden,
-			"primary_window":      toJSON(quota.PrimaryWindow),
-			"secondary_window":    toJSON(quota.SecondaryWindow),
-			"code_review_window":  toJSON(quota.CodeReviewWindow),
-		})
+	query := tenantScope(r.db.gorm.Model(&CodexQuota{}), quota.TenantID)
+	if identityKey != "" {
+		query = query.Where("identity_key = ? AND deleted_at = 0", identityKey)
+	} else {
+		query = query.Where("email = ? AND deleted_at = 0", quota.Email)
+	}
+
+	result := query.Updates(map[string]any{
+		"updated_at":         toTimestamp(now),
+		"identity_key":       identityKey,
+		"email":              quota.Email,
+		"account_id":         quota.AccountID,
+		"plan_type":          quota.PlanType,
+		"is_forbidden":       quota.IsForbidden,
+		"primary_window":     toJSON(quota.PrimaryWindow),
+		"secondary_window":   toJSON(quota.SecondaryWindow),
+		"code_review_window": toJSON(quota.CodeReviewWindow),
+	})
 
 	if result.Error != nil {
 		return result.Error
@@ -51,6 +59,21 @@ func (r *CodexQuotaRepository) Upsert(quota *domain.CodexQuota) error {
 	quota.UpdatedAt = now
 
 	return nil
+}
+
+func (r *CodexQuotaRepository) GetByIdentityKey(tenantID uint64, identityKey string) (*domain.CodexQuota, error) {
+	if identityKey == "" {
+		return nil, nil
+	}
+	var model CodexQuota
+	err := tenantScope(r.db.gorm, tenantID).Where("identity_key = ? AND deleted_at = 0", identityKey).First(&model).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return r.toDomain(&model), nil
 }
 
 func (r *CodexQuotaRepository) GetByEmail(tenantID uint64, email string) (*domain.CodexQuota, error) {
@@ -94,6 +117,7 @@ func (r *CodexQuotaRepository) toModel(q *domain.CodexQuota) *CodexQuota {
 			DeletedAt: toTimestampPtr(q.DeletedAt),
 		},
 		TenantID:         q.TenantID,
+		IdentityKey:      q.IdentityKey,
 		Email:            q.Email,
 		AccountID:        q.AccountID,
 		PlanType:         q.PlanType,
@@ -111,6 +135,7 @@ func (r *CodexQuotaRepository) toDomain(m *CodexQuota) *domain.CodexQuota {
 		UpdatedAt:        fromTimestamp(m.UpdatedAt),
 		DeletedAt:        fromTimestampPtr(m.DeletedAt),
 		TenantID:         m.TenantID,
+		IdentityKey:      m.IdentityKey,
 		Email:            m.Email,
 		AccountID:        m.AccountID,
 		PlanType:         m.PlanType,

--- a/internal/repository/sqlite/codex_quota_test.go
+++ b/internal/repository/sqlite/codex_quota_test.go
@@ -1,0 +1,66 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestCodexQuotaRepository_UpsertUsesIdentityKey(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewCodexQuotaRepository(db)
+
+	quota1 := &domain.CodexQuota{
+		TenantID:  1,
+		Email:     "same@example.com",
+		AccountID: "acct-1",
+		PlanType:  "team",
+	}
+	if err := repo.Upsert(quota1); err != nil {
+		t.Fatalf("Upsert quota1 failed: %v", err)
+	}
+
+	quota2 := &domain.CodexQuota{
+		TenantID:  1,
+		Email:     "same@example.com",
+		AccountID: "acct-2",
+		PlanType:  "team",
+	}
+	if err := repo.Upsert(quota2); err != nil {
+		t.Fatalf("Upsert quota2 failed: %v", err)
+	}
+
+	quota1.PlanType = "team-updated"
+	if err := repo.Upsert(quota1); err != nil {
+		t.Fatalf("Upsert quota1 update failed: %v", err)
+	}
+
+	list, err := repo.List(1)
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 quota rows, got %d", len(list))
+	}
+
+	got1, err := repo.GetByIdentityKey(1, domain.CodexQuotaIdentityKey(quota1.Email, quota1.AccountID))
+	if err != nil {
+		t.Fatalf("GetByIdentityKey quota1 failed: %v", err)
+	}
+	if got1 == nil || got1.AccountID != "acct-1" || got1.PlanType != "team-updated" {
+		t.Fatalf("unexpected quota1 row: %#v", got1)
+	}
+
+	got2, err := repo.GetByIdentityKey(1, domain.CodexQuotaIdentityKey(quota2.Email, quota2.AccountID))
+	if err != nil {
+		t.Fatalf("GetByIdentityKey quota2 failed: %v", err)
+	}
+	if got2 == nil || got2.AccountID != "acct-2" {
+		t.Fatalf("unexpected quota2 row: %#v", got2)
+	}
+}

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -119,7 +119,7 @@ var migrations = []Migration{
 
 			// 2. Update all existing rows to belong to default tenant
 			for _, table := range tenantScopedTables {
-				result := db.Exec("UPDATE "+table+" SET tenant_id = 1 WHERE tenant_id = 0 OR tenant_id IS NULL")
+				result := db.Exec("UPDATE " + table + " SET tenant_id = 1 WHERE tenant_id = 0 OR tenant_id IS NULL")
 				if result.Error != nil {
 					log.Printf("[Migration] Warning: Failed to update tenant_id for %s: %v", table, result.Error)
 					// Continue with other tables
@@ -208,6 +208,87 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     7,
+		Description: "Make Codex quota identity account-aware to avoid same-email quota collisions",
+		Up: func(db *gorm.DB) error {
+			var backfillSQL string
+			switch db.Dialector.Name() {
+			case "mysql":
+				backfillSQL = `
+					UPDATE codex_quotas
+					SET identity_key = CASE
+						WHEN account_id IS NOT NULL AND TRIM(account_id) != '' THEN CONCAT('account:', TRIM(account_id))
+						WHEN email IS NOT NULL AND TRIM(email) != '' THEN CONCAT('email:', TRIM(email))
+						ELSE NULL
+					END
+					WHERE identity_key IS NULL OR TRIM(identity_key) = ''
+				`
+			default:
+				backfillSQL = `
+					UPDATE codex_quotas
+					SET identity_key = CASE
+						WHEN account_id IS NOT NULL AND TRIM(account_id) != '' THEN 'account:' || TRIM(account_id)
+						WHEN email IS NOT NULL AND TRIM(email) != '' THEN 'email:' || TRIM(email)
+						ELSE NULL
+					END
+					WHERE identity_key IS NULL OR TRIM(identity_key) = ''
+				`
+			}
+			if err := db.Exec(backfillSQL).Error; err != nil {
+				return err
+			}
+
+			switch db.Dialector.Name() {
+			case "mysql":
+				if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+					return err
+				}
+				if err := db.Exec("CREATE INDEX idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+					return err
+				}
+				if err := db.Exec("CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+					return err
+				}
+			default:
+				if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
+					return err
+				}
+				if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
+					return err
+				}
+				if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)").Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Down: func(db *gorm.DB) error {
+			switch db.Dialector.Name() {
+			case "mysql":
+				if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_identity ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+					return err
+				}
+				if err := db.Exec("DROP INDEX idx_codex_quotas_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+					return err
+				}
+				if err := db.Exec("CREATE UNIQUE INDEX idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+					return err
+				}
+			default:
+				if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
+					return err
+				}
+				if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_email").Error; err != nil {
+					return err
+				}
+				if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)").Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 func isMySQLDuplicateIndexError(err error) bool {
@@ -221,6 +302,18 @@ func isMySQLDuplicateIndexError(err error) bool {
 	// 兜底：错误可能被包装成字符串，避免使用过宽的 "duplicate" 匹配导致吞掉其它错误。
 	lower := strings.ToLower(err.Error())
 	return strings.Contains(lower, "duplicate key name") || strings.Contains(lower, "error 1061")
+}
+
+func isMySQLMissingIndexError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var mysqlErr *mysqlDriver.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1091 // ER_CANT_DROP_FIELD_OR_KEY
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "can't drop") && strings.Contains(lower, "check that column/key exists")
 }
 
 // RunMigrations 运行所有待执行的迁移

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -21,3 +21,15 @@ func TestIsMySQLDuplicateIndexError(t *testing.T) {
 		t.Fatalf("expected false for unrelated error")
 	}
 }
+
+func TestIsMySQLMissingIndexError(t *testing.T) {
+	if !isMySQLMissingIndexError(&mysqlDriver.MySQLError{Number: 1091, Message: "Can't DROP"}) {
+		t.Fatalf("expected true for ER_CANT_DROP_FIELD_OR_KEY(1091)")
+	}
+	if !isMySQLMissingIndexError(errors.New("Error 1091: Can't DROP 'idx_x'; check that column/key exists")) {
+		t.Fatalf("expected true for missing index string match fallback")
+	}
+	if isMySQLMissingIndexError(errors.New("some other error")) {
+		t.Fatalf("expected false for unrelated error")
+	}
+}

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -249,8 +249,9 @@ func (AntigravityQuota) TableName() string { return "antigravity_quotas" }
 // CodexQuota model
 type CodexQuota struct {
 	SoftDeleteModel
-	TenantID         uint64 `gorm:"uniqueIndex:idx_codex_quotas_tenant_email"`
-	Email            string `gorm:"size:255;uniqueIndex:idx_codex_quotas_tenant_email"`
+	TenantID         uint64 `gorm:"uniqueIndex:idx_codex_quotas_tenant_identity"`
+	IdentityKey      string `gorm:"size:255;column:identity_key;uniqueIndex:idx_codex_quotas_tenant_identity"`
+	Email            string `gorm:"size:255;index:idx_codex_quotas_email"`
 	AccountID        string `gorm:"size:128;column:account_id"`
 	PlanType         string `gorm:"size:64"`
 	IsForbidden      int

--- a/internal/service/codex_task.go
+++ b/internal/service/codex_task.go
@@ -205,12 +205,13 @@ func (s *CodexTaskService) isTokenExpired(expiresAt string) bool {
 
 // saveQuotaToDB saves Codex quota to database
 func (s *CodexTaskService) saveQuotaToDB(tenantID uint64, email, accountID, planType string, usage *codex.CodexUsageResponse, isForbidden bool) {
-	if s.quotaRepo == nil || email == "" {
+	if s.quotaRepo == nil || domain.CodexQuotaIdentityKey(email, accountID) == "" {
 		return
 	}
 
 	quota := &domain.CodexQuota{
 		TenantID:    tenantID,
+		IdentityKey: domain.CodexQuotaIdentityKey(email, accountID),
 		Email:       email,
 		AccountID:   accountID,
 		PlanType:    planType,
@@ -303,9 +304,11 @@ func (s *CodexTaskService) autoSortRoutesForTenant(ctx context.Context, tenantID
 	}
 	log.Printf("[CodexTask] Tenant %d: found %d quotas in database", tenantID, len(quotas))
 
-	quotaByEmail := make(map[string]*domain.CodexQuota)
+	quotaByIdentity := make(map[string]*domain.CodexQuota)
 	for _, q := range quotas {
-		quotaByEmail[q.Email] = q
+		if key := domain.CodexQuotaIdentityKey(q.Email, q.AccountID); key != "" {
+			quotaByIdentity[key] = q
+		}
 	}
 
 	// Collect all unique scopes
@@ -320,7 +323,7 @@ func (s *CodexTaskService) autoSortRoutesForTenant(ctx context.Context, tenantID
 
 	var allUpdates []domain.RoutePositionUpdate
 	for sc := range scopes {
-		updates := s.sortRoutesForScope(routes, providerMap, quotaByEmail, sc.clientType, sc.projectID)
+		updates := s.sortRoutesForScope(routes, providerMap, quotaByIdentity, sc.clientType, sc.projectID)
 		allUpdates = append(allUpdates, updates...)
 	}
 
@@ -340,7 +343,7 @@ func (s *CodexTaskService) autoSortRoutesForTenant(ctx context.Context, tenantID
 func (s *CodexTaskService) sortRoutesForScope(
 	routes []*domain.Route,
 	providerMap map[uint64]*domain.Provider,
-	quotaByEmail map[string]*domain.CodexQuota,
+	quotaByIdentity map[string]*domain.CodexQuota,
 	clientType domain.ClientType,
 	projectID uint64,
 ) []domain.RoutePositionUpdate {
@@ -380,8 +383,8 @@ func (s *CodexTaskService) sortRoutesForScope(
 		var remainingPercent *float64
 
 		if provider.Config != nil && provider.Config.Codex != nil {
-			email := provider.Config.Codex.Email
-			if quota := quotaByEmail[email]; quota != nil && !quota.IsForbidden {
+			identityKey := domain.CodexQuotaIdentityKey(provider.Config.Codex.Email, provider.Config.Codex.AccountID)
+			if quota := quotaByIdentity[identityKey]; quota != nil && !quota.IsForbidden {
 				resetTime, remainingPercent = s.getSortKey(quota)
 			}
 		}


### PR DESCRIPTION
## Summary
- store and read Codex quota cache by an account-aware identity key
- prefer `account:<account_id>` and fall back to `email:<email>` for older providers
- migrate existing `codex_quotas` rows and indexes to the new identity key

## Why
- multiple Codex OAuth accounts can share the same email
- the current email-only key causes quota cache collisions and identical 5h/weekly quota display

## Validation
- added repository test for same-email different-account upsert behavior
- added migration helper test for missing-index handling
- verified targeted packages compile and targeted sqlite tests pass

## Notes
- this keeps email for display and compatibility fallback
- when `accountId` is unavailable, behavior remains email-based as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 配额身份识别改为基于“身份键”（优先使用账户ID，回退到邮箱），提高多账户场景下的配额关联与分辨能力
  * 配额检索与路由排序改为按身份键进行，提升配额匹配准确性

* **基础设施**
  * 数据库模式更新以支持身份键与新的配额窗口字段
  * 增量迁移脚本用于平滑回填与索引调整

* **测试**
  * 新增迁移与存取行为相关的单元测试验证身份键逻辑
<!-- end of auto-generated comment: release notes by coderabbit.ai -->