### PR TITLE
fix: restore token tab & codex auto-config fallback (#462)

### DIFF
--- a/internal/adapter/provider/cliproxyapi_codex/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter.go
@@ -107,7 +107,7 @@ func (a *CLIProxyAPICodexAdapter) getAccessToken(ctx context.Context) (string, e
 	// 检查缓存
 	a.tokenMu.RLock()
 	if a.tokenCache.AccessToken != "" {
-		if a.tokenCache.ExpiresAt.IsZero() || time.Now().Add(60*time.Second).Before(a.tokenCache.ExpiresAt) {
+		if !isFallbackCodexAccessToken(a.tokenCache.AccessToken) && (a.tokenCache.ExpiresAt.IsZero() || time.Now().Add(60*time.Second).Before(a.tokenCache.ExpiresAt)) {
 			token := a.tokenCache.AccessToken
 			a.tokenMu.RUnlock()
 			return token, nil
@@ -123,7 +123,7 @@ func (a *CLIProxyAPICodexAdapter) getAccessToken(ctx context.Context) (string, e
 	cfgRefreshToken := cfg.RefreshToken
 	a.tokenMu.RUnlock()
 
-	if cfgAccessToken != "" {
+	if cfgAccessToken != "" && !isFallbackCodexAccessToken(cfgAccessToken) {
 		var expiresAt time.Time
 		if cfgExpiresAt != "" {
 			if parsed, err := time.Parse(time.RFC3339, cfgExpiresAt); err == nil {
@@ -154,7 +154,7 @@ func (a *CLIProxyAPICodexAdapter) getAccessToken(ctx context.Context) (string, e
 		a.tokenCache = &TokenCache{AccessToken: fallbackToken}
 		a.tokenMu.Unlock()
 		cfg.AccessToken = fallbackToken
-		cfg.ExpiresAt = ""
+		cfg.ExpiresAt = time.Now().Add(5 * time.Second).Format(time.RFC3339)
 		if a.authObj.Metadata == nil {
 			a.authObj.Metadata = make(map[string]any)
 		}
@@ -170,7 +170,7 @@ func (a *CLIProxyAPICodexAdapter) getAccessToken(ctx context.Context) (string, e
 	tokenResp, err := refreshAccessToken(ctx, cfgRefreshToken)
 	if err != nil {
 		// 刷新失败时，如果有旧 token 就兜底使用
-		if cfgAccessToken != "" {
+		if cfgAccessToken != "" && !isFallbackCodexAccessToken(cfgAccessToken) {
 			return cfgAccessToken, nil
 		}
 		return "", err
@@ -452,9 +452,10 @@ type tokenResponse struct {
 }
 
 const (
-	openAITokenURL = "https://auth.openai.com/oauth/token"
-	oauthClientID  = "app_EMoamEEZ73f0CkXaXp7hrann"
+	oauthClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
 )
+
+var openAITokenURL = "https://auth.openai.com/oauth/token"
 
 // refreshAccessToken refreshes the access token using a refresh token
 func refreshAccessToken(ctx context.Context, refreshToken string) (*tokenResponse, error) {

--- a/internal/adapter/provider/cliproxyapi_codex/fallback.go
+++ b/internal/adapter/provider/cliproxyapi_codex/fallback.go
@@ -7,6 +7,8 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
+const fallbackCodexTokenPrefix = "maxx-local-"
+
 func ensureCodexConfig(p *domain.Provider) *domain.ProviderConfigCodex {
 	if p.Config == nil {
 		p.Config = &domain.ProviderConfig{}
@@ -22,5 +24,9 @@ func buildFallbackCodexAccessToken(p *domain.Provider) string {
 	if p != nil && strings.TrimSpace(p.Name) != "" {
 		name = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(p.Name), " ", "-"))
 	}
-	return fmt.Sprintf("maxx-local-%s", name)
+	return fmt.Sprintf("%s%s", fallbackCodexTokenPrefix, name)
+}
+
+func isFallbackCodexAccessToken(token string) bool {
+	return strings.HasPrefix(strings.TrimSpace(token), fallbackCodexTokenPrefix)
 }

--- a/internal/adapter/provider/cliproxyapi_codex/testing_exports.go
+++ b/internal/adapter/provider/cliproxyapi_codex/testing_exports.go
@@ -1,0 +1,9 @@
+package cliproxyapi_codex
+
+func GetOpenAITokenURLForTest() string {
+	return openAITokenURL
+}
+
+func SetOpenAITokenURLForTest(url string) {
+	openAITokenURL = url
+}

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -261,7 +261,7 @@ func (a *CodexAdapter) getAccessToken(ctx context.Context) (string, error) {
 	// Check cache
 	a.tokenMu.RLock()
 	if a.tokenCache.AccessToken != "" {
-		if a.tokenCache.ExpiresAt.IsZero() || time.Now().Add(60*time.Second).Before(a.tokenCache.ExpiresAt) {
+		if !isFallbackCodexAccessToken(a.tokenCache.AccessToken) && (a.tokenCache.ExpiresAt.IsZero() || time.Now().Add(60*time.Second).Before(a.tokenCache.ExpiresAt)) {
 			token := a.tokenCache.AccessToken
 			a.tokenMu.RUnlock()
 			return token, nil
@@ -271,7 +271,7 @@ func (a *CodexAdapter) getAccessToken(ctx context.Context) (string, error) {
 
 	// Use persisted access token if present (even if expiry is unknown)
 	config := ensureCodexConfig(a.provider)
-	if strings.TrimSpace(config.AccessToken) != "" {
+	if strings.TrimSpace(config.AccessToken) != "" && !isFallbackCodexAccessToken(config.AccessToken) {
 		var expiresAt time.Time
 		if strings.TrimSpace(config.ExpiresAt) != "" {
 			if parsed, err := time.Parse(time.RFC3339, config.ExpiresAt); err == nil {
@@ -302,7 +302,7 @@ func (a *CodexAdapter) getAccessToken(ctx context.Context) (string, error) {
 		a.tokenCache = &TokenCache{AccessToken: fallbackToken}
 		a.tokenMu.Unlock()
 		config.AccessToken = fallbackToken
-		config.ExpiresAt = ""
+		config.ExpiresAt = time.Now().Add(5 * time.Second).Format(time.RFC3339)
 		if a.providerUpdate != nil {
 			if err := a.providerUpdate(a.provider); err != nil {
 				log.Printf("[Codex] failed to persist fallback token: %v", err)
@@ -313,7 +313,7 @@ func (a *CodexAdapter) getAccessToken(ctx context.Context) (string, error) {
 
 	tokenResp, err := RefreshAccessToken(ctx, config.RefreshToken)
 	if err != nil {
-		if strings.TrimSpace(config.AccessToken) != "" {
+		if strings.TrimSpace(config.AccessToken) != "" && !isFallbackCodexAccessToken(config.AccessToken) {
 			return config.AccessToken, nil
 		}
 		return "", err

--- a/internal/adapter/provider/codex/fallback.go
+++ b/internal/adapter/provider/codex/fallback.go
@@ -7,6 +7,8 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
+const fallbackCodexTokenPrefix = "maxx-local-"
+
 func ensureCodexConfig(p *domain.Provider) *domain.ProviderConfigCodex {
 	if p.Config == nil {
 		p.Config = &domain.ProviderConfig{}
@@ -22,5 +24,9 @@ func buildFallbackCodexAccessToken(p *domain.Provider) string {
 	if p != nil && strings.TrimSpace(p.Name) != "" {
 		name = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(p.Name), " ", "-"))
 	}
-	return fmt.Sprintf("maxx-local-%s", name)
+	return fmt.Sprintf("%s%s", fallbackCodexTokenPrefix, name)
+}
+
+func isFallbackCodexAccessToken(token string) bool {
+	return strings.HasPrefix(strings.TrimSpace(token), fallbackCodexTokenPrefix)
 }

--- a/tests/e2e/codex_fallback_test.go
+++ b/tests/e2e/codex_fallback_test.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	cliproxycodex "github.com/awsl-project/maxx/internal/adapter/provider/cliproxyapi_codex"
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
@@ -15,14 +18,103 @@ func TestCodexRequestFallsBackWithoutPersistedCodexConfig(t *testing.T) {
 	defer mock.Close()
 
 	env := NewProxyTestEnv(t)
+	providerID := createCodexProvider(t, env, map[string]any{
+		"baseURL": mock.URL,
+	})
+	createRoute(t, env, "codex", providerID)
 
+	proxyResp := env.ProxyPost("/responses", codexRequest("gpt-4o"), nil)
+	defer proxyResp.Body.Close()
+	assertStatus(t, proxyResp, http.StatusOK)
+
+	_, path, headers, _ := captured.Get()
+	if path != "/responses" && path != "/responses/compact" {
+		t.Fatalf("expected upstream /responses or /responses/compact, got %s", path)
+	}
+	if got := headers.Get("Authorization"); got == "" {
+		t.Fatalf("expected Authorization header to be synthesized for fallback flow")
+	}
+
+	stored := getCodexProvider(t, env, providerID)
+	if stored.Config == nil || stored.Config.Codex == nil {
+		t.Fatalf("expected codex config to exist after fallback")
+	}
+	if stored.Config.Codex.AccessToken == "" {
+		t.Fatalf("expected fallback access token to be persisted")
+	}
+	if stored.Config.Codex.ExpiresAt == "" {
+		t.Fatalf("expected fallback token to have a short expiry sentinel")
+	}
+}
+
+func TestCLIProxyAPICodexFallbackRefreshRecovery(t *testing.T) {
+	refreshHits := 0
+	refreshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshHits++
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse refresh form: %v", err)
+		}
+		if got := r.Form.Get("refresh_token"); got != "refresh-after-fallback" {
+			t.Fatalf("unexpected refresh token: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"real-access-token","refresh_token":"refresh-after-fallback","expires_in":3600,"token_type":"Bearer"}`)
+	}))
+	defer refreshServer.Close()
+
+	originalTokenURL := cliproxycodex.GetOpenAITokenURLForTest()
+	cliproxycodex.SetOpenAITokenURLForTest(refreshServer.URL)
+	defer cliproxycodex.SetOpenAITokenURLForTest(originalTokenURL)
+
+	provider := &domain.Provider{
+		ID:   42,
+		Name: "Codex CLIProxy Fallback",
+		Type: "codex",
+		Config: &domain.ProviderConfig{
+			Codex: &domain.ProviderConfigCodex{
+				UseCLIProxyAPI: true,
+			},
+		},
+	}
+
+	adapterIface, err := cliproxycodex.NewAdapter(provider)
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	adapter := adapterIface.(*cliproxycodex.CLIProxyAPICodexAdapter)
+	adapter.SetProviderUpdateFunc(func(updated *domain.Provider) error {
+		provider = updated
+		return nil
+	})
+
+	if err := adapter.WarmToken(t.Context()); err != nil {
+		t.Fatalf("warm fallback token: %v", err)
+	}
+	if provider.Config.Codex.AccessToken == "" || provider.Config.Codex.ExpiresAt == "" {
+		t.Fatalf("expected persisted fallback token with short expiry sentinel, got %+v", provider.Config.Codex)
+	}
+
+	provider.Config.Codex.RefreshToken = "refresh-after-fallback"
+	provider.Config.Codex.ExpiresAt = time.Now().Add(-time.Minute).Format(time.RFC3339)
+
+	if err := adapter.WarmToken(t.Context()); err != nil {
+		t.Fatalf("warm refreshed token: %v", err)
+	}
+	if refreshHits == 0 {
+		t.Fatalf("expected CLIProxyAPI adapter to refresh token after refresh token was restored")
+	}
+	if provider.Config.Codex.AccessToken != "real-access-token" {
+		t.Fatalf("expected refreshed access token to replace fallback token, got %q", provider.Config.Codex.AccessToken)
+	}
+}
+
+func createCodexProvider(t *testing.T, env *ProxyTestEnv, codexConfig map[string]any) uint64 {
+	t.Helper()
 	resp := env.AdminPost("/api/admin/providers", map[string]any{
 		"name": "Codex Fallback",
 		"type": "codex",
 		"config": map[string]any{
-			"codex": map[string]any{
-				"baseURL": mock.URL,
-			},
+			"codex": codexConfig,
 		},
 		"supportedClientTypes": []string{"codex"},
 		"supportModels":        []string{"*"},
@@ -38,22 +130,12 @@ func TestCodexRequestFallsBackWithoutPersistedCodexConfig(t *testing.T) {
 		t.Fatalf("decode provider: %v", err)
 	}
 	resp.Body.Close()
+	return provider.ID
+}
 
-	createRoute(t, env, "codex", provider.ID)
-
-	proxyResp := env.ProxyPost("/responses", codexRequest("gpt-4o"), nil)
-	defer proxyResp.Body.Close()
-	assertStatus(t, proxyResp, http.StatusOK)
-
-	_, path, headers, _ := captured.Get()
-	if path != "/responses" && path != "/responses/compact" {
-		t.Fatalf("expected upstream /responses or /responses/compact, got %s", path)
-	}
-	if got := headers.Get("Authorization"); got == "" {
-		t.Fatalf("expected Authorization header to be synthesized for fallback flow")
-	}
-
-	getResp := env.doRequest(http.MethodGet, "/api/admin/providers/"+itoa(provider.ID), nil, env.Token)
+func getCodexProvider(t *testing.T, env *ProxyTestEnv, providerID uint64) domain.Provider {
+	t.Helper()
+	getResp := env.doRequest(http.MethodGet, "/api/admin/providers/"+itoa(providerID), nil, env.Token)
 	if getResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(getResp.Body)
 		t.Fatalf("get provider failed: status=%d body=%s", getResp.StatusCode, body)
@@ -63,13 +145,7 @@ func TestCodexRequestFallsBackWithoutPersistedCodexConfig(t *testing.T) {
 		t.Fatalf("decode stored provider: %v", err)
 	}
 	getResp.Body.Close()
-
-	if stored.Config == nil || stored.Config.Codex == nil {
-		t.Fatalf("expected codex config to exist after fallback")
-	}
-	if stored.Config.Codex.AccessToken == "" {
-		t.Fatalf("expected fallback access token to be persisted")
-	}
+	return stored
 }
 
 func itoa(n uint64) string {


### PR DESCRIPTION
## 变更摘要
- 为 Codex provider 补充无本地配置场景下的 fallback 初始化，避免 `provider.Config.Codex` 缺失时直接中断请求链路
- 在 `codex` 与 `cliproxyapi_codex` 两条请求链路上增加缺少 refresh token 时的自动重建兜底逻辑，并落结构化 INFO 日志（含 `trigger=fallback`）
- 新增端到端回归测试，覆盖“无持久化 Codex 配置时仍可完成本地请求并回写 fallback access token”场景

## 影响范围
- Codex provider 初始化与本地请求兜底逻辑
- CLIProxyAPI Codex 转发链路
- Codex 本地无配置场景下的请求恢复能力
- e2e 回归测试覆盖面

## 测试用例
- `pnpm -s tsc --noEmit`
- `go test ./...`
- `go test ./tests/e2e -run TestCodexRequestFallsBackWithoutPersistedCodexConfig -count=1`

## 回滚方案
- 回滚本 PR 即可恢复到原有 Codex provider 初始化逻辑
- 如需局部回滚，可单独撤销 `codex` / `cliproxyapi_codex` fallback 辅助文件与对应 adapter 改动

Closes #462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在缺少或不完整配置时自动生成并使用备用 Codex 访问令牌以保证请求可用性。

* **改进**
  * 优化令牌获取与刷新逻辑：避免将占位式回退令牌视为有效缓存或刷新失败回退目标，改进持久化与过期处理。
  * 将部分令牌端点可在测试时替换以便更可靠的集成验证。

* **测试**
  * 新增端到端测试，覆盖回退令牌生成、持久化和刷新恢复场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->