### PR TITLE
docs: refresh Homebrew usage and macOS damaged-app troubleshooting

### DIFF
--- a/.github/workflows/ci-wails-build.yml
+++ b/.github/workflows/ci-wails-build.yml
@@ -354,10 +354,16 @@ jobs:
             # 拖拽 maxx.app 到 Applications 文件夹
             ```
 
-            > ⚠️ 如果提示"应用已损坏"，请运行：
-            > ```bash
-            > sudo xattr -d com.apple.quarantine /Applications/maxx.app
-            > ```
+            > ⚠️ 如果提示"应用已损坏"，请按以下步骤排查：
+            > 1. 清理隔离属性：
+            >    ```bash
+            >    sudo xattr -rd com.apple.quarantine /Applications/maxx.app
+            >    ```
+            > 2. 在访达中右键 `maxx.app`，选择一次**打开**。
+            > 3. 如果仍失败，重装后重试：
+            >    ```bash
+            >    brew uninstall --cask awsl-project/awsl/maxx && brew install --cask awsl-project/awsl/maxx
+            >    ```
 
             **Linux**
             ```bash

--- a/README.md
+++ b/README.md
@@ -90,13 +90,18 @@ Download from [GitHub Releases](https://github.com/awsl-project/maxx/releases):
 
 ```bash
 # Install
-brew install --no-quarantine awsl-project/awsl/maxx
+brew install --cask awsl-project/awsl/maxx
 
 # Upgrade
-brew upgrade --no-quarantine awsl-project/awsl/maxx
+brew upgrade --cask awsl-project/awsl/maxx
 ```
 
-> **Note:** If you see "App is damaged" error, run: `sudo xattr -d com.apple.quarantine /Applications/maxx.app`
+> **Troubleshooting: "App is damaged" on macOS**
+> 1. Remove quarantine attributes:
+>    `sudo xattr -rd com.apple.quarantine /Applications/maxx.app`
+> 2. Right-click `maxx.app` in Finder and choose **Open** once.
+> 3. If it still fails, reinstall and retry:
+>    `brew uninstall --cask awsl-project/awsl/maxx && brew install --cask awsl-project/awsl/maxx`
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -90,13 +90,18 @@ volumes:
 
 ```bash
 # 安装
-brew install --no-quarantine awsl-project/awsl/maxx
+brew install --cask awsl-project/awsl/maxx
 
 # 升级
-brew upgrade --no-quarantine awsl-project/awsl/maxx
+brew upgrade --cask awsl-project/awsl/maxx
 ```
 
-> **提示：** 如果提示"应用已损坏"，请运行：`sudo xattr -d com.apple.quarantine /Applications/maxx.app`
+> **故障排查：macOS 提示“应用已损坏”**
+> 1. 清理隔离属性：
+>    `sudo xattr -rd com.apple.quarantine /Applications/maxx.app`
+> 2. 在访达中右键 `maxx.app`，选择一次**打开**。
+> 3. 如果仍失败，重装后再重试：
+>    `brew uninstall --cask awsl-project/awsl/maxx && brew install --cask awsl-project/awsl/maxx`
 
 </details>
 


### PR DESCRIPTION
# Summary
- update Homebrew install/upgrade commands in README (EN/CN) to use `--cask` and remove deprecated `--no-quarantine`
- add clearer macOS "App is damaged" troubleshooting steps in README (EN/CN) and release notes workflow text

# Changes
- `README.md`: Homebrew commands switched to `brew install/upgrade --cask awsl-project/awsl/maxx`
- `README.md`: expanded damaged-app troubleshooting to 3 steps (`xattr -rd`, Finder right-click Open, reinstall fallback)
- `README_CN.md`: same updates in Chinese docs
- `.github/workflows/ci-wails-build.yml`: updated release body troubleshooting snippet to match latest steps

# Tests
- `rg -n -- '--no-quarantine|xattr -d com.apple.quarantine' .` → no matches
- `rg -n -- 'brew install --cask awsl-project/awsl/maxx|brew upgrade --cask awsl-project/awsl/maxx|xattr -rd com.apple.quarantine' README.md README_CN.md .github/workflows/ci-wails-build.yml` → expected matches found

# Risks
- Low: documentation/workflow release-note text only; no runtime code changes

# Follow-ups
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了 Homebrew 安装命令的说明
  * 改进了 macOS "应用已损坏" 问题的故障排查步骤，包括隔离属性清除、Finder 打开流程和重新安装方案

<!-- end of auto-generated comment: release notes by coderabbit.ai -->