### PR TITLE
fix(web): show copied icon for api token rows

### DIFF
--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -88,6 +88,7 @@ export function APITokensPage() {
     expiresAt?: string;
   } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copiedTokenId, setCopiedTokenId] = useState<number | null>(null);
   const [codexConfigDialog, setCodexConfigDialog] = useState<CodexConfigDialogState | null>(null);
   const [copiedCodexSection, setCopiedCodexSection] = useState<'configToml' | 'authJson' | null>(
     null,
@@ -401,10 +402,24 @@ export function APITokensPage() {
                               size="sm"
                               className="h-6 w-6 p-0"
                               onClick={async () => {
-                                await navigator.clipboard.writeText(token.token);
+                                try {
+                                  await navigator.clipboard.writeText(token.token);
+                                  setCopiedTokenId(token.id);
+                                  setTimeout(() => {
+                                    setCopiedTokenId((current) =>
+                                      current === token.id ? null : current,
+                                    );
+                                  }, 2000);
+                                } catch (error) {
+                                  console.error('Failed to copy API token.', error);
+                                }
                               }}
                             >
-                              <Copy className="h-3 w-3" />
+                              {copiedTokenId === token.id ? (
+                                <Check className="h-3 w-3 text-green-500" />
+                              ) : (
+                                <Copy className="h-3 w-3" />
+                              )}
                             </Button>
                           </div>
                         </TableCell>


### PR DESCRIPTION
## Summary
- add copied-state tracking for API Tokens table row copy buttons
- switch the row copy icon to a green check after a successful copy
- keep the change minimal and scoped to the missing copied-icon feedback

## Testing
- pnpm --dir web typecheck
- pnpm --dir web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## API 令牌管理改进

* **Bug Fixes**
  * 改进了 API 令牌复制功能的用户体验，每个令牌行现在都有独立的复制反馈
  * 添加了复制成功的视觉反馈，复制时显示勾号图标以确认操作完成
  * 增强了复制功能的可靠性和错误处理能力

<!-- end of auto-generated comment: release notes by coderabbit.ai -->