### PR TITLE
fix: 健康检查接口校验数据库依赖可用性

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -410,11 +410,16 @@ func main() {
 	// Gemini API (Google AI Studio style)
 	mux.Handle("/v1beta/models/", proxyHandler)
 
-	// Health check
+	// 健康检查：校验数据库等核心依赖的可用性
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if err := db.Ping(); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"status":"unhealthy","database":"unreachable"}`))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		w.Write([]byte(`{"status":"ok","database":"ok"}`))
 	})
 
 	// WebSocket endpoint

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -73,6 +73,7 @@ type DatabaseRepos struct {
 
 // ServerComponents 包含服务器运行所需的所有组件
 type ServerComponents struct {
+	DB                  *sqlite.DB
 	Router              *router.Router
 	WebSocketHub        *handler.WebSocketHub
 	WailsBroadcaster    *event.WailsBroadcaster
@@ -415,6 +416,7 @@ func InitializeServerComponents(
 	proxyHandler.SetRequestTracker(requestTracker)
 
 	components := &ServerComponents{
+		DB:                  repos.DB,
 		Router:              r,
 		WebSocketHub:        wsHub,
 		WailsBroadcaster:    wailsBroadcaster,

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -96,10 +96,18 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	mux.Handle("/v1/models", components.ModelsHandler)
 	mux.Handle("/v1beta/models/", components.ProxyHandler)
 
+	// 健康检查：校验数据库等核心依赖的可用性
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if components.DB != nil {
+			if err := components.DB.Ping(); err != nil {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				w.Write([]byte(`{"status":"unhealthy","database":"unreachable"}`))
+				return
+			}
+		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		w.Write([]byte(`{"status":"ok","database":"ok"}`))
 	})
 
 	mux.HandleFunc("/ws", components.WebSocketHub.HandleWebSocket)

--- a/internal/repository/sqlite/db.go
+++ b/internal/repository/sqlite/db.go
@@ -111,6 +111,15 @@ func (d *DB) autoMigrate() error {
 	return d.gorm.AutoMigrate(AllModels()...)
 }
 
+// Ping 检查数据库连接是否可用
+func (d *DB) Ping() error {
+	sqlDB, err := d.gorm.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Ping()
+}
+
 func (d *DB) Close() error {
 	sqlDB, err := d.gorm.DB()
 	if err != nil {

--- a/tests/e2e/health_test.go
+++ b/tests/e2e/health_test.go
@@ -17,4 +17,9 @@ func TestHealthCheck(t *testing.T) {
 	if result["status"] != "ok" {
 		t.Fatalf("Expected status 'ok', got %q", result["status"])
 	}
+
+	// 校验数据库状态字段
+	if result["database"] != "ok" {
+		t.Fatalf("Expected database 'ok', got %q", result["database"])
+	}
 }


### PR DESCRIPTION
## Summary

修复 #349

当前 `/health` 接口无论数据库等依赖是否正常，均固定返回 `{"status":"ok"}`，导致监控无法识别真实服务健康度。

### 改动内容

- `sqlite/db.go`: 新增 `Ping()` 方法，用于检查数据库连接可用性
- `core/database.go`: `ServerComponents` 新增 `DB` 字段，供健康检查使用
- `core/server.go` + `cmd/maxx/main.go`: 健康检查接口调用 `db.Ping()` 校验数据库状态，不可用时返回 503 + `{"status":"unhealthy","database":"unreachable"}`
- `tests/e2e/health_test.go`: 补充 `database` 字段断言

### 行为变化

- 数据库正常: `200 {"status":"ok","database":"ok"}`
- 数据库不可达: `503 {"status":"unhealthy","database":"unreachable"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 健康检查端点现已支持数据库连接检测，在数据库无法访问时返回服务不可用状态

* **改进**
  * 健康检查响应信息现包含数据库状态字段，提供更全面的服务健康状态评估

<!-- end of auto-generated comment: release notes by coderabbit.ai -->