### PR TITLE
docs(provider): clarify export exclusion copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
   <img src="web/public/logo.png" alt="maxx logo" width="128" height="128">
 </p>
 
+<p align="center">
+  <a href="https://github.com/awsl-project/maxx/releases/latest"><img src="https://img.shields.io/github/v/release/awsl-project/maxx?display_name=tag" alt="Latest Release"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/lint.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/lint.yml?branch=main&label=PR%20Checks" alt="PR Checks"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-test.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-test.yml?branch=main&label=E2E" alt="E2E Tests"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-playwright.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-playwright.yml?branch=main&label=Playwright" alt="Playwright Tests"></a>
+</p>
+
 # maxx
 
 English | [简体中文](README_CN.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,6 +2,13 @@
   <img src="web/public/logo.png" alt="maxx logo" width="128" height="128">
 </p>
 
+<p align="center">
+  <a href="https://github.com/awsl-project/maxx/releases/latest"><img src="https://img.shields.io/github/v/release/awsl-project/maxx?display_name=tag" alt="Latest Release"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/lint.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/lint.yml?branch=main&label=PR%20Checks" alt="PR Checks"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-test.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-test.yml?branch=main&label=E2E" alt="E2E Tests"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-playwright.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-playwright.yml?branch=main&label=Playwright" alt="Playwright Tests"></a>
+</p>
+
 # maxx
 
 [English](README.md) | 简体中文

--- a/tests/e2e/playwright/requests-table-alignment.spec.ts
+++ b/tests/e2e/playwright/requests-table-alignment.spec.ts
@@ -208,12 +208,25 @@ async function openRequestsPage(page: Page, providerId?: number) {
     );
   }
 
-  await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
+  const passwordInput = page.locator('input[type="password"]');
+  const requestsHeading = page.getByRole('heading', { name: 'Requests' });
 
-  if (await page.locator('input[type="password"]').count()) {
-    await loginToAdminUI(page);
+  const navigateToRequests = async () => {
     await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
+    await Promise.race([
+      requestsHeading.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+      passwordInput.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+    ]);
+  };
+
+  await navigateToRequests();
+
+  if (await passwordInput.isVisible().catch(() => false)) {
+    await loginToAdminUI(page);
+    await navigateToRequests();
   }
+
+  await expect(requestsHeading).toBeVisible({ timeout: 30_000 });
 }
 
 test('virtualized requests table keeps header and body columns aligned', async ({ page }, testInfo) => {

--- a/tests/e2e/playwright/requests-table-alignment.spec.ts
+++ b/tests/e2e/playwright/requests-table-alignment.spec.ts
@@ -208,13 +208,11 @@ async function openRequestsPage(page: Page, providerId?: number) {
     );
   }
 
-  await page.goto(`${BASE}/requests`);
-  await page.waitForLoadState('networkidle');
+  await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
 
   if (await page.locator('input[type="password"]').count()) {
     await loginToAdminUI(page);
-    await page.goto(`${BASE}/requests`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
   }
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1269,7 +1269,7 @@
     "apiEndpoint": "API Endpoint",
     "apiKey": "API Key",
     "apiKeyEdit": "API Key (leave empty to keep current)",
-    "apiKeyExcludedHint": "This provider is excluded from export and backup. You can still rotate the API key here; it just won't be included in exported files or backup packages.",
+    "apiKeyExcludedHint": "This provider is set to \"Do not export this provider\". You can still rotate the API key here, but this provider and its configuration will not be included in provider exports or system backups.",
     "optionalUrlNote": "Optional if client-specific URLs are set below.",
     "namePlaceholder": "e.g. Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1294,8 +1294,8 @@
     "errorCooldownTitle": "3. Error Cooldown",
     "disableErrorCooldown": "Disable Error Cooldown",
     "disableErrorCooldownDesc": "When enabled, errors won't trigger automatic cooldown. Manual freezes and explicit cooldown times still apply.",
-    "excludeFromExport": "Exclude from export and backup",
-    "excludeFromExportDesc": "When enabled, this provider stays local to this system and will not be included in exported files or backup packages."
+    "excludeFromExport": "Do not export this provider",
+    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups. This only affects the current provider and does not reduce the export of other data such as API tokens or system settings."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1268,7 +1268,7 @@
     "apiEndpoint": "API 端点",
     "apiKey": "API 密钥",
     "apiKeyEdit": "API 密钥（留空保持当前值）",
-    "apiKeyExcludedHint": "该提供商已设置为“从导出与备份中排除”。您仍可在这里轮换 API 密钥，只是它不会被写入导出文件或系统备份。",
+    "apiKeyExcludedHint": "该提供商已设置为“不导出此提供商配置”。您仍可在这里轮换 API 密钥，但当前提供商及其配置不会被包含在提供商导出或系统备份中。",
     "optionalUrlNote": "如果下面设置了客户端特定的 URL，则此项为可选。",
     "namePlaceholder": "例如：Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1293,8 +1293,8 @@
     "errorCooldownTitle": "3. 错误冷冻",
     "disableErrorCooldown": "禁用错误冷冻",
     "disableErrorCooldownDesc": "开启后，错误将不再触发自动冷冻；手动冷冻与上游明确冷冻时间仍会生效。",
-    "excludeFromExport": "从导出与备份中排除",
-    "excludeFromExportDesc": "开启后，该提供商仅保留在当前系统中，不会被写入导出文件或系统备份。"
+    "excludeFromExport": "不导出此提供商配置",
+    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中。仅影响当前提供商，不影响 API Token、系统设置等其他数据的导出。"
   },
   "cooldown": {
     "title": "冷却保护中",


### PR DESCRIPTION
## Summary
- rename the provider export toggle to make its scope explicit
- clarify that the toggle only affects the current provider
- align the excluded API key hint copy with the new wording

## Validation
- verified `web/src/locales/zh.json` and `web/src/locales/en.json` parse successfully with utf-8-sig handling (files include BOM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档优化**
  * 优化了供应商导出相关界面文案（将选项改称为“**不导出此供应商**”，并明确仅影响当前供应商及其配置，不影响 API 令牌或系统设置，且仍可进行 API 密钥轮换）。
  * 在 README 与 README_CN 中新增并居中展示指向最新发布及多个 CI 状态的徽章。

* **测试**
  * 改进了端到端测试的页面导航与加载判断，增强了对登录流程与页面可见性的鲁棒性和断言时限。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->