### PR TITLE
fix: escape Scoop autoupdate $version placeholder

### DIFF
--- a/.github/workflows/update-scoop.yml
+++ b/.github/workflows/update-scoop.yml
@@ -80,7 +80,7 @@ jobs:
             "autoupdate": {
               "architecture": {
                 "64bit": {
-                  "url": "https://github.com/awsl-project/maxx/releases/download/v$version/maxx.exe"
+                  "url": "https://github.com/awsl-project/maxx/releases/download/v\$version/maxx.exe"
                 }
               }
             }


### PR DESCRIPTION
# Summary
- Fix the Scoop release workflow so it preserves the literal `v$version` placeholder in the generated manifest.
- Prevent the `update-scoop` job from failing on releases with `version: unbound variable`.

# Changes
- Escape `$version` in `.github/workflows/update-scoop.yml` when generating `maxx.json`.
- Keep the emitted Scoop `autoupdate` URL unchanged for Scoop consumers while avoiding shell expansion during workflow execution.

# Tests
- `bash /tmp/test-scoop-heredoc.sh` — passed; output manifest kept literal `https://github.com/awsl-project/maxx/releases/download/v$version/maxx.exe`.

# Risks
- Low: workflow-only change scoped to Scoop manifest generation.

# Follow-ups
- Re-run the release workflow (or trigger the reusable workflow) to update `awsl-project/scoop-bucket` to the latest tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了软件分发配置中的版本占位符转义处理，确保自动更新功能正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->