### PR TITLE
fix(auth): skip token validation when auth is disabled

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -651,9 +651,9 @@ func (h *AuthHandler) handleStatus(w http.ResponseWriter, r *http.Request) {
 		"authEnabled": h.authEnabled,
 	}
 
-	// If authenticated, return user info
+	// If authenticated, return user info (only when auth is enabled)
 	authHeader := r.Header.Get(AuthHeader)
-	if strings.HasPrefix(authHeader, "Bearer ") {
+	if h.authEnabled && strings.HasPrefix(authHeader, "Bearer ") {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		if claims, valid := h.authMiddleware.ValidateToken(token); valid {
 			userInfo := map[string]any{

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -101,8 +101,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
           return;
         }
         console.error('[AuthProvider] Auth check failed, fallback to authenticated:', error);
-        // Auth check failed, assume no auth required
+        // Auth check failed, assume no auth required — grant admin so UI is not locked
         setIsAuthenticated(true);
+        setUser({
+          id: 1,
+          username: 'admin',
+          tenantID: 1,
+          role: 'admin',
+        });
       }
     };
 
@@ -131,6 +137,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
           error,
         );
         setIsAuthenticated(true);
+        setUser({
+          id: 1,
+          username: 'admin',
+          tenantID: 1,
+          role: 'admin',
+        });
       } finally {
         if (timeoutId) {
           clearTimeout(timeoutId);

--- a/web/src/lib/auth-context.tsx
+++ b/web/src/lib/auth-context.tsx
@@ -100,15 +100,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (shouldSkip()) {
           return;
         }
-        console.error('[AuthProvider] Auth check failed, fallback to authenticated:', error);
-        // Auth check failed, assume no auth required — grant admin so UI is not locked
-        setIsAuthenticated(true);
-        setUser({
-          id: 1,
-          username: 'admin',
-          tenantID: 1,
-          role: 'admin',
-        });
+        console.error('[AuthProvider] Auth check failed:', error);
+        // Fail closed: treat unknown state as auth-required so admin routes stay guarded
+        setAuthEnabled(true);
+        setIsAuthenticated(false);
+        setUser(null);
       }
     };
 
@@ -132,17 +128,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
 
         timedOut = true;
-        console.error(
-          '[AuthProvider] Auth bootstrap failed or timed out, fallback to authenticated:',
-          error,
-        );
-        setIsAuthenticated(true);
-        setUser({
-          id: 1,
-          username: 'admin',
-          tenantID: 1,
-          role: 'admin',
-        });
+        console.error('[AuthProvider] Auth bootstrap failed or timed out:', error);
+        // Fail closed: treat unknown state as auth-required so admin routes stay guarded
+        setAuthEnabled(true);
+        setIsAuthenticated(false);
+        setUser(null);
       } finally {
         if (timeoutId) {
           clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
- **Backend**: When `MAXX_ADMIN_PASSWORD` is not set, `authMiddleware` is nil. If the browser still holds a stale JWT token from a previous session, the `/admin/auth/status` endpoint panics on nil pointer dereference. Fixed by guarding token validation with `h.authEnabled`.
- **Frontend**: Auth error/timeout fallback now sets a default admin user so the UI is not locked into a "member" state where providers cannot be managed.

## Test plan
- [ ] Start server without `MAXX_ADMIN_PASSWORD`, verify providers page is fully functional
- [ ] Start server without `MAXX_ADMIN_PASSWORD` but with a stale JWT in localStorage, verify no panic and providers page works
- [ ] Start server with `MAXX_ADMIN_PASSWORD`, verify admin/member RBAC still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了身份验证处理：当认证被禁用时，不再解析或使用传入的 Bearer 令牌以填充用户信息。
  * 在身份验证检查异常或启动超时时，系统现在“失败封闭”：将认证视为启用且置为未认证，清除用户信息，避免错误地回退为已认证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->