### PR TITLE
feat(sidebar): simplify footer account layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
   <img src="web/public/logo.png" alt="maxx logo" width="128" height="128">
 </p>
 
+<p align="center">
+  <a href="https://github.com/awsl-project/maxx/releases/latest"><img src="https://img.shields.io/github/v/release/awsl-project/maxx?display_name=tag" alt="Latest Release"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/lint.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/lint.yml?branch=main&label=PR%20Checks" alt="PR Checks"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-test.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-test.yml?branch=main&label=E2E" alt="E2E Tests"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-playwright.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-playwright.yml?branch=main&label=Playwright" alt="Playwright Tests"></a>
+</p>
+
 # maxx
 
 English | [简体中文](README_CN.md)

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,6 +2,13 @@
   <img src="web/public/logo.png" alt="maxx logo" width="128" height="128">
 </p>
 
+<p align="center">
+  <a href="https://github.com/awsl-project/maxx/releases/latest"><img src="https://img.shields.io/github/v/release/awsl-project/maxx?display_name=tag" alt="Latest Release"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/lint.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/lint.yml?branch=main&label=PR%20Checks" alt="PR Checks"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-test.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-test.yml?branch=main&label=E2E" alt="E2E Tests"></a>
+  <a href="https://github.com/awsl-project/maxx/actions/workflows/e2e-playwright.yml"><img src="https://img.shields.io/github/actions/workflow/status/awsl-project/maxx/e2e-playwright.yml?branch=main&label=Playwright" alt="Playwright Tests"></a>
+</p>
+
 # maxx
 
 [English](README.md) | 简体中文

--- a/tests/e2e/playwright/requests-table-alignment.spec.ts
+++ b/tests/e2e/playwright/requests-table-alignment.spec.ts
@@ -208,12 +208,25 @@ async function openRequestsPage(page: Page, providerId?: number) {
     );
   }
 
-  await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
+  const passwordInput = page.locator('input[type="password"]');
+  const requestsHeading = page.getByRole('heading', { name: 'Requests' });
 
-  if (await page.locator('input[type="password"]').count()) {
-    await loginToAdminUI(page);
+  const navigateToRequests = async () => {
     await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
+    await Promise.race([
+      requestsHeading.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+      passwordInput.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
+    ]);
+  };
+
+  await navigateToRequests();
+
+  if (await passwordInput.isVisible().catch(() => false)) {
+    await loginToAdminUI(page);
+    await navigateToRequests();
   }
+
+  await expect(requestsHeading).toBeVisible({ timeout: 30_000 });
 }
 
 test('virtualized requests table keeps header and body columns aligned', async ({ page }, testInfo) => {

--- a/tests/e2e/playwright/requests-table-alignment.spec.ts
+++ b/tests/e2e/playwright/requests-table-alignment.spec.ts
@@ -208,13 +208,11 @@ async function openRequestsPage(page: Page, providerId?: number) {
     );
   }
 
-  await page.goto(`${BASE}/requests`);
-  await page.waitForLoadState('networkidle');
+  await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
 
   if (await page.locator('input[type="password"]').count()) {
     await loginToAdminUI(page);
-    await page.goto(`${BASE}/requests`);
-    await page.waitForLoadState('networkidle');
+    await page.goto(`${BASE}/requests`, { waitUntil: 'domcontentloaded' });
   }
 }
 

--- a/tests/e2e/playwright/sidebar-user-footer.spec.ts
+++ b/tests/e2e/playwright/sidebar-user-footer.spec.ts
@@ -4,14 +4,15 @@ import { loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 
-test('expanded sidebar footer keeps compact single-line user chip', async ({ page }) => {
+test('expanded sidebar footer separates account summary from utility actions', async ({ page }) => {
   await loginToAdminUI(page);
 
-  const menuButton = page.locator('button[title="Menu"]');
-  await expect(menuButton).toBeVisible({ timeout: 10000 });
+  const settingsButton = page.locator('button[title="Settings"], button[title="设置"]');
+  await expect(settingsButton).toBeVisible({ timeout: 10000 });
 
-  const footerCard = menuButton.locator('xpath=ancestor::div[contains(@class, "rounded-xl")]');
+  const footerCard = settingsButton.locator('xpath=ancestor::div[contains(@class, "rounded-xl")]');
   await expect(footerCard).toContainText(/admin/i);
+  await expect(footerCard).toContainText(/GitHub/i);
   await expect(footerCard).not.toContainText(/受保护|Protected/);
   await expect(footerCard).not.toContainText(/用户 .*租户|UID .*TID/);
 });

--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -8,7 +8,7 @@ import {
   Sparkles,
   Gem,
   Github,
-  ChevronsUp,
+  Settings2,
   RefreshCw,
   LogOut,
   KeyRound,
@@ -335,7 +335,7 @@ export function NavUser() {
     subtitle: accountSubtitle,
     identity: accountIdentity,
     status: accountStatusLabel,
-    avatar: '/logo.png',
+    avatar: undefined,
   };
   const displayUserFallback = (displayUser.name || 'U').slice(0, 2).toUpperCase();
   const menuDisplayName = displayUser.name || 'Maxx';
@@ -347,101 +347,121 @@ export function NavUser() {
       <SidebarMenuItem>
         <div
           className={cn(
-            'flex items-center gap-2 rounded-xl border border-sidebar-border/70 bg-sidebar/70 p-1.5 backdrop-blur-sm',
-            isCollapsed ? 'flex-col' : 'justify-between',
+            'rounded-xl border border-sidebar-border/70 bg-sidebar/70 backdrop-blur-sm',
+            isCollapsed ? 'flex flex-col items-center gap-2 p-1.5' : 'space-y-2 p-2',
           )}
         >
-          <a
-            href="https://github.com/awsl-project/maxx"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-            title="GitHub"
-          >
-            <Github className="h-4 w-4" />
-          </a>
-
-          <button
-            type="button"
-            onClick={handleToggleLanguage}
-            title={`${t('nav.language')}: ${currentLanguageLabel}`}
-            className={cn(
-              'inline-flex items-center rounded-full border border-sidebar-border/70 bg-sidebar-accent/40 p-0.5 text-sidebar-foreground transition-colors hover:bg-sidebar-accent',
-              isCollapsed ? 'h-8 w-8 justify-center' : 'h-8 px-1 gap-1',
-            )}
-          >
-            {isCollapsed ? (
-              <span className="text-[11px] font-semibold uppercase">
-                {currentLanguage === 'zh' ? '中' : 'EN'}
-              </span>
-            ) : (
-              <>
-                <span className="inline-flex items-center rounded-full bg-sidebar/70 p-0.5">
-                  <span
-                    className={cn(
-                      'rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase transition-colors',
-                      currentLanguage === 'zh'
-                        ? 'bg-sidebar text-sidebar-foreground shadow-sm'
-                        : 'text-sidebar-foreground/55',
-                    )}
-                  >
-                    中
-                  </span>
-                  <span
-                    className={cn(
-                      'rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase transition-colors',
-                      currentLanguage === 'en'
-                        ? 'bg-sidebar text-sidebar-foreground shadow-sm'
-                        : 'text-sidebar-foreground/55',
-                    )}
-                  >
-                    EN
-                  </span>
-                </span>
-              </>
-            )}
-          </button>
-
           {isCollapsed ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={(props) => (
-                  <button
-                    {...props}
-                    type="button"
-                    className={cn(
-                      'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/40 text-sidebar-foreground transition-colors hover:bg-sidebar-accent',
-                      props.className,
-                    )}
-                  >
-                    <Avatar className="h-6 w-6 rounded-lg">
-                      <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
-                      <AvatarFallback className="rounded-lg text-[10px]">
-                        {displayUserFallback}
-                      </AvatarFallback>
-                    </Avatar>
-                  </button>
-                )}
-              />
-              <TooltipContent side={isMobile ? 'top' : 'right'} align="center">
-                <span className="text-xs font-medium">{displayUser.name}</span>
-              </TooltipContent>
-            </Tooltip>
+            <>
+              <Tooltip>
+                <TooltipTrigger
+                  render={(props) => (
+                    <button
+                      {...props}
+                      type="button"
+                      className={cn(
+                        'inline-flex h-9 w-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-sidebar-foreground transition-colors hover:bg-sidebar-accent',
+                        props.className,
+                      )}
+                    >
+                      <Avatar className="h-7 w-7 rounded-lg">
+                        <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
+                        <AvatarFallback className="rounded-lg text-[10px] font-semibold">
+                          {displayUserFallback}
+                        </AvatarFallback>
+                      </Avatar>
+                    </button>
+                  )}
+                />
+                <TooltipContent side={isMobile ? 'top' : 'right'} align="center">
+                  <span className="text-xs font-medium">{displayUser.name}</span>
+                </TooltipContent>
+              </Tooltip>
+
+              <button
+                type="button"
+                onClick={handleToggleLanguage}
+                title={`${t('nav.language')}: ${currentLanguageLabel}`}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-[11px] font-semibold uppercase text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+              >
+                {currentLanguage === 'zh' ? '中' : 'EN'}
+              </button>
+
+              <a
+                href="https://github.com/awsl-project/maxx"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                title="GitHub"
+              >
+                <Github className="h-4 w-4" />
+              </a>
+            </>
           ) : (
-            <div
-              className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2"
-              title={accountTitle}
-            >
-              <Avatar className="h-6 w-6 rounded-lg">
-                <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
-                <AvatarFallback className="rounded-lg text-[10px]">
-                  {displayUserFallback}
-                </AvatarFallback>
-              </Avatar>
-              <div className="min-w-0">
-                <span className="block truncate text-xs font-medium">{displayUser.name}</span>
+            <>
+              <div
+                className="flex min-w-0 items-center gap-3 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/15 px-3 py-2"
+                title={accountTitle}
+              >
+                <Avatar className="h-9 w-9 rounded-lg border border-sidebar-border/60 bg-sidebar-accent/30">
+                  <AvatarImage src={displayUser.avatar} alt={displayUser.name} />
+                  <AvatarFallback className="rounded-lg text-xs font-semibold">
+                    {displayUserFallback}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-medium text-sidebar-foreground">
+                    {displayUser.name}
+                  </span>
+                  <span className="block truncate text-xs text-sidebar-foreground/60">
+                    {displayUser.subtitle}
+                  </span>
+                </div>
               </div>
-            </div>
+
+              <div className="grid grid-cols-3 gap-1.5">
+                <button
+                  type="button"
+                  onClick={handleToggleLanguage}
+                  title={`${t('nav.language')}: ${currentLanguageLabel}`}
+                  className="inline-flex h-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+                >
+                  <span className="inline-flex items-center rounded-full bg-sidebar/70 p-0.5">
+                    <span
+                      className={cn(
+                        'rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase transition-colors',
+                        currentLanguage === 'zh'
+                          ? 'bg-sidebar text-sidebar-foreground shadow-sm'
+                          : 'text-sidebar-foreground/55',
+                      )}
+                    >
+                      中
+                    </span>
+                    <span
+                      className={cn(
+                        'rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase transition-colors',
+                        currentLanguage === 'en'
+                          ? 'bg-sidebar text-sidebar-foreground shadow-sm'
+                          : 'text-sidebar-foreground/55',
+                      )}
+                    >
+                      EN
+                    </span>
+                  </span>
+                </button>
+
+                <a
+                  href="https://github.com/awsl-project/maxx"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                  title="GitHub"
+                >
+                  <Github className="h-4 w-4" />
+                  <span className="text-xs font-medium">GitHub</span>
+                </a>
+              </div>
+            </>
           )}
 
           <DropdownMenu>
@@ -450,13 +470,16 @@ export function NavUser() {
                 <button
                   {...props}
                   type="button"
-                  title="Menu"
+                  title={t('nav.settings')}
                   className={cn(
-                    'inline-flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                    isCollapsed
+                      ? 'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                      : 'inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
                     props.className,
                   )}
                 >
-                  <ChevronsUp className="h-4 w-4" />
+                  <Settings2 className="h-4 w-4" />
+                  {!isCollapsed && <span className="text-xs font-medium">{t('nav.settings')}</span>}
                 </button>
               )}
             />

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1269,7 +1269,7 @@
     "apiEndpoint": "API Endpoint",
     "apiKey": "API Key",
     "apiKeyEdit": "API Key (leave empty to keep current)",
-    "apiKeyExcludedHint": "This provider is excluded from export and backup. You can still rotate the API key here; it just won't be included in exported files or backup packages.",
+    "apiKeyExcludedHint": "This provider is set to \"Do not export this provider\". You can still rotate the API key here, but this provider and its configuration will not be included in provider exports or system backups.",
     "optionalUrlNote": "Optional if client-specific URLs are set below.",
     "namePlaceholder": "e.g. Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1294,8 +1294,8 @@
     "errorCooldownTitle": "3. Error Cooldown",
     "disableErrorCooldown": "Disable Error Cooldown",
     "disableErrorCooldownDesc": "When enabled, errors won't trigger automatic cooldown. Manual freezes and explicit cooldown times still apply.",
-    "excludeFromExport": "Exclude from export and backup",
-    "excludeFromExportDesc": "When enabled, this provider stays local to this system and will not be included in exported files or backup packages."
+    "excludeFromExport": "Do not export this provider",
+    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups. This only affects the current provider and does not reduce the export of other data such as API tokens or system settings."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1268,7 +1268,7 @@
     "apiEndpoint": "API 端点",
     "apiKey": "API 密钥",
     "apiKeyEdit": "API 密钥（留空保持当前值）",
-    "apiKeyExcludedHint": "该提供商已设置为“从导出与备份中排除”。您仍可在这里轮换 API 密钥，只是它不会被写入导出文件或系统备份。",
+    "apiKeyExcludedHint": "该提供商已设置为“不导出此提供商配置”。您仍可在这里轮换 API 密钥，但当前提供商及其配置不会被包含在提供商导出或系统备份中。",
     "optionalUrlNote": "如果下面设置了客户端特定的 URL，则此项为可选。",
     "namePlaceholder": "例如：Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1293,8 +1293,8 @@
     "errorCooldownTitle": "3. 错误冷冻",
     "disableErrorCooldown": "禁用错误冷冻",
     "disableErrorCooldownDesc": "开启后，错误将不再触发自动冷冻；手动冷冻与上游明确冷冻时间仍会生效。",
-    "excludeFromExport": "从导出与备份中排除",
-    "excludeFromExportDesc": "开启后，该提供商仅保留在当前系统中，不会被写入导出文件或系统备份。"
+    "excludeFromExport": "不导出此提供商配置",
+    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中。仅影响当前提供商，不影响 API Token、系统设置等其他数据的导出。"
   },
   "cooldown": {
     "title": "冷却保护中",


### PR DESCRIPTION
## Summary
- simplify the expanded sidebar footer into a clearer account summary plus utility actions layout
- remove the footer logo avatar treatment and fall back to account initials for a calmer user chip
- cover the new footer structure with the sidebar Playwright spec

## Validation
- cd web && pnpm build
- cd tests/e2e/playwright && MAXX_E2E_BASE_URL=http://localhost:9890 CI=1 npm test -- --grep "expanded sidebar footer separates account summary from utility actions"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能增强**
  * 优化侧边栏用户区域布局，改进账户摘要与实用工具操作的分离展示。
  * 明确了提供商导出和系统备份排除功能的行为描述。

* **文档**
  * 在项目README中新增GitHub发布版本和CI工作流状态徽章。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->