### PR TITLE
 fix(sqlite): 修复 Codex quota 身份迁移在软删除历史数据下的唯一约束冲突

### DIFF
--- a/internal/repository/sqlite/db_test.go
+++ b/internal/repository/sqlite/db_test.go
@@ -26,6 +26,11 @@ func TestNewDBWithDSN_CodexQuotaMigrationHandlesDuplicateHistoricalIdentities(t 
 	if err != nil {
 		t.Fatalf("open seed db: %v", err)
 	}
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		t.Fatalf("get seed sql.DB: %v", err)
+	}
+	defer sqlDB.Close()
 
 	seedSQL := []string{
 		`CREATE TABLE codex_quotas (
@@ -67,5 +72,74 @@ func TestNewDBWithDSN_CodexQuotaMigrationHandlesDuplicateHistoricalIdentities(t 
 	}
 	if count != 1 {
 		t.Fatalf("expected duplicate historical identity rows to collapse to 1, got %d", count)
+	}
+}
+
+func TestNewDBWithDSN_CodexQuotaMigrationPreservesDeletedHistory(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "codex-quota-deleted-history.db")
+	gormDB, err := gorm.Open(gormsqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		t.Fatalf("get seed sql.DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	seedSQL := []string{
+		`CREATE TABLE codex_quotas (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER DEFAULT 0,
+			updated_at INTEGER DEFAULT 0,
+			deleted_at INTEGER DEFAULT 0,
+			tenant_id INTEGER NOT NULL,
+			identity_key TEXT,
+			email TEXT,
+			account_id TEXT,
+			plan_type TEXT,
+			is_forbidden INTEGER DEFAULT 0,
+			primary_window TEXT,
+			secondary_window TEXT,
+			code_review_window TEXT
+		)`,
+		`CREATE UNIQUE INDEX idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-deleted', 1, NULL, 'old@example.com', 'acct-1', 111, 100)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-active', 1, NULL, 'current@example.com', 'acct-1', 0, 200)`,
+	}
+	for _, sql := range seedSQL {
+		if err := gormDB.Exec(sql).Error; err != nil {
+			t.Fatalf("seed fixture: %v", err)
+		}
+	}
+
+	db, err := NewDBWithDSN("sqlite://" + dsn)
+	if err != nil {
+		t.Fatalf("NewDBWithDSN should preserve deleted history while migrating: %v", err)
+	}
+	defer db.Close()
+
+	var activeCount int64
+	if err := db.GormDB().Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1 AND identity_key = 'account:acct-1' AND deleted_at = 0
+	`).Scan(&activeCount).Error; err != nil {
+		t.Fatalf("count active rows: %v", err)
+	}
+	if activeCount != 1 {
+		t.Fatalf("expected one active row after migration, got %d", activeCount)
+	}
+
+	var deletedCount int64
+	if err := db.GormDB().Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1 AND identity_key = 'account:acct-1' AND deleted_at != 0
+	`).Scan(&deletedCount).Error; err != nil {
+		t.Fatalf("count deleted rows: %v", err)
+	}
+	if deletedCount != 1 {
+		t.Fatalf("expected deleted row to be preserved after migration, got %d", deletedCount)
 	}
 }

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -276,30 +276,7 @@ func applyCodexQuotaIdentityMigration(db *gorm.DB) error {
 	if err := dedupeCodexQuotaIdentityRows(db); err != nil {
 		return err
 	}
-
-	switch db.Dialector.Name() {
-	case "mysql":
-		if err := db.Exec("CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
-			return err
-		}
-		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
-			return err
-		}
-		if err := db.Exec("CREATE INDEX idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
-			return err
-		}
-	default:
-		if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)").Error; err != nil {
-			return err
-		}
-		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
-			return err
-		}
-		if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
-			return err
-		}
-	}
-	return nil
+	return ensureCodexQuotaIdentityIndexes(db)
 }
 
 func revertCodexQuotaIdentityMigration(db *gorm.DB) error {
@@ -318,6 +295,7 @@ func dedupeCodexQuotaIdentityRows(db *gorm.DB) error {
 			JOIN codex_quotas AS keeper
 			  ON doomed.tenant_id = keeper.tenant_id
 			 AND doomed.identity_key = keeper.identity_key
+			 AND COALESCE(doomed.deleted_at, 0) = COALESCE(keeper.deleted_at, 0)
 			 AND (
 				COALESCE(keeper.updated_at, 0) > COALESCE(doomed.updated_at, 0)
 				OR (
@@ -337,6 +315,7 @@ func dedupeCodexQuotaIdentityRows(db *gorm.DB) error {
 				JOIN codex_quotas AS keeper
 				  ON doomed.tenant_id = keeper.tenant_id
 				 AND doomed.identity_key = keeper.identity_key
+				 AND COALESCE(doomed.deleted_at, 0) = COALESCE(keeper.deleted_at, 0)
 				 AND (
 					COALESCE(keeper.updated_at, 0) > COALESCE(doomed.updated_at, 0)
 					OR (
@@ -349,6 +328,59 @@ func dedupeCodexQuotaIdentityRows(db *gorm.DB) error {
 			)
 		`).Error
 	}
+}
+
+func ensureCodexQuotaIdentityIndexes(db *gorm.DB) error {
+	switch db.Dialector.Name() {
+	case "mysql":
+		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_identity ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+			return err
+		}
+		if err := db.Exec("CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key, deleted_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+			return err
+		}
+		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+			return err
+		}
+		if err := db.Exec("CREATE INDEX idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+			return err
+		}
+	case "postgres":
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
+			return err
+		}
+		if err := db.Exec(`
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity
+			ON codex_quotas(tenant_id, identity_key)
+			WHERE deleted_at = 0 AND identity_key IS NOT NULL AND TRIM(identity_key) != ''
+		`).Error; err != nil {
+			return err
+		}
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
+			return err
+		}
+		if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
+			return err
+		}
+	default:
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
+			return err
+		}
+		if err := db.Exec(`
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity
+			ON codex_quotas(tenant_id, identity_key)
+			WHERE deleted_at = 0 AND identity_key IS NOT NULL AND TRIM(identity_key) != ''
+		`).Error; err != nil {
+			return err
+		}
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
+			return err
+		}
+		if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func isMySQLDuplicateIndexError(err error) bool {

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -65,6 +65,44 @@ func TestCodexQuotaIdentityMigrationV8Up(t *testing.T) {
 	assertIndexMissing(t, gormDB, "idx_codex_quotas_tenant_email")
 }
 
+func TestCodexQuotaIdentityMigrationV8UpPreservesDeletedHistory(t *testing.T) {
+	gormDB := openRawSQLiteDB(t)
+	prepareCodexQuotaMigrationFixtureWithDeletedHistory(t, gormDB)
+
+	migration := findMigrationByVersion(t, 8)
+	if err := migration.Up(gormDB); err != nil {
+		t.Fatalf("run migration v8 up with deleted history: %v", err)
+	}
+
+	var activeCount int64
+	if err := gormDB.Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1
+		  AND identity_key = 'account:acct-1'
+		  AND deleted_at = 0
+	`).Scan(&activeCount).Error; err != nil {
+		t.Fatalf("count active rows: %v", err)
+	}
+	if activeCount != 1 {
+		t.Fatalf("expected one active row to remain, got %d", activeCount)
+	}
+
+	var deletedCount int64
+	if err := gormDB.Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1
+		  AND identity_key = 'account:acct-1'
+		  AND deleted_at != 0
+	`).Scan(&deletedCount).Error; err != nil {
+		t.Fatalf("count deleted rows: %v", err)
+	}
+	if deletedCount != 1 {
+		t.Fatalf("expected deleted historical row to be preserved, got %d", deletedCount)
+	}
+}
+
 func TestCodexQuotaIdentityMigrationV8DownReturnsIrreversibleError(t *testing.T) {
 	gormDB := openRawSQLiteDB(t)
 	prepareCodexQuotaMigrationFixture(t, gormDB)
@@ -89,6 +127,13 @@ func openRawSQLiteDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open raw sqlite db: %v", err)
 	}
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		t.Fatalf("get raw sqlite sql.DB: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = sqlDB.Close()
+	})
 	return gormDB
 }
 
@@ -163,6 +208,45 @@ func prepareCodexQuotaMigrationFixture(t *testing.T, gormDB *gorm.DB) {
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-3', 1, NULL, 'third@example.com', 'acct-2', 150)`,
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-4', 2, NULL, 'other-tenant@example.com', 'acct-1', 120)`,
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-5', 1, NULL, 'legacy@example.com', '', 90)`,
+	}
+	for _, sql := range inserts {
+		if err := gormDB.Exec(sql).Error; err != nil {
+			t.Fatalf("insert fixture: %v", err)
+		}
+	}
+}
+
+func prepareCodexQuotaMigrationFixtureWithDeletedHistory(t *testing.T, gormDB *gorm.DB) {
+	t.Helper()
+	if err := gormDB.Exec(`DROP TABLE IF EXISTS codex_quotas`).Error; err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	if err := gormDB.Exec(`
+		CREATE TABLE codex_quotas (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER DEFAULT 0,
+			updated_at INTEGER DEFAULT 0,
+			deleted_at INTEGER DEFAULT 0,
+			tenant_id INTEGER NOT NULL,
+			identity_key TEXT,
+			email TEXT,
+			account_id TEXT,
+			plan_type TEXT,
+			is_forbidden INTEGER DEFAULT 0,
+			primary_window TEXT,
+			secondary_window TEXT,
+			code_review_window TEXT
+		)
+	`).Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if err := gormDB.Exec(`CREATE UNIQUE INDEX idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)`).Error; err != nil {
+		t.Fatalf("create old unique index: %v", err)
+	}
+	inserts := []string{
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-deleted', 1, NULL, 'old@example.com', 'acct-1', 111, 100)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-active', 1, NULL, 'current@example.com', 'acct-1', 0, 200)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-other', 1, NULL, 'other@example.com', 'acct-2', 0, 150)`,
 	}
 	for _, sql := range inserts {
 		if err := gormDB.Exec(sql).Error; err != nil {


### PR DESCRIPTION
  ## 背景 / 问题

  部分老库在启动时会因为迁移失败直接退出，日志类似：

  `UNIQUE constraint failed: codex_quotas.tenant_id, codex_quotas.identity_key (2067)`

  触发条件是 `codex_quotas` 表里同时存在：
  - 一条活跃记录（`deleted_at = 0`）
  - 一条软删除历史记录（`deleted_at != 0`）

  且它们共享同一个 `(tenant_id, identity_key)`。

  ## 根因

  旧的身份迁移与去重逻辑把 `(tenant_id, identity_key)` 当成“全表唯一”，并且去重只按这两个字段分组。

  但真实数据里“同一 identity 在活跃记录 + 软删除历史记录同时存在”是合法的，导致：
  - 去重会把历史与活跃混到一个集合里
  - 在建唯一索引/约束时出现冲突，从而迁移失败

  ## 修复内容

  - 去重逻辑改为按以下维度分组：
    - `tenant_id`
    - `identity_key`
    - `deleted_at`（`COALESCE` 后参与分组）

    这样软删除历史不会和活跃记录互相影响。

  - 唯一性约束调整为“只约束活跃行”：
    - SQLite/Postgres：使用 partial unique index，仅对活跃行生效（同时过滤空/空白 identity）
    - MySQL：唯一索引改为 `(tenant_id, identity_key, deleted_at)`，语义同样是“活跃唯一，历史保留”

  - 补充回归测试：
    - 覆盖“软删除历史 + 活跃 quota 同 identity”的迁移场景
    - 覆盖 `NewDBWithDSN` 启动路径（真实 on-disk SQLite DB 夹具）

  ## 验证

  关键回归用例连续跑 15 次稳定通过：

  ```bash
  go test ./internal/repository/sqlite -run "Test(NewDBWithDSN_CodexQuotaMigrationPreservesDeletedHistory|
  CodexQuotaIdentityMigrationV8UpPreservesDeletedHistory)" -count=1

  额外相关用例集合通过：

  go test ./internal/repository/sqlite -run "Test(NewDBWithDSN_CodexQuotaMigration|CodexQuotaIdentityMigrationV8|CodexQuotaRepository_UpsertUsesIdentityKey|
  DedupeCodexQuotaIdentityRows)" -count=1

  ## 风险评估

  低风险：改动聚焦在 Codex quota 身份迁移/索引逻辑，并且新增了针对该数据形态的回归测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug Fixes**
  * 改进了数据库迁移对软删除记录的处理，确保在配额数据迁移过程中保留已删除的历史记录。

* **Tests**
  * 增强了数据库迁移测试覆盖率，包括软删除场景验证和资源管理优化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->