### PR TITLE
fix(sqlite): 修复 Codex quota 迁移在旧 identity 唯一索引下的启动失败

### DIFF
--- a/internal/repository/sqlite/db_test.go
+++ b/internal/repository/sqlite/db_test.go
@@ -143,3 +143,77 @@ func TestNewDBWithDSN_CodexQuotaMigrationPreservesDeletedHistory(t *testing.T) {
 		t.Fatalf("expected deleted row to be preserved after migration, got %d", deletedCount)
 	}
 }
+
+func TestNewDBWithDSN_CodexQuotaMigrationHandlesPreexistingIdentityIndex(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), "codex-quota-preexisting-identity-index.db")
+	gormDB, err := gorm.Open(gormsqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	sqlDB, err := gormDB.DB()
+	if err != nil {
+		t.Fatalf("get seed sql.DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	seedSQL := []string{
+		`CREATE TABLE codex_quotas (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER DEFAULT 0,
+			updated_at INTEGER DEFAULT 0,
+			deleted_at INTEGER DEFAULT 0,
+			tenant_id INTEGER NOT NULL,
+			identity_key TEXT,
+			email TEXT,
+			account_id TEXT,
+			plan_type TEXT,
+			is_forbidden INTEGER DEFAULT 0,
+			primary_window TEXT,
+			secondary_window TEXT,
+			code_review_window TEXT
+		)`,
+		`CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)`,
+		`CREATE UNIQUE INDEX idx_codex_quotas_email ON codex_quotas(email)`,
+		`CREATE UNIQUE INDEX idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-8', 1, NULL, 'cnc6n2io9xvfev2mtm5t6hu8@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456445476)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-11', 1, NULL, 'fcew8ua8r6u6zekrwqfi60nl@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456444987)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-7', 1, NULL, 'puckxqnzu6ktt7k4bcevlw06@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456443639)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-9', 1, NULL, 'n7e87dj5hxv2c2m4u0e6l5zo@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456443366)`,
+	}
+	for _, sql := range seedSQL {
+		if err := gormDB.Exec(sql).Error; err != nil {
+			t.Fatalf("seed fixture: %v", err)
+		}
+	}
+
+	db, err := NewDBWithDSN("sqlite://" + dsn)
+	if err != nil {
+		t.Fatalf("NewDBWithDSN should survive preexisting identity index: %v", err)
+	}
+	defer db.Close()
+
+	var count int64
+	if err := db.GormDB().Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1 AND identity_key = 'account:e94ce011-80f4-490b-b285-d3109db72b0e' AND deleted_at = 0
+	`).Scan(&count).Error; err != nil {
+		t.Fatalf("count migrated rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected rows to collapse to one active account identity, got %d", count)
+	}
+
+	var rows []struct {
+		Name   string `gorm:"column:name"`
+		Unique int    `gorm:"column:unique"`
+	}
+	if err := db.GormDB().Raw(`PRAGMA index_list('codex_quotas')`).Scan(&rows).Error; err != nil {
+		t.Fatalf("list indexes: %v", err)
+	}
+	for _, row := range rows {
+		if row.Name == "idx_codex_quotas_email" && row.Unique != 0 {
+			t.Fatalf("expected idx_codex_quotas_email to be recreated as non-unique, got unique=%d", row.Unique)
+		}
+	}
+}

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -247,6 +247,9 @@ func applyCodexQuotaIdentityMigration(db *gorm.DB) error {
 	if !db.Migrator().HasColumn(&CodexQuota{}, "identity_key") {
 		return nil
 	}
+	if err := dropCodexQuotaIdentityIndexesBeforeBackfill(db); err != nil {
+		return err
+	}
 	if err := db.Exec(codexQuotaIdentityBackfillSQL(db.Dialector.Name())).Error; err != nil {
 		return err
 	}
@@ -339,22 +342,19 @@ func codexQuotaIdentityDedupeSQL(dialector string) string {
 func ensureCodexQuotaIdentityIndexes(db *gorm.DB) error {
 	switch db.Dialector.Name() {
 	case "mysql":
-		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_identity ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
-			return err
-		}
 		if err := db.Exec("CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key, deleted_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
 			return err
 		}
 		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
 			return err
 		}
+		if err := db.Exec("DROP INDEX idx_codex_quotas_email ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+			return err
+		}
 		if err := db.Exec("CREATE INDEX idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
 			return err
 		}
 	case "postgres":
-		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
-			return err
-		}
 		if err := db.Exec(`
 			CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity
 			ON codex_quotas(tenant_id, identity_key)
@@ -363,15 +363,15 @@ func ensureCodexQuotaIdentityIndexes(db *gorm.DB) error {
 			return err
 		}
 		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
+			return err
+		}
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_email").Error; err != nil {
 			return err
 		}
 		if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
 			return err
 		}
 	default:
-		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
-			return err
-		}
 		if err := db.Exec(`
 			CREATE UNIQUE INDEX IF NOT EXISTS idx_codex_quotas_tenant_identity
 			ON codex_quotas(tenant_id, identity_key)
@@ -382,7 +382,28 @@ func ensureCodexQuotaIdentityIndexes(db *gorm.DB) error {
 		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_email").Error; err != nil {
 			return err
 		}
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_email").Error; err != nil {
+			return err
+		}
 		if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_codex_quotas_email ON codex_quotas(email)").Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dropCodexQuotaIdentityIndexesBeforeBackfill(db *gorm.DB) error {
+	switch db.Dialector.Name() {
+	case "mysql":
+		if err := db.Exec("DROP INDEX idx_codex_quotas_tenant_identity ON codex_quotas").Error; err != nil && !isMySQLMissingIndexError(err) {
+			return err
+		}
+	case "postgres":
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
+			return err
+		}
+	default:
+		if err := db.Exec("DROP INDEX IF EXISTS idx_codex_quotas_tenant_identity").Error; err != nil {
 			return err
 		}
 	}

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -103,6 +103,33 @@ func TestCodexQuotaIdentityMigrationV8UpPreservesDeletedHistory(t *testing.T) {
 	}
 }
 
+func TestCodexQuotaIdentityMigrationV8UpHandlesPreexistingIdentityIndex(t *testing.T) {
+	gormDB := openRawSQLiteDB(t)
+	prepareCodexQuotaMigrationFixtureWithPreexistingIdentityIndex(t, gormDB)
+
+	migration := findMigrationByVersion(t, 8)
+	if err := migration.Up(gormDB); err != nil {
+		t.Fatalf("run migration v8 up with preexisting identity index: %v", err)
+	}
+
+	var count int64
+	if err := gormDB.Raw(`
+		SELECT COUNT(*)
+		FROM codex_quotas
+		WHERE tenant_id = 1
+		  AND identity_key = 'account:e94ce011-80f4-490b-b285-d3109db72b0e'
+		  AND deleted_at = 0
+	`).Scan(&count).Error; err != nil {
+		t.Fatalf("count migrated rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected preexisting index collision rows to collapse to 1, got %d", count)
+	}
+	assertIndexExists(t, gormDB, "idx_codex_quotas_tenant_identity", true)
+	assertIndexExists(t, gormDB, "idx_codex_quotas_email", false)
+	assertIndexMissing(t, gormDB, "idx_codex_quotas_tenant_email")
+}
+
 func TestCodexQuotaIdentityMigrationV8DownReturnsIrreversibleError(t *testing.T) {
 	gormDB := openRawSQLiteDB(t)
 	prepareCodexQuotaMigrationFixture(t, gormDB)
@@ -285,6 +312,52 @@ func prepareCodexQuotaMigrationFixtureWithDeletedHistory(t *testing.T, gormDB *g
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-deleted', 1, NULL, 'old@example.com', 'acct-1', 111, 100)`,
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-active', 1, NULL, 'current@example.com', 'acct-1', 0, 200)`,
 		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, deleted_at, updated_at) VALUES ('row-other', 1, NULL, 'other@example.com', 'acct-2', 0, 150)`,
+	}
+	for _, sql := range inserts {
+		if err := gormDB.Exec(sql).Error; err != nil {
+			t.Fatalf("insert fixture: %v", err)
+		}
+	}
+}
+
+func prepareCodexQuotaMigrationFixtureWithPreexistingIdentityIndex(t *testing.T, gormDB *gorm.DB) {
+	t.Helper()
+	if err := gormDB.Exec(`DROP TABLE IF EXISTS codex_quotas`).Error; err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	if err := gormDB.Exec(`
+		CREATE TABLE codex_quotas (
+			id TEXT PRIMARY KEY,
+			created_at INTEGER DEFAULT 0,
+			updated_at INTEGER DEFAULT 0,
+			deleted_at INTEGER DEFAULT 0,
+			tenant_id INTEGER NOT NULL,
+			identity_key TEXT,
+			email TEXT,
+			account_id TEXT,
+			plan_type TEXT,
+			is_forbidden INTEGER DEFAULT 0,
+			primary_window TEXT,
+			secondary_window TEXT,
+			code_review_window TEXT
+		)
+	`).Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if err := gormDB.Exec(`CREATE UNIQUE INDEX idx_codex_quotas_tenant_identity ON codex_quotas(tenant_id, identity_key)`).Error; err != nil {
+		t.Fatalf("create legacy identity index: %v", err)
+	}
+	if err := gormDB.Exec(`CREATE UNIQUE INDEX idx_codex_quotas_email ON codex_quotas(email)`).Error; err != nil {
+		t.Fatalf("create broken email index: %v", err)
+	}
+	if err := gormDB.Exec(`CREATE UNIQUE INDEX idx_codex_quotas_tenant_email ON codex_quotas(tenant_id, email)`).Error; err != nil {
+		t.Fatalf("create legacy tenant email index: %v", err)
+	}
+	inserts := []string{
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-8', 1, NULL, 'cnc6n2io9xvfev2mtm5t6hu8@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456445476)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-11', 1, NULL, 'fcew8ua8r6u6zekrwqfi60nl@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456444987)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-7', 1, NULL, 'puckxqnzu6ktt7k4bcevlw06@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456443639)`,
+		`INSERT INTO codex_quotas (id, tenant_id, identity_key, email, account_id, updated_at) VALUES ('row-9', 1, NULL, 'n7e87dj5hxv2c2m4u0e6l5zo@example.com', 'e94ce011-80f4-490b-b285-d3109db72b0e', 1773456443366)`,
 	}
 	for _, sql := range inserts {
 		if err := gormDB.Exec(sql).Error; err != nil {


### PR DESCRIPTION
  ## 问题

  部分老库启动时会在 `v8` 迁移失败：

  `UNIQUE constraint failed: codex_quotas.tenant_id, codex_quotas.identity_key`

  根因不是单纯的数据重复，而是库里已经存在旧的 `idx_codex_quotas_tenant_identity` 唯一索引。
  `v8` 在回填 `identity_key` 时，多条同账号记录会先更新成同一个 `account:...`，结果在 dedupe 之前就被旧索引拦住，导致启动失败。

  ## 修复

  - 回填 `identity_key` 之前，先移除旧的 `idx_codex_quotas_tenant_identity`
  - 回填完成后执行 dedupe
  - 最后按新规则重建 identity 索引
  - 同时修正半失败状态下遗留的错误唯一 `idx_codex_quotas_email`

  ## 验证

  通过 targeted tests：

  ```bash
  go test ./internal/repository/sqlite -run "Test(CodexQuotaIdentityMigrationV8UpHandlesPreexistingIdentityIndex|
  NewDBWithDSN_CodexQuotaMigrationHandlesPreexistingIdentityIndex|NewDBWithDSN_CodexQuotaMigration|CodexQuotaIdentityMigrationV8|
  DedupeCodexQuotaIdentityRows)" -count=1

  并使用真实 maxx.db 副本重复重放启动迁移，v8/v9 均成功完成，迁移后重复 identity 分组为 0。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Tests**
  * 添加了数据库迁移路径的测试，验证在现有索引状态下的数据完整性处理
  * 新增迁移场景测试，确保重复记录的正确合并

* **Chores**
  * 改进了数据库索引管理逻辑，增强了迁移过程的稳定性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->