### PR TITLE
feat: release 支持版本号自动递增与预览

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
 name: Release
 
-run-name: Release ${{ inputs.version }}
+run-name: Release ${{ inputs.version != '' && inputs.version || 'auto' }}
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: '版本号 (例如: v1.0.0)'
-        required: true
+        description: '版本号 (例如: v1.0.0，留空则自动递增 patch)'
+        required: false
+        default: ''
         type: string
 
 jobs:
@@ -15,34 +16,78 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      resolved_version: ${{ steps.resolve-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version (manual or auto-increment)
+        id: resolve-version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          INPUT_VERSION="${{ inputs.version }}"
+          INPUT_VERSION="${INPUT_VERSION//[[:space:]]/}"
+
+          if [[ -n "$INPUT_VERSION" ]]; then
+            RESOLVED_VERSION="$INPUT_VERSION"
+            echo "Using manual version: $RESOLVED_VERSION"
+          else
+            git fetch --tags --force
+            LAST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+
+            if [[ -z "$LAST_TAG" ]]; then
+              RESOLVED_VERSION="v0.0.1"
+              echo "No existing semantic version tag found, defaulting to $RESOLVED_VERSION"
+            else
+              VERSION_PART="${LAST_TAG#v}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_PART"
+              PATCH=$((PATCH + 1))
+              RESOLVED_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+              echo "Auto increment from $LAST_TAG to $RESOLVED_VERSION"
+            fi
+          fi
+
+          echo "Resolved version: $RESOLVED_VERSION"
+          echo "version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release Version Preview"
+            echo ""
+            echo "- Input version: ${INPUT_VERSION:-<empty>}"
+            echo "- Resolved version: $RESOLVED_VERSION"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Validate version format
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          VERSION="${{ steps.resolve-version.outputs.version }}"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: 版本号格式不正确，应为 vX.Y.Z"
             exit 1
           fi
 
       - name: Check if tag exists
         run: |
-          if git rev-parse "${{ inputs.version }}" >/dev/null 2>&1; then
-            echo "Error: Tag ${{ inputs.version }} 已存在"
+          VERSION="${{ steps.resolve-version.outputs.version }}"
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag $VERSION 已存在"
             exit 1
           fi
 
       - name: Create tag
         run: |
-          git tag ${{ inputs.version }}
-          git push origin ${{ inputs.version }}
+          VERSION="${{ steps.resolve-version.outputs.version }}"
+          git tag "$VERSION"
+          git push origin "$VERSION"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.version }}
-          name: ${{ inputs.version }}
+          tag_name: ${{ steps.resolve-version.outputs.version }}
+          name: ${{ steps.resolve-version.outputs.version }}
           generate_release_notes: true
           draft: false
           prerelease: false
@@ -51,7 +96,7 @@ jobs:
     needs: release
     uses: ./.github/workflows/ci-docker-build.yml
     with:
-      tag: ${{ inputs.version }}
+      tag: ${{ needs.release.outputs.resolved_version }}
     permissions:
       contents: read
       packages: write
@@ -60,7 +105,7 @@ jobs:
     needs: release
     uses: ./.github/workflows/ci-wails-build.yml
     with:
-      tag: ${{ inputs.version }}
+      tag: ${{ needs.release.outputs.resolved_version }}
     permissions:
       contents: write
 
@@ -68,6 +113,6 @@ jobs:
     needs: wails-build
     uses: ./.github/workflows/update-homebrew.yml
     with:
-      tag: ${{ inputs.version }}
+      tag: ${{ needs.release.outputs.resolved_version }}
     secrets:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- make `Release` workflow `version` input optional
- auto-resolve version when input is empty by reading latest semantic tag and incrementing patch
- print resolved version preview to job summary before tagging
- keep manual override behavior and retain format/tag-exists checks
- pass resolved version to downstream build jobs via job output

## Why
- closes #354
- reduces manual release typo risk on high-frequency release path

## Notes
- if no existing semantic tag is found, defaults to `v0.0.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化了发布流程，现支持自动版本号解析和递增功能，可根据现有版本历史自动确定下一个版本号，无需手动指定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->