### PR TITLE
fix: restrict token and invite management to admins

### DIFF
--- a/internal/handler/admin_invite_codes_test.go
+++ b/internal/handler/admin_invite_codes_test.go
@@ -118,7 +118,7 @@ func TestAdminHandler_UpdateInviteCode_AllowsZeroMaxUses(t *testing.T) {
 	}
 }
 
-func TestAdminHandler_ListInviteCodes_MemberFiltersOwn(t *testing.T) {
+func TestAdminHandler_ListInviteCodes_MemberForbidden(t *testing.T) {
 	inviteRepo := &adminTestInviteCodeRepo{
 		list: []*domain.InviteCode{
 			{ID: 1, TenantID: 1, CreatedByUserID: 10},
@@ -136,20 +136,12 @@ func TestAdminHandler_ListInviteCodes_MemberFiltersOwn(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
-	}
-
-	var result []domain.InviteCode
-	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if len(result) != 1 || result[0].ID != 1 {
-		t.Fatalf("filtered result = %+v, want only invite code 1", result)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
 }
 
-func TestAdminHandler_GetInviteCode_MemberOwnAllowed(t *testing.T) {
+func TestAdminHandler_GetInviteCode_MemberForbidden(t *testing.T) {
 	inviteRepo := &adminTestInviteCodeRepo{
 		code: &domain.InviteCode{ID: 1, TenantID: 1, CreatedByUserID: 10},
 	}
@@ -164,8 +156,8 @@ func TestAdminHandler_GetInviteCode_MemberOwnAllowed(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
 }
 
@@ -184,8 +176,8 @@ func TestAdminHandler_GetInviteCode_MemberOtherForbidden(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
 }
 
@@ -204,8 +196,8 @@ func TestAdminHandler_DeleteInviteCode_MemberOtherForbidden(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
 	if inviteRepo.deleteCalled {
 		t.Fatalf("delete should not be called for unauthorized member")
@@ -227,7 +219,7 @@ func TestAdminHandler_InviteCodeUsages_MemberOtherForbidden(t *testing.T) {
 
 	h.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
 }

--- a/internal/handler/rbac.go
+++ b/internal/handler/rbac.go
@@ -9,13 +9,13 @@ import (
 
 // memberAllowedResources defines resources that member role can access (GET only)
 var memberAllowedResources = map[string]bool{
-	"dashboard":     true,
-	"requests":      true,
-	"sessions":      true,
-	"usage-stats":   true,
-	"proxy-status":  true,
-	"cooldowns":     true,
-	"logs":          true,
+	"dashboard":    true,
+	"requests":     true,
+	"sessions":     true,
+	"usage-stats":  true,
+	"proxy-status": true,
+	"cooldowns":    true,
+	"logs":         true,
 }
 
 // CheckRBAC checks if the current user has permission for the given resource and method
@@ -35,10 +35,6 @@ func CheckRBAC(r *http.Request, resource string) bool {
 
 	// Member can only GET certain resources
 	if role == string(domain.UserRoleMember) {
-		// Members can manage invite codes
-		if resource == "invite-codes" {
-			return true
-		}
 		if r.Method != http.MethodGet {
 			return false
 		}

--- a/main.go
+++ b/main.go
@@ -30,9 +30,12 @@ var webDistAssets embed.FS
 var appCtx context.Context
 
 func main() {
-	// Set embedded static files for HTTP server
+	// Set embedded static files for HTTP server only when a built frontend is embedded.
+	// CI/backend-only test runs may include only a placeholder to satisfy go:embed.
 	if subFS, err := fs.Sub(webDistAssets, "web/dist"); err == nil {
-		handler.StaticFS = subFS
+		if _, statErr := fs.Stat(subFS, "index.html"); statErr == nil {
+			handler.StaticFS = subFS
+		}
 	}
 
 	// Create desktop app instance

--- a/tests/e2e/rbac_test.go
+++ b/tests/e2e/rbac_test.go
@@ -147,6 +147,22 @@ func TestRBAC_MemberCannotGetRoutes(t *testing.T) {
 	AssertStatus(t, resp, http.StatusForbidden)
 }
 
+func TestRBAC_MemberCannotGetAPITokens(t *testing.T) {
+	env := NewTestEnv(t)
+	memberToken := getMemberToken(t, env)
+
+	resp := env.RequestWithToken(http.MethodGet, "/api/admin/api-tokens", nil, memberToken)
+	AssertStatus(t, resp, http.StatusForbidden)
+}
+
+func TestRBAC_MemberCannotGetInviteCodes(t *testing.T) {
+	env := NewTestEnv(t)
+	memberToken := getMemberToken(t, env)
+
+	resp := env.RequestWithToken(http.MethodGet, "/api/admin/invite-codes", nil, memberToken)
+	AssertStatus(t, resp, http.StatusForbidden)
+}
+
 func TestRBAC_MemberCannotPutRequests(t *testing.T) {
 	env := NewTestEnv(t)
 	memberToken := getMemberToken(t, env)

--- a/web/dist/.keep
+++ b/web/dist/.keep
@@ -1,0 +1,2 @@
+# Placeholder file to keep web/dist present for backend-only CI and tests.
+# Real frontend build artifacts are generated into this directory during web builds.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,8 +71,22 @@ function AppRoutes() {
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="projects/:id" element={<ProjectDetailPage />} />
           <Route path="sessions" element={<SessionsPage />} />
-          <Route path="api-tokens" element={<APITokensPage />} />
-          <Route path="invite-codes" element={<InviteCodesPage />} />
+          <Route
+            path="api-tokens"
+            element={
+              <AdminRoute>
+                <APITokensPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="invite-codes"
+            element={
+              <AdminRoute>
+                <InviteCodesPage />
+              </AdminRoute>
+            }
+          />
           <Route path="model-mappings" element={<ModelMappingsPage />} />
           <Route path="model-prices" element={<ModelPricesPage />} />
           <Route path="retry-configs" element={<RetryConfigsPage />} />

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -105,6 +105,8 @@ export const sidebarConfig: SidebarConfig = {
           to: '/api-tokens',
           icon: Key,
           labelKey: 'nav.apiTokens',
+          adminOnly: true,
+          authOnly: true,
         },
         {
           type: 'standard',
@@ -112,6 +114,7 @@ export const sidebarConfig: SidebarConfig = {
           to: '/invite-codes',
           icon: Ticket,
           labelKey: 'nav.inviteCodes',
+          adminOnly: true,
           authOnly: true,
         },
         {


### PR DESCRIPTION
## Summary
- restrict API token and invite code pages to admin users in the frontend
- deny member access to invite code admin APIs so non-admins cannot browse invitation data
- keep backend CI green in backend-only runs by tolerating missing built frontend assets

## Testing
- go test ./internal/handler/... ./tests/e2e -run 'TestRBAC_|TestAdminHandler_.*Member'
- go test ./...

Fixes #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 加强了成员角色的访问控制，成员现在无法访问API令牌和邀请代码资源
  * 改进了后端静态文件加载，确保仅在存在有效的前端构建时才提供文件

* **新功能**
  * 在UI中为API令牌和邀请代码页面添加了管理员权限验证层
  * 侧边栏菜单中标记受限功能为仅限管理员访问

<!-- end of auto-generated comment: release notes by coderabbit.ai -->