### PR TITLE
fix(sanitizer): remove orphaned tool_results before upstream

### DIFF
--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -30,7 +31,9 @@ func sanitizeRequestBody(body []byte) []byte {
 		body, _ = sjson.DeleteBytes(body, "stream")
 	}
 
-	return SanitizeForBedrockCompat(body)
+	body = SanitizeForBedrockCompat(body)
+	body = RemoveOrphanedToolResults(body)
+	return body
 }
 
 // SanitizeForBedrockCompat applies the subset of Bedrock-compatibility
@@ -111,6 +114,113 @@ func EnsureMaxTokensAboveThinkingBudget(body []byte) []byte {
 		body, _ = sjson.SetBytes(body, "max_tokens", newMax)
 	}
 	return body
+}
+
+// RemoveOrphanedToolResults removes tool_result blocks from user messages
+// whose tool_use_id does not match any tool_use block in the immediately
+// preceding assistant message. The Anthropic API (and Bedrock) rejects such
+// requests with: "unexpected `tool_use_id` found in `tool_result` blocks".
+//
+// Exported so both the direct Bedrock adapter and the custom adapter can
+// call it before sending requests upstream.
+func RemoveOrphanedToolResults(body []byte) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return body
+	}
+
+	msgArr := messages.Array()
+	if len(msgArr) < 2 {
+		return body
+	}
+
+	rebuilt := make([]string, 0, len(msgArr))
+	modified := false
+
+	for i := 0; i < len(msgArr); i++ {
+		msg := msgArr[i]
+
+		// Only process user messages that follow an assistant message.
+		if msg.Get("role").String() != "user" || i == 0 {
+			rebuilt = append(rebuilt, msg.Raw)
+			continue
+		}
+
+		prevMsg := msgArr[i-1]
+		if prevMsg.Get("role").String() != "assistant" {
+			rebuilt = append(rebuilt, msg.Raw)
+			continue
+		}
+
+		content := msg.Get("content")
+		if !content.IsArray() {
+			rebuilt = append(rebuilt, msg.Raw)
+			continue
+		}
+
+		// Collect tool_use IDs from the preceding assistant message.
+		validIDs := make(map[string]bool)
+		prevContent := prevMsg.Get("content")
+		if prevContent.IsArray() {
+			prevContent.ForEach(func(_, block gjson.Result) bool {
+				if block.Get("type").String() == "tool_use" {
+					if id := block.Get("id").String(); id != "" {
+						validIDs[id] = true
+					}
+				}
+				return true
+			})
+		}
+
+		// If the preceding assistant has no tool_use blocks, nothing to orphan.
+		if len(validIDs) == 0 {
+			rebuilt = append(rebuilt, msg.Raw)
+			continue
+		}
+
+		// Filter content blocks: keep non-tool_result blocks and
+		// tool_result blocks whose tool_use_id is valid.
+		var kept []string
+		removed := false
+		content.ForEach(func(_, block gjson.Result) bool {
+			if block.Get("type").String() == "tool_result" {
+				id := block.Get("tool_use_id").String()
+				if !validIDs[id] {
+					removed = true
+					return true // skip this block
+				}
+			}
+			kept = append(kept, block.Raw)
+			return true
+		})
+
+		if !removed {
+			rebuilt = append(rebuilt, msg.Raw)
+			continue
+		}
+
+		modified = true
+		if len(kept) == 0 {
+			// All content was orphaned tool_results; replace with a minimal text block
+			// so the message isn't empty (Anthropic rejects empty content arrays).
+			kept = append(kept, `{"type":"text","text":"[empty]"}`)
+		}
+		if updatedMsg, err := sjson.SetRaw(msg.Raw, "content", "["+strings.Join(kept, ",")+"]"); err == nil {
+			rebuilt = append(rebuilt, updatedMsg)
+		} else {
+			rebuilt = append(rebuilt, msg.Raw)
+		}
+	}
+
+	if !modified {
+		return body
+	}
+
+	updatedBody, err := sjson.SetRawBytes(body, "messages", []byte("["+strings.Join(rebuilt, ",")+"]"))
+	if err != nil {
+		return body
+	}
+	return updatedBody
 }
 
 // stripCacheControlScope removes the "scope" sub-field from all cache_control objects.

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -172,14 +172,10 @@ func RemoveOrphanedToolResults(body []byte) []byte {
 			})
 		}
 
-		// If the preceding assistant has no tool_use blocks, nothing to orphan.
-		if len(validIDs) == 0 {
-			rebuilt = append(rebuilt, msg.Raw)
-			continue
-		}
-
 		// Filter content blocks: keep non-tool_result blocks and
 		// tool_result blocks whose tool_use_id is valid.
+		// When validIDs is empty (assistant had no tool_use), ALL tool_results
+		// in this user message are orphaned and will be removed.
 		var kept []string
 		removed := false
 		content.ForEach(func(_, block gjson.Result) bool {

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -258,6 +258,34 @@ func TestRemoveOrphanedToolResults(t *testing.T) {
 		}
 	})
 
+	t.Run("removes tool_result when preceding assistant has only text", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"text","text":"I don't need any tools for this."}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"toolu_stale","content":"leftover"},
+					{"type":"text","text":"ok thanks"}
+				]}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		msgs := gjson.GetBytes(result, "messages").Array()
+		userContent := msgs[1].Get("content").Array()
+		if len(userContent) != 1 {
+			t.Fatalf("expected 1 content block, got %d", len(userContent))
+		}
+		if userContent[0].Get("type").String() != "text" {
+			t.Error("expected text block preserved")
+		}
+		if userContent[0].Get("text").String() != "ok thanks" {
+			t.Errorf("text = %q, want 'ok thanks'", userContent[0].Get("text").String())
+		}
+	})
+
 	t.Run("does not touch user message without preceding assistant", func(t *testing.T) {
 		body := []byte(`{
 			"messages":[

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -165,6 +165,117 @@ func TestEnsureMaxTokensAboveThinkingBudgetIdempotent(t *testing.T) {
 	}
 }
 
+func TestRemoveOrphanedToolResults(t *testing.T) {
+	t.Run("removes orphaned tool_result", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"toolu_aaa","name":"get_weather","input":{"city":"Tokyo"}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"toolu_aaa","content":"sunny"},
+					{"type":"tool_result","tool_use_id":"toolu_orphan","content":"stale"},
+					{"type":"text","text":"thanks"}
+				]}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		msgs := gjson.GetBytes(result, "messages").Array()
+		userContent := msgs[2].Get("content").Array()
+
+		if len(userContent) != 2 {
+			t.Fatalf("expected 2 content blocks, got %d", len(userContent))
+		}
+		// Valid tool_result kept
+		if userContent[0].Get("tool_use_id").String() != "toolu_aaa" {
+			t.Error("valid tool_result should be kept")
+		}
+		// Text block kept
+		if userContent[1].Get("type").String() != "text" {
+			t.Error("text block should be kept")
+		}
+	})
+
+	t.Run("replaces with empty text when all tool_results orphaned", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"toolu_aaa","name":"f","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"toolu_bad","content":"x"}
+				]}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		msgs := gjson.GetBytes(result, "messages").Array()
+		userContent := msgs[1].Get("content").Array()
+		if len(userContent) != 1 {
+			t.Fatalf("expected 1 content block, got %d", len(userContent))
+		}
+		if userContent[0].Get("type").String() != "text" {
+			t.Error("expected fallback text block")
+		}
+	})
+
+	t.Run("no-op when all tool_results match", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"toolu_1","name":"f","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}
+				]}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		// Should be unchanged (byte-exact)
+		if gjson.GetBytes(result, "messages.1.content.0.tool_use_id").String() != "toolu_1" {
+			t.Error("matching tool_result should be preserved")
+		}
+	})
+
+	t.Run("no-op when no tool_results", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"user","content":"hi"},
+				{"role":"assistant","content":"hello"}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		if string(result) != string(body) {
+			t.Error("should be unchanged when no tool_results")
+		}
+	})
+
+	t.Run("does not touch user message without preceding assistant", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"toolu_x","content":"y"}
+				]}
+			]
+		}`)
+
+		result := RemoveOrphanedToolResults(body)
+
+		// First message has no preceding assistant, should be untouched
+		if gjson.GetBytes(result, "messages.0.content.0.tool_use_id").String() != "toolu_x" {
+			t.Error("first user message should not be modified")
+		}
+	})
+}
+
 func TestSanitizeRequestBodyRemovesModelAndStream(t *testing.T) {
 	// The direct-Bedrock helper should strip both fields and set anthropic_version.
 	body := []byte(`{

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -101,7 +101,10 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 	// 6. Remove empty text content blocks to satisfy Anthropic validation.
 	body = sanitizeClaudeMessages(body)
 
-	// 7. Inject missing tool_results to satisfy tool_use/tool_result correspondence.
+	// 7. Fix tool_use/tool_result correspondence:
+	//    a) Remove orphaned tool_results (tool_use_id not in preceding assistant message)
+	//    b) Inject missing tool_results (tool_use without corresponding tool_result)
+	body = bedrock.RemoveOrphanedToolResults(body)
 	body = ensureToolResultCorrespondence(body)
 
 	// 8. Extract betas from body (to be added to header)


### PR DESCRIPTION
## Summary
- Add `RemoveOrphanedToolResults()` to bedrock sanitizer — removes `tool_result` blocks whose `tool_use_id` has no matching `tool_use` in the preceding assistant message
- Called from both direct Bedrock adapter and custom adapter's `processClaudeRequestBody` pipeline
- Prevents Bedrock/Anthropic 400 errors (`unexpected tool_use_id found in tool_result blocks`) that previously cascaded through all provider channels

## Root cause
Clients sometimes send `tool_result` blocks referencing stale `tool_use_id`s from earlier turns. The API rejects these with a 400 error. Without sanitization, every provider channel fails on the same bad input.

## Test plan
- [x] 5 unit tests covering: orphan removal, all-orphaned fallback, no-op on valid input, no-op without tool_results, first-message edge case
- [x] All existing provider adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化了AI工具调用消息的处理流程，移除孤立的工具结果记录，确保消息链的完整性和一致性

## Tests
* 为工具结果处理功能添加了全面的测试套件

<!-- end of auto-generated comment: release notes by coderabbit.ai -->