### PR TITLE
ci(release): add scoop bucket update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,4 +131,4 @@ jobs:
     with:
       tag: ${{ needs.release.outputs.resolved_version }}
     secrets:
-      SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -93,8 +93,8 @@ jobs:
           cp maxx.rb homebrew-awsl/Casks/maxx.rb
 
           cd homebrew-awsl
-          git config user.name "awsl233777"
-          git config user.email "awsl233777@gmail.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/maxx.rb
           git commit -m "Update maxx to ${VERSION}" || echo "No changes to commit"
           git push

--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
     secrets:
-      SCOOP_BUCKET_TOKEN:
+      HOMEBREW_TAP_TOKEN:
         required: true
 
 jobs:
@@ -49,7 +49,7 @@ jobs:
 
       - name: Update Scoop manifest
         env:
-          GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           set -euo pipefail
           VERSION="${{ steps.validate-tag.outputs.tag }}"
@@ -91,8 +91,8 @@ jobs:
           cp maxx.json scoop-bucket/bucket/maxx.json
 
           cd scoop-bucket
-          git config user.name "awsl233777"
-          git config user.email "awsl233777@gmail.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add bucket/maxx.json
           git commit -m "Update maxx to ${VERSION}" || echo "No changes to commit"
           git push


### PR DESCRIPTION
# Summary
- add an automated Scoop bucket update workflow for maxx releases
- align downstream package-repo commits to use awsl233777 identity for both Homebrew and Scoop updates

# Changes
- add `.github/workflows/update-scoop.yml` to fetch `maxx.exe.sha256`, regenerate `bucket/maxx.json`, and push updates to `awsl-project/scoop-bucket`
- wire `release.yml` to run the Scoop update after `release` and `wails-build`, mirroring the existing Homebrew flow
- update `update-homebrew.yml` commit identity to `awsl233777 <awsl233777@gmail.com>`

# Tests
- not run (GitHub Actions workflow changes only)

# Risks
- requires `SCOOP_BUCKET_TOKEN` to be configured in `awsl-project/maxx` secrets with push access to `awsl-project/scoop-bucket`

# Follow-ups
- add `SCOOP_BUCKET_TOKEN` repository secret before the next release run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 改进了发布流程，现在会自动更新 Scoop 包管理器中的应用版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->