### PR TITLE
ci: cache Docker/Wails dependencies and enable provenance

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -92,7 +94,10 @@ jobs:
           file: Dockerfile.ci
           platforms: linux/amd64,linux/arm64
           push: true
-          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
           tags: |
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}
             ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest

--- a/.github/workflows/ci-wails-build.yml
+++ b/.github/workflows/ci-wails-build.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - uses: pnpm/action-setup@v4
         with:
@@ -116,6 +118,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - uses: pnpm/action-setup@v4
         with:
@@ -183,6 +187,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Install Linux Build Dependencies
         run: |


### PR DESCRIPTION
## Summary
- add pnpm dependency caching to Docker and Wails build workflows
- enable GitHub Actions buildx layer caching for Docker image builds
- turn on provenance attestations and SBOM generation for published container images
- keep Go cache logic unchanged because `actions/setup-go@v5` already provides built-in caching; the real missing cache path here was pnpm

## Testing
- python3 - <<'PY'
  import yaml, pathlib
  for path in [
      pathlib.Path('.github/workflows/ci-docker-build.yml'),
      pathlib.Path('.github/workflows/ci-wails-build.yml'),
  ]:
      with path.open('r', encoding='utf-8') as f:
          yaml.safe_load(f)
      print(path.name)
  PY
- git diff --check

Closes #359
