### PR TITLE
fix: isolate requests page state across tenant logins

### DIFF
--- a/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
+++ b/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
@@ -175,7 +175,7 @@ test('requests page does not leak cached requests or token filters across tenant
 
     if (url.pathname === '/api/api-tokens') {
       if (bearer === TENANT_TOKEN) {
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await new Promise((resolve) => setTimeout(resolve, 5000));
         tenantTokensResolved = true;
       }
       await route.fulfill({
@@ -258,7 +258,7 @@ test('requests page does not leak cached requests or token filters across tenant
   await page.fill('input[type="password"]', 'test123');
   await page.locator('button[type="submit"]').click();
 
-  await expect(page.locator('body')).not.toContainText('admin-tenant-model', { timeout: 800 });
-  await expect(page.locator('body')).toContainText('tenant-two-model', { timeout: 1200 });
+  await expect(page.locator('body')).not.toContainText('admin-tenant-model', { timeout: 1200 });
+  await expect(page.locator('body')).toContainText('tenant-two-model', { timeout: 3000 });
   expect(tenantTokensResolved).toBeFalsy();
 });

--- a/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
+++ b/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * Playwright E2E Test: Requests Page - auth/session isolation
+ *
+ * Regression test for issue #438.
+ *
+ * 使用方式：
+ *   npx playwright test -c playwright.config.ts requests-auth-switch-isolation.spec.ts --project=e2e-chromium
+ */
+import { expect, test } from 'playwright/test';
+
+const UI_BASE = 'http://127.0.0.1:4173';
+
+const ADMIN_TOKEN = 'admin-token';
+const TENANT_TOKEN = 'tenant-2-token';
+
+const adminUser = {
+  id: 1,
+  username: 'admin',
+  tenantID: 1,
+  tenantName: 'Admin Tenant',
+  role: 'admin',
+};
+
+const tenantUser = {
+  id: 2,
+  username: 'tenant-two-admin',
+  tenantID: 2,
+  tenantName: 'Tenant Two',
+  role: 'admin',
+};
+
+const adminTokenOptions = [{ id: 101, name: 'Admin Token' }];
+const tenantTokenOptions = [{ id: 202, name: 'Tenant Two Token' }];
+const providers = [{ id: 1, name: 'Claude Provider', type: 'custom' }];
+
+function buildRequest(id: number, model: string, apiTokenID: number) {
+  return {
+    id,
+    createdAt: '2026-04-10T05:05:00Z',
+    updatedAt: '2026-04-10T05:05:05Z',
+    instanceID: 'instance-test',
+    requestID: `req-${id}`,
+    sessionID: `session-${id}`,
+    clientType: 'claude',
+    requestModel: model,
+    responseModel: '',
+    startTime: '2026-04-10T05:05:00Z',
+    endTime: '2026-04-10T05:05:05Z',
+    duration: 5_000_000_000,
+    ttft: 0,
+    isStream: false,
+    status: 'COMPLETED',
+    statusCode: 200,
+    requestInfo: null,
+    responseInfo: null,
+    error: '',
+    proxyUpstreamAttemptCount: 1,
+    finalProxyUpstreamAttemptID: 0,
+    routeID: 1,
+    providerID: 1,
+    projectID: 0,
+    inputTokenCount: 32,
+    outputTokenCount: 64,
+    cacheReadCount: 0,
+    cacheWriteCount: 0,
+    cache5mWriteCount: 0,
+    cache1hWriteCount: 0,
+    modelPriceId: 0,
+    multiplier: 10000,
+    cost: 0,
+    apiTokenID,
+  };
+}
+
+function readBearerToken(header: string | null): string | null {
+  if (!header) {
+    return null;
+  }
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
+}
+
+test('requests page does not leak cached requests or token filters across tenant logins', async ({
+  page,
+}) => {
+  const adminRequest = buildRequest(4381, 'admin-tenant-model', 101);
+  const tenantRequest = buildRequest(4382, 'tenant-two-model', 202);
+
+  let tenantTokensResolved = false;
+
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const bearer = readBearerToken(await route.request().headerValue('authorization'));
+
+    const session =
+      bearer === ADMIN_TOKEN
+        ? { user: adminUser, requests: [adminRequest], tokens: adminTokenOptions }
+        : bearer === TENANT_TOKEN
+          ? { user: tenantUser, requests: [tenantRequest], tokens: tenantTokenOptions }
+          : null;
+
+    if (url.pathname === '/api/admin/auth/status') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ authEnabled: true, user: session?.user ?? null }),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/admin/auth/login' && route.request().method() === 'POST') {
+      const payload = route.request().postDataJSON() as { username?: string };
+      if (payload.username === 'admin') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, token: ADMIN_TOKEN, user: adminUser }),
+        });
+        return;
+      }
+      if (payload.username === 'tenant-two-admin') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, token: TENANT_TOKEN, user: tenantUser }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'invalid credentials' }),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/settings') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          api_token_auth_enabled: 'true',
+          force_project_binding: 'false',
+        }),
+      });
+      return;
+    }
+
+    if (!session) {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'unauthorized' }),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/admin/providers') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(providers),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/projects') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/api-tokens') {
+      if (bearer === TENANT_TOKEN) {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        tenantTokensResolved = true;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(session.tokens),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/admin/requests/count') {
+      if (bearer === TENANT_TOKEN) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(session.requests.length),
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/admin/requests') {
+      if (bearer === TENANT_TOKEN) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      const requestedTokenId = url.searchParams.get('apiTokenId');
+      const items = requestedTokenId
+        ? session.requests.filter((item) => String(item.apiTokenID) === requestedTokenId)
+        : session.requests;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          items,
+          hasMore: false,
+          firstId: items[0]?.id ?? 0,
+          lastId: items[items.length - 1]?.id ?? 0,
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: `Unhandled API route: ${url.pathname}` }),
+    });
+  });
+
+  await page.goto(`${UI_BASE}/requests`);
+
+  await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
+  await page.fill('input[type="text"]', 'admin');
+  await page.fill('input[type="password"]', 'test123');
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page.locator('body')).toContainText('admin-tenant-model', { timeout: 10000 });
+
+  await page.evaluate(() => {
+    localStorage.setItem('maxx-requests-filter-mode', 'token');
+    localStorage.setItem('maxx-requests-token-filter', '101');
+    localStorage.setItem('maxx-requests-filter-mode:tenant-1:user-1', 'token');
+    localStorage.setItem('maxx-requests-token-filter:tenant-1:user-1', '101');
+  });
+
+  await page.reload();
+  await expect(page.locator('body')).toContainText('admin-tenant-model', { timeout: 10000 });
+
+  const menuButton = page.locator('button[aria-haspopup="menu"]').last();
+  await menuButton.click();
+  const logoutItem = page.locator('[role="menuitem"]').filter({ hasText: /Log out|退出登录/ }).first();
+  await expect(logoutItem).toBeVisible({ timeout: 5000 });
+  await logoutItem.click();
+  await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 5000 });
+
+  await page.fill('input[type="text"]', 'tenant-two-admin');
+  await page.fill('input[type="password"]', 'test123');
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page.locator('body')).not.toContainText('admin-tenant-model', { timeout: 800 });
+  await expect(page.locator('body')).toContainText('tenant-two-model', { timeout: 1200 });
+  expect(tenantTokensResolved).toBeFalsy();
+});

--- a/tests/e2e/playwright/requests-loading-state.spec.ts
+++ b/tests/e2e/playwright/requests-loading-state.spec.ts
@@ -153,6 +153,8 @@ test('requests page shows loading fallback when filter dependency is delayed', a
       ({ pid }) => {
         localStorage.setItem('maxx-requests-filter-mode', 'provider');
         localStorage.setItem('maxx-requests-provider-filter', String(pid));
+        localStorage.setItem('maxx-requests-filter-mode:tenant-1:user-1', 'provider');
+        localStorage.setItem('maxx-requests-provider-filter:tenant-1:user-1', String(pid));
       },
       { pid: providerId },
     );

--- a/tests/e2e/playwright/requests-mixed-stress.spec.ts
+++ b/tests/e2e/playwright/requests-mixed-stress.spec.ts
@@ -19,6 +19,10 @@ const REQUEST_FILTER_MODE_STORAGE_KEY = 'maxx-requests-filter-mode';
 const REQUEST_PROVIDER_FILTER_STORAGE_KEY = 'maxx-requests-provider-filter';
 const REQUEST_TOKEN_FILTER_STORAGE_KEY = 'maxx-requests-token-filter';
 const REQUEST_PROJECT_FILTER_STORAGE_KEY = 'maxx-requests-project-filter';
+const REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY = 'maxx-requests-filter-mode:tenant-1:user-1';
+const REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-provider-filter:tenant-1:user-1';
+const REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-token-filter:tenant-1:user-1';
+const REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-project-filter:tenant-1:user-1';
 
 const STRESS_DURATION_MS = 60_000;
 const SAMPLE_INTERVAL_MS = 30_000;
@@ -292,6 +296,11 @@ async function openRequestsPage(page: Page, providerId: number) {
     localStorage.setItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY, String(id));
     localStorage.removeItem(REQUEST_TOKEN_FILTER_STORAGE_KEY);
     localStorage.removeItem(REQUEST_PROJECT_FILTER_STORAGE_KEY);
+
+    localStorage.setItem(REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY, 'provider');
+    localStorage.setItem(REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY, String(id));
+    localStorage.removeItem(REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY);
+    localStorage.removeItem(REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY);
   }, providerId);
 
   await page.goto(`${BASE}/requests`);

--- a/tests/e2e/playwright/requests-table-alignment.spec.ts
+++ b/tests/e2e/playwright/requests-table-alignment.spec.ts
@@ -14,6 +14,10 @@ const REQUEST_FILTER_MODE_STORAGE_KEY = 'maxx-requests-filter-mode';
 const REQUEST_PROVIDER_FILTER_STORAGE_KEY = 'maxx-requests-provider-filter';
 const REQUEST_TOKEN_FILTER_STORAGE_KEY = 'maxx-requests-token-filter';
 const REQUEST_PROJECT_FILTER_STORAGE_KEY = 'maxx-requests-project-filter';
+const REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY = 'maxx-requests-filter-mode:tenant-1:user-1';
+const REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-provider-filter:tenant-1:user-1';
+const REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-token-filter:tenant-1:user-1';
+const REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-project-filter:tenant-1:user-1';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -182,6 +186,11 @@ async function openRequestsPage(page: Page, providerId?: number) {
         localStorage.setItem(keys.provider, String(id));
         localStorage.removeItem(keys.token);
         localStorage.removeItem(keys.project);
+
+        localStorage.setItem(keys.scopedMode, 'provider');
+        localStorage.setItem(keys.scopedProvider, String(id));
+        localStorage.removeItem(keys.scopedToken);
+        localStorage.removeItem(keys.scopedProject);
       },
       {
         id: providerId,
@@ -190,6 +199,10 @@ async function openRequestsPage(page: Page, providerId?: number) {
           provider: REQUEST_PROVIDER_FILTER_STORAGE_KEY,
           token: REQUEST_TOKEN_FILTER_STORAGE_KEY,
           project: REQUEST_PROJECT_FILTER_STORAGE_KEY,
+          scopedMode: REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY,
+          scopedProvider: REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY,
+          scopedToken: REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY,
+          scopedProject: REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY,
         },
       },
     );

--- a/tests/e2e/playwright/requests-ws-reconnect-sync.spec.ts
+++ b/tests/e2e/playwright/requests-ws-reconnect-sync.spec.ts
@@ -17,6 +17,10 @@ const REQUEST_FILTER_MODE_STORAGE_KEY = 'maxx-requests-filter-mode';
 const REQUEST_PROVIDER_FILTER_STORAGE_KEY = 'maxx-requests-provider-filter';
 const REQUEST_TOKEN_FILTER_STORAGE_KEY = 'maxx-requests-token-filter';
 const REQUEST_PROJECT_FILTER_STORAGE_KEY = 'maxx-requests-project-filter';
+const REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY = 'maxx-requests-filter-mode:tenant-1:user-1';
+const REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-provider-filter:tenant-1:user-1';
+const REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-token-filter:tenant-1:user-1';
+const REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY = 'maxx-requests-project-filter:tenant-1:user-1';
 
 const ACTIVE_STATUS_RE = /pending|stream|waiting|in progress|等待|传输|绑定/i;
 const TERMINAL_STATUS_RE = /completed|failed|cancelled|rejected|完成|失败|取消|拒绝/i;
@@ -120,6 +124,11 @@ async function openRequestsPage(page: Page, providerId: number) {
       localStorage.setItem(keys.provider, String(id));
       localStorage.removeItem(keys.token);
       localStorage.removeItem(keys.project);
+
+      localStorage.setItem(keys.scopedMode, 'provider');
+      localStorage.setItem(keys.scopedProvider, String(id));
+      localStorage.removeItem(keys.scopedToken);
+      localStorage.removeItem(keys.scopedProject);
     },
     {
       id: providerId,
@@ -128,6 +137,10 @@ async function openRequestsPage(page: Page, providerId: number) {
         provider: REQUEST_PROVIDER_FILTER_STORAGE_KEY,
         token: REQUEST_TOKEN_FILTER_STORAGE_KEY,
         project: REQUEST_PROJECT_FILTER_STORAGE_KEY,
+        scopedMode: REQUEST_FILTER_MODE_SCOPED_STORAGE_KEY,
+        scopedProvider: REQUEST_PROVIDER_FILTER_SCOPED_STORAGE_KEY,
+        scopedToken: REQUEST_TOKEN_FILTER_SCOPED_STORAGE_KEY,
+        scopedProject: REQUEST_PROJECT_FILTER_SCOPED_STORAGE_KEY,
       },
     },
   );

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -359,15 +359,14 @@ export function useProxyRequestUpdates() {
           });
         }
 
-        // 新请求时乐观更新 count（增加保护：避免因“未观察详情缓存”导致重复 +1）
+        // 新请求时乐观更新 count。重连后首个看到的增量可能已经是 COMPLETED，
+        // 不能只盯 PENDING，否则会把断线窗口内完成的新请求漏掉。
         if (!isKnown) {
           const startTimeMs = new Date(updatedRequest.startTime).getTime();
-          const looksLikeNewRequest =
-            updatedRequest.status === 'PENDING' &&
-            Number.isFinite(startTimeMs) &&
-            Date.now() - startTimeMs < 15_000;
+          const looksLikeRecentRequest =
+            Number.isFinite(startTimeMs) && Date.now() - startTimeMs < 15_000;
 
-          if (looksLikeNewRequest) {
+          if (looksLikeRecentRequest) {
             for (const query of countQueries) {
               const filterProviderId = query.queryKey[1] as number | undefined;
               const filterStatus = query.queryKey[2] as string | undefined;

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTransport } from '@/lib/transport';
 import type { UserRole } from '@/lib/transport/types';
 
@@ -30,10 +31,15 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const { transport } = useTransport();
+  const queryClient = useQueryClient();
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [authEnabled, setAuthEnabled] = useState(false);
   const [user, setUser] = useState<AuthUser | null>(null);
+
+  const resetClientState = useCallback(() => {
+    queryClient.clear();
+  }, [queryClient]);
 
   useEffect(() => {
     let cancelled = false;
@@ -77,6 +83,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             );
             localStorage.removeItem(AUTH_TOKEN_KEY);
             transport.clearAuthToken();
+            resetClientState();
             return;
           }
 
@@ -142,10 +149,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         clearTimeout(timeoutId);
       }
     };
-  }, [transport]);
+  }, [resetClientState, transport]);
 
   const login = useCallback(
     (token: string, userInfo?: AuthUser) => {
+      resetClientState();
       localStorage.setItem(AUTH_TOKEN_KEY, token);
       transport.setAuthToken(token);
       if (userInfo) {
@@ -153,15 +161,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
       setIsAuthenticated(true);
     },
-    [transport],
+    [resetClientState, transport],
   );
 
   const logout = useCallback(() => {
+    resetClientState();
     localStorage.removeItem(AUTH_TOKEN_KEY);
     transport.clearAuthToken();
     setUser(null);
     setIsAuthenticated(false);
-  }, [transport]);
+  }, [resetClientState, transport]);
 
   return (
     <AuthContext.Provider value={{ isAuthenticated, isLoading, authEnabled, user, login, logout }}>

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -39,6 +39,7 @@ import {
 import { cn } from '@/lib/utils';
 import { PageHeader } from '@/components/layout/page-header';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useAuth } from '@/lib/auth-context';
 import { calculateVirtualRange } from './virtual-range';
 
 type ProviderTypeKey = 'antigravity' | 'kiro' | 'codex' | 'custom';
@@ -81,6 +82,24 @@ function readStoredNumber(key: string): number | undefined {
   return parsed;
 }
 
+function readStoredFilterMode(key: string): RequestFilterMode {
+  if (typeof window === 'undefined') {
+    return 'token';
+  }
+  const stored = window.localStorage.getItem(key);
+  if (stored === 'provider' || stored === 'project') {
+    return stored;
+  }
+  return 'token';
+}
+
+function buildScopedStorageKey(baseKey: string, tenantID?: number, userID?: number): string {
+  if (!tenantID || !userID) {
+    return `${baseKey}:anonymous`;
+  }
+  return `${baseKey}:tenant-${tenantID}:user-${userID}`;
+}
+
 /** Maps each proxy request status to its corresponding badge variant. */
 export const statusVariant: Record<
   ProxyRequestStatus,
@@ -99,27 +118,40 @@ export function RequestsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+  const { user } = useAuth();
+
+  const filterModeStorageKey = useMemo(
+    () => buildScopedStorageKey(REQUEST_FILTER_MODE_STORAGE_KEY, user?.tenantID, user?.id),
+    [user?.id, user?.tenantID],
+  );
+  const providerFilterStorageKey = useMemo(
+    () => buildScopedStorageKey(REQUEST_PROVIDER_FILTER_STORAGE_KEY, user?.tenantID, user?.id),
+    [user?.id, user?.tenantID],
+  );
+  const tokenFilterStorageKey = useMemo(
+    () => buildScopedStorageKey(REQUEST_TOKEN_FILTER_STORAGE_KEY, user?.tenantID, user?.id),
+    [user?.id, user?.tenantID],
+  );
+  const projectFilterStorageKey = useMemo(
+    () => buildScopedStorageKey(REQUEST_PROJECT_FILTER_STORAGE_KEY, user?.tenantID, user?.id),
+    [user?.id, user?.tenantID],
+  );
 
   // 过滤维度（默认令牌）
-  const [filterMode, setFilterMode] = useState<RequestFilterMode>(() => {
-    if (typeof window === 'undefined') {
-      return 'token';
-    }
-    const stored = window.localStorage.getItem(REQUEST_FILTER_MODE_STORAGE_KEY);
-    if (stored === 'provider' || stored === 'project') return stored;
-    return 'token';
-  });
+  const [filterMode, setFilterMode] = useState<RequestFilterMode>(() =>
+    readStoredFilterMode(filterModeStorageKey),
+  );
   // Provider 过滤器
   const [selectedProviderId, setSelectedProviderId] = useState<number | undefined>(() =>
-    readStoredNumber(REQUEST_PROVIDER_FILTER_STORAGE_KEY),
+    readStoredNumber(providerFilterStorageKey),
   );
   // Token 过滤器
   const [selectedTokenId, setSelectedTokenId] = useState<number | undefined>(() =>
-    readStoredNumber(REQUEST_TOKEN_FILTER_STORAGE_KEY),
+    readStoredNumber(tokenFilterStorageKey),
   );
   // Project 过滤器
   const [selectedProjectId, setSelectedProjectId] = useState<number | undefined>(() =>
-    readStoredNumber(REQUEST_PROJECT_FILTER_STORAGE_KEY),
+    readStoredNumber(projectFilterStorageKey),
   );
   // Status 过滤器
   const [selectedStatus, setSelectedStatus] = useState<string | undefined>(undefined);
@@ -305,44 +337,57 @@ export function RequestsPage() {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   useEffect(() => {
+    setFilterMode(readStoredFilterMode(filterModeStorageKey));
+    setSelectedProviderId(readStoredNumber(providerFilterStorageKey));
+    setSelectedTokenId(readStoredNumber(tokenFilterStorageKey));
+    setSelectedProjectId(readStoredNumber(projectFilterStorageKey));
+    setSelectedStatus(undefined);
+  }, [
+    filterModeStorageKey,
+    projectFilterStorageKey,
+    providerFilterStorageKey,
+    tokenFilterStorageKey,
+  ]);
+
+  useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
-    window.localStorage.setItem(REQUEST_FILTER_MODE_STORAGE_KEY, filterMode);
-  }, [filterMode]);
+    window.localStorage.setItem(filterModeStorageKey, filterMode);
+  }, [filterMode, filterModeStorageKey]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
     if (selectedProviderId === undefined) {
-      window.localStorage.removeItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY);
+      window.localStorage.removeItem(providerFilterStorageKey);
       return;
     }
-    window.localStorage.setItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY, String(selectedProviderId));
-  }, [selectedProviderId]);
+    window.localStorage.setItem(providerFilterStorageKey, String(selectedProviderId));
+  }, [providerFilterStorageKey, selectedProviderId]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
     if (selectedTokenId === undefined) {
-      window.localStorage.removeItem(REQUEST_TOKEN_FILTER_STORAGE_KEY);
+      window.localStorage.removeItem(tokenFilterStorageKey);
       return;
     }
-    window.localStorage.setItem(REQUEST_TOKEN_FILTER_STORAGE_KEY, String(selectedTokenId));
-  }, [selectedTokenId]);
+    window.localStorage.setItem(tokenFilterStorageKey, String(selectedTokenId));
+  }, [selectedTokenId, tokenFilterStorageKey]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;
     }
     if (selectedProjectId === undefined) {
-      window.localStorage.removeItem(REQUEST_PROJECT_FILTER_STORAGE_KEY);
+      window.localStorage.removeItem(projectFilterStorageKey);
       return;
     }
-    window.localStorage.setItem(REQUEST_PROJECT_FILTER_STORAGE_KEY, String(selectedProjectId));
-  }, [selectedProjectId]);
+    window.localStorage.setItem(projectFilterStorageKey, String(selectedProjectId));
+  }, [projectFilterStorageKey, selectedProjectId]);
 
   useEffect(() => {
     if (!providersIsSuccess || selectedProviderId === undefined) {

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -82,7 +82,15 @@ function readStoredNumber(key: string): number | undefined {
   return parsed;
 }
 
-function readStoredFilterMode(key: string): RequestFilterMode {
+function readStoredNumberWithLegacy(key: string, legacyKey?: string): number | undefined {
+  const scopedValue = readStoredNumber(key);
+  if (scopedValue !== undefined || !legacyKey) {
+    return scopedValue;
+  }
+  return readStoredNumber(legacyKey);
+}
+
+function readStoredFilterMode(key: string, legacyKey?: string): RequestFilterMode {
   if (typeof window === 'undefined') {
     return 'token';
   }
@@ -90,7 +98,59 @@ function readStoredFilterMode(key: string): RequestFilterMode {
   if (stored === 'provider' || stored === 'project') {
     return stored;
   }
+  if (stored === 'token') {
+    return 'token';
+  }
+  if (legacyKey) {
+    const legacyStored = window.localStorage.getItem(legacyKey);
+    if (legacyStored === 'provider' || legacyStored === 'project') {
+      return legacyStored;
+    }
+  }
   return 'token';
+}
+
+function migrateLegacyRequestFilterValue(scopedKey: string, legacyKey: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const scopedValue = window.localStorage.getItem(scopedKey);
+  const legacyValue = window.localStorage.getItem(legacyKey);
+
+  if (scopedValue !== null || legacyValue === null) {
+    return;
+  }
+
+  window.localStorage.setItem(scopedKey, legacyValue);
+  window.localStorage.removeItem(legacyKey);
+}
+
+function migrateLegacyRequestFilters({
+  modeKey,
+  providerKey,
+  tokenKey,
+  projectKey,
+}: {
+  modeKey: string;
+  providerKey: string;
+  tokenKey: string;
+  projectKey: string;
+}) {
+  migrateLegacyRequestFilterValue(modeKey, REQUEST_FILTER_MODE_STORAGE_KEY);
+  migrateLegacyRequestFilterValue(providerKey, REQUEST_PROVIDER_FILTER_STORAGE_KEY);
+  migrateLegacyRequestFilterValue(tokenKey, REQUEST_TOKEN_FILTER_STORAGE_KEY);
+  migrateLegacyRequestFilterValue(projectKey, REQUEST_PROJECT_FILTER_STORAGE_KEY);
+}
+
+function removeLegacyRequestFilters() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.removeItem(REQUEST_FILTER_MODE_STORAGE_KEY);
+  window.localStorage.removeItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY);
+  window.localStorage.removeItem(REQUEST_TOKEN_FILTER_STORAGE_KEY);
+  window.localStorage.removeItem(REQUEST_PROJECT_FILTER_STORAGE_KEY);
 }
 
 function buildScopedStorageKey(baseKey: string, tenantID?: number, userID?: number): string {
@@ -139,19 +199,19 @@ export function RequestsPage() {
 
   // 过滤维度（默认令牌）
   const [filterMode, setFilterMode] = useState<RequestFilterMode>(() =>
-    readStoredFilterMode(filterModeStorageKey),
+    readStoredFilterMode(filterModeStorageKey, REQUEST_FILTER_MODE_STORAGE_KEY),
   );
   // Provider 过滤器
   const [selectedProviderId, setSelectedProviderId] = useState<number | undefined>(() =>
-    readStoredNumber(providerFilterStorageKey),
+    readStoredNumberWithLegacy(providerFilterStorageKey, REQUEST_PROVIDER_FILTER_STORAGE_KEY),
   );
   // Token 过滤器
   const [selectedTokenId, setSelectedTokenId] = useState<number | undefined>(() =>
-    readStoredNumber(tokenFilterStorageKey),
+    readStoredNumberWithLegacy(tokenFilterStorageKey, REQUEST_TOKEN_FILTER_STORAGE_KEY),
   );
   // Project 过滤器
   const [selectedProjectId, setSelectedProjectId] = useState<number | undefined>(() =>
-    readStoredNumber(projectFilterStorageKey),
+    readStoredNumberWithLegacy(projectFilterStorageKey, REQUEST_PROJECT_FILTER_STORAGE_KEY),
   );
   // Status 过滤器
   const [selectedStatus, setSelectedStatus] = useState<string | undefined>(undefined);
@@ -337,10 +397,23 @@ export function RequestsPage() {
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   useEffect(() => {
-    setFilterMode(readStoredFilterMode(filterModeStorageKey));
-    setSelectedProviderId(readStoredNumber(providerFilterStorageKey));
-    setSelectedTokenId(readStoredNumber(tokenFilterStorageKey));
-    setSelectedProjectId(readStoredNumber(projectFilterStorageKey));
+    migrateLegacyRequestFilters({
+      modeKey: filterModeStorageKey,
+      providerKey: providerFilterStorageKey,
+      tokenKey: tokenFilterStorageKey,
+      projectKey: projectFilterStorageKey,
+    });
+
+    setFilterMode(readStoredFilterMode(filterModeStorageKey, REQUEST_FILTER_MODE_STORAGE_KEY));
+    setSelectedProviderId(
+      readStoredNumberWithLegacy(providerFilterStorageKey, REQUEST_PROVIDER_FILTER_STORAGE_KEY),
+    );
+    setSelectedTokenId(
+      readStoredNumberWithLegacy(tokenFilterStorageKey, REQUEST_TOKEN_FILTER_STORAGE_KEY),
+    );
+    setSelectedProjectId(
+      readStoredNumberWithLegacy(projectFilterStorageKey, REQUEST_PROJECT_FILTER_STORAGE_KEY),
+    );
     setSelectedStatus(undefined);
   }, [
     filterModeStorageKey,
@@ -354,6 +427,7 @@ export function RequestsPage() {
       return;
     }
     window.localStorage.setItem(filterModeStorageKey, filterMode);
+    removeLegacyRequestFilters();
   }, [filterMode, filterModeStorageKey]);
 
   useEffect(() => {
@@ -362,9 +436,11 @@ export function RequestsPage() {
     }
     if (selectedProviderId === undefined) {
       window.localStorage.removeItem(providerFilterStorageKey);
+      window.localStorage.removeItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY);
       return;
     }
     window.localStorage.setItem(providerFilterStorageKey, String(selectedProviderId));
+    window.localStorage.removeItem(REQUEST_PROVIDER_FILTER_STORAGE_KEY);
   }, [providerFilterStorageKey, selectedProviderId]);
 
   useEffect(() => {
@@ -373,9 +449,11 @@ export function RequestsPage() {
     }
     if (selectedTokenId === undefined) {
       window.localStorage.removeItem(tokenFilterStorageKey);
+      window.localStorage.removeItem(REQUEST_TOKEN_FILTER_STORAGE_KEY);
       return;
     }
     window.localStorage.setItem(tokenFilterStorageKey, String(selectedTokenId));
+    window.localStorage.removeItem(REQUEST_TOKEN_FILTER_STORAGE_KEY);
   }, [selectedTokenId, tokenFilterStorageKey]);
 
   useEffect(() => {
@@ -384,9 +462,11 @@ export function RequestsPage() {
     }
     if (selectedProjectId === undefined) {
       window.localStorage.removeItem(projectFilterStorageKey);
+      window.localStorage.removeItem(REQUEST_PROJECT_FILTER_STORAGE_KEY);
       return;
     }
     window.localStorage.setItem(projectFilterStorageKey, String(selectedProjectId));
+    window.localStorage.removeItem(REQUEST_PROJECT_FILTER_STORAGE_KEY);
   }, [projectFilterStorageKey, selectedProjectId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- clear React Query client state when auth identity changes so the requests page does not reuse the previous tenant's cached data
- scope requests page localStorage filters by tenant and user instead of sharing one global key across every login
- add a Playwright regression test covering admin -> tenant login switching on the requests page

## Root cause
The requests API path still enforced tenant scoping on the backend. The leak came from frontend session state: request caches and persisted filter keys survived logout/login, so a new tenant could momentarily reuse the previous account's requests/token filter state.

## Testing
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm exec playwright test -c playwright.config.ts requests-auth-switch-isolation.spec.ts --project=e2e-chromium

Fixes #438.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复多租户环境中租户切换时请求列表与筛选状态可能相互泄露的问题，筛选范围现在基于租户/用户隔离存储。

* **改进**
  * 登录/登出与认证失败时会重置客户端缓存以避免残留数据。
  * 优化对“新近请求”计数的识别逻辑，使请求计数更准确及时。

* **测试**
  * 新增端到端测试覆盖租户切换时的过滤器与请求数据隔离与加载行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->