### PR TITLE
fix: harden documentation quickstart shell quoting and clipboard copy

### DIFF
--- a/web/src/pages/documentation/index.tsx
+++ b/web/src/pages/documentation/index.tsx
@@ -518,8 +518,8 @@ function DocumentationSection() {
                 </p>
                 <CodeBlock
                   code={`claude_maxx() {
-    export ANTHROPIC_BASE_URL="${baseUrl}"
-    export ANTHROPIC_AUTH_TOKEN="${quickstartToken.trim() || 'maxx_your_token_here'}"
+    export ANTHROPIC_BASE_URL=${shellQuote(baseUrl)}
+    export ANTHROPIC_AUTH_TOKEN=${shellQuote(quickstartToken.trim() || 'maxx_your_token_here')}
     claude "$@"
 }`}
                   id="quickstart-claude-shell"


### PR DESCRIPTION
## Summary
- Apply `shellQuote()` consistently to all generated verify/oneliner commands across Claude, OpenAI, Codex, and Gemini clients to prevent shell injection with crafted tokens or URLs
- Make `copyToClipboard` async with a `textarea` fallback for non-secure contexts (HTTP)
- Use `useRef` to manage the copy feedback timer, preventing stale timeout leaks on rapid clicks
- Remove redundant `authJson` variable in Codex case, reuse `bundle.authJson` directly

## Test plan
- [x] Playwright `documentation-page.spec.ts` passes (tab switching, token input, diagnostics)
- [x] Visual verification of oneliner output for all 4 clients (Claude, OpenAI, Codex, Gemini)
- [ ] Manual: verify copy button works in both HTTPS and HTTP contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了复制到剪贴板的兼容性与稳定性：优先使用现代剪贴板 API，回退到兼容方案并加入防抖与错误处理。
  * 增强了代码片段中敏感参数的处理与错误日志记录。

* **Refactor**
  * 统一并安全化了示例命令中的 URL/令牌引用，减少拼接导致的问题。

* **Documentation**
  * 优化了快速开始和诊断指南中的示例显示与复制交互体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->