### PR TITLE
feat: add provider-scoped proxy routes

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -376,6 +376,7 @@ func main() {
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
 	// Setup routes
 	mux := http.NewServeMux()
@@ -409,6 +410,8 @@ func main() {
 	mux.Handle("/v1/responses/", proxyHandler)
 	// Gemini API (Google AI Studio style)
 	mux.Handle("/v1beta/models/", proxyHandler)
+	// Provider-scoped proxy routes
+	mux.Handle("/provider/", providerProxyHandler)
 
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -89,6 +89,7 @@ type ServerComponents struct {
 	ClaudeHandler       *handler.ClaudeHandler
 	ClaudeOAuthServer   *ClaudeOAuthServer
 	ProjectProxyHandler *handler.ProjectProxyHandler
+	ProviderProxyHandler *handler.ProviderProxyHandler
 	RequestTracker      *RequestTracker
 	PprofManager        *PprofManager
 	AuthMiddleware      *handler.AuthMiddleware
@@ -431,6 +432,7 @@ func InitializeServerComponents(
 		ClaudeHandler:       claudeHandler,
 		ClaudeOAuthServer:   claudeOAuthServer,
 		ProjectProxyHandler: projectProxyHandler,
+		ProviderProxyHandler: handler.NewProviderProxyHandler(proxyHandler, modelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
 		RequestTracker:      requestTracker,
 		PprofManager:        pprofMgr,
 		AuthMiddleware:      authMiddleware,

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -103,6 +103,7 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	})
 
 	mux.HandleFunc("/ws", components.WebSocketHub.HandleWebSocket)
+	mux.Handle("/provider/", components.ProviderProxyHandler)
 
 	if s.config.ServeStatic {
 		staticHandler := handler.NewStaticHandler()

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -1,0 +1,294 @@
+package handler
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/executor"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository"
+)
+
+// ProviderProxyHandler handles provider-prefixed proxy requests like /provider/{id}/v1/messages.
+// Unlike the generic proxy path, provider-scoped requests are forwarded one-to-one to the
+// requested provider without going through the generic route selection / retry chain.
+type ProviderProxyHandler struct {
+	proxyHandler     *ProxyHandler
+	modelsHandler    *ModelsHandler
+	providerRepo     repository.ProviderRepository
+	routeRepo        repository.RouteRepository
+	proxyRequestRepo repository.ProxyRequestRepository
+}
+
+// NewProviderProxyHandler creates a new provider proxy handler.
+func NewProviderProxyHandler(
+	proxyHandler *ProxyHandler,
+	modelsHandler *ModelsHandler,
+	providerRepo repository.ProviderRepository,
+	routeRepo repository.RouteRepository,
+	proxyRequestRepo repository.ProxyRequestRepository,
+) *ProviderProxyHandler {
+	return &ProviderProxyHandler{
+		proxyHandler:     proxyHandler,
+		modelsHandler:    modelsHandler,
+		providerRepo:     providerRepo,
+		routeRepo:        routeRepo,
+		proxyRequestRepo: proxyRequestRepo,
+	}
+}
+
+// ServeHTTP handles provider-prefixed proxy requests.
+func (h *ProviderProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	providerID, apiPath, ok := h.parseProviderPath(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "invalid provider proxy path")
+		return
+	}
+
+	providerIDNum, err := strconv.ParseUint(providerID, 10, 64)
+	if err != nil || providerIDNum == 0 {
+		writeError(w, http.StatusBadRequest, "invalid provider id")
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	provider, err := h.providerRepo.GetByID(tenantID, providerIDNum)
+	if err != nil {
+		log.Printf("[ProviderProxy] failed to load provider tenant=%d id=%d: %v", tenantID, providerIDNum, err)
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if provider == nil {
+		log.Printf("[ProviderProxy] Provider not found for id: %s", providerID)
+		writeError(w, http.StatusNotFound, "provider not found")
+		return
+	}
+
+	if apiPath == "/v1/models" {
+		r.URL.Path = apiPath
+		h.modelsHandler.ServeHTTP(w, r)
+		return
+	}
+
+	log.Printf("[ProviderProxy] Direct forwarding through provider: %s (ID: %d)", provider.Name, provider.ID)
+	r.URL.Path = apiPath
+
+	ctx := flow.NewCtx(w, r)
+	handlers := append([]flow.HandlerFunc{}, h.proxyHandler.extra...)
+	handlers = append(handlers, h.directDispatch(provider))
+	h.proxyHandler.engine.HandleWith(ctx, handlers...)
+}
+
+func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.HandlerFunc {
+	return func(c *flow.Ctx) {
+		tenantID := maxxctx.GetTenantID(c.Request.Context())
+		clientType := flow.GetClientType(c)
+		if clientType == "" {
+			writeError(c.Writer, http.StatusBadRequest, "unable to determine client type")
+			c.Abort()
+			return
+		}
+
+		route, err := h.routeRepo.FindByKey(tenantID, 0, provider.ID, clientType)
+		if err != nil || route == nil {
+			log.Printf("[ProviderProxy] route not found tenant=%d provider=%d clientType=%s: %v", tenantID, provider.ID, clientType, err)
+			writeError(c.Writer, http.StatusNotFound, "provider route not found")
+			c.Abort()
+			return
+		}
+
+		factory, ok := provideradapter.GetAdapterFactory(provider.Type)
+		if !ok {
+			writeError(c.Writer, http.StatusBadGateway, "provider adapter not found")
+			c.Abort()
+			return
+		}
+		adapter, err := factory(provider)
+		if err != nil {
+			log.Printf("[ProviderProxy] failed to create adapter provider=%d type=%s: %v", provider.ID, provider.Type, err)
+			writeError(c.Writer, http.StatusBadGateway, "provider adapter init failed")
+			c.Abort()
+			return
+		}
+		if !providerSupportsClientType(adapter.SupportedClientTypes(), clientType) {
+			writeError(c.Writer, http.StatusBadRequest, "provider does not support this client type")
+			c.Abort()
+			return
+		}
+
+		requestModel := flow.GetRequestModel(c)
+		mappedModel := requestModel
+		isStream := flow.GetIsStream(c)
+		proxyReq := h.newProxyRequest(c, route, provider, requestModel, mappedModel, isStream)
+		if err := h.proxyRequestRepo.Create(proxyReq); err != nil {
+			log.Printf("[ProviderProxy] failed to create proxy request: %v", err)
+		}
+
+		c.Set(flow.KeyMappedModel, mappedModel)
+		c.Set(flow.KeyOriginalClientType, clientType)
+		c.Set(flow.KeyProxyRequest, proxyReq)
+
+		responseCapture := executor.NewResponseCapture(c.Writer)
+		originalWriter := c.Writer
+		c.Writer = responseCapture
+		err = adapter.Execute(c, provider)
+		c.Writer = originalWriter
+
+		now := time.Now()
+		proxyReq.EndTime = now
+		proxyReq.Duration = now.Sub(proxyReq.StartTime)
+		proxyReq.StatusCode = responseCapture.StatusCode()
+		proxyReq.ResponseModel = mappedModel
+		proxyReq.ResponseInfo = &domain.ResponseInfo{
+			Status:  responseCapture.StatusCode(),
+			Headers: responseCapture.CapturedHeaders(),
+			Body:    responseCapture.Body(),
+		}
+
+		if err == nil {
+			proxyReq.Status = "COMPLETED"
+			_ = h.proxyRequestRepo.Update(proxyReq)
+			return
+		}
+
+		proxyReq.Status = "FAILED"
+		proxyReq.Error = err.Error()
+		if proxyErr, ok := err.(*domain.ProxyError); ok {
+			if isStream {
+				writeStreamError(responseCapture, proxyErr)
+			} else {
+				writeProxyError(responseCapture, proxyErr)
+			}
+			if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+				proxyReq.StatusCode = proxyErr.HTTPStatusCode
+			}
+		} else {
+			writeError(responseCapture, http.StatusBadGateway, err.Error())
+			proxyReq.StatusCode = http.StatusBadGateway
+		}
+		_ = h.proxyRequestRepo.Update(proxyReq)
+		c.Abort()
+	}
+}
+
+func (h *ProviderProxyHandler) newProxyRequest(c *flow.Ctx, route *domain.Route, provider *domain.Provider, requestModel, mappedModel string, isStream bool) *domain.ProxyRequest {
+	requestHeaders := flow.GetRequestHeaders(c)
+	requestURI := flow.GetRequestURI(c)
+	requestBody := flow.GetRequestBody(c)
+	apiTokenID := flow.GetAPITokenID(c)
+	projectID := flow.GetProjectID(c)
+	tenantID := maxxctx.GetTenantID(c.Request.Context())
+	devMode := false
+	if v, ok := c.Get(flow.KeyAPITokenDevMode); ok {
+		if b, ok := v.(bool); ok {
+			devMode = b
+		}
+	}
+
+	return &domain.ProxyRequest{
+		TenantID:      tenantID,
+		RequestID:     generateProxyRequestID(),
+		SessionID:     flow.GetSessionID(c),
+		ClientType:    flow.GetClientType(c),
+		RequestModel:  requestModel,
+		ResponseModel: mappedModel,
+		StartTime:     time.Now(),
+		IsStream:      isStream,
+		Status:        "IN_PROGRESS",
+		StatusCode:    http.StatusOK,
+		RequestInfo: &domain.RequestInfo{
+			Method:  c.Request.Method,
+			Headers: flattenRequestHeaders(requestHeaders),
+			URL:     requestURI,
+			Body:    string(requestBody),
+		},
+		RouteID:    route.ID,
+		ProviderID: provider.ID,
+		ProjectID:  projectID,
+		APITokenID: apiTokenID,
+		DevMode:    devMode,
+	}
+}
+
+func generateProxyRequestID() string {
+	return time.Now().Format("20060102150405.000000")
+}
+
+func flattenRequestHeaders(h http.Header) map[string]string {
+	if h == nil {
+		return nil
+	}
+	result := make(map[string]string)
+	for key, values := range h {
+		if len(values) > 0 {
+			result[key] = values[0]
+		}
+	}
+	return result
+}
+
+func providerSupportsClientType(supported []domain.ClientType, clientType domain.ClientType) bool {
+	for _, ct := range supported {
+		if ct == clientType {
+			return true
+		}
+	}
+	return false
+}
+
+// parseProviderPath extracts the provider ID and API path from a provider-prefixed URL.
+func (h *ProviderProxyHandler) parseProviderPath(path string) (providerID, apiPath string, ok bool) {
+	if !strings.HasPrefix(path, "/provider/") {
+		return "", "", false
+	}
+
+	path = strings.TrimPrefix(path, "/provider/")
+	parts := strings.SplitN(path, "/", 2)
+	if len(parts) < 2 {
+		return "", "", false
+	}
+
+	providerID = strings.TrimSpace(parts[0])
+	if providerID == "" {
+		return "", "", false
+	}
+
+	apiPath = "/" + parts[1]
+	if !isValidProviderAPIPath(apiPath) {
+		return "", "", false
+	}
+
+	return providerID, apiPath, true
+}
+
+func isProviderProxyPath(urlPath string) bool {
+	return strings.HasPrefix(urlPath, "/provider/")
+}
+
+func isValidProviderAPIPath(path string) bool {
+	if path == "/v1/messages" || strings.HasPrefix(path, "/v1/messages/") {
+		return true
+	}
+	if path == "/v1/chat/completions" || strings.HasPrefix(path, "/v1/chat/completions/") {
+		return true
+	}
+	if path == "/responses" || strings.HasPrefix(path, "/responses/") {
+		return true
+	}
+	if path == "/v1/responses" || strings.HasPrefix(path, "/v1/responses/") {
+		return true
+	}
+	if path == "/v1/models" || strings.HasPrefix(path, "/v1/models/") {
+		return true
+	}
+	if path == "/v1beta/models" || strings.HasPrefix(path, "/v1beta/models/") {
+		return true
+	}
+	return false
+}

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import "testing"
+
+func TestParseProviderPath(t *testing.T) {
+	h := &ProviderProxyHandler{}
+	providerID, apiPath, ok := h.parseProviderPath("/provider/1/v1/chat/completions")
+	if !ok {
+		t.Fatal("expected provider path to parse")
+	}
+	if providerID != "1" {
+		t.Fatalf("providerID = %q, want 1", providerID)
+	}
+	if apiPath != "/v1/chat/completions" {
+		t.Fatalf("apiPath = %q, want /v1/chat/completions", apiPath)
+	}
+}
+
+func TestParseProviderPath_TrimsProviderID(t *testing.T) {
+	h := &ProviderProxyHandler{}
+	providerID, apiPath, ok := h.parseProviderPath("/provider/ 1 /v1/messages")
+	if !ok {
+		t.Fatal("expected provider path to parse")
+	}
+	if providerID != "1" {
+		t.Fatalf("providerID = %q, want 1", providerID)
+	}
+	if apiPath != "/v1/messages" {
+		t.Fatalf("apiPath = %q, want /v1/messages", apiPath)
+	}
+}
+
+func TestIsValidProviderAPIPath_AllowsExactAndSubpathsOnly(t *testing.T) {
+	valid := []string{
+		"/v1/messages",
+		"/v1/messages/stream",
+		"/v1/chat/completions",
+		"/v1/chat/completions/extra",
+		"/responses",
+		"/responses/items",
+		"/v1/responses",
+		"/v1/responses/abc",
+		"/v1/models",
+		"/v1/models/list",
+		"/v1beta/models",
+		"/v1beta/models/gemini-2.5-pro",
+	}
+	for _, path := range valid {
+		if !isValidProviderAPIPath(path) {
+			t.Fatalf("expected %q to be valid", path)
+		}
+	}
+
+	invalid := []string{
+		"/v1/messages-debug",
+		"/v1/chat/completionsXYZ",
+		"/responses123",
+		"/v1/responsesXYZ",
+		"/v1/models-debug",
+		"/v1beta/modelsX",
+	}
+	for _, path := range invalid {
+		if isValidProviderAPIPath(path) {
+			t.Fatalf("expected %q to be invalid", path)
+		}
+	}
+}
+
+func TestIsProviderProxyPath(t *testing.T) {
+	if !isProviderProxyPath("/provider/1/v1/messages") {
+		t.Fatal("expected provider path to be detected")
+	}
+	if isProviderProxyPath("/project/demo/v1/messages") {
+		t.Fatal("did not expect project path to be detected as provider path")
+	}
+	if isProviderProxyPath("/providers") {
+		t.Fatal("did not expect regular web route to be detected")
+	}
+}

--- a/tests/e2e/playwright/package.json
+++ b/tests/e2e/playwright/package.json
@@ -11,6 +11,7 @@
     "test:passkey": "playwright test -c playwright.config.ts passkey-discoverable.spec.ts --project=e2e-chromium",
     "test:project-filter": "playwright test -c playwright.config.ts requests-project-filter.spec.ts --project=e2e-chromium",
     "test:project-update-tenant": "playwright test -c playwright.config.ts project-update-tenant.spec.ts --project=e2e-chromium",
+    "test:provider-proxy-route": "playwright test -c playwright.config.ts provider-proxy-route.spec.ts --project=e2e-chromium",
     "test:stats-chart": "playwright test -c playwright.config.ts stats-chart-resize.spec.ts --project=e2e-chromium",
     "test:stats-page": "playwright test -c playwright.config.ts stats-page.spec.ts",
     "test:stats-page:headed": "playwright test -c playwright.config.ts stats-page.spec.ts --headed",

--- a/tests/e2e/playwright/provider-proxy-route.spec.ts
+++ b/tests/e2e/playwright/provider-proxy-route.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * Playwright E2E Test: Provider-scoped proxy route
+ *
+ * 使用方式：
+ *   npx playwright test -c playwright.config.ts provider-proxy-route.spec.ts --project=e2e-chromium
+ */
+import http from 'node:http';
+
+import { expect, test } from 'playwright/test';
+
+import { BASE, PASS, USER, adminAPI } from './helpers';
+
+test.describe.configure({ mode: 'serial' });
+
+function startMockClaudeServer(): Promise<{ server: http.Server; port: number }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === 'POST' && req.url?.startsWith('/v1/messages')) {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          let parsed: any = {};
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            // ignore malformed JSON in the mock
+          }
+
+          const model = parsed.model || 'claude-sonnet-4-20250514';
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              id: `msg_provider_proxy_${Date.now()}`,
+              type: 'message',
+              role: 'assistant',
+              model,
+              content: [{ type: 'text', text: 'Hello from provider-scoped mock Claude!' }],
+              stop_reason: 'end_turn',
+              stop_sequence: null,
+              usage: {
+                input_tokens: 15,
+                output_tokens: 8,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+              },
+            }),
+          );
+        });
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to determine mock server port'));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+test('provider-scoped proxy route records requests in the UI', async ({ page }, testInfo) => {
+  const mock = await startMockClaudeServer();
+  let jwt: string | null = null;
+  let providerId: number | null = null;
+  let routeId: number | null = null;
+  let tokenId: number | null = null;
+  let apiToken: string | null = null;
+  let previousApiTokenAuthEnabled: string | undefined;
+
+  try {
+    const loginResponse = await adminAPI('POST', '/auth/login', {
+      username: USER,
+      password: PASS,
+    });
+    jwt = loginResponse.token as string;
+    expect(jwt).toBeTruthy();
+
+    const settings = await adminAPI('GET', '/settings', undefined, jwt);
+    previousApiTokenAuthEnabled = settings.api_token_auth_enabled;
+    await adminAPI('PUT', '/settings/api_token_auth_enabled', { value: 'true' }, jwt);
+
+    const provider = await adminAPI(
+      'POST',
+      '/providers',
+      {
+        name: 'Provider Scoped Claude UI',
+        type: 'custom',
+        config: {
+          custom: {
+            baseURL: `http://127.0.0.1:${mock.port}`,
+            apiKey: 'mock-key',
+          },
+        },
+        supportedClientTypes: ['claude'],
+        supportModels: ['*'],
+      },
+      jwt,
+    );
+    providerId = provider.id;
+
+    const route = await adminAPI(
+      'POST',
+      '/routes',
+      {
+        isEnabled: true,
+        isNative: false,
+        clientType: 'claude',
+        providerID: provider.id,
+        projectID: 0,
+        position: 1,
+      },
+      jwt,
+    );
+    routeId = route.id;
+
+    const tokenResult = await adminAPI(
+      'POST',
+      '/api-tokens',
+      { name: 'Provider Scoped Route Token', description: 'Playwright token for provider-scoped route' },
+      jwt,
+    );
+    tokenId = tokenResult.apiToken.id;
+    apiToken = tokenResult.token as string;
+    expect(apiToken).toBeTruthy();
+
+    const requestModel = `claude-sonnet-4-20250514-provider-ui-${Date.now()}`;
+    const response = await fetch(`${BASE}/provider/${provider.id}/v1/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'x-api-key': apiToken!,
+      },
+      body: JSON.stringify({
+        model: requestModel,
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'Hello provider scoped route!' }],
+      }),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`Provider-scoped proxy request failed (${response.status}): ${text}`);
+    }
+    const payload = JSON.parse(text);
+    expect(payload.model).toBe(requestModel);
+
+    await page.goto(BASE);
+    await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
+    await page.fill('input[type="text"]', USER);
+    await page.fill('input[type="password"]', PASS);
+    await page.locator('button[type="submit"]').click();
+    await expect(page.locator('body')).toContainText(/Dashboard|dashboard/, { timeout: 10000 });
+
+    await page.goto(`${BASE}/requests`);
+    await expect(page.locator('body')).toContainText(/Requests|请求/, { timeout: 15000 });
+
+    await expect
+      .poll(async () => {
+        const content = (await page.textContent('body')) ?? '';
+        return content.includes(requestModel);
+      }, { timeout: 15000 })
+      .toBe(true);
+
+    await page.screenshot({ path: testInfo.outputPath('provider-proxy-route.png'), fullPage: true });
+  } finally {
+    if (tokenId) {
+      await adminAPI('DELETE', `/api-tokens/${tokenId}`, undefined, jwt ?? undefined).catch(() => undefined);
+    }
+    if (routeId) {
+      await adminAPI('DELETE', `/routes/${routeId}`, undefined, jwt ?? undefined).catch(() => undefined);
+    }
+    if (providerId) {
+      await adminAPI('DELETE', `/providers/${providerId}`, undefined, jwt ?? undefined).catch(() => undefined);
+    }
+    if (previousApiTokenAuthEnabled !== undefined) {
+      await adminAPI(
+        'PUT',
+        '/settings/api_token_auth_enabled',
+        { value: previousApiTokenAuthEnabled },
+        jwt ?? undefined,
+      ).catch(() => undefined);
+    }
+    await new Promise<void>((resolve, reject) => {
+      mock.server.close((error?: Error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+});

--- a/tests/e2e/provider_proxy_test.go
+++ b/tests/e2e/provider_proxy_test.go
@@ -1,0 +1,114 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func startMockClaudeProxyServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		model, _ := body["model"].(string)
+		if model == "" {
+			model = "claude-sonnet-4-20250514"
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "msg_provider_scope_test",
+			"type":  "message",
+			"role":  "assistant",
+			"model": model,
+			"content": []map[string]any{{
+				"type": "text",
+				"text": "hello from provider-scoped route",
+			}},
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+			"usage": map[string]any{
+				"input_tokens":                12,
+				"output_tokens":               6,
+				"cache_creation_input_tokens": 0,
+				"cache_read_input_tokens":     0,
+			},
+		})
+	}))
+}
+
+func TestProviderScopedProxyRoute(t *testing.T) {
+	env := NewProxyTestEnv(t)
+	mock := startMockClaudeProxyServer(t)
+	defer mock.Close()
+
+	providerResp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "Provider Scoped Claude",
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": mock.URL,
+				"apiKey":  "mock-key",
+			},
+		},
+		"supportedClientTypes": []string{"claude"},
+		"supportModels":        []string{"*"},
+	})
+	AssertStatus(t, providerResp, http.StatusCreated)
+
+	var provider map[string]any
+	DecodeJSON(t, providerResp, &provider)
+	providerID := int(provider["id"].(float64))
+
+	routeResp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   false,
+		"clientType": "claude",
+		"providerID": providerID,
+		"projectID":  0,
+		"position":   1,
+	})
+	AssertStatus(t, routeResp, http.StatusCreated)
+
+	model := fmt.Sprintf("claude-sonnet-4-20250514-provider-%d", providerID)
+	resp := env.ProxyPost(fmt.Sprintf("/provider/%d/v1/messages", providerID), map[string]any{
+		"model":      model,
+		"max_tokens": 64,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "hello provider route",
+		}},
+	}, map[string]string{
+		"anthropic-version": "2023-06-01",
+	})
+	AssertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	DecodeJSON(t, resp, &result)
+	if result["model"] != model {
+		t.Fatalf("expected model %q, got %v", model, result["model"])
+	}
+
+	requestsResp := env.doRequest(http.MethodGet, fmt.Sprintf("/api/admin/requests?limit=20&providerId=%d", providerID), nil, env.Token)
+	AssertStatus(t, requestsResp, http.StatusOK)
+
+	var requests struct {
+		Items []map[string]any `json:"items"`
+	}
+	DecodeJSON(t, requestsResp, &requests)
+	if len(requests.Items) == 0 {
+		t.Fatalf("expected at least one request for provider %d", providerID)
+	}
+	if got := int(requests.Items[0]["providerID"].(float64)); got != providerID {
+		t.Fatalf("expected providerID %d in recorded request, got %d", providerID, got)
+	}
+}

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -194,6 +194,8 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
 	// Setup routes (mirroring main.go)
 	mux := http.NewServeMux()
@@ -216,6 +218,8 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	mux.Handle("/v1/responses", proxyHandler)
 	mux.Handle("/v1/responses/", proxyHandler)
 	mux.Handle("/v1beta/models/", proxyHandler)
+	mux.Handle("/project/", projectProxyHandler)
+	mux.Handle("/provider/", providerProxyHandler)
 
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# Summary
- add provider-scoped proxy routes so requests can target `/provider/{id}/...` directly
- thread provider scope through proxy matching while keeping the design easy to extend later

# Changes
- add scoped proxy parsing for `/provider/{id}/...` alongside `/project/{slug}/...`
- pass `providerID` through proxy ingress and router matching so only routes for that provider are considered
- update combined/static routing to recognize provider-scoped proxy paths
- add handler tests plus Go E2E and Playwright E2E coverage for provider-scoped requests

# Tests
- `go test ./...`
- `MAXX_E2E_BASE_URL=http://127.0.0.1:9980 MAXX_E2E_USERNAME=admin MAXX_E2E_PASSWORD=test123 pnpm --dir tests/e2e/playwright test:provider-proxy-route`

# Risks
- low: this changes scoped proxy path handling and route filtering, so regressions would likely show up in scoped proxy entrypoints

# Follow-ups
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增提供者作用域代理路由，支持 /provider/{id}/... 请求并将其作为提供者级别的代理处理；根路由同时支持项目与提供者作用域并分别路由。
  * 支持通过路径或 X-Maxx-Provider-ID 头关联提供者；有效 ID 会在请求流中可用并在响应/日志中体现。

* **测试**
  * 新增单元与端到端测试，覆盖路径解析、路由匹配、头部验证及在 UI/请求记录中的可见性验证（含截图）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->