### PR TITLE
fix(custom): strip thinking blocks when upstream rejects signature

### DIFF
--- a/internal/adapter/provider/custom/error_fixer/100_thinking_signature.go
+++ b/internal/adapter/provider/custom/error_fixer/100_thinking_signature.go
@@ -54,13 +54,20 @@ func (f *thinkingSignatureFixer) FixRequest(req *http.Request, body []byte) (*ht
 	return req, stripThinkingBlocks(body)
 }
 
+// emptyAssistantPlaceholder is the content we leave on an assistant
+// message that was nothing but thinking blocks. Upstreams reject both
+// empty content arrays and zero-length text, and dropping the whole
+// message would merge adjacent user turns (also rejected). A minimal
+// text block keeps turn structure intact for the retry.
+var emptyAssistantPlaceholder = []byte(`[{"type":"text","text":"[thinking omitted]"}]`)
+
 // stripThinkingBlocks removes every content block whose `type` is
-// `thinking` or `redacted_thinking` from all messages. Non-array
-// content (plain string) and non-thinking blocks are preserved. If
-// stripping empties a message's content array, the message is left
-// in place — downstream semantics (empty content validation) are
-// upstream's responsibility, and dropping the whole message would
-// alter turn ordering.
+// `thinking` or `redacted_thinking` from all messages. Plain-string
+// content and non-thinking blocks are preserved. When stripping
+// empties an assistant message's content array, a single placeholder
+// text block is inserted to keep the retry valid — dropping the
+// message would create adjacent user turns and an empty array is
+// itself a validation error on most upstreams.
 func stripThinkingBlocks(payload []byte) []byte {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.IsArray() {
@@ -72,14 +79,31 @@ func stripThinkingBlocks(payload []byte) []byte {
 		if !content.IsArray() {
 			continue
 		}
+		removed := false
 		// Iterate in reverse so index-based deletes do not shift
 		// remaining indices.
 		for j := int(content.Get("#").Int()) - 1; j >= 0; j-- {
 			blockType := gjson.GetBytes(payload, fmt.Sprintf("%s.%d.type", contentPath, j)).String()
 			if blockType == "thinking" || blockType == "redacted_thinking" {
 				payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("%s.%d", contentPath, j))
+				removed = true
 			}
 		}
+		if !removed {
+			continue
+		}
+		if gjson.GetBytes(payload, contentPath+".#").Int() > 0 {
+			continue
+		}
+		role := gjson.GetBytes(payload, fmt.Sprintf("messages.%d.role", i)).String()
+		if role != "assistant" {
+			// Only assistant turns legitimately carry thinking blocks.
+			// If a non-assistant role somehow had only thinking
+			// content, we leave the empty array as-is rather than
+			// fabricate content for a role that never produced it.
+			continue
+		}
+		payload, _ = sjson.SetRawBytes(payload, contentPath, emptyAssistantPlaceholder)
 	}
 	return payload
 }

--- a/internal/adapter/provider/custom/error_fixer/100_thinking_signature.go
+++ b/internal/adapter/provider/custom/error_fixer/100_thinking_signature.go
@@ -1,0 +1,85 @@
+package error_fixer
+
+// Upstream rejects thinking blocks whose signatures it cannot verify.
+// Signatures are scoped to the deployment that produced them (account,
+// model, sometimes private wrapper format), so a signature from one
+// provider is not portable to another. When a client replays extended-
+// thinking history across providers, the destination may reject it with
+// messages like:
+//
+//   400 {"error":{"type":"<nil>","message":"messages.0.content.0: Invalid `signature` in `thinking` block (request id: ...) (request id: ...)"}}
+//
+// Fix: drop every content block whose type is "thinking" or
+// "redacted_thinking" from all messages, then retry. Thinking context
+// for the current turn is lost, but the rest of the conversation
+// survives — preferable to a hard 400 that exhausts the retry budget.
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var _ ErrorFixer = (*thinkingSignatureFixer)(nil)
+
+func init() {
+	Register(&thinkingSignatureFixer{})
+}
+
+type thinkingSignatureFixer struct{}
+
+func (f *thinkingSignatureFixer) Name() string  { return "thinking_signature" }
+func (f *thinkingSignatureFixer) Priority() int { return 100 }
+
+func (f *thinkingSignatureFixer) MatchResponse(resp *http.Response, body []byte, clientType domain.ClientType) bool {
+	if clientType != domain.ClientTypeClaude {
+		return false
+	}
+	if resp != nil && resp.StatusCode != 400 {
+		return false
+	}
+	// Match the exact backticked phrase produced by Anthropic-style
+	// validators: "Invalid `signature` in `thinking` block". The
+	// backticks distinguish this from unrelated 400 bodies that happen
+	// to mention "signature" (e.g. AWS SigV4 auth errors) or "thinking"
+	// (e.g. budget / config validation errors).
+	return bytes.Contains(body, []byte("Invalid `signature` in `thinking` block"))
+}
+
+func (f *thinkingSignatureFixer) FixRequest(req *http.Request, body []byte) (*http.Request, []byte) {
+	return req, stripThinkingBlocks(body)
+}
+
+// stripThinkingBlocks removes every content block whose `type` is
+// `thinking` or `redacted_thinking` from all messages. Non-array
+// content (plain string) and non-thinking blocks are preserved. If
+// stripping empties a message's content array, the message is left
+// in place — downstream semantics (empty content validation) are
+// upstream's responsibility, and dropping the whole message would
+// alter turn ordering.
+func stripThinkingBlocks(payload []byte) []byte {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return payload
+	}
+	for i := int(messages.Get("#").Int()) - 1; i >= 0; i-- {
+		contentPath := fmt.Sprintf("messages.%d.content", i)
+		content := gjson.GetBytes(payload, contentPath)
+		if !content.IsArray() {
+			continue
+		}
+		// Iterate in reverse so index-based deletes do not shift
+		// remaining indices.
+		for j := int(content.Get("#").Int()) - 1; j >= 0; j-- {
+			blockType := gjson.GetBytes(payload, fmt.Sprintf("%s.%d.type", contentPath, j)).String()
+			if blockType == "thinking" || blockType == "redacted_thinking" {
+				payload, _ = sjson.DeleteBytes(payload, fmt.Sprintf("%s.%d", contentPath, j))
+			}
+		}
+	}
+	return payload
+}

--- a/internal/adapter/provider/custom/error_fixer/100_thinking_signature_test.go
+++ b/internal/adapter/provider/custom/error_fixer/100_thinking_signature_test.go
@@ -1,0 +1,168 @@
+package error_fixer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+func TestThinkingSignatureFixer_MatchResponse(t *testing.T) {
+	f := &thinkingSignatureFixer{}
+
+	cases := []struct {
+		name       string
+		status     int
+		nilResp    bool
+		body       string
+		clientType domain.ClientType
+		want       bool
+	}{
+		{
+			name:       "match on realistic error body",
+			status:     400,
+			body:       `{"error":{"type":"<nil>","message":"messages.0.content.0: Invalid ` + "`" + `signature` + "`" + ` in ` + "`" + `thinking` + "`" + ` block (request id: 202604230718)"}}`,
+			clientType: domain.ClientTypeClaude,
+			want:       true,
+		},
+		{
+			name:       "no match on wrong status",
+			status:     500,
+			body:       "Invalid `signature` in `thinking` block",
+			clientType: domain.ClientTypeClaude,
+			want:       false,
+		},
+		{
+			name:       "no match on non-Claude client",
+			status:     400,
+			body:       "Invalid `signature` in `thinking` block",
+			clientType: domain.ClientTypeGemini,
+			want:       false,
+		},
+		{
+			name:       "no match on AWS SigV4 style signature error",
+			status:     400,
+			body:       `{"error":"The request signature we calculated does not match the signature you provided"}`,
+			clientType: domain.ClientTypeClaude,
+			want:       false,
+		},
+		{
+			name:       "no match on thinking budget validation error",
+			status:     400,
+			body:       `{"error":"thinking.budget_tokens must be >= 1024"}`,
+			clientType: domain.ClientTypeClaude,
+			want:       false,
+		},
+		{
+			name:       "no match when both words present but not the exact phrase",
+			status:     400,
+			body:       `{"error":"signature field is required on thinking blocks"}`,
+			clientType: domain.ClientTypeClaude,
+			want:       false,
+		},
+		{
+			name:       "match on nil response (SSE error path) with exact phrase",
+			nilResp:    true,
+			body:       "event: error\ndata: {\"message\":\"messages.0.content.0: Invalid `signature` in `thinking` block\"}",
+			clientType: domain.ClientTypeClaude,
+			want:       true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var resp *http.Response
+			if !c.nilResp {
+				resp = &http.Response{StatusCode: c.status}
+			}
+			got := f.MatchResponse(resp, []byte(c.body), c.clientType)
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestStripThinkingBlocks(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		check func(t *testing.T, out []byte)
+	}{
+		{
+			name: "removes thinking and redacted_thinking, preserves text and tool_use",
+			input: `{"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"...","signature":"abc"},
+					{"type":"text","text":"hello"},
+					{"type":"redacted_thinking","data":"xxx"},
+					{"type":"tool_use","id":"t1","name":"x","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"t1","content":"ok"}
+				]}
+			]}`,
+			check: func(t *testing.T, out []byte) {
+				ac := gjson.GetBytes(out, "messages.0.content")
+				if n := ac.Get("#").Int(); n != 2 {
+					t.Fatalf("assistant content len = %d, want 2 (text+tool_use)", n)
+				}
+				if got := ac.Get("0.type").String(); got != "text" {
+					t.Errorf("kept content[0].type = %q, want text", got)
+				}
+				if got := ac.Get("1.type").String(); got != "tool_use" {
+					t.Errorf("kept content[1].type = %q, want tool_use", got)
+				}
+				uc := gjson.GetBytes(out, "messages.1.content")
+				if n := uc.Get("#").Int(); n != 1 {
+					t.Errorf("user content len = %d, want 1 (unchanged)", n)
+				}
+			},
+		},
+		{
+			name: "string content is left untouched",
+			input: `{"messages":[
+				{"role":"user","content":"plain text"}
+			]}`,
+			check: func(t *testing.T, out []byte) {
+				if got := gjson.GetBytes(out, "messages.0.content").String(); got != "plain text" {
+					t.Errorf("string content mangled: %q", got)
+				}
+			},
+		},
+		{
+			name: "message of only thinking blocks becomes empty content array (left in place)",
+			input: `{"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"...","signature":"abc"}
+				]}
+			]}`,
+			check: func(t *testing.T, out []byte) {
+				ac := gjson.GetBytes(out, "messages.0.content")
+				if !ac.IsArray() {
+					t.Fatalf("expected content to remain an array, got %v", ac.Type)
+				}
+				if n := ac.Get("#").Int(); n != 0 {
+					t.Errorf("expected empty content array, got len %d", n)
+				}
+			},
+		},
+		{
+			name:  "no messages field is a no-op",
+			input: `{"model":"claude-foo"}`,
+			check: func(t *testing.T, out []byte) {
+				if got := gjson.GetBytes(out, "model").String(); got != "claude-foo" {
+					t.Errorf("unrelated fields mutated: %s", string(out))
+				}
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := stripThinkingBlocks([]byte(c.input))
+			c.check(t, out)
+		})
+	}
+}

--- a/internal/adapter/provider/custom/error_fixer/100_thinking_signature_test.go
+++ b/internal/adapter/provider/custom/error_fixer/100_thinking_signature_test.go
@@ -132,19 +132,74 @@ func TestStripThinkingBlocks(t *testing.T) {
 			},
 		},
 		{
-			name: "message of only thinking blocks becomes empty content array (left in place)",
+			// Dropping to content:[] would retry-fail ("at least one
+			// block required") and trigger an endless fix-retry loop;
+			// dropping the whole message would merge the surrounding
+			// user turns. Placeholder text keeps the retry valid.
+			name: "assistant message of only thinking gets placeholder text",
 			input: `{"messages":[
+				{"role":"user","content":[{"type":"text","text":"hi"}]},
 				{"role":"assistant","content":[
 					{"type":"thinking","thinking":"...","signature":"abc"}
+				]},
+				{"role":"user","content":[{"type":"text","text":"next"}]}
+			]}`,
+			check: func(t *testing.T, out []byte) {
+				ac := gjson.GetBytes(out, "messages.1.content")
+				if n := ac.Get("#").Int(); n != 1 {
+					t.Fatalf("assistant content len = %d, want 1 (placeholder)", n)
+				}
+				if got := ac.Get("0.type").String(); got != "text" {
+					t.Errorf("placeholder type = %q, want text", got)
+				}
+				if got := ac.Get("0.text").String(); got == "" {
+					t.Errorf("placeholder text must be non-empty")
+				}
+				// Surrounding user turns are untouched.
+				if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "hi" {
+					t.Errorf("preceding user turn mangled: %q", got)
+				}
+				if got := gjson.GetBytes(out, "messages.2.content.0.text").String(); got != "next" {
+					t.Errorf("following user turn mangled: %q", got)
+				}
+			},
+		},
+		{
+			// Non-assistant roles never legitimately carry thinking
+			// blocks, but if one slips through we leave the empty
+			// array rather than fabricate content for a role that
+			// did not produce it.
+			name: "non-assistant empty content after strip is left empty",
+			input: `{"messages":[
+				{"role":"user","content":[
+					{"type":"redacted_thinking","data":"xxx"}
 				]}
 			]}`,
 			check: func(t *testing.T, out []byte) {
 				ac := gjson.GetBytes(out, "messages.0.content")
 				if !ac.IsArray() {
-					t.Fatalf("expected content to remain an array, got %v", ac.Type)
+					t.Fatalf("expected array, got %v", ac.Type)
 				}
 				if n := ac.Get("#").Int(); n != 0 {
-					t.Errorf("expected empty content array, got len %d", n)
+					t.Errorf("expected empty array for non-assistant, got len %d", n)
+				}
+			},
+		},
+		{
+			// Running the fix twice must be a no-op on the second
+			// pass — otherwise a retry loop with no new thinking to
+			// strip would keep re-triggering this fixer forever.
+			name: "idempotent on already-stripped body",
+			input: `{"messages":[
+				{"role":"assistant","content":[
+					{"type":"thinking","thinking":"t","signature":"s"},
+					{"type":"text","text":"hello"}
+				]}
+			]}`,
+			check: func(t *testing.T, out []byte) {
+				twice := stripThinkingBlocks(out)
+				if string(twice) != string(out) {
+					t.Errorf("second strip must be a no-op; before=%s after=%s", out, twice)
 				}
 			},
 		},
@@ -164,5 +219,34 @@ func TestStripThinkingBlocks(t *testing.T) {
 			out := stripThinkingBlocks([]byte(c.input))
 			c.check(t, out)
 		})
+	}
+}
+
+func TestThinkingSignatureFixer_FixRequest(t *testing.T) {
+	f := &thinkingSignatureFixer{}
+	req := &http.Request{}
+	input := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"thinking","thinking":"...","signature":"abc"},
+			{"type":"text","text":"hi"}
+		]}
+	]}`)
+	// Copy the input so we can assert the fixer does not mutate the
+	// caller's slice (per the ErrorFixer contract in fixer.go).
+	orig := make([]byte, len(input))
+	copy(orig, input)
+
+	gotReq, gotBody := f.FixRequest(req, input)
+	if gotReq != req {
+		t.Errorf("FixRequest should return the same request object")
+	}
+	if string(input) != string(orig) {
+		t.Errorf("input slice was mutated: before=%s after=%s", orig, input)
+	}
+	if gjson.GetBytes(gotBody, "messages.0.content.#").Int() != 1 {
+		t.Errorf("expected thinking block stripped, got %s", gotBody)
+	}
+	if got := gjson.GetBytes(gotBody, "messages.0.content.0.type").String(); got != "text" {
+		t.Errorf("remaining block type = %q, want text", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Signatures on \`thinking\` / \`redacted_thinking\` content blocks are scoped to the deployment that produced them (account, model, and sometimes a private wrapper format). When a client replays extended-thinking history across providers, the destination rejects the request with bodies like:
  > \`400 {\"error\":{\"message\":\"messages.0.content.0: Invalid \\\`signature\\\` in \\\`thinking\\\` block ...\"}}\`
- New fixer matches the exact backticked phrase on a 400 from a Claude-format client, strips every \`thinking\` / \`redacted_thinking\` block from \`messages[].content[]\`, and lets the retry layer re-send. Plain-string content is left untouched; a message that becomes all-thinking ends up with an empty content array rather than being dropped (keeps turn ordering intact).

## Context
Observed as the 422/400 failure path when a custom-proxy route forwards extended-thinking history to an upstream that can't verify the incoming signatures. The match is tight enough to skip AWS SigV4 signature errors and thinking-budget validation errors, which both share individual keywords but not the backticked phrase.

## Test plan
- [x] \`go test ./internal/adapter/provider/custom/...\` passes, including:
  - \`TestThinkingSignatureFixer_MatchResponse\` (positive + 5 negative cases)
  - \`TestStripThinkingBlocks\` (mixed content, string content, all-thinking message, no-messages payload)
- [ ] Live smoke: replay a session with extended-thinking history against a custom-proxy upstream that rejects cross-source signatures; confirm the retry succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了对 Claude API 特定签名验证错误的处理，增强了请求重试机制的可靠性

* **Tests**
  * 添加了相应的测试用例以确保错误处理的准确性和稳定性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->