### PR TITLE
前置 PR 前后端校验并补齐生产构建检查

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,21 @@
-name: Lint
+name: PR Checks
 
 on:
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/lint.yml'
+      - '.node-version'
       - 'web/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'tests/**'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
-  lint:
+  frontend:
+    name: Frontend Checks
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,3 +50,26 @@ jobs:
 
       - name: Run type check
         run: pnpm run typecheck
+
+      - name: Run production build
+        run: pnpm run build
+
+  backend:
+    name: Backend Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go vet
+        run: go vet ./cmd/... ./internal/...
+
+      - name: Run unit tests
+        run: go test -count=1 -timeout 600s ./cmd/... ./internal/...
+
+      - name: Build backend
+        run: go build -o /tmp/maxx-ci-build ./cmd/maxx


### PR DESCRIPTION
  ## 背景

  当前 PR 流程只校验前端 `lint/typecheck`，与 Release 阶段不一致：

  - 前端未执行完整生产构建，像 `user is possibly null` 这类仅在 `pnpm build` 暴露的问
  题只能在发布时发现
  - 后端改动未执行构建、lint、单元测试，回归风险无法在 PR 阶段提前阻断

  这会导致问题滞后到发布阶段才暴露，影响交付效率和线上稳定性。

  ## 变更

  本次将 PR 校验扩展为统一的前后端检查：

  ### 前端
  - 保留现有 `lint`
  - 保留现有 `typecheck`
  - 新增 `pnpm run build`，提前执行与发布一致的生产构建校验

  ### 后端
  - 新增 `go vet ./cmd/... ./internal/...`
  - 新增 `go test -count=1 -timeout 600s ./cmd/... ./internal/...`
  - 新增 `go build -o /tmp/maxx-ci-build ./cmd/maxx`

  ### CI 触发范围
  - 将 PR workflow 触发范围从仅 `web/**` 扩展到：
    - `cmd/**`
    - `internal/**`
    - `tests/**`
    - `go.mod`
    - `go.sum`
    - `.node-version`
    - `.github/workflows/lint.yml`

  ## 说明

  后端校验范围限定为 `cmd/maxx` 和 `internal`，避免把 Wails 桌面端根包的 `web/dist`
  嵌入要求混入服务端 PR 校验，减少与当前发布链路无关的噪音。

  ## 收益

  - 前端生产构建错误在 PR 阶段即可阻断
  - 后端编译、静态检查、单元测试前置到 PR
  - PR 校验与发布质量门槛更接近，减少发布阶段才失败的情况

  ## 验证

  已完成本地验证：

  - workflow YAML 解析通过
  - `go vet ./cmd/... ./internal/...` 通过
  - `go test -count=1 -timeout 600s ./cmd/... ./internal/...` 通过
  - `go build -o /tmp/maxx-ci-build ./cmd/maxx` 通过

  前端未在本地执行 `pnpm build`，因为当前环境缺少 `pnpm` 和 `web/node_modules`，该部
  分通过 CI 执行校验。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 优化持续集成工作流配置，将代码检查任务分离为前端和后端两个独立流程
  * 新增生产环境构建验证和后端单元测试自动执行
  * 扩展工作流触发范围，确保更全面的变更监测

<!-- end of auto-generated comment: release notes by coderabbit.ai -->