### PR TITLE
fix(web): expose routing strategies in admin sidebar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,7 +90,14 @@ function AppRoutes() {
           <Route path="model-mappings" element={<ModelMappingsPage />} />
           <Route path="model-prices" element={<ModelPricesPage />} />
           <Route path="retry-configs" element={<RetryConfigsPage />} />
-          <Route path="routing-strategies" element={<RoutingStrategiesPage />} />
+          <Route
+            path="routing-strategies"
+            element={
+              <AdminRoute>
+                <RoutingStrategiesPage />
+              </AdminRoute>
+            }
+          />
           <Route path="stats" element={<StatsPage />} />
           <Route path="settings" element={<SettingsPage />} />
           <Route

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -13,6 +13,7 @@ import {
   DollarSign,
   BookOpen,
   Ticket,
+  Workflow,
 } from 'lucide-react';
 import type { SidebarConfig } from '@/types/sidebar';
 import { RequestsNavItem } from './requests-nav-item';
@@ -145,6 +146,15 @@ export const sidebarConfig: SidebarConfig = {
           to: '/model-prices',
           icon: DollarSign,
           labelKey: 'nav.modelPrices',
+        },
+        {
+          type: 'standard',
+          key: 'routing-strategies',
+          to: '/routing-strategies',
+          icon: Workflow,
+          labelKey: 'nav.routingStrategies',
+          adminOnly: true,
+          authOnly: true,
         },
         {
           type: 'standard',

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -79,6 +79,7 @@
     "modelMappings": "Model Mappings",
     "modelPrices": "Model Prices",
     "retryConfigs": "Retry Configs",
+    "routingStrategies": "Routing Strategies",
     "settings": "Settings",
     "stats": "Statistics",
     "routes": "ROUTES",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -79,6 +79,7 @@
     "modelMappings": "模型映射",
     "modelPrices": "模型价格",
     "retryConfigs": "重试配置",
+    "routingStrategies": "路由策略",
     "settings": "设置",
     "stats": "统计",
     "routes": "路由",


### PR DESCRIPTION
## Summary
- add the routing strategies entry to the config section of the sidebar
- only show the entry for authenticated admin users
- guard the /routing-strategies route with AdminRoute to match the sidebar visibility

## Validation
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增路由策略管理功能，仅限管理员访问
  * 在侧边栏导航菜单中添加"路由策略"选项
  * 支持英文和中文界面显示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->