### PR TITLE
fix(bedrock): resolve bare anthropic.<short> via discovery

### DIFF
--- a/internal/adapter/provider/bedrock/model_mapping.go
+++ b/internal/adapter/provider/bedrock/model_mapping.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"regexp"
+	"strings"
 )
 
 // modelDatePattern matches an Anthropic short name that already carries an
@@ -66,6 +67,22 @@ func resolveModelID(model string, configMapping map[string]string, modelPrefix s
 		return applyPrefix("anthropic."+model+"-v1:0", modelPrefix), true
 	}
 	if bedrockIDPattern.MatchString(model) {
+		// Bare "anthropic.<short>" (no region prefix, no date+version) is a
+		// foundation-model shape. Many current Claude releases have no
+		// on-demand foundation SKU and only invoke through an inference
+		// profile, so give discovery a chance at the short name before
+		// falling back to passthrough. If discovery is absent or misses,
+		// the original passthrough stands (operators/tests relying on it
+		// stay unaffected).
+		if discovered != nil &&
+			!regionPrefixedPattern.MatchString(model) &&
+			!inferenceProfilePattern.MatchString(model) {
+			if short, ok := strings.CutPrefix(model, "anthropic."); ok {
+				if id, hit := discovered(short); hit {
+					return id, true
+				}
+			}
+		}
 		return applyPrefix(model, modelPrefix), true
 	}
 	return "", false

--- a/internal/adapter/provider/bedrock/model_mapping.go
+++ b/internal/adapter/provider/bedrock/model_mapping.go
@@ -46,7 +46,11 @@ type discoveredLookup func(shortName string) (id string, hit bool)
 //                          and ListFoundationModels; returns ready-to-use
 //                          IDs that must not be further prefixed
 //  3. client-supplied dated name (claude-*-YYYYMMDD) — wrap as anthropic.X-v1:0
-//  4. client-supplied fully-qualified Bedrock ID — passthrough
+//  4. client-supplied bare "anthropic.<short>" — retry discovery on the
+//                          stripped short name so releases that Bedrock
+//                          only serves via inference profile can resolve
+//                          to an invoke-ready ID; miss falls through to 5
+//  5. client-supplied fully-qualified Bedrock ID — passthrough
 func resolveModelID(model string, configMapping map[string]string, modelPrefix string, discovered discoveredLookup) (string, bool) {
 	if configMapping != nil {
 		if mapped, ok := configMapping[model]; ok {
@@ -77,7 +81,7 @@ func resolveModelID(model string, configMapping map[string]string, modelPrefix s
 		if discovered != nil &&
 			!regionPrefixedPattern.MatchString(model) &&
 			!inferenceProfilePattern.MatchString(model) {
-			if short, ok := strings.CutPrefix(model, "anthropic."); ok {
+			if short, ok := strings.CutPrefix(model, "anthropic."); ok && short != "" {
 				if id, hit := discovered(short); hit {
 					return id, true
 				}

--- a/internal/adapter/provider/bedrock/model_mapping_test.go
+++ b/internal/adapter/provider/bedrock/model_mapping_test.go
@@ -173,6 +173,37 @@ func TestResolveModelIDPriority(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			// Foundation-only release: client sends "anthropic.<short>"
+			// and discovery returns a bare foundation ID (no region
+			// prefix). The invoke-ready value from discovery must be
+			// returned verbatim — applyPrefix must not be re-applied on
+			// top of it, since region-prefixing a foundation model ID
+			// makes it invalid.
+			name:   "client-supplied bare anthropic.X with foundation-only discovery hit returns verbatim",
+			model:  "anthropic.claude-sonnet-4-6",
+			lookup: discovered,
+			prefix: "us",
+			wantID: "anthropic.claude-sonnet-4-6",
+			wantOK: true,
+		},
+		{
+			// Degenerate input "anthropic." (empty short after strip)
+			// must not query discovery — an empty-string lookup key is
+			// meaningless and a future discoverer change could surprise.
+			// Falls through to the existing passthrough contract.
+			name:   "degenerate anthropic. passes through without querying discovery",
+			model:  "anthropic.",
+			lookup: func(name string) (string, bool) {
+				if name == "" {
+					t.Fatalf("discovery must not be called with empty key")
+				}
+				return "", false
+			},
+			prefix: "us",
+			wantID: "anthropic.",
+			wantOK: true,
+		},
+		{
 			name:   "client-supplied fully-qualified bedrock ID passes through",
 			model:  "anthropic.claude-opus-4-5-20251101-v1:0",
 			lookup: discovered,

--- a/internal/adapter/provider/bedrock/model_mapping_test.go
+++ b/internal/adapter/provider/bedrock/model_mapping_test.go
@@ -148,6 +148,31 @@ func TestResolveModelIDPriority(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			// Client sends "anthropic.<short>" for a model that Bedrock
+			// refuses on-demand (no foundation SKU — must invoke via an
+			// inference profile). Discovery knows the profile under the
+			// short name, so stripping "anthropic." and consulting
+			// discovery lets us resolve to an invoke-ready profile ID
+			// instead of letting the bare foundation ID hit Bedrock and
+			// fail with "on-demand throughput isn't supported".
+			name:   "client-supplied bare anthropic.X resolves via discovery",
+			model:  "anthropic.claude-sonnet-4-9",
+			lookup: discovered,
+			prefix: "us",
+			wantID: "us.anthropic.claude-sonnet-4-9-20260201-v1:0",
+			wantOK: true,
+		},
+		{
+			// Discovery-miss on the stripped short name must fall back to
+			// the original passthrough, not synthesize a profile ID.
+			name:   "client-supplied bare anthropic.X with discovery miss falls back to passthrough",
+			model:  "anthropic.claude-unreleased-99",
+			lookup: discovered,
+			prefix: "us",
+			wantID: "anthropic.claude-unreleased-99",
+			wantOK: true,
+		},
+		{
 			name:   "client-supplied fully-qualified bedrock ID passes through",
 			model:  "anthropic.claude-opus-4-5-20251101-v1:0",
 			lookup: discovered,


### PR DESCRIPTION
## Summary
- When a client sends a bare foundation-model ID like `anthropic.claude-sonnet-4-6`, Bedrock rejects the invoke for models that have no on-demand foundation SKU (`on-demand throughput isn't supported — retry with an inference profile`). `resolveModelID` previously passed these through unchanged, so the call always failed even when discovery had an invoke-ready profile under the short name.
- Strip the `anthropic.` prefix and consult the discoverer when the ID is bare (not region-prefixed, not dated+versioned). On a hit, return the discovered invoke-ready ID; on a miss, fall back to the existing passthrough so explicit client intent still wins when discovery is unavailable.

## Context
Observed as the second failure in a chain: a request whose primary route returned `Invalid signature in thinking block` failed over to a Bedrock route carrying the bare foundation ID, which Bedrock then refused with the on-demand message. This PR only addresses the Bedrock ID resolution side of that chain; the signature handling is a separate concern.

## Test plan
- [x] `go test ./internal/adapter/provider/bedrock/...` passes, including two new cases:
  - `client-supplied bare anthropic.X resolves via discovery`
  - `client-supplied bare anthropic.X with discovery miss falls back to passthrough`
- [ ] Live Bedrock smoke: send `anthropic.claude-sonnet-4-6` with discovery enabled and confirm the request reaches an inference profile rather than returning the on-demand error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了模型ID解析逻辑，增强了对Anthropic模型的智能识别和自动转换功能。

* **Tests**
  * 添加了新的测试用例以验证模型ID解析的准确性和容错能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->