### PR TITLE
fix: harden codex quota identity migration

### DIFF
--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -318,7 +318,13 @@ func dedupeCodexQuotaIdentityRows(db *gorm.DB) error {
 			JOIN codex_quotas AS keeper
 			  ON doomed.tenant_id = keeper.tenant_id
 			 AND doomed.identity_key = keeper.identity_key
-			 AND doomed.id > keeper.id
+			 AND (
+				COALESCE(keeper.updated_at, 0) > COALESCE(doomed.updated_at, 0)
+				OR (
+					COALESCE(keeper.updated_at, 0) = COALESCE(doomed.updated_at, 0)
+					AND keeper.id < doomed.id
+				)
+			 )
 			WHERE doomed.identity_key IS NOT NULL
 			  AND TRIM(doomed.identity_key) != ''
 		`).Error
@@ -331,7 +337,13 @@ func dedupeCodexQuotaIdentityRows(db *gorm.DB) error {
 				JOIN codex_quotas AS keeper
 				  ON doomed.tenant_id = keeper.tenant_id
 				 AND doomed.identity_key = keeper.identity_key
-				 AND doomed.id > keeper.id
+				 AND (
+					COALESCE(keeper.updated_at, 0) > COALESCE(doomed.updated_at, 0)
+					OR (
+						COALESCE(keeper.updated_at, 0) = COALESCE(doomed.updated_at, 0)
+						AND keeper.id < doomed.id
+					)
+				 )
 				WHERE doomed.identity_key IS NOT NULL
 				  AND TRIM(doomed.identity_key) != ''
 			)

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -117,11 +117,11 @@ func prepareCodexQuotaDedupeFixture(t *testing.T, gormDB *gorm.DB) {
 		t.Fatalf("create table: %v", err)
 	}
 	inserts := []string{
-		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id) VALUES (1, 'account:acct-1', 'first@example.com', 'acct-1')`,
-		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id) VALUES (1, 'account:acct-1', 'second@example.com', 'acct-1')`,
-		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id) VALUES (1, 'account:acct-2', 'third@example.com', 'acct-2')`,
-		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id) VALUES (2, 'account:acct-1', 'other-tenant@example.com', 'acct-1')`,
-		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id) VALUES (1, NULL, 'legacy@example.com', '')`,
+		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id, updated_at) VALUES (1, 'account:acct-1', 'first@example.com', 'acct-1', 100)`,
+		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id, updated_at) VALUES (1, 'account:acct-1', 'second@example.com', 'acct-1', 200)`,
+		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id, updated_at) VALUES (1, 'account:acct-2', 'third@example.com', 'acct-2', 150)`,
+		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id, updated_at) VALUES (2, 'account:acct-1', 'other-tenant@example.com', 'acct-1', 120)`,
+		`INSERT INTO codex_quotas (tenant_id, identity_key, email, account_id, updated_at) VALUES (1, NULL, 'legacy@example.com', '', 90)`,
 	}
 	for _, sql := range inserts {
 		if err := gormDB.Exec(sql).Error; err != nil {


### PR DESCRIPTION
## Summary

This hotfix addresses a startup/deploy regression risk in the Codex quota identity migration introduced by #418 and shipped in v0.12.40.

## Root cause

The migration that switches Codex quotas from `(tenant_id, email)` uniqueness to `(tenant_id, identity_key)` backfills `identity_key` and then creates a new unique index.

That is unsafe for historical data where multiple rows can collapse to the same computed identity key (for example, same account ID with different emails). In that case:

- creating `idx_codex_quotas_tenant_identity` can fail
- on MySQL the previous DDL order can also leave the DB in a half-migrated state because the old unique index was dropped too early
- startup can fail, which can surface upstream as `502 Bad Gateway`

## Fix

- dedupe historical `codex_quotas` rows by `(tenant_id, identity_key)` before creating the new unique index
  - keep a single canonical row per identity
  - preserve rows from other tenants
  - preserve rows with `NULL` identity keys
- create the new `(tenant_id, identity_key)` unique index **before** dropping the old `(tenant_id, email)` unique index
- only recreate the plain email index after the new unique index succeeds

## Regression test

- add `TestDedupeCodexQuotaIdentityRows` to verify duplicate historical identity rows are collapsed without touching other-tenant rows or `NULL` identities

## Testing

- `go test ./internal/repository/sqlite ./internal/service/... ./internal/handler/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 清理并合并配额表中按租户与身份键重复的记录，保留空身份键条目并调整索引以提升数据一致性与查询稳定性。
* **Tests**
  * 新增迁移与去重相关单元测试，覆盖迁移前后数据与索引状态，增强回归保护。
* **Refactor**
  * 集中并规范了配额身份的迁移流程，新增迁移版本以提升迁移可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->