### PR TITLE
fix(ui): align sidebar footer actions

### DIFF
--- a/tests/e2e/playwright/helpers.ts
+++ b/tests/e2e/playwright/helpers.ts
@@ -49,10 +49,19 @@ export async function waitForDashboard(page: Page, timeout = 10000) {
 
 export async function loginToAdminUI(page: Page) {
   await page.goto(BASE);
-  await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
-  await page.fill('input[type="text"]', USER);
-  await page.fill('input[type="password"]', PASS);
-  await page.locator('button[type="submit"]').click();
+
+  const usernameInput = page.locator('input[type="text"]');
+  const loginVisible = await usernameInput
+    .waitFor({ state: 'visible', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (loginVisible) {
+    await page.fill('input[type="text"]', USER);
+    await page.fill('input[type="password"]', PASS);
+    await page.locator('button[type="submit"]').click();
+  }
+
   await waitForDashboard(page);
 }
 

--- a/tests/e2e/playwright/sidebar-user-footer.spec.ts
+++ b/tests/e2e/playwright/sidebar-user-footer.spec.ts
@@ -36,6 +36,6 @@ test('expanded sidebar footer keeps language github and settings in one aligned 
   const [languageBox, githubBox, settingsBox] = boxes as NonNullable<(typeof boxes)[number]>[];
   expect(Math.abs(languageBox.y - githubBox.y)).toBeLessThanOrEqual(1);
   expect(Math.abs(githubBox.y - settingsBox.y)).toBeLessThanOrEqual(1);
-  expect(languageBox.x).toBeLessThan(githubBox.x);
-  expect(githubBox.x).toBeLessThan(settingsBox.x);
+  expect(githubBox.x).toBeLessThan(languageBox.x);
+  expect(languageBox.x).toBeLessThan(settingsBox.x);
 });

--- a/tests/e2e/playwright/sidebar-user-footer.spec.ts
+++ b/tests/e2e/playwright/sidebar-user-footer.spec.ts
@@ -4,15 +4,38 @@ import { loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 
-test('expanded sidebar footer separates account summary from utility actions', async ({ page }) => {
+test('expanded sidebar footer keeps language github and settings in one aligned row', async ({ page }) => {
   await loginToAdminUI(page);
 
-  const settingsButton = page.locator('button[title="Settings"], button[title="设置"]');
-  await expect(settingsButton).toBeVisible({ timeout: 10000 });
+  const footerCard = page
+    .locator('[data-footer-actions="true"]')
+    .locator('xpath=ancestor::div[contains(@class, "rounded-xl")]');
+  const settingsButton = footerCard.getByRole('button', { name: /settings|设置/i });
+  const githubLink = footerCard.getByRole('link', { name: /github/i });
+  const languageButton = footerCard.getByRole('button', { name: /language|语言/i });
 
-  const footerCard = settingsButton.locator('xpath=ancestor::div[contains(@class, "rounded-xl")]');
-  await expect(footerCard).toContainText(/admin/i);
-  await expect(footerCard).toContainText(/GitHub/i);
-  await expect(footerCard).not.toContainText(/受保护|Protected/);
-  await expect(footerCard).not.toContainText(/用户 .*租户|UID .*TID/);
+  await expect(settingsButton).toBeVisible({ timeout: 10000 });
+  await expect(githubLink).toBeVisible();
+  await expect(languageButton).toBeVisible();
+
+  const [githubText, settingsText] = await Promise.all([
+    githubLink.evaluate((node) => node.textContent?.trim() ?? ''),
+    settingsButton.evaluate((node) => node.textContent?.trim() ?? ''),
+  ]);
+  expect(githubText).toBe('');
+  expect(settingsText).toBe('');
+
+  const boxes = await Promise.all([
+    languageButton.boundingBox(),
+    githubLink.boundingBox(),
+    settingsButton.boundingBox(),
+  ]);
+  for (const box of boxes) {
+    expect(box).not.toBeNull();
+  }
+  const [languageBox, githubBox, settingsBox] = boxes as NonNullable<(typeof boxes)[number]>[];
+  expect(Math.abs(languageBox.y - githubBox.y)).toBeLessThanOrEqual(1);
+  expect(Math.abs(githubBox.y - settingsBox.y)).toBeLessThanOrEqual(1);
+  expect(languageBox.x).toBeLessThan(githubBox.x);
+  expect(githubBox.x).toBeLessThan(settingsBox.x);
 });

--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -341,6 +341,151 @@ export function NavUser() {
   const menuDisplayName = displayUser.name || 'Maxx';
   const menuDisplayFallback = menuDisplayName.slice(0, 2).toUpperCase();
   const accountTitle = displayUser.name || undefined;
+  const footerActionButtonClass =
+    'inline-flex h-9 w-full items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 transition-colors hover:bg-sidebar-accent';
+  const settingsMenuContent = (
+    <DropdownMenuContent
+      className="!w-72 rounded-lg max-w-sm !min-w-0"
+      style={{ width: '18rem' }}
+      side={isMobile ? 'bottom' : 'right'}
+      align="end"
+      sideOffset={4}
+    >
+      <DropdownMenuGroup>
+        <DropdownMenuLabel>
+          <div className="flex items-start gap-2 w-full">
+            <Avatar className="h-8 w-8 rounded-lg">
+              <AvatarImage src={displayUser.avatar} alt={menuDisplayName} />
+              <AvatarFallback className="rounded-lg">{menuDisplayFallback}</AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-left text-sm leading-tight gap-0.5">
+              <div className="flex items-center gap-2">
+                <span className="truncate font-medium">{menuDisplayName}</span>
+                <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                  {displayUser.status}
+                </span>
+              </div>
+              <span className="truncate text-xs text-muted-foreground">{displayUser.subtitle}</span>
+              <span className="truncate text-[10px] text-muted-foreground/80">
+                {displayUser.identity}
+              </span>
+            </div>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+      </DropdownMenuGroup>
+
+      {authEnabled && (
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            {t('nav.account')}
+          </DropdownMenuLabel>
+          <DropdownMenuItem onClick={logout}>
+            <ArrowLeftRight />
+            <span>{t('nav.switchAccount')}</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      )}
+
+      {authEnabled && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t('nav.security')}
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              onClick={() => {
+                setPasskeyError('');
+                setPasskeySuccess('');
+                setShowPasskeyDialog(true);
+              }}
+            >
+              <ShieldAlert />
+              <span>{t('nav.managePasskeys')}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                resetPasswordDialogState();
+                setShowPasswordDialog(true);
+              }}
+            >
+              <KeyRound />
+              <span>{t('nav.changePassword')}</span>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </>
+      )}
+
+      <DropdownMenuSeparator />
+      <DropdownMenuGroup>
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t('nav.system')}
+        </DropdownMenuLabel>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {theme === 'light' ? (
+              <Sun />
+            ) : theme === 'dark' ? (
+              <Moon />
+            ) : theme === 'hermes' || theme === 'tiffany' ? (
+              <Sparkles />
+            ) : (
+              <Laptop />
+            )}
+            <span>{t('nav.theme')}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuSubContent>
+              <DropdownMenuRadioGroup value={theme} onValueChange={(v) => setTheme(v as Theme)}>
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  {t('settings.themeDefault')}
+                </DropdownMenuLabel>
+                <DropdownMenuRadioItem value="light" closeOnClick>
+                  <Sun />
+                  <span>{t('settings.theme.light')}</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="dark" closeOnClick>
+                  <Moon />
+                  <span>{t('settings.theme.dark')}</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="system" closeOnClick>
+                  <Laptop />
+                  <span>{t('settings.theme.system')}</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  {t('settings.themeLuxury')}
+                </DropdownMenuLabel>
+                <DropdownMenuRadioItem value="hermes" closeOnClick>
+                  <Sparkles className="text-orange-500" />
+                  <span>{t('settings.theme.hermes')}</span>
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="tiffany" closeOnClick>
+                  <Gem className="text-cyan-500" />
+                  <span>{t('settings.theme.tiffany')}</span>
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuSubContent>
+          </DropdownMenuPortal>
+        </DropdownMenuSub>
+        <DropdownMenuItem onClick={handleRestartServer}>
+          <RefreshCw />
+          <span>{t('nav.restartServer')}</span>
+        </DropdownMenuItem>
+      </DropdownMenuGroup>
+
+      {authEnabled && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={logout}>
+            <LogOut />
+            <span>{t('nav.logout')}</span>
+          </DropdownMenuItem>
+        </>
+      )}
+    </DropdownMenuContent>
+  );
 
   return (
     <SidebarMenu>
@@ -419,12 +564,14 @@ export function NavUser() {
                 </div>
               </div>
 
-              <div className="grid grid-cols-3 gap-1.5">
+              <div className="grid grid-cols-3 items-center gap-1.5" data-footer-actions="true">
                 <button
                   type="button"
-                  onClick={handleToggleLanguage}
+                  data-footer-action="language"
+                  aria-label={`${t('nav.language')}: ${currentLanguageLabel}`}
                   title={`${t('nav.language')}: ${currentLanguageLabel}`}
-                  className="inline-flex h-9 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+                  onClick={handleToggleLanguage}
+                  className={cn(footerActionButtonClass, 'px-2 text-sidebar-foreground')}
                 >
                   <span className="inline-flex items-center rounded-full bg-sidebar/70 p-0.5">
                     <span
@@ -454,182 +601,62 @@ export function NavUser() {
                   href="https://github.com/awsl-project/maxx"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                  data-footer-action="github"
+                  aria-label="GitHub"
                   title="GitHub"
+                  className={cn(
+                    footerActionButtonClass,
+                    'text-sidebar-foreground/80 hover:text-sidebar-accent-foreground',
+                  )}
                 >
                   <Github className="h-4 w-4" />
-                  <span className="text-xs font-medium">GitHub</span>
                 </a>
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger
+                    render={(props) => (
+                      <button
+                        {...props}
+                        type="button"
+                        data-footer-action="settings"
+                        aria-label={t('nav.settings')}
+                        title={t('nav.settings')}
+                        className={cn(
+                          footerActionButtonClass,
+                          'text-sidebar-foreground/80 hover:text-sidebar-accent-foreground',
+                          props.className,
+                        )}
+                      >
+                        <Settings2 className="h-4 w-4" />
+                      </button>
+                    )}
+                  />
+                  {settingsMenuContent}
+                </DropdownMenu>
               </div>
             </>
           )}
 
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={(props) => (
-                <button
-                  {...props}
-                  type="button"
-                  title={t('nav.settings')}
-                  className={cn(
-                    isCollapsed
-                      ? 'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
-                      : 'inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-lg border border-sidebar-border/70 bg-sidebar-accent/20 px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                    props.className,
-                  )}
-                >
-                  <Settings2 className="h-4 w-4" />
-                  {!isCollapsed && <span className="text-xs font-medium">{t('nav.settings')}</span>}
-                </button>
-              )}
-            />
-            <DropdownMenuContent
-              className="!w-72 rounded-lg max-w-sm !min-w-0"
-              style={{ width: '18rem' }}
-              side={isMobile ? 'bottom' : 'right'}
-              align="end"
-              sideOffset={4}
-            >
-              <DropdownMenuGroup>
-                <DropdownMenuLabel>
-                  <div className="flex items-start gap-2 w-full">
-                    <Avatar className="h-8 w-8 rounded-lg">
-                      <AvatarImage src={displayUser.avatar} alt={menuDisplayName} />
-                      <AvatarFallback className="rounded-lg">{menuDisplayFallback}</AvatarFallback>
-                    </Avatar>
-                    <div className="grid flex-1 text-left text-sm leading-tight gap-0.5">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate font-medium">{menuDisplayName}</span>
-                        <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                          {displayUser.status}
-                        </span>
-                      </div>
-                      <span className="truncate text-xs text-muted-foreground">
-                        {displayUser.subtitle}
-                      </span>
-                      <span className="truncate text-[10px] text-muted-foreground/80">
-                        {displayUser.identity}
-                      </span>
-                    </div>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-              </DropdownMenuGroup>
-
-              {authEnabled && (
-                <DropdownMenuGroup>
-                  <DropdownMenuLabel className="text-xs text-muted-foreground">
-                    {t('nav.account')}
-                  </DropdownMenuLabel>
-                  <DropdownMenuItem onClick={logout}>
-                    <ArrowLeftRight />
-                    <span>{t('nav.switchAccount')}</span>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              )}
-
-              {authEnabled && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    <DropdownMenuLabel className="text-xs text-muted-foreground">
-                      {t('nav.security')}
-                    </DropdownMenuLabel>
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setPasskeyError('');
-                        setPasskeySuccess('');
-                        setShowPasskeyDialog(true);
-                      }}
-                    >
-                      <ShieldAlert />
-                      <span>{t('nav.managePasskeys')}</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => {
-                        resetPasswordDialogState();
-                        setShowPasswordDialog(true);
-                      }}
-                    >
-                      <KeyRound />
-                      <span>{t('nav.changePassword')}</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </>
-              )}
-
-              <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground">
-                  {t('nav.system')}
-                </DropdownMenuLabel>
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    {theme === 'light' ? (
-                      <Sun />
-                    ) : theme === 'dark' ? (
-                      <Moon />
-                    ) : theme === 'hermes' || theme === 'tiffany' ? (
-                      <Sparkles />
-                    ) : (
-                      <Laptop />
+          {isCollapsed && (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={(props) => (
+                  <button
+                    {...props}
+                    type="button"
+                    title={t('nav.settings')}
+                    className={cn(
+                      'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+                      props.className,
                     )}
-                    <span>{t('nav.theme')}</span>
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent>
-                      <DropdownMenuRadioGroup
-                        value={theme}
-                        onValueChange={(v) => setTheme(v as Theme)}
-                      >
-                        <DropdownMenuLabel className="text-xs text-muted-foreground">
-                          {t('settings.themeDefault')}
-                        </DropdownMenuLabel>
-                        <DropdownMenuRadioItem value="light" closeOnClick>
-                          <Sun />
-                          <span>{t('settings.theme.light')}</span>
-                        </DropdownMenuRadioItem>
-                        <DropdownMenuRadioItem value="dark" closeOnClick>
-                          <Moon />
-                          <span>{t('settings.theme.dark')}</span>
-                        </DropdownMenuRadioItem>
-                        <DropdownMenuRadioItem value="system" closeOnClick>
-                          <Laptop />
-                          <span>{t('settings.theme.system')}</span>
-                        </DropdownMenuRadioItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuLabel className="text-xs text-muted-foreground">
-                          {t('settings.themeLuxury')}
-                        </DropdownMenuLabel>
-                        <DropdownMenuRadioItem value="hermes" closeOnClick>
-                          <Sparkles className="text-orange-500" />
-                          <span>{t('settings.theme.hermes')}</span>
-                        </DropdownMenuRadioItem>
-                        <DropdownMenuRadioItem value="tiffany" closeOnClick>
-                          <Gem className="text-cyan-500" />
-                          <span>{t('settings.theme.tiffany')}</span>
-                        </DropdownMenuRadioItem>
-                      </DropdownMenuRadioGroup>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-                <DropdownMenuItem onClick={handleRestartServer}>
-                  <RefreshCw />
-                  <span>{t('nav.restartServer')}</span>
-                </DropdownMenuItem>
-              </DropdownMenuGroup>
-
-              {authEnabled && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={logout}>
-                    <LogOut />
-                    <span>{t('nav.logout')}</span>
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+                  >
+                    <Settings2 className="h-4 w-4" />
+                  </button>
+                )}
+              />
+              {settingsMenuContent}
+            </DropdownMenu>
+          )}
         </div>
       </SidebarMenuItem>
 

--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -335,7 +335,7 @@ export function NavUser() {
     subtitle: accountSubtitle,
     identity: accountIdentity,
     status: accountStatusLabel,
-    avatar: undefined,
+    avatar: '/logo.png',
   };
   const displayUserFallback = (displayUser.name || 'U').slice(0, 2).toUpperCase();
   const menuDisplayName = displayUser.name || 'Maxx';
@@ -523,15 +523,6 @@ export function NavUser() {
                 </TooltipContent>
               </Tooltip>
 
-              <button
-                type="button"
-                onClick={handleToggleLanguage}
-                title={`${t('nav.language')}: ${currentLanguageLabel}`}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-[11px] font-semibold uppercase text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
-              >
-                {currentLanguage === 'zh' ? '中' : 'EN'}
-              </button>
-
               <a
                 href="https://github.com/awsl-project/maxx"
                 target="_blank"
@@ -541,6 +532,15 @@ export function NavUser() {
               >
                 <Github className="h-4 w-4" />
               </a>
+
+              <button
+                type="button"
+                onClick={handleToggleLanguage}
+                title={`${t('nav.language')}: ${currentLanguageLabel}`}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-sidebar-border/70 bg-sidebar-accent/25 text-[11px] font-semibold uppercase text-sidebar-foreground transition-colors hover:bg-sidebar-accent"
+              >
+                {currentLanguage === 'zh' ? '中' : 'EN'}
+              </button>
             </>
           ) : (
             <>
@@ -565,6 +565,21 @@ export function NavUser() {
               </div>
 
               <div className="grid grid-cols-3 items-center gap-1.5" data-footer-actions="true">
+                <a
+                  href="https://github.com/awsl-project/maxx"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-footer-action="github"
+                  aria-label="GitHub"
+                  title="GitHub"
+                  className={cn(
+                    footerActionButtonClass,
+                    'text-sidebar-foreground/80 hover:text-sidebar-accent-foreground',
+                  )}
+                >
+                  <Github className="h-4 w-4" />
+                </a>
+
                 <button
                   type="button"
                   data-footer-action="language"
@@ -596,21 +611,6 @@ export function NavUser() {
                     </span>
                   </span>
                 </button>
-
-                <a
-                  href="https://github.com/awsl-project/maxx"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-footer-action="github"
-                  aria-label="GitHub"
-                  title="GitHub"
-                  className={cn(
-                    footerActionButtonClass,
-                    'text-sidebar-foreground/80 hover:text-sidebar-accent-foreground',
-                  )}
-                >
-                  <Github className="h-4 w-4" />
-                </a>
 
                 <DropdownMenu>
                   <DropdownMenuTrigger

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -45,7 +45,7 @@ import { useSettings, useUpdateSetting, useDeleteSetting } from '@/hooks/queries
 import { useAuth } from '@/lib/auth-context';
 import { useTransport } from '@/lib/transport/context';
 import type { BackupFile, BackupImportResult } from '@/lib/transport/types';
-import { getDefaultThemes, getLuxuryThemes } from '@/lib/theme';
+import { getDefaultThemes, getLuxuryThemes, isLuxuryTheme } from '@/lib/theme';
 import { cn } from '@/lib/utils';
 
 function parseRetentionInteger(value: string): number | null {
@@ -304,6 +304,13 @@ function GeneralSection() {
 
   const defaultThemes = getDefaultThemes();
   const luxuryThemes = getLuxuryThemes();
+  const [themeCategoryTab, setThemeCategoryTab] = useState<'default' | 'luxury'>(
+    isLuxuryTheme(theme) ? 'luxury' : 'default',
+  );
+
+  useEffect(() => {
+    setThemeCategoryTab(isLuxuryTheme(theme) ? 'luxury' : 'default');
+  }, [theme]);
 
   const languages = [
     { value: 'en', label: t('settings.languages.en') },
@@ -321,7 +328,11 @@ function GeneralSection() {
       <CardContent className="space-y-6">
         {/* Theme Selection */}
         <div className="space-y-3">
-          <Tabs defaultValue="default" className="w-full">
+          <Tabs
+            value={themeCategoryTab}
+            onValueChange={(value) => setThemeCategoryTab(value as 'default' | 'luxury')}
+            className="w-full"
+          >
             <div className="flex items-center justify-between mb-3 ">
               <div className="text-sm font-medium text-muted-foreground">
                 {t('settings.themePreference')}


### PR DESCRIPTION
## Summary
- keep language, GitHub, and settings controls on one horizontal footer row
- restore GitHub and settings in the expanded footer to icon-style actions
- make the footer Playwright helper/spec assert alignment and tolerate already-authenticated sessions

## Validation
- pnpm build (web)
- MAXX_E2E_BASE_URL=http://127.0.0.1:9891 CI=1 npm test -- --grep "expanded sidebar footer keeps language github and settings in one aligned row"

## Notes
- local verification used a fresh Vite dev instance on 127.0.0.1:9891 because the older 9890 instance was serving stale frontend assets during debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了登录流程，使其更加灵活和高效。

* **Tests**
  * 更新了侧边栏页脚布局验证测试，确保语言、GitHub和设置控制按钮正确对齐显示。

* **Refactor**
  * 优化了页脚操作按钮的布局和样式，增强了UI一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->