### PR TITLE
fix(ci): install pnpm before setup-node cache

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -32,17 +32,17 @@ jobs:
           TAG="${{ inputs.tag || github.ref_name }}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version-file: '.node-version'
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          package_json_file: web/package.json
 
       - name: Build frontend
         working-directory: web

--- a/.github/workflows/ci-wails-build.yml
+++ b/.github/workflows/ci-wails-build.yml
@@ -29,15 +29,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
@@ -115,15 +115,15 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
-
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
@@ -184,6 +184,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
@@ -198,10 +202,6 @@ jobs:
             pkg-config \
             libgtk-3-dev \
             libwebkit2gtk-4.0-dev
-
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: web/package.json
 
       - name: Install Wails
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest


### PR DESCRIPTION
## Summary
- fix release build workflows that enabled `setup-node` pnpm caching before pnpm was installed
- move `pnpm/action-setup` ahead of `actions/setup-node` in docker and wails release jobs
- keep the release build steps otherwise unchanged

## Root cause
The failed release run 24272381791 showed multiple jobs dying in `setup-node`/pnpm cache initialization with `Unable to locate executable file: pnpm`.

## Validation
- inspected failed run `24272381791` and confirmed all failing jobs stopped before pnpm setup
- reviewed workflow diffs to ensure every release job now installs pnpm before `setup-node` uses `cache: pnpm`
- note: this release workflow path depends on GitHub-hosted runners and cannot be fully executed locally without dispatching a real release/tag workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

## 杂务
* **CI/CD 流程优化**
  * 优化了前端和桌面应用的构建流程顺序，提高了构建效率。

---

**注**: 本次更新主要涉及内部构建流程优化，不包含面向用户的新功能或改进。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->