### PR TITLE
fix: preserve copied proxy link scheme

### DIFF
--- a/web/src/components/layout/nav-proxy-status.tsx
+++ b/web/src/components/layout/nav-proxy-status.tsx
@@ -5,6 +5,7 @@ import { useSidebar } from '@/components/ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
+import { buildProxyBaseUrl } from '@/lib/codex-config';
 
 export function NavProxyStatus() {
   const { t } = useTranslation();
@@ -13,7 +14,7 @@ export function NavProxyStatus() {
   const [copied, setCopied] = useState(false);
 
   const proxyAddress = proxyStatus?.address ?? '...';
-  const fullUrl = `http://${proxyAddress}`;
+  const fullUrl = proxyStatus?.address ? buildProxyBaseUrl(proxyStatus) : '...';
   const isCollapsed = state === 'collapsed';
   const versionDisplay = proxyStatus?.version ?? '...';
   const handleCopy = async () => {


### PR DESCRIPTION
# Summary
- fix the top-left proxy copy link so it no longer hard-codes `http://`
- reuse the same scheme-aware proxy URL builder used by the documentation page

# Changes
- update `web/src/components/layout/nav-proxy-status.tsx`
- replace the hard-coded `http://${proxyAddress}` copy target with `buildProxyBaseUrl(proxyStatus)`
- keep sidebar copy behavior aligned with documentation quickstart URL generation

# Tests
- `cd web && pnpm build` ✅

# Risks
- Low: small frontend-only change that only affects the copied proxy URL in the sidebar status widget

# Follow-ups
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 改进了代理状态URL的动态构建方式，确保URL显示更加准确和一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->