### PR TITLE
fix(bedrock): strip empty arrays and prevent false-positive model cooldowns

### DIFF
--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -379,8 +379,10 @@ func classifyBedrockHTTPError(statusCode int, body []byte, headers http.Header, 
 	case statusCode == 400:
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.Retryable = false
-		if strings.Contains(bodyLower, "validationexception") && model != "" &&
-			(strings.Contains(bodyLower, "model") || strings.Contains(bodyLower, "inference profile")) {
+		// Only upgrade to ScopeModel for genuine model-availability errors.
+		// Use specific Bedrock error patterns to avoid false positives from
+		// field validation errors that happen to mention "model".
+		if model != "" && isBedrockModelUnavailable(bodyLower) {
 			proxyErr.Scope = domain.ScopeModel
 			proxyErr.Reason = domain.CooldownReasonModelUnavailable
 			proxyErr.Model = model
@@ -439,6 +441,28 @@ func classifyBedrockHTTPError(statusCode int, body []byte, headers http.Header, 
 	}
 
 	return proxyErr
+}
+
+// isBedrockModelUnavailable checks whether a Bedrock 400 error body indicates
+// the model itself is unavailable (as opposed to a request validation error
+// that happens to mention the word "model"). This prevents false-positive
+// ScopeModel classification that would wrongly freeze the provider.
+func isBedrockModelUnavailable(bodyLower string) bool {
+	// Bedrock model-access errors use specific exception types and phrases.
+	modelPatterns := []string{
+		"could not resolve the foundation model",
+		"is not authorized to perform: bedrock",
+		"you don't have access to the model",
+		"access denied for model",
+		"model identifier is invalid",
+		"inference profile",
+	}
+	for _, p := range modelPatterns {
+		if strings.Contains(bodyLower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func isRetryableStatusCode(status int) bool {

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -382,7 +382,7 @@ func classifyBedrockHTTPError(statusCode int, body []byte, headers http.Header, 
 		// Only upgrade to ScopeModel for genuine model-availability errors.
 		// Use specific Bedrock error patterns to avoid false positives from
 		// field validation errors that happen to mention "model".
-		if model != "" && isBedrockModelUnavailable(bodyLower) {
+		if model != "" && isBedrockModelUnavailable(bodyStr) {
 			proxyErr.Scope = domain.ScopeModel
 			proxyErr.Reason = domain.CooldownReasonModelUnavailable
 			proxyErr.Model = model
@@ -447,7 +447,8 @@ func classifyBedrockHTTPError(statusCode int, body []byte, headers http.Header, 
 // the model itself is unavailable (as opposed to a request validation error
 // that happens to mention the word "model"). This prevents false-positive
 // ScopeModel classification that would wrongly freeze the provider.
-func isBedrockModelUnavailable(bodyLower string) bool {
+func isBedrockModelUnavailable(body string) bool {
+	bodyLower := strings.ToLower(body)
 	// Bedrock model-access errors use specific exception types and phrases.
 	modelPatterns := []string{
 		"could not resolve the foundation model",

--- a/internal/adapter/provider/bedrock/classify_test.go
+++ b/internal/adapter/provider/bedrock/classify_test.go
@@ -1,0 +1,56 @@
+package bedrock
+
+import "testing"
+
+func TestIsBedrockModelUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "foundation model resolution failure",
+			body: `{"message":"could not resolve the foundation model from the given identifier"}`,
+			want: true,
+		},
+		{
+			name: "not authorized to perform bedrock",
+			body: `{"message":"user is not authorized to perform: bedrock:invokemodel"}`,
+			want: true,
+		},
+		{
+			name: "no access to model",
+			body: `{"message":"you don't have access to the model with the specified model id"}`,
+			want: true,
+		},
+		{
+			name: "inference profile error",
+			body: `{"message":"the inference profile arn is invalid"}`,
+			want: true,
+		},
+		{
+			name: "field validation mentioning model — should NOT match",
+			body: `{"message":"validationexception: 1 validation error: value at 'model' failed to satisfy constraint"}`,
+			want: false,
+		},
+		{
+			name: "generic validation error — should NOT match",
+			body: `{"message":"validationexception: extra inputs are not permitted"}`,
+			want: false,
+		},
+		{
+			name: "tool_result error — should NOT match",
+			body: `{"message":"messages.16.content.0: unexpected tool_use_id found in tool_result blocks"}`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBedrockModelUnavailable(tt.body)
+			if got != tt.want {
+				t.Errorf("isBedrockModelUnavailable(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -84,6 +84,16 @@ func SanitizeForBedrockCompat(body []byte) []byte {
 		}
 	}
 
+	// Remove empty top-level arrays that Bedrock rejects with ValidationException.
+	// Clients sometimes send `"system":[]` or `"tools":[]` which Anthropic API
+	// tolerates but Bedrock does not.
+	for _, field := range []string{"system", "tools"} {
+		v := gjson.GetBytes(body, field)
+		if v.IsArray() && v.Get("#").Int() == 0 {
+			body, _ = sjson.DeleteBytes(body, field)
+		}
+	}
+
 	return body
 }
 

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -304,6 +304,44 @@ func TestRemoveOrphanedToolResults(t *testing.T) {
 	})
 }
 
+func TestSanitizeForBedrockCompatStripsEmptyArrays(t *testing.T) {
+	body := []byte(`{
+		"system":[],
+		"tools":[],
+		"messages":[{"role":"user","content":"hi"}]
+	}`)
+
+	result := SanitizeForBedrockCompat(body)
+
+	if gjson.GetBytes(result, "system").Exists() {
+		t.Error("empty system[] should be stripped")
+	}
+	if gjson.GetBytes(result, "tools").Exists() {
+		t.Error("empty tools[] should be stripped")
+	}
+	// messages should be preserved (it's not empty)
+	if !gjson.GetBytes(result, "messages").Exists() {
+		t.Error("non-empty messages should be preserved")
+	}
+}
+
+func TestSanitizeForBedrockCompatPreservesNonEmptyArrays(t *testing.T) {
+	body := []byte(`{
+		"system":[{"type":"text","text":"hello"}],
+		"tools":[{"name":"tool1"}],
+		"messages":[{"role":"user","content":"hi"}]
+	}`)
+
+	result := SanitizeForBedrockCompat(body)
+
+	if !gjson.GetBytes(result, "system").Exists() {
+		t.Error("non-empty system should be preserved")
+	}
+	if !gjson.GetBytes(result, "tools").Exists() {
+		t.Error("non-empty tools should be preserved")
+	}
+}
+
 func TestSanitizeRequestBodyRemovesModelAndStream(t *testing.T) {
 	// The direct-Bedrock helper should strip both fields and set anthropic_version.
 	body := []byte(`{

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock.go
@@ -71,7 +71,15 @@ func (f *bedrockFixer) FixRequest(req *http.Request, body []byte) (*http.Request
 		}
 	}
 
-	// 4. Filter anthropic-beta header (Bedrock rejects unknown betas too)
+	// 4. Remove empty top-level arrays (Bedrock rejects empty system/tools)
+	for _, field := range []string{"system", "tools"} {
+		v := gjson.GetBytes(body, field)
+		if v.IsArray() && v.Get("#").Int() == 0 {
+			body, _ = sjson.DeleteBytes(body, field)
+		}
+	}
+
+	// 5. Filter anthropic-beta header (Bedrock rejects unknown betas too)
 	filterRejectedBetas(req)
 
 	return req, body


### PR DESCRIPTION
## Summary
- **Sanitizer**: Strip empty `system:[]` and `tools:[]` arrays that Bedrock rejects but Anthropic API tolerates
- **Error classification**: Replace broad `contains("model")` check with `isBedrockModelUnavailable()` using specific Bedrock error patterns — prevents field validation errors from being misclassified as `ScopeModel` which would wrongly freeze the provider
- **Error fixer**: Add empty array stripping as reactive fallback for requests that bypass the proactive sanitizer (e.g. raw/relay mode)

## Root cause
Bedrock ValidationException errors containing the word "model" (e.g. field validation) were being misclassified as model-unavailability errors, triggering provider cooldowns. Additionally, empty arrays sent by clients caused preventable 400 errors.

## Test plan
- [x] 2 tests for empty array stripping (empty vs non-empty preserved)
- [x] 7 tests for `isBedrockModelUnavailable` (4 true positives, 3 false positive rejections)
- [x] All existing adapter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了 Bedrock 模型不可用错误的检测和分类，现在能更准确地识别特定的模型相关错误场景。
  * 修复了请求处理中的空字段问题，确保空的顶级 `system` 和 `tools` 字段被正确删除。
  * 优化了 HTTP 400 响应的错误处理逻辑，提供更精确的错误诊断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->