### PR TITLE
feat: redesign sidebar user identity display

### DIFF
--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -317,7 +317,9 @@ export function NavUser() {
     : t('nav.accountFallback');
   const tenantLabel = user?.tenantName?.trim()
     ? user.tenantName.trim()
-    : t('nav.tenantFallback', { id: user?.tenantID ?? 1 });
+    : user?.tenantID && user.tenantID > 0
+      ? t('nav.tenantFallback', { id: user.tenantID })
+      : t('nav.tenantUnknown');
   const accountName = username || t('nav.accountFallback');
   const accountStatusLabel = authEnabled
     ? t('nav.accountStatusProtected')

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -90,6 +90,7 @@
     "accountStatusLocal": "Local",
     "accountIdentityUnknown": "Identity unavailable",
     "tenantFallback": "Workspace #{{id}}",
+    "tenantUnknown": "Workspace unavailable",
     "identityMaskUser": "UID {{value}}",
     "identityMaskTenant": "TID {{value}}",
     "switchAccount": "Switch Account",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -90,6 +90,7 @@
     "accountStatusLocal": "本地",
     "accountIdentityUnknown": "身份信息不可用",
     "tenantFallback": "工作区 #{{id}}",
+    "tenantUnknown": "工作区信息不可用",
     "identityMaskUser": "用户 {{value}}",
     "identityMaskTenant": "租户 {{value}}",
     "switchAccount": "切换账号",


### PR DESCRIPTION
Fixes #347

## Design review

I do **not** think the previous sidebar user-area design was reasonable for multi-account/admin scenarios:

- it only exposed the username in the expanded sidebar, so identity recognition was too weak
- role and tenant context were buried in the dropdown instead of being visible at a glance
- account/security actions existed nearby, but the structure was not clearly grouped
- missing identity data had weak fallbacks, which made multi-account states harder to distinguish

## Redesign

This PR redesigns the sidebar user section around **quick identity recognition + safe grouped actions**.

### What changed

- enrich the sidebar user card with:
  - display name
  - role + tenant/workspace line
  - masked identity line (`UID` / `TID`)
  - auth status badge (`Protected` / `Local`)
- make the collapsed tooltip show the same identity summary instead of only a username
- widen and restructure the dropdown menu header to show the same identity summary
- group menu actions into clearer sections:
  - `Account`
  - `Security`
  - `System`
- add a clear `Switch Account` entry (implemented by returning to the login flow via logout)
- add fallbacks for missing username / tenant information
- keep identifiers masked instead of dumping raw internal IDs in the sidebar

## Why this is better

- current identity becomes recognizable much faster in multi-account contexts
- role / tenant / status stop being hidden metadata
- account/security/logout entry points become easier to scan
- missing data no longer collapses the UI into a vague single-line name chip

## Testing

- `pnpm -C web exec tsc --noEmit`
- `pnpm -C web exec eslint src/components/layout/app-sidebar/nav-user.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 侧边栏用户信息界面改进，展示账户状态和身份标识
  * 账户菜单新增切换账户、安全设置、密钥管理、密码修改等功能选项
  * 补充英文和中文本地化文案支持

<!-- end of auto-generated comment: release notes by coderabbit.ai -->