### PR TITLE
fix: propagate codex retry-after hints

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -869,7 +869,9 @@ func applyRateLimitRetryHints(proxyErr *domain.ProxyError, resp *http.Response, 
 
 	if rateLimitInfo != nil && !rateLimitInfo.QuotaResetTime.IsZero() {
 		until := rateLimitInfo.QuotaResetTime
-		proxyErr.CooldownUntil = &until
+		if proxyErr.CooldownUntil == nil {
+			proxyErr.CooldownUntil = &until
+		}
 		if proxyErr.RetryAfter <= 0 {
 			if retryAfter := time.Until(until); retryAfter > 0 {
 				proxyErr.RetryAfter = retryAfter
@@ -892,7 +894,7 @@ func parseRetryAfterHeader(value string) (time.Duration, *time.Time) {
 		if delay > 0 {
 			return delay, &t
 		}
-		return 0, &t
+		return 0, nil
 	}
 	return 0, nil
 }

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -12,8 +12,9 @@ func TestApplyRateLimitRetryHintsUsesRetryAfterHeader(t *testing.T) {
 	proxyErr := &domain.ProxyError{}
 	resp := &http.Response{Header: make(http.Header)}
 	resp.Header.Set("Retry-After", "3")
+	now := time.Now()
 	rateLimitInfo := &domain.RateLimitInfo{
-		QuotaResetTime: time.Now().Add(10 * time.Second),
+		QuotaResetTime: now.Add(10 * time.Second),
 	}
 
 	applyRateLimitRetryHints(proxyErr, resp, rateLimitInfo)
@@ -23,6 +24,20 @@ func TestApplyRateLimitRetryHintsUsesRetryAfterHeader(t *testing.T) {
 	}
 	if proxyErr.CooldownUntil == nil {
 		t.Fatal("CooldownUntil should be set")
+	}
+	untilDelta := proxyErr.CooldownUntil.Sub(now)
+	if untilDelta < 2*time.Second || untilDelta > 4*time.Second {
+		t.Fatalf("CooldownUntil delta = %v, want derived from Retry-After header", untilDelta)
+	}
+}
+
+func TestParseRetryAfterHeaderSkipsExpiredHTTPDate(t *testing.T) {
+	retryAfter, until := parseRetryAfterHeader(time.Now().Add(-1 * time.Minute).UTC().Format(http.TimeFormat))
+	if retryAfter != 0 {
+		t.Fatalf("RetryAfter = %v, want 0", retryAfter)
+	}
+	if until != nil {
+		t.Fatalf("CooldownUntil = %v, want nil", *until)
 	}
 }
 

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -322,14 +322,22 @@ func writeProxyError(w http.ResponseWriter, err *domain.ProxyError) {
 func writeStreamError(w http.ResponseWriter, err *domain.ProxyError) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
-	if err.RetryAfter > 0 {
-		sec := int64(err.RetryAfter.Seconds())
+	retryAfter := err.RetryAfter
+	if retryAfter <= 0 && err.CooldownUntil != nil {
+		retryAfter = time.Until(*err.CooldownUntil)
+	}
+	if retryAfter > 0 {
+		sec := int64(retryAfter.Seconds())
 		if sec <= 0 {
 			sec = 1
 		}
 		w.Header().Set("Retry-After", strconv.FormatInt(sec, 10))
 	}
-	w.WriteHeader(http.StatusOK)
+	statusCode := http.StatusOK
+	if err.HTTPStatusCode >= 400 && err.HTTPStatusCode < 600 {
+		statusCode = err.HTTPStatusCode
+	}
+	w.WriteHeader(statusCode)
 
 	errorEvent := map[string]interface{}{
 		"type": "error",

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,7 +46,45 @@ func TestWriteProxyErrorPreservesStatusAndRetryAfter(t *testing.T) {
 	if rec.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTooManyRequests)
 	}
-	if got := rec.Header().Get("Retry-After"); got == "" {
+	got := rec.Header().Get("Retry-After")
+	if got == "" {
 		t.Fatal("expected Retry-After header")
+	}
+	sec, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatalf("Retry-After = %q, parse error: %v", got, err)
+	}
+	if sec < 1 || sec > 2 {
+		t.Fatalf("Retry-After = %d, want 1 or 2", sec)
+	}
+}
+
+func TestWriteStreamErrorPreservesStatusAndRetryAfter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	until := time.Now().Add(2 * time.Second)
+	writeStreamError(rec, &domain.ProxyError{
+		Err:            domain.ErrUpstreamError,
+		Message:        "upstream returned status 429",
+		Retryable:      true,
+		HTTPStatusCode: http.StatusTooManyRequests,
+		CooldownUntil:  &until,
+	})
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusTooManyRequests)
+	}
+	got := rec.Header().Get("Retry-After")
+	if got == "" {
+		t.Fatal("expected Retry-After header")
+	}
+	sec, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatalf("Retry-After = %q, parse error: %v", got, err)
+	}
+	if sec < 1 || sec > 2 {
+		t.Fatalf("Retry-After = %d, want 1 or 2", sec)
+	}
+	if !strings.Contains(rec.Body.String(), `"type":"error"`) {
+		t.Fatalf("stream body = %q, want error event", rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

Fix Codex requests routed through custom providers so upstream 429 retry hints are preserved instead of being dropped.

## Changes

- propagate `Retry-After` / reset-time hints from custom-provider 429 responses into `proxyErr.RetryAfter` and `proxyErr.CooldownUntil`
- parse nested structured reset timestamps from upstream error bodies as a fallback when `Retry-After` is absent
- preserve upstream HTTP status in proxy error responses and return `Retry-After` to the client
- add focused tests for custom-provider rate limit hint propagation and proxy error response headers

## Testing

- `go test ./internal/adapter/provider/custom ./internal/handler`

Fixes #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复和改进**
  * 优化限流提示：在遇到 429 时提供更准确的重试延迟和冷却截止时间
  * 支持从响应体结构化数据提取限流重置时间
  * 仅在计算出正向重试时间时发送 Retry-After 头
  * 代理错误响应现在可采用上游返回的有效 HTTP 状态码，以反映更精确的错误状态
<!-- end of auto-generated comment: release notes by coderabbit.ai -->