### PR TITLE
fix(codex): report incomplete stream termination

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -489,7 +489,7 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 
 		if err != nil {
 			a.sendFinalStreamEvents(eventChan, &collector, &model, resp)
-			if err == io.EOF || responseCompleted {
+			if responseCompleted {
 				return nil
 			}
 			if ctx.Err() != nil {
@@ -497,7 +497,10 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 				proxyErr.Scope = domain.ScopeRequest
 				return proxyErr
 			}
-			return nil
+			proxyErr := domain.NewProxyErrorWithMessage(err, true, "stream closed before response.completed")
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonNetworkError
+			return proxyErr
 		}
 	}
 }

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -1,7 +1,10 @@
 package codex
 
 import (
+	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -9,6 +12,31 @@ import (
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/tidwall/gjson"
 )
+
+type scriptedReadCloser struct {
+	chunks [][]byte
+	err    error
+	idx    int
+}
+
+func (r *scriptedReadCloser) Read(p []byte) (int, error) {
+	if r.idx < len(r.chunks) {
+		chunk := r.chunks[r.idx]
+		r.idx++
+		copy(p, chunk)
+		return len(chunk), nil
+	}
+	if r.err != nil {
+		err := r.err
+		r.err = nil
+		return 0, err
+	}
+	return 0, io.EOF
+}
+
+func (r *scriptedReadCloser) Close() error {
+	return nil
+}
 
 func TestApplyCodexRequestTuning(t *testing.T) {
 	c := flow.NewCtx(nil, nil)
@@ -144,10 +172,10 @@ func TestApplyCodexHeadersUsesDefaultUAWhenClientUAIsBlank(t *testing.T) {
 
 func TestExtractModelFromSSELine(t *testing.T) {
 	tests := []struct {
-		name     string
-		line     string
-		wantSet  bool
-		wantVal  string
+		name    string
+		line    string
+		wantSet bool
+		wantVal string
 	}{
 		{"extracts model", `data: {"model":"gpt-4.1","type":"response.created"}`, true, "gpt-4.1"},
 		{"ignores non-data", `event: response.created`, false, ""},
@@ -183,5 +211,88 @@ func TestExtractModelFromSSELine_KeepsLast(t *testing.T) {
 	}
 	if model != "gpt-4.1-2025-04-14" {
 		t.Fatalf("expected last model, got %q", model)
+	}
+}
+
+func TestHandleStreamResponseReturnsProviderErrorWhenStreamEndsBeforeCompleted(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n",
+		)),
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	if err == nil {
+		t.Fatal("expected incomplete stream to return error")
+	}
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Fatalf("expected scope %q, got %q", domain.ScopeProvider, proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Fatalf("expected reason %q, got %q", domain.CooldownReasonNetworkError, proxyErr.Reason)
+	}
+	if proxyErr.Message != "stream closed before response.completed" {
+		t.Fatalf("expected message %q, got %q", "stream closed before response.completed", proxyErr.Message)
+	}
+}
+
+func TestHandleStreamResponseReturnsProviderErrorOnReadErrorBeforeCompleted(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: &scriptedReadCloser{
+			chunks: [][]byte{[]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n")},
+			err:    errors.New("boom"),
+		},
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	if err == nil {
+		t.Fatal("expected read error before completion to return error")
+	}
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Fatalf("expected scope %q, got %q", domain.ScopeProvider, proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Fatalf("expected reason %q, got %q", domain.CooldownReasonNetworkError, proxyErr.Reason)
+	}
+	if proxyErr.Message != "stream closed before response.completed" {
+		t.Fatalf("expected message %q, got %q", "stream closed before response.completed", proxyErr.Message)
+	}
+}
+
+func TestHandleStreamResponseAllowsCompletedStreamWithoutTrailingNewline(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body: io.NopCloser(strings.NewReader(
+			"data: {\"type\":\"response.completed\",\"response\":{}}",
+		)),
+	}
+
+	if err := a.handleStreamResponse(ctx, resp); err != nil {
+		t.Fatalf("expected completed stream without trailing newline to succeed, got %v", err)
 	}
 }

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -17,14 +17,27 @@ type scriptedReadCloser struct {
 	chunks [][]byte
 	err    error
 	idx    int
+	off    int
 }
 
 func (r *scriptedReadCloser) Read(p []byte) (int, error) {
-	if r.idx < len(r.chunks) {
+	for r.idx < len(r.chunks) {
 		chunk := r.chunks[r.idx]
-		r.idx++
-		copy(p, chunk)
-		return len(chunk), nil
+		if r.off >= len(chunk) {
+			r.idx++
+			r.off = 0
+			continue
+		}
+
+		n := copy(p, chunk[r.off:])
+		r.off += n
+		if r.off >= len(chunk) {
+			r.idx++
+			r.off = 0
+		}
+		if n > 0 {
+			return n, nil
+		}
 	}
 	if r.err != nil {
 		err := r.err
@@ -36,6 +49,33 @@ func (r *scriptedReadCloser) Read(p []byte) (int, error) {
 
 func (r *scriptedReadCloser) Close() error {
 	return nil
+}
+
+func TestScriptedReadCloserPreservesUnreadBytesAcrossPartialReads(t *testing.T) {
+	r := &scriptedReadCloser{chunks: [][]byte{[]byte("hello")}}
+	buf := make([]byte, 3)
+
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("expected first read to succeed, got %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("expected first read count 3, got %d", n)
+	}
+	if got := string(buf[:n]); got != "hel" {
+		t.Fatalf("expected first read %q, got %q", "hel", got)
+	}
+
+	n, err = r.Read(buf)
+	if err != nil {
+		t.Fatalf("expected second read to succeed, got %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected second read count 2, got %d", n)
+	}
+	if got := string(buf[:n]); got != "lo" {
+		t.Fatalf("expected second read %q, got %q", "lo", got)
+	}
 }
 
 func TestApplyCodexRequestTuning(t *testing.T) {


### PR DESCRIPTION
## Summary

- treat Codex streams as complete only after `response.completed`, instead of silently accepting upstream EOF/read errors as success
- return structured provider/network errors when the stream closes before completion so the proxy does not hide issue #471 behind a fake success path
- add Codex adapter regression tests for incomplete EOF, non-EOF read failure, and a completed stream without trailing newline

Fixes #471

## Test plan

- [x] `go test ./internal/adapter/provider/codex`
- [x] `go test ./internal/adapter/provider/...`
- [x] `go test ./internal/... ./tests/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进流式响应的错误识别：在上游流在未标记完成时异常中断，会返回网络错误以便更可靠地反映连接/传输故障；在已标记完成但末尾无换行的情况下仍能成功处理。
* **Tests**
  * 增加模拟分片读取的测试用例，验证部分读取、读取错误及流提前关闭等场景下的行为，提升鲁棒性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->