### PR TITLE
chore: update CLIProxyAPI replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,4 +114,4 @@ require (
 	modernc.org/sqlite v1.23.1 // indirect
 )
 
-replace github.com/router-for-me/CLIProxyAPI/v6 => github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260420045258-92994371ac9e
+replace github.com/router-for-me/CLIProxyAPI/v6 => github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260422044143-f9815769243e

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260420045258-92994371ac9e h1:v9QFOmzO1kVeqYQlmFnkR0+kxe1QJbe7jAzAtmjiAkY=
-github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260420045258-92994371ac9e/go.mod h1:P1jsIPFXorYGuS2N/3BlZYkpRKi/z7+oR3+1tdG0u4k=
+github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260422044143-f9815769243e h1:+L1oaYblnKAn6qLgGyLGGfLJeNrHN/3Pe5aIC9G3d70=
+github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260422044143-f9815769243e/go.mod h1:P1jsIPFXorYGuS2N/3BlZYkpRKi/z7+oR3+1tdG0u4k=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=


### PR DESCRIPTION
Automated dependency update by CLIProxyAPI Sync workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新内部依赖的伪版本以指向新的修订（仅构建元数据变更，无功能或对外 API 影响）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->