### PR TITLE
feat(ui): show provider proxy url in provider details

### DIFF
--- a/tests/e2e/playwright/provider-proxy-route.spec.ts
+++ b/tests/e2e/playwright/provider-proxy-route.spec.ts
@@ -67,7 +67,7 @@ function startMockClaudeServer(): Promise<{ server: http.Server; port: number }>
   });
 }
 
-test('provider-scoped proxy route records requests in the UI', async ({ page }, testInfo) => {
+test('provider-scoped proxy route records requests and shows provider URL in the UI', async ({ page }, testInfo) => {
   const mock = await startMockClaudeServer();
   let jwt: string | null = null;
   let providerId: number | null = null;
@@ -133,6 +133,7 @@ test('provider-scoped proxy route records requests in the UI', async ({ page }, 
     expect(apiToken).toBeTruthy();
 
     const requestModel = `claude-sonnet-4-20250514-provider-ui-${Date.now()}`;
+    const expectedProviderProxyUrl = `${new URL(BASE).origin}/provider/${provider.id}/`;
     const response = await fetch(`${BASE}/provider/${provider.id}/v1/messages`, {
       method: 'POST',
       headers: {
@@ -170,7 +171,14 @@ test('provider-scoped proxy route records requests in the UI', async ({ page }, 
       }, { timeout: 15000 })
       .toBe(true);
 
-    await page.screenshot({ path: testInfo.outputPath('provider-proxy-route.png'), fullPage: true });
+    await page.goto(`${BASE}/providers/${provider.id}/edit`);
+    await expect(page.locator('[data-testid="provider-proxy-url"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[data-testid="provider-proxy-url"]')).toContainText(
+      expectedProviderProxyUrl,
+      { timeout: 10000 },
+    );
+
+    await page.screenshot({ path: testInfo.outputPath('provider-edit-url.png'), fullPage: true });
   } finally {
     if (tokenId) {
       await adminAPI('DELETE', `/api-tokens/${tokenId}`, undefined, jwt ?? undefined).catch(() => undefined);

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1223,6 +1223,7 @@
     "cancel": "Cancel",
     "none": "None",
     "defaultEndpoint": "Default endpoint",
+    "proxyUrl": "Provider URL",
     "validationFailed": "Validation failed",
     "tokenValidationFailed": "Token validation failed",
     "multiplier": "Price Multiplier",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1223,6 +1223,7 @@
     "cancel": "取消",
     "none": "无",
     "defaultEndpoint": "默认端点",
+    "proxyUrl": "提供商 URL",
     "validationFailed": "验证失败",
     "tokenValidationFailed": "令牌验证失败",
     "multiplier": "价格倍率",

--- a/web/src/pages/providers/components/antigravity-provider-view.tsx
+++ b/web/src/pages/providers/components/antigravity-provider-view.tsx
@@ -36,6 +36,7 @@ import { Button, Switch } from '@/components/ui';
 import { ModelInput } from '@/components/ui/model-input';
 import { ANTIGRAVITY_COLOR } from '../types';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
 
 interface AntigravityProviderViewProps {
   provider: Provider;
@@ -396,6 +397,8 @@ export function AntigravityProviderView({
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
           {/* Info Card */}
           <div className="bg-muted rounded-xl p-6 border border-border">
             <div className="flex items-start justify-between gap-6">

--- a/web/src/pages/providers/components/claude-provider-view.tsx
+++ b/web/src/pages/providers/components/claude-provider-view.tsx
@@ -31,6 +31,7 @@ import {
 import { Button, Switch } from '@/components/ui';
 import { ModelInput } from '@/components/ui/model-input';
 import { CLAUDE_COLOR } from '../types';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
 
 interface ClaudeProviderViewProps {
   provider: Provider;
@@ -299,6 +300,8 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
           {/* Info Card */}
           <div className="bg-muted rounded-xl p-6 border border-border">
             <div className="flex items-start justify-between gap-6">

--- a/web/src/pages/providers/components/codex-provider-view.tsx
+++ b/web/src/pages/providers/components/codex-provider-view.tsx
@@ -42,6 +42,7 @@ import { ModelInput } from '@/components/ui/model-input';
 import { CODEX_COLOR } from '../types';
 import { useCodexBatchQuotas } from '@/hooks/queries';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
 
 interface CodexProviderViewProps {
   provider: Provider;
@@ -557,6 +558,8 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
           {/* Info Card */}
           <div className="bg-muted rounded-xl p-6 border border-border">
             <div className="flex items-start justify-between gap-6">

--- a/web/src/pages/providers/components/kiro-provider-view.tsx
+++ b/web/src/pages/providers/components/kiro-provider-view.tsx
@@ -24,6 +24,7 @@ import {
 import { Button, Switch } from '@/components/ui';
 import { ModelInput } from '@/components/ui/model-input';
 import { KIRO_COLOR } from '../types';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
 
 interface KiroProviderViewProps {
   provider: Provider;
@@ -344,6 +345,8 @@ export function KiroProviderView({ provider, onDelete, onClose }: KiroProviderVi
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
           {/* Info Card */}
           <div className="bg-muted rounded-xl p-6 border border-border">
             <div className="flex items-start justify-between gap-6">

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -49,6 +49,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui';
 import { ModelInput } from '@/components/ui/model-input';
 import { PageHeader } from '@/components/layout/page-header';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
 
 // Provider Model Mappings Section for Custom Providers
 function ProviderModelMappings({ provider }: { provider: Provider }) {
@@ -614,6 +615,8 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
           <div className="space-y-6">
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
               {t('provider.basicInfo')}

--- a/web/src/pages/providers/components/provider-proxy-url-card.tsx
+++ b/web/src/pages/providers/components/provider-proxy-url-card.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Check, Copy, Link as LinkIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { Provider } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+
+export function ProviderProxyURLCard({ provider }: { provider: Provider }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+  const providerProxyUrl = `${window.location.origin}/provider/${provider.id}/`;
+  const copyLabel = copied ? t('proxy.copied') : t('projects.copyUrl');
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(providerProxyUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy provider proxy URL', error);
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 md:p-5">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-lg border border-border bg-muted p-2 text-muted-foreground">
+          <LinkIcon size={16} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 text-sm font-semibold text-foreground">{t('provider.proxyUrl')}</div>
+          <p className="mb-3 text-xs text-muted-foreground">
+            {t('projects.proxyConfigDesc')}
+          </p>
+          <div className="flex items-center gap-2">
+            <code
+              data-testid="provider-proxy-url"
+              className="flex-1 rounded border border-border bg-muted/60 px-3 py-2 text-xs text-foreground font-mono break-all"
+            >
+              {providerProxyUrl}
+            </code>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 shrink-0 p-0"
+              title={copyLabel}
+              aria-label={copyLabel}
+              onClick={copyToClipboard}
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary
- add a copyable provider-scoped URL to the provider edit/details page opened from the Providers tab so the `/provider/{id}/` entrypoint is visible where users manage a provider
- extend the provider Playwright e2e to verify both the request log entry and the provider URL display end to end on `/providers/:id/edit`

# Changes
- add a shared `ProviderProxyURLCard` and render it on the provider edit/details page for custom, Claude, Codex, Kiro, and Antigravity providers
- remove the earlier placement from the route dialog so the URL is shown on the intended provider page instead
- update `provider-proxy-route.spec.ts` to open `/providers/:id/edit` and assert the provider URL is visible after the request is recorded

# Tests
- `pnpm --dir web build` ✅
- `go build -o maxx ./cmd/maxx` ✅
- `MAXX_ADMIN_PASSWORD=test123 ./maxx -addr :9880` + `MAXX_E2E_BASE_URL=http://127.0.0.1:9880 MAXX_E2E_USERNAME=admin MAXX_E2E_PASSWORD=test123 pnpm --dir tests/e2e/playwright test:provider-proxy-route` ✅

# Risks
- Low: the UI derives the displayed provider URL from `window.location.origin`, matching the current backend origin used by the admin UI

# Follow-ups
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在提供商详情与编辑页面新增“提供商 URL”展示卡片，显示专属代理 URL 并支持一键复制。
* **本地化**
  * 新增该 UI 文本的中英文翻译条目。
* **测试**
  * 更新端到端测试，新增对请求记录与 UI 中代理 URL 显示的断言并调整截图位置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->