### PR TITLE
 fix(proxy): restore direct /v1/models routing

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -440,20 +440,11 @@ func main() {
 	mux.Handle("/api/claude/", http.StripPrefix("/api", claudeHandler))
 
 	// Proxy routes - catch all AI API endpoints
-	// Claude API
-	mux.Handle("/v1/messages", proxyHandler)
-	mux.Handle("/v1/messages/", proxyHandler)
-	// OpenAI API
-	mux.Handle("/v1/chat/completions", proxyHandler)
-	// Codex API
-	mux.Handle("/responses", proxyHandler)
-	mux.Handle("/responses/", proxyHandler)
-	mux.Handle("/v1/responses", proxyHandler)
-	mux.Handle("/v1/responses/", proxyHandler)
-	// Gemini API (Google AI Studio style)
-	mux.Handle("/v1beta/models/", proxyHandler)
-	// Provider-scoped proxy routes
-	mux.Handle("/provider/", providerProxyHandler)
+	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
+		ProxyHandler:         proxyHandler,
+		ModelsHandler:        modelsHandler,
+		ProviderProxyHandler: providerProxyHandler,
+	})
 
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -1,0 +1,41 @@
+package core
+
+import "net/http"
+
+// ProxyRouteHandlers groups the public AI API handlers that must stay in sync
+// across CLI, desktop, and test route registration.
+type ProxyRouteHandlers struct {
+	ProxyHandler         http.Handler
+	ModelsHandler        http.Handler
+	ProviderProxyHandler http.Handler
+}
+
+// RegisterProxyRoutes registers the shared public AI API routes.
+func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
+	if mux == nil {
+		return
+	}
+
+	if handlers.ProxyHandler != nil {
+		// Claude API
+		mux.Handle("/v1/messages", handlers.ProxyHandler)
+		mux.Handle("/v1/messages/", handlers.ProxyHandler)
+		// OpenAI API
+		mux.Handle("/v1/chat/completions", handlers.ProxyHandler)
+		// Codex API
+		mux.Handle("/responses", handlers.ProxyHandler)
+		mux.Handle("/responses/", handlers.ProxyHandler)
+		mux.Handle("/v1/responses", handlers.ProxyHandler)
+		mux.Handle("/v1/responses/", handlers.ProxyHandler)
+		// Gemini API (Google AI Studio style)
+		mux.Handle("/v1beta/models/", handlers.ProxyHandler)
+	}
+
+	if handlers.ModelsHandler != nil {
+		mux.Handle("/v1/models", handlers.ModelsHandler)
+	}
+
+	if handlers.ProviderProxyHandler != nil {
+		mux.Handle("/provider/", handlers.ProviderProxyHandler)
+	}
+}

--- a/internal/core/proxy_routes_test.go
+++ b/internal/core/proxy_routes_test.go
@@ -1,0 +1,30 @@
+package core
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRegisterProxyRoutes_RegistersModelsRoute(t *testing.T) {
+	mux := http.NewServeMux()
+	called := false
+
+	RegisterProxyRoutes(mux, ProxyRouteHandlers{
+		ModelsHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if !called {
+		t.Fatal("expected /v1/models to be routed to ModelsHandler")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -96,15 +96,11 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	mux.Handle("/api/codex/", http.StripPrefix("/api", components.CodexHandler))
 	mux.Handle("/api/claude/", http.StripPrefix("/api", components.ClaudeHandler))
 
-	mux.Handle("/v1/messages", components.ProxyHandler)
-	mux.Handle("/v1/messages/", components.ProxyHandler)
-	mux.Handle("/v1/chat/completions", components.ProxyHandler)
-	mux.Handle("/responses", components.ProxyHandler)
-	mux.Handle("/responses/", components.ProxyHandler)
-	mux.Handle("/v1/responses", components.ProxyHandler)
-	mux.Handle("/v1/responses/", components.ProxyHandler)
-	mux.Handle("/v1/models", components.ModelsHandler)
-	mux.Handle("/v1beta/models/", components.ProxyHandler)
+	RegisterProxyRoutes(mux, ProxyRouteHandlers{
+		ProxyHandler:         components.ProxyHandler,
+		ModelsHandler:        components.ModelsHandler,
+		ProviderProxyHandler: components.ProviderProxyHandler,
+	})
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -113,7 +109,6 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	})
 
 	mux.HandleFunc("/ws", components.WebSocketHub.HandleWebSocket)
-	mux.Handle("/provider/", components.ProviderProxyHandler)
 
 	if s.config.ServeStatic {
 		staticHandler := handler.NewStaticHandler()

--- a/internal/handler/models_test.go
+++ b/internal/handler/models_test.go
@@ -27,8 +27,8 @@ type fakeProviderRepo struct {
 	err       error
 }
 
-func (f *fakeProviderRepo) Create(provider *domain.Provider) error { return nil }
-func (f *fakeProviderRepo) Update(provider *domain.Provider) error { return nil }
+func (f *fakeProviderRepo) Create(provider *domain.Provider) error  { return nil }
+func (f *fakeProviderRepo) Update(provider *domain.Provider) error  { return nil }
 func (f *fakeProviderRepo) Delete(tenantID uint64, id uint64) error { return nil }
 func (f *fakeProviderRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
 	return nil, domain.ErrNotFound
@@ -172,6 +172,9 @@ func TestModelsHandlerPricingSupplementByUserAgent(t *testing.T) {
 	}
 	if !containsModel(openAIIDs, "gpt-5.3") {
 		t.Fatalf("expected gpt-5.3 in openai model list")
+	}
+	if !containsModel(openAIIDs, "gpt-5.4-mini") {
+		t.Fatalf("expected gpt-5.4-mini in openai model list")
 	}
 	if containsModel(openAIIDs, "claude-opus-4-6") {
 		t.Fatalf("did not expect claude pricing-only model in codex model list")

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -125,6 +125,15 @@ func TestCalculator_Calculate(t *testing.T) {
 			wantZero: false,
 		},
 		{
+			name:  "gpt-5.4-mini basic",
+			model: "gpt-5.4-mini",
+			metrics: &usage.Metrics{
+				InputTokens:  50_000,
+				OutputTokens: 5_000,
+			},
+			wantZero: false,
+		},
+		{
 			name:  "gemini-2.5-pro basic",
 			model: "gemini-2.5-pro",
 			metrics: &usage.Metrics{
@@ -226,6 +235,7 @@ func TestPriceTable_Get_PrefixMatch(t *testing.T) {
 		{"gpt-5.2", true},
 		{"gpt-5.3", true},
 		{"gpt-5.4", true},
+		{"gpt-5.4-mini", true},
 		{"gemini-2.5-pro", true},
 		{"gemini-2.5-flash", true},
 		{"gemini-3-pro-preview", true},

--- a/internal/pricing/default_prices.go
+++ b/internal/pricing/default_prices.go
@@ -284,6 +284,14 @@ func initDefaultPrices() *PriceTable {
 		CacheReadPriceMicro: 250_000,    // $0.25/M
 	})
 
+	// gpt-5.4-mini: input=$0.75, cache_read=$0.075, output=$4.50
+	pt.Set(&ModelPricing{
+		ModelID:             "gpt-5.4-mini",
+		InputPriceMicro:     750_000,   // $0.75/M
+		OutputPriceMicro:    4_500_000, // $4.50/M
+		CacheReadPriceMicro: 75_000,    // $0.075/M
+	})
+
 	// ========== GPT-4o 系列 ==========
 	// gpt-4o: input=$2.50, output=$10, cache_read=$1.25
 	pt.Set(&ModelPricing{

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -11,6 +11,7 @@ import (
 
 	client "github.com/awsl-project/maxx/internal/adapter/client"
 	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/core"
 	"github.com/awsl-project/maxx/internal/executor"
 	"github.com/awsl-project/maxx/internal/handler"
 	"github.com/awsl-project/maxx/internal/repository/cached"
@@ -206,20 +207,12 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	// Admin API routes with authentication
 	mux.Handle("/api/admin/", http.StripPrefix("/api", authMiddleware.Wrap(adminHandler)))
 
-	// Models endpoint
-	mux.Handle("/v1/models", modelsHandler)
-
-	// Proxy routes - all AI API endpoints
-	mux.Handle("/v1/messages", proxyHandler)
-	mux.Handle("/v1/messages/", proxyHandler)
-	mux.Handle("/v1/chat/completions", proxyHandler)
-	mux.Handle("/responses", proxyHandler)
-	mux.Handle("/responses/", proxyHandler)
-	mux.Handle("/v1/responses", proxyHandler)
-	mux.Handle("/v1/responses/", proxyHandler)
-	mux.Handle("/v1beta/models/", proxyHandler)
+	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
+		ProxyHandler:         proxyHandler,
+		ModelsHandler:        modelsHandler,
+		ProviderProxyHandler: providerProxyHandler,
+	})
 	mux.Handle("/project/", projectProxyHandler)
-	mux.Handle("/provider/", providerProxyHandler)
 
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/core"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/handler"
 	"github.com/awsl-project/maxx/internal/repository/cached"
@@ -173,7 +174,9 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	handler.RegisterSelfServiceRoutes(mux, authMiddleware.Wrap, adminHandler, selfServiceHandler)
 
 	// Models endpoint (public)
-	mux.Handle("/v1/models", modelsHandler)
+	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
+		ModelsHandler: modelsHandler,
+	})
 
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/web/src/components/ui/model-input.tsx
+++ b/web/src/components/ui/model-input.tsx
@@ -64,6 +64,7 @@ const COMMON_MODELS = [
   { id: 'gpt-5.3', name: 'GPT-5.3', provider: 'OpenAI' },
   { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', provider: 'OpenAI' },
   { id: 'gpt-5.4', name: 'GPT-5.4', provider: 'OpenAI' },
+  { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', provider: 'OpenAI' },
   // NVIDIA models
   { id: 'minimaxai/minimax-m2.1', name: 'MiniMax M2.1', provider: 'NVIDIA' },
   { id: 'z-ai/glm4.7', name: 'GLM 4.7', provider: 'NVIDIA' },


### PR DESCRIPTION
 ## Summary

  - restore direct `/v1/models` support without requiring `/project/{slug}`
  - centralize shared proxy route registration so runtime and tests stay aligned
  - add `gpt-5.4-mini` to the shared model picker and default pricing table

## Validation

- `go test ./internal/core ./tests/e2e`
- `go test ./internal/pricing ./internal/handler`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* **新功能**
  * 新增 GPT-5.4 Mini 模型，用户现可在模型选择器中选择使用该模型
  * 已配置新模型的定价信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->