### PR TITLE
feat: 加权随机路由策略按实际权重分配流量

### DIFF
--- a/internal/domain/backup.go
+++ b/internal/domain/backup.go
@@ -67,6 +67,7 @@ type BackupRoute struct {
 	ClientType      ClientType `json:"clientType"`
 	ProviderName    string     `json:"providerName"`
 	Position        int        `json:"position"`
+	Weight          int        `json:"weight,omitempty"`
 	RetryConfigName string     `json:"retryConfigName"` // empty = default
 }
 

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -308,6 +308,9 @@ type Route struct {
 	// 位置，数字越小越优先
 	Position int `json:"position"`
 
+	// 权重，用于加权随机路由策略，值越大被选中概率越高，默认 1
+	Weight int `json:"weight"`
+
 	// 重试配置，0 表示使用系统默认
 	RetryConfigID uint64 `json:"retryConfigID"`
 }

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -361,6 +361,15 @@ func (h *AdminHandler) handleRoutes(w http.ResponseWriter, r *http.Request, id u
 				existing.Position = int(f)
 			}
 		}
+		if v, ok := updates["weight"]; ok {
+			if f, ok := v.(float64); ok {
+				w := int(f)
+				if w <= 0 {
+					w = 1
+				}
+				existing.Weight = w
+			}
+		}
 		if v, ok := updates["retryConfigID"]; ok {
 			if f, ok := v.(float64); ok {
 				existing.RetryConfigID = uint64(f)

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -133,6 +133,7 @@ type Route struct {
 	ClientType    string `gorm:"size:64"`
 	ProviderID    uint64
 	Position      int
+	Weight        int `gorm:"default:1"`
 	RetryConfigID uint64
 }
 

--- a/internal/repository/sqlite/route.go
+++ b/internal/repository/sqlite/route.go
@@ -126,11 +126,16 @@ func (r *RouteRepository) toModel(route *domain.Route) *Route {
 		ClientType:    string(route.ClientType),
 		ProviderID:    route.ProviderID,
 		Position:      route.Position,
+		Weight:        route.Weight,
 		RetryConfigID: route.RetryConfigID,
 	}
 }
 
 func (r *RouteRepository) toDomain(m *Route) *domain.Route {
+	weight := m.Weight
+	if weight <= 0 {
+		weight = 1
+	}
 	return &domain.Route{
 		ID:            m.ID,
 		CreatedAt:     fromTimestamp(m.CreatedAt),
@@ -143,6 +148,7 @@ func (r *RouteRepository) toDomain(m *Route) *domain.Route {
 		ClientType:    domain.ClientType(m.ClientType),
 		ProviderID:    m.ProviderID,
 		Position:      m.Position,
+		Weight:        weight,
 		RetryConfigID: m.RetryConfigID,
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -272,14 +272,44 @@ func (r *Router) getRoutingStrategy(tenantID uint64, projectID uint64) *domain.R
 func (r *Router) sortRoutes(routes []*domain.Route, strategy *domain.RoutingStrategy) {
 	switch strategy.Type {
 	case domain.RoutingStrategyWeightedRandom:
-		// Shuffle with weights (simplified - just shuffle for now)
-		rand.Shuffle(len(routes), func(i, j int) {
-			routes[i], routes[j] = routes[j], routes[i]
-		})
+		// 按权重做概率排序：权重越大，排在前面的概率越高
+		weightedShuffle(routes)
 	default: // priority
 		sort.Slice(routes, func(i, j int) bool {
 			return routes[i].Position < routes[j].Position
 		})
+	}
+}
+
+// weightedShuffle 按权重做加权随机排序
+// 使用加权采样算法：每次从剩余路由中按权重概率选一个放到当前位置
+func weightedShuffle(routes []*domain.Route) {
+	n := len(routes)
+	for i := 0; i < n-1; i++ {
+		// 计算剩余路由的权重总和
+		totalWeight := 0
+		for j := i; j < n; j++ {
+			w := routes[j].Weight
+			if w <= 0 {
+				w = 1
+			}
+			totalWeight += w
+		}
+
+		// 按权重随机选择一个
+		r := rand.Intn(totalWeight)
+		cumulative := 0
+		for j := i; j < n; j++ {
+			w := routes[j].Weight
+			if w <= 0 {
+				w = 1
+			}
+			cumulative += w
+			if r < cumulative {
+				routes[i], routes[j] = routes[j], routes[i]
+				break
+			}
+		}
 	}
 }
 

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -179,6 +179,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 			ClientType:      r.ClientType,
 			ProviderName:    providerIDToName[r.ProviderID],
 			Position:        r.Position,
+			Weight:          r.Weight,
 			RetryConfigName: retryConfigIDToName[r.RetryConfigID],
 		})
 	}
@@ -667,6 +668,10 @@ func (s *BackupService) importRoutes(tenantID uint64, routes []domain.BackupRout
 			}
 		}
 
+		weight := br.Weight
+		if weight <= 0 {
+			weight = 1
+		}
 		r := &domain.Route{
 			TenantID:      tenantID,
 			IsEnabled:     br.IsEnabled,
@@ -675,6 +680,7 @@ func (s *BackupService) importRoutes(tenantID uint64, routes []domain.BackupRout
 			ClientType:    br.ClientType,
 			ProviderID:    providerID,
 			Position:      br.Position,
+			Weight:        weight,
 			RetryConfigID: retryConfigID,
 		}
 


### PR DESCRIPTION
## Summary

修复 #294

当前 weighted_random 路由策略仅做 `rand.Shuffle` 纯随机打散，未读取和计算权重字段，权重配置不生效。

### 改动内容

- `domain/model.go`: Route 新增 `Weight` 字段（默认 1），值越大被选中概率越高
- `domain/backup.go`: BackupRoute 同步新增 `Weight` 字段
- `sqlite/models.go`: GORM Route 模型新增 `Weight` 列（`default:1`），GORM AutoMigrate 自动添加列
- `sqlite/route.go`: domain 与 GORM 模型映射同步 Weight 字段，读取时保底为 1
- `router/router.go`: 实现加权随机排序算法（加权采样），替换原来的纯随机 Shuffle
- `handler/admin.go`: 路由更新接口支持 `weight` 字段
- `service/backup.go`: 备份导入导出同步 Weight 字段

### 算法说明

使用加权采样算法：从头到尾遍历，每次从剩余路由中按权重概率选一个放到当前位置。时间复杂度 O(n²)，路由数量通常很少，性能无影响。

### 行为变化

- 权重配置现在真正生效，流量按权重比例分配
- 未配置权重的路由默认权重为 1，行为与之前一致
- 备份文件向后兼容，旧备份无 weight 字段时导入默认为 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 为加权随机路由策略添加了权重支持，用户可以设置路由权重值来控制其被选中的概率。权重值越大，路由被选中概率越高，默认值为1。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->