### PR TITLE
fix: 恢复侧边栏左下角为紧凑单行用户信息

### DIFF
--- a/tests/e2e/playwright/sidebar-user-footer.spec.ts
+++ b/tests/e2e/playwright/sidebar-user-footer.spec.ts
@@ -1,0 +1,17 @@
+﻿import { expect, test } from 'playwright/test';
+
+import { loginToAdminUI } from './helpers';
+
+test.describe.configure({ mode: 'serial' });
+
+test('expanded sidebar footer keeps compact single-line user chip', async ({ page }) => {
+  await loginToAdminUI(page);
+
+  const menuButton = page.locator('button[title="Menu"]');
+  await expect(menuButton).toBeVisible({ timeout: 10000 });
+
+  const footerCard = menuButton.locator('xpath=ancestor::div[contains(@class, "rounded-xl")]');
+  await expect(footerCard).toContainText(/admin/i);
+  await expect(footerCard).not.toContainText(/受保护|Protected/);
+  await expect(footerCard).not.toContainText(/用户 .*租户|UID .*TID/);
+});

--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -340,9 +340,7 @@ export function NavUser() {
   const displayUserFallback = (displayUser.name || 'U').slice(0, 2).toUpperCase();
   const menuDisplayName = displayUser.name || 'Maxx';
   const menuDisplayFallback = menuDisplayName.slice(0, 2).toUpperCase();
-  const accountTitle = [displayUser.name, displayUser.subtitle, displayUser.identity]
-    .filter(Boolean)
-    .join(' · ');
+  const accountTitle = displayUser.name || undefined;
 
   return (
     <SidebarMenu>
@@ -426,42 +424,22 @@ export function NavUser() {
                 )}
               />
               <TooltipContent side={isMobile ? 'top' : 'right'} align="center">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-medium">{displayUser.name}</span>
-                    <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                      {displayUser.status}
-                    </span>
-                  </div>
-                  <div className="text-[11px] text-muted-foreground">{displayUser.subtitle}</div>
-                  <div className="text-[10px] text-muted-foreground/80">{displayUser.identity}</div>
-                </div>
+                <span className="text-xs font-medium">{displayUser.name}</span>
               </TooltipContent>
             </Tooltip>
           ) : (
             <div
-              className="flex min-w-0 flex-1 items-center gap-2 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 py-1.5"
+              className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2"
               title={accountTitle}
             >
-              <Avatar className="h-7 w-7 rounded-lg">
+              <Avatar className="h-6 w-6 rounded-lg">
                 <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
                 <AvatarFallback className="rounded-lg text-[10px]">
                   {displayUserFallback}
                 </AvatarFallback>
               </Avatar>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="block truncate text-xs font-medium">{displayUser.name}</span>
-                  <span className="rounded-full bg-sidebar px-1.5 py-0.5 text-[9px] font-medium text-sidebar-foreground/75">
-                    {displayUser.status}
-                  </span>
-                </div>
-                <span className="block truncate text-[11px] text-sidebar-foreground/75">
-                  {displayUser.subtitle}
-                </span>
-                <span className="block truncate text-[10px] text-sidebar-foreground/55">
-                  {displayUser.identity}
-                </span>
+              <div className="min-w-0">
+                <span className="block truncate text-xs font-medium">{displayUser.name}</span>
               </div>
             </div>
           )}


### PR DESCRIPTION
## 背景

  最近侧边栏左下角用户区域的样式改版后，原本紧凑的一行用户信息被扩展成了多行身份卡片，额外展示了：

  - `Protected`
  - 角色 / 租户信息
  - `UID` / `TID` 掩码信息

  这导致左下角 footer 视觉上明显变高，破坏了原本的紧凑布局，也就是这次反馈的样式错误问题。

  ## 问题原因

  问题不在整体 sidebar 布局系统，而在 `NavUser` 组件本身。

  这次改版把用户状态、身份摘要和掩码 ID 直接塞进了左下角 footer，使 footer 从“单行 chip”变成了“多行身份卡片”，导致：

  - 左下角区域高度异常增大
  - 信息密度过高
  - 与现有 sidebar 视觉层级不一致
  - 展开态 footer 样式偏离既有预期

  ## 本次修复

  本 PR 采用最小改动方案，直接把左下角 footer 恢复为原本的紧凑单行展示。

  具体包括：

  - 展开态 sidebar footer 只保留用户名
  - 折叠态 tooltip 只保留用户名
  - 将详细身份信息继续保留在 dropdown 菜单中，不再放进 footer
  - 保持现有 dropdown 能力不变，只修正 footer 展示层

  这样可以在不影响菜单详细信息的前提下，恢复左下角样式稳定性。

  ## 变更内容

  - 精简 `web/src/components/layout/app-sidebar/nav-user.tsx`
  - 移除 footer 中的 `Protected` / 角色租户 / `UID` / `TID` 展示
  - 恢复为单行用户名 chip
  - 新增 Playwright 回归测试，防止相同问题再次出现

  ## 验证

  已执行以下验证：

  - `pnpm --dir web typecheck`
  - `npm test -- sidebar-user-footer.spec.ts --project=e2e-chromium`

  结果：

  - `typecheck` 通过
  - Playwright 用例通过：`1 passed`

  另外已通过浏览器实际渲染确认：

  - 左下角 footer 恢复为紧凑单行
  - `Protected`
  - `UID`
  - `TID`

  均不再出现在 sidebar 左下角区域

  ## 影响范围

  本次修改仅影响侧边栏左下角用户 footer 的展示方式，不调整：

  - 用户 dropdown 菜单的详细信息
  - 登录逻辑
  - 用户信息来源
  - 其他 sidebar 导航项布局

  属于一次聚焦的样式回归修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **改进**
  * 简化侧边栏用户信息显示，仅显示用户名，移除冗余详情块以优化界面布局。

* **测试**
  * 新增端到端测试，验证管理界面用户信息显示的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->