### PR TITLE
fix: pass release tag into homebrew update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,11 @@ jobs:
             echo "Using manual version: $RESOLVED_VERSION"
           else
             git fetch --tags --force
-            LAST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1)
+            LAST_TAG=$(
+              git tag --list --sort=-version:refname |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              head -n 1
+            )
 
             if [[ -z "$LAST_TAG" ]]; then
               RESOLVED_VERSION="v0.0.1"

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${{ inputs.tag }}"
-          VERSION="${VERSION//[[:space:]]/}"
+          VERSION="$(printf '%s' "$VERSION" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 
           if [[ -z "$VERSION" ]]; then
             echo "Error: tag input is empty"


### PR DESCRIPTION
## Summary
- make the `release` job a direct dependency of the Homebrew update reusable workflow call
- fail fast when the Homebrew workflow receives an empty or invalid tag
- validate downloaded checksum content before writing the cask

## Problem
The release workflow passed `needs.release.outputs.resolved_version` into `update-homebrew`, but `update-homebrew` only declared `needs: wails-build`.

In GitHub Actions this made the `release` output unavailable in that job context, so the reusable workflow received an empty `tag`. The job still appeared green because it did not validate the input and tolerated no-op commits.

## Validation
- inspected the successful-but-bad run logs and confirmed `Inputs tag:` was empty
- verified the workflow graph and patched the dependency chain
- added fail-fast guards so future empty tag / bad checksum cases go red instead of silently succeeding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 发布流程支持在未指定版本时自动补丁递增，并在手动输入时保留指定版本；发布时会显示解析后的版本预览并向后续流程公开。

* **改进**
  * 增强了版本与标签输入的验证与规范化，确保格式正确后再继续发布流程。
  * 提升 Homebrew 更新流程的数据完整性检查（更严格的校验和验证与更稳健的下载/执行行为）。
  * 发布依赖关系调整，确保版本解析完成后再执行后续任务。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->