### PR TITLE
feat(bedrock): discover 4.6/4.7, persist catalog, fix adaptive thinking

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/bedrock" // Register bedrock adapter
+	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"  // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"  // Register custom adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"    // Register kiro adapter
@@ -120,6 +120,12 @@ func main() {
 	userRepo := sqlite.NewUserRepository(db)
 	inviteCodeRepo := sqlite.NewInviteCodeRepository(db)
 	inviteCodeUsageRepo := sqlite.NewInviteCodeUsageRepository(db)
+
+	// Wire Bedrock discovery persistence: each BedrockAdapter will rehydrate
+	// its short-name → inference-profile catalog from SQLite at startup,
+	// avoiding the ~1-5s ListInferenceProfiles round-trip on the first
+	// request after a restart.
+	bedrock.SetDiscoveryRepository(sqlite.NewBedrockDiscoveryRepository(db))
 
 	// Initialize cooldown manager with database persistence
 	cooldown.Default().SetRepository(cooldownRepo)

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/usage"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -25,6 +26,20 @@ import (
 
 func init() {
 	provider.RegisterAdapterFactory("bedrock", NewAdapter)
+}
+
+// discoveryRepo is the persistence backend for the profileDiscoverer,
+// shared by every BedrockAdapter instance. Wired at process startup by
+// the binary that owns the database; stays nil in unit tests, in which
+// case discovery falls back to in-memory-only behaviour. Set once at
+// boot — reassigning under concurrent NewAdapter calls is undefined.
+var discoveryRepo repository.BedrockDiscoveryRepository
+
+// SetDiscoveryRepository wires the per-process persistence backend for
+// Bedrock discovery. Called once from main after the sqlite layer is
+// available. Passing nil disables persistence.
+func SetDiscoveryRepository(r repository.BedrockDiscoveryRepository) {
+	discoveryRepo = r
 }
 
 // BedrockAdapter handles communication with AWS Bedrock.
@@ -46,11 +61,22 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 		region = DefaultRegion
 	}
 	httpClient := newHTTPClient()
+	discoverer := newProfileDiscoverer(httpClient, creds, region)
+	if discoveryRepo != nil && p.ID > 0 {
+		discoverer.repo = discoveryRepo
+		discoverer.providerID = p.ID
+		// Warm the in-memory cache from the persisted catalog so the
+		// first request doesn't pay ~1-5s of AWS round-trip latency.
+		// If the persisted FetchedAt is older than the TTL, Lookup
+		// will refresh on demand — loadFromStore only primes, it does
+		// not extend the TTL.
+		discoverer.loadFromStore()
+	}
 	return &BedrockAdapter{
 		provider:   p,
 		httpClient: httpClient,
 		creds:      creds,
-		discoverer: newProfileDiscoverer(httpClient, creds, region),
+		discoverer: discoverer,
 	}, nil
 }
 
@@ -79,6 +105,23 @@ type DiscoveredModelsResult struct {
 	Available bool              `json:"available"`
 	Region    string            `json:"region"`
 	Models    []DiscoveredModel `json:"models"`
+}
+
+// RefreshDiscoveredModels forces a fresh ListInferenceProfiles +
+// ListFoundationModels round-trip, bypassing the normal TTL and the
+// Invalidate() rate-limit. Used by the admin UI's "refresh" button —
+// the operator's intent is explicit, so the rate-limit that protects
+// against error-path stampedes is not needed here. Returns the refreshed
+// catalog and any fetch error (the catalog still reflects whatever was
+// in memory when the fetch failed).
+func (a *BedrockAdapter) RefreshDiscoveredModels(ctx context.Context) (DiscoveredModelsResult, error) {
+	var refreshErr error
+	if a.discoverer != nil {
+		lookupCtx, cancel := context.WithTimeout(ctx, discoveryLookupTimeout)
+		defer cancel()
+		refreshErr = a.discoverer.ForceRefresh(lookupCtx)
+	}
+	return a.DiscoveredModels(ctx), refreshErr
 }
 
 // DiscoveredModels triggers a discovery refresh (subject to the normal
@@ -168,6 +211,16 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 	// Sanitize request body for Bedrock
 	requestBody = sanitizeRequestBody(requestBody)
+
+	// Model-specific thinking config: Opus 4.7 rejects the classic
+	// thinking.type="enabled" shape and requires adaptive. Earlier
+	// sanitize steps run without knowing the target model; this step
+	// rewrites the thinking block (and sets output_config.effort) based
+	// on the resolved Bedrock ID's short name, so classic-shape clients
+	// (e.g. Claude Code CLI) can still hit adaptive-only models.
+	if short, _, ok := extractNameAndDate(bedrockModelID); ok {
+		requestBody = adaptThinkingForModel(requestBody, short)
+	}
 
 	// Build upstream URL
 	upstreamURL := buildBedrockURL(region, bedrockModelID, clientWantsStream)

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -65,6 +65,11 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 	if discoveryRepo != nil && p.ID > 0 {
 		discoverer.repo = discoveryRepo
 		discoverer.providerID = p.ID
+		// Access-key ID (not the secret) identifies the IAM principal;
+		// storing it alongside region lets loadFromStore reject rows
+		// from a previous config when the operator rotates credentials
+		// or retargets the provider at another account/region.
+		discoverer.accessKeyID = config.AccessKeyID
 		// Warm the in-memory cache from the persisted catalog so the
 		// first request doesn't pay ~1-5s of AWS round-trip latency.
 		// If the persisted FetchedAt is older than the TTL, Lookup

--- a/internal/adapter/provider/bedrock/discovery.go
+++ b/internal/adapter/provider/bedrock/discovery.go
@@ -110,6 +110,10 @@ type profileDiscoverer struct {
 	// discovery falls back to in-memory-only behaviour.
 	repo       repository.BedrockDiscoveryRepository
 	providerID uint64
+	// accessKeyID is the AWS access-key identifier used to fingerprint
+	// stored rows so a config edit to different creds invalidates the
+	// cache. Non-secret by definition (the "AKIA…" half of a key pair).
+	accessKeyID string
 
 	mu          sync.Mutex
 	entries     map[string]discoveredEntry
@@ -143,7 +147,7 @@ func (d *profileDiscoverer) loadFromStore() {
 	if d.repo == nil {
 		return
 	}
-	rows, fetchedAt, err := d.repo.Load(d.providerID)
+	rows, fetchedAt, err := d.repo.Load(d.providerID, d.region, d.accessKeyID)
 	if err != nil {
 		log.Printf("bedrock discovery: load from store failed (%v); continuing with cold cache", err)
 		return
@@ -368,7 +372,7 @@ func (d *profileDiscoverer) ensureFresh(ctx context.Context) {
 	d.mu.Unlock()
 
 	if shouldPersist && d.repo != nil {
-		if err := d.repo.Replace(d.providerID, toPersist, now); err != nil {
+		if err := d.repo.Replace(d.providerID, d.region, d.accessKeyID, toPersist, now); err != nil {
 			log.Printf("bedrock discovery: save to store failed (%v)", err)
 		}
 	}

--- a/internal/adapter/provider/bedrock/discovery.go
+++ b/internal/adapter/provider/bedrock/discovery.go
@@ -15,31 +15,34 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
 )
 
-// profileIDPattern extracts the Anthropic short name + date from a Bedrock
-// inference profile ID. Supported shapes:
+// bedrockAnthropicPattern matches any Anthropic Bedrock ID — inference
+// profile or foundation model, region-prefixed or bare, dated or dateless,
+// with or without a version suffix. Observed shapes in us-east-1 as of
+// 2026-04 (via `listAll` against ListInferenceProfiles + ListFoundationModels):
 //
-//	us.anthropic.claude-opus-4-7-20260115-v1:0
+//	us.anthropic.claude-opus-4-7                        // new bare
+//	global.anthropic.claude-opus-4-7
+//	us.anthropic.claude-opus-4-6-v1                     // bare + -v suffix
+//	us.anthropic.claude-sonnet-4-6                      // bare
+//	us.anthropic.claude-opus-4-5-20251101-v1:0          // classic dated + versioned
 //	anthropic.claude-3-5-sonnet-20241022-v2:0
-//	eu.anthropic.claude-sonnet-4-5-20250514-v1:0
+//	eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+//	anthropic.claude-sonnet-4-6                         // FM bare
+//	anthropic.claude-v2                                 // legacy, no date
 //
-// Capture groups: 1=short name (e.g. "claude-opus-4-7"), 2=date (YYYYMMDD).
-var profileIDPattern = regexp.MustCompile(
-	`^(?:[a-z]{2,}\.)?anthropic\.(claude-[a-z0-9-]+?)-(\d{8})-v\d+:\d+$`,
-)
-
-// foundationModelPattern extracts the short name from a Bedrock foundation-
-// model ID that has no release date (newer AWS releases frequently omit
-// it). Shapes:
+// Capture groups:
+//   1 = short name (e.g. "claude-opus-4-7")
+//   2 = date (YYYYMMDD) or empty
 //
-//	anthropic.claude-sonnet-4-6
-//	anthropic.claude-opus-4-6-v1
-//
-// The capture requires at least one digit to reject ancient legacy IDs
-// like "anthropic.claude-v2" that would otherwise collapse to "claude".
-var foundationModelPattern = regexp.MustCompile(
-	`^anthropic\.(claude-[a-z0-9-]*?\d[a-z0-9-]*?)(?:-v\d+)?$`,
+// The capture's \d requirement prevents collapsing legacy "claude" (no
+// version digits) into an empty short name, and keeps non-Anthropic IDs
+// out of the match entirely.
+var bedrockAnthropicPattern = regexp.MustCompile(
+	`^(?:[a-z]{2,}\.)?anthropic\.(claude-[a-z0-9-]*?\d[a-z0-9-]*?)(?:-(\d{8}))?(?:-v\d+(?::\d+)?)?$`,
 )
 
 // defaultDiscoveryTTL is how long a successful discovery result is cached.
@@ -101,6 +104,12 @@ type profileDiscoverer struct {
 	region     string
 	ttl        time.Duration
 
+	// repo persists this provider's catalog across restarts. nil means
+	// persistence is disabled (unit tests, or before main wires it up) —
+	// discovery falls back to in-memory-only behaviour.
+	repo       repository.BedrockDiscoveryRepository
+	providerID uint64
+
 	mu          sync.Mutex
 	entries     map[string]discoveredEntry
 	expiresAt   time.Time
@@ -117,6 +126,71 @@ func newProfileDiscoverer(httpClient *http.Client, creds credentials.StaticCrede
 		region:     region,
 		ttl:        defaultDiscoveryTTL,
 		entries:    map[string]discoveredEntry{},
+	}
+}
+
+// loadFromStore seeds the in-memory cache from persistent storage.
+// Called once at adapter construction. Rehydrated entries are treated
+// as "already loaded" so Available() returns true immediately and the
+// UI doesn't show an empty list during the first request. The TTL
+// clock is re-anchored to the persisted fetchedAt — an hour-old cache
+// will trigger a refresh on the next Lookup, a 2-minute-old one won't.
+// Failures are logged and ignored: a dead store must not prevent
+// discovery from working, it just means the first request eats the
+// cold-start latency.
+func (d *profileDiscoverer) loadFromStore() {
+	if d.repo == nil {
+		return
+	}
+	rows, fetchedAt, err := d.repo.Load(d.providerID)
+	if err != nil {
+		log.Printf("bedrock discovery: load from store failed (%v); continuing with cold cache", err)
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+	entries := make(map[string]discoveredEntry, len(rows))
+	for _, r := range rows {
+		var src entrySource
+		if r.Source == "inference-profile" {
+			src = sourceInferenceProfile
+		} else {
+			src = sourceFoundation
+		}
+		entries[r.ShortName] = discoveredEntry{id: r.BedrockID, source: src}
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.entries = entries
+	d.lastFetchAt = fetchedAt
+	d.expiresAt = fetchedAt.Add(d.ttl)
+	d.everLoaded = true
+}
+
+// persistEntries copies the current catalog to the store. Called after
+// a successful fetch (holding d.mu). Errors are logged, not surfaced —
+// a broken store should not fail an otherwise-good fetch.
+func (d *profileDiscoverer) persistEntries(fetchedAt time.Time) {
+	if d.repo == nil {
+		return
+	}
+	rows := make([]*domain.BedrockDiscoveryEntry, 0, len(d.entries))
+	for k, v := range d.entries {
+		// Skip the internal dated-name index; on reload it will be
+		// reconstructed (or not) from fresh discovery. Persisting it
+		// would double the row count for no caller benefit.
+		if modelDatePattern.MatchString(k) {
+			continue
+		}
+		rows = append(rows, &domain.BedrockDiscoveryEntry{
+			ShortName: k,
+			BedrockID: v.id,
+			Source:    v.source.label(),
+		})
+	}
+	if err := d.repo.Replace(d.providerID, rows, fetchedAt); err != nil {
+		log.Printf("bedrock discovery: save to store failed (%v)", err)
 	}
 }
 
@@ -199,6 +273,21 @@ func (s entrySource) label() string {
 	return "foundation-model"
 }
 
+// ForceRefresh clears the cache expiry and performs a synchronous
+// refresh, bypassing the Invalidate() rate-limit. Used by the admin
+// "refresh" endpoint where the operator's intent is explicit and a
+// stampede is not possible (one user, one click). Returns the most
+// recent fetch error if the refresh failed, nil otherwise.
+func (d *profileDiscoverer) ForceRefresh(ctx context.Context) error {
+	d.mu.Lock()
+	d.expiresAt = time.Time{}
+	d.mu.Unlock()
+	d.ensureFresh(ctx)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.lastErr
+}
+
 // Invalidate marks the cache as stale so the next Lookup forces a refresh.
 // Rate-limited: if the most recent fetch completed less than
 // minInvalidateInterval ago, the call is a no-op. This protects against a
@@ -250,6 +339,7 @@ func (d *profileDiscoverer) ensureFresh(ctx context.Context) {
 		d.expiresAt = now.Add(d.ttl)
 		d.lastFetchAt = now
 		d.everLoaded = true
+		d.persistEntries(now)
 	case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
 		// Transient cancellation from a caller-supplied context — do not
 		// poison the cache with a failure TTL, the next caller should retry
@@ -314,9 +404,14 @@ func (d *profileDiscoverer) fetchInferenceProfiles(ctx context.Context) (map[str
 	var nextToken string
 	base := fmt.Sprintf("https://bedrock.%s.amazonaws.com/inference-profiles", d.region)
 
+	// NOTE: intentionally no `typeEquals` filter. AWS surfaces newly-
+	// entitled cross-region profiles (e.g. us.anthropic.claude-opus-4-7
+	// once the account has access) under type=APPLICATION, not
+	// SYSTEM_DEFINED. Filtering to SYSTEM_DEFINED hides them from
+	// discovery entirely; the unfiltered query returns the union and
+	// upsertEntry's newer-wins rule deduplicates any overlap.
 	for {
 		q := url.Values{}
-		q.Set("typeEquals", "SYSTEM_DEFINED")
 		q.Set("maxResults", "100")
 		if nextToken != "" {
 			q.Set("nextToken", nextToken)
@@ -380,7 +475,8 @@ func (d *profileDiscoverer) fetchFoundationModels(ctx context.Context) (map[stri
 
 	var parsed struct {
 		ModelSummaries []struct {
-			ModelID        string `json:"modelId"`
+			ModelID                  string   `json:"modelId"`
+			InferenceTypesSupported  []string `json:"inferenceTypesSupported"`
 			ModelLifecycle struct {
 				Status string `json:"status"`
 			} `json:"modelLifecycle"`
@@ -394,6 +490,17 @@ func (d *profileDiscoverer) fetchFoundationModels(ctx context.Context) (map[stri
 		if s.ModelLifecycle.Status != "" && s.ModelLifecycle.Status != "ACTIVE" {
 			continue
 		}
+		// Skip foundation models that AWS will not serve on-demand.
+		// Claude 4.x currently ships as FM-only entries whose
+		// inferenceTypesSupported is ["INFERENCE_PROFILE"] — invoking
+		// them directly yields "on-demand throughput isn't supported",
+		// and there is no way for this adapter to invoke a foundation
+		// model through a profile it cannot discover. Missing/empty
+		// field is treated as on-demand-capable (older catalog shapes
+		// and unit-test fixtures that don't set it).
+		if len(s.InferenceTypesSupported) > 0 && !containsString(s.InferenceTypesSupported, "ON_DEMAND") {
+			continue
+		}
 		short, date, ok := extractNameAndDate(s.ModelID)
 		if !ok {
 			continue
@@ -404,6 +511,15 @@ func (d *profileDiscoverer) fetchFoundationModels(ctx context.Context) (map[stri
 		}
 	}
 	return entries, nil
+}
+
+func containsString(xs []string, target string) bool {
+	for _, x := range xs {
+		if x == target {
+			return true
+		}
+	}
+	return false
 }
 
 // signedGet issues a SigV4-signed GET and returns the body. Non-2xx becomes
@@ -452,11 +568,8 @@ func upsertEntry(m map[string]string, key, id string) {
 // shape isn't recognised (non-Anthropic, malformed, or an ancient legacy
 // name without any version digits).
 func extractNameAndDate(modelID string) (short, date string, ok bool) {
-	if m := profileIDPattern.FindStringSubmatch(modelID); len(m) >= 3 {
+	if m := bedrockAnthropicPattern.FindStringSubmatch(modelID); len(m) >= 3 {
 		return m[1], m[2], true
-	}
-	if m := foundationModelPattern.FindStringSubmatch(modelID); len(m) >= 2 {
-		return m[1], "", true
 	}
 	return "", "", false
 }

--- a/internal/adapter/provider/bedrock/discovery.go
+++ b/internal/adapter/provider/bedrock/discovery.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -150,7 +151,7 @@ func (d *profileDiscoverer) loadFromStore() {
 	if len(rows) == 0 {
 		return
 	}
-	entries := make(map[string]discoveredEntry, len(rows))
+	entries := make(map[string]discoveredEntry, len(rows)*2)
 	for _, r := range rows {
 		var src entrySource
 		if r.Source == "inference-profile" {
@@ -158,7 +159,18 @@ func (d *profileDiscoverer) loadFromStore() {
 		} else {
 			src = sourceFoundation
 		}
-		entries[r.ShortName] = discoveredEntry{id: r.BedrockID, source: src}
+		entry := discoveredEntry{id: r.BedrockID, source: src}
+		entries[r.ShortName] = entry
+		// Rebuild the dated-name alias from the Bedrock ID so clients
+		// that send explicit release-dated names (e.g.
+		// "claude-3-5-sonnet-20241022") keep resolving to the correct
+		// versioned profile ID after a restart. Without this, a cold
+		// discoverer misses on the dated lookup and resolveModelID
+		// synthesises "anthropic.claude-3-5-sonnet-20241022-v1:0"
+		// which hits a different model (the real profile is -v2:0).
+		if _, date, ok := extractNameAndDate(r.BedrockID); ok && date != "" {
+			entries[r.ShortName+"-"+date] = entry
+		}
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -168,18 +180,14 @@ func (d *profileDiscoverer) loadFromStore() {
 	d.everLoaded = true
 }
 
-// persistEntries copies the current catalog to the store. Called after
-// a successful fetch (holding d.mu). Errors are logged, not surfaced —
-// a broken store should not fail an otherwise-good fetch.
-func (d *profileDiscoverer) persistEntries(fetchedAt time.Time) {
-	if d.repo == nil {
-		return
-	}
+// snapshotPersistableRows collects the short-name entries worth
+// persisting from the current catalog. Runs while d.mu is held so the
+// caller can release the lock before doing the blocking DB write.
+// Dated-name aliases are skipped — loadFromStore reconstructs them from
+// the stored Bedrock ID.
+func (d *profileDiscoverer) snapshotPersistableRows() []*domain.BedrockDiscoveryEntry {
 	rows := make([]*domain.BedrockDiscoveryEntry, 0, len(d.entries))
 	for k, v := range d.entries {
-		// Skip the internal dated-name index; on reload it will be
-		// reconstructed (or not) from fresh discovery. Persisting it
-		// would double the row count for no caller benefit.
 		if modelDatePattern.MatchString(k) {
 			continue
 		}
@@ -189,9 +197,7 @@ func (d *profileDiscoverer) persistEntries(fetchedAt time.Time) {
 			Source:    v.source.label(),
 		})
 	}
-	if err := d.repo.Replace(d.providerID, rows, fetchedAt); err != nil {
-		log.Printf("bedrock discovery: save to store failed (%v)", err)
-	}
+	return rows
 }
 
 // Lookup returns the discovered Bedrock profile ID for an Anthropic short name
@@ -330,16 +336,25 @@ func (d *profileDiscoverer) ensureFresh(ctx context.Context) {
 	d.loadingCh = nil
 	close(ch)
 	now := time.Now()
+	// Snapshot rows to persist *inside* the lock, but perform the
+	// blocking DB write outside — SQLite's transaction can stall on
+	// contention and holding d.mu would serialise every concurrent
+	// Lookup behind it.
+	var toPersist []*domain.BedrockDiscoveryEntry
+	var shouldPersist bool
 	switch {
 	case err == nil:
 		d.lastErr = nil
 		if entries != nil {
 			d.entries = entries
+			shouldPersist = true
 		}
 		d.expiresAt = now.Add(d.ttl)
 		d.lastFetchAt = now
 		d.everLoaded = true
-		d.persistEntries(now)
+		if shouldPersist {
+			toPersist = d.snapshotPersistableRows()
+		}
 	case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
 		// Transient cancellation from a caller-supplied context — do not
 		// poison the cache with a failure TTL, the next caller should retry
@@ -351,6 +366,12 @@ func (d *profileDiscoverer) ensureFresh(ctx context.Context) {
 		d.lastFetchAt = now
 	}
 	d.mu.Unlock()
+
+	if shouldPersist && d.repo != nil {
+		if err := d.repo.Replace(d.providerID, toPersist, now); err != nil {
+			log.Printf("bedrock discovery: save to store failed (%v)", err)
+		}
+	}
 }
 
 // fetch builds the Anthropic short-name → Bedrock-ID map for the configured
@@ -498,7 +519,7 @@ func (d *profileDiscoverer) fetchFoundationModels(ctx context.Context) (map[stri
 		// model through a profile it cannot discover. Missing/empty
 		// field is treated as on-demand-capable (older catalog shapes
 		// and unit-test fixtures that don't set it).
-		if len(s.InferenceTypesSupported) > 0 && !containsString(s.InferenceTypesSupported, "ON_DEMAND") {
+		if len(s.InferenceTypesSupported) > 0 && !slices.Contains(s.InferenceTypesSupported, "ON_DEMAND") {
 			continue
 		}
 		short, date, ok := extractNameAndDate(s.ModelID)
@@ -513,14 +534,6 @@ func (d *profileDiscoverer) fetchFoundationModels(ctx context.Context) (map[stri
 	return entries, nil
 }
 
-func containsString(xs []string, target string) bool {
-	for _, x := range xs {
-		if x == target {
-			return true
-		}
-	}
-	return false
-}
 
 // signedGet issues a SigV4-signed GET and returns the body. Non-2xx becomes
 // an error containing a truncated body so failures stay debuggable without

--- a/internal/adapter/provider/bedrock/discovery_live_test.go
+++ b/internal/adapter/provider/bedrock/discovery_live_test.go
@@ -52,6 +52,21 @@ func TestLiveDiscovery(t *testing.T) {
 	sort.Strings(names)
 	t.Logf("region=%s discovered %d Anthropic profiles:", region, len(d.entries))
 	for _, n := range names {
-		t.Logf("  %-30s -> %s", n, d.entries[n].id)
+		t.Logf("  %-30s -> %s (%s)", n, d.entries[n].id, d.entries[n].source.label())
+	}
+
+	// Regression pin: Claude 4.x FM-only entries are listed by AWS with
+	// inferenceTypesSupported=["INFERENCE_PROFILE"]. If the filter in
+	// fetchFoundationModels regressed, one of these would be indexed as a
+	// bare foundation-model ID and InvokeModel would fail at runtime with
+	// "on-demand throughput isn't supported".
+	for _, short := range []string{"claude-sonnet-4-6", "claude-opus-4-6"} {
+		e, ok := d.entries[short]
+		if !ok {
+			continue
+		}
+		if e.source == sourceFoundation {
+			t.Errorf("%s was indexed as foundation-model (%s) — filter must skip non-ON_DEMAND FM entries", short, e.id)
+		}
 	}
 }

--- a/internal/adapter/provider/bedrock/discovery_test.go
+++ b/internal/adapter/provider/bedrock/discovery_test.go
@@ -457,10 +457,10 @@ type fakeRepo struct {
 	saveErr   error
 }
 
-func (s *fakeRepo) Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
+func (s *fakeRepo) Load(providerID uint64, region, accessKeyID string) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
 	return s.loaded, s.loadedAt, s.loadErr
 }
-func (s *fakeRepo) Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
+func (s *fakeRepo) Replace(providerID uint64, region, accessKeyID string, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
 	s.saveCount++
 	if s.saveErr != nil {
 		return s.saveErr
@@ -510,6 +510,60 @@ func TestProfileDiscovererLoadsFromStore(t *testing.T) {
 	// -v1:0 target for models whose real profile is -v2:0.
 	if id, ok := d.Lookup(context.Background(), "claude-sonnet-4-5-20250929"); !ok || id != "us.anthropic.claude-sonnet-4-5-20250929-v1:0" {
 		t.Errorf("dated-name alias not reconstructed: got (%q,%v)", id, ok)
+	}
+}
+
+// fakeRepoStrict rejects Load calls whose fingerprint doesn't match the
+// stored rows, mirroring the sqlite implementation's WHERE clause. Used
+// to verify the discoverer passes its own (region, accessKeyID) into
+// the repo instead of e.g. empty strings.
+type fakeRepoStrict struct {
+	storedRegion      string
+	storedAccessKeyID string
+	rows              []*domain.BedrockDiscoveryEntry
+	fetchedAt         time.Time
+}
+
+func (s *fakeRepoStrict) Load(providerID uint64, region, accessKeyID string) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
+	if region != s.storedRegion || accessKeyID != s.storedAccessKeyID {
+		// Config mismatch: pretend no rows match, same as sqlite.
+		return nil, time.Time{}, nil
+	}
+	return s.rows, s.fetchedAt, nil
+}
+func (s *fakeRepoStrict) Replace(providerID uint64, region, accessKeyID string, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
+	s.storedRegion = region
+	s.storedAccessKeyID = accessKeyID
+	s.rows = append([]*domain.BedrockDiscoveryEntry(nil), entries...)
+	s.fetchedAt = fetchedAt
+	return nil
+}
+
+func TestProfileDiscovererInvalidatesOnConfigChange(t *testing.T) {
+	// Pre-populate the store with rows tagged for region us-west-2 +
+	// the old access key; simulate a config edit that retargets the
+	// adapter at us-east-1 + a new key. loadFromStore must not load
+	// the stale rows, and everLoaded stays false so the UI doesn't
+	// falsely report "available" for the previous region's catalog.
+	repo := &fakeRepoStrict{
+		storedRegion:      "us-west-2",
+		storedAccessKeyID: "AKIAOLD",
+		rows: []*domain.BedrockDiscoveryEntry{
+			{ShortName: "claude-opus-4-5", BedrockID: "us.anthropic.claude-opus-4-5-20251101-v1:0", Source: "inference-profile"},
+		},
+		fetchedAt: time.Now().Add(-1 * time.Minute),
+	}
+	d := newDiscovererForTest("http://unused.local")
+	d.repo = repo
+	d.region = "us-east-1"
+	d.accessKeyID = "AKIANEW"
+	d.loadFromStore()
+
+	if d.Available() {
+		t.Error("Available() must be false — persisted rows were from a previous config")
+	}
+	if _, ok := d.entries["claude-opus-4-5"]; ok {
+		t.Error("loadFromStore must not rehydrate rows whose region/accessKeyID don't match current config")
 	}
 }
 

--- a/internal/adapter/provider/bedrock/discovery_test.go
+++ b/internal/adapter/provider/bedrock/discovery_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/awsl-project/maxx/internal/domain"
 )
 
 func TestExtractShortName(t *testing.T) {
@@ -289,8 +290,13 @@ func TestExtractNameAndDateAcceptsFoundationModels(t *testing.T) {
 		{"anthropic.claude-sonnet-4-6", "claude-sonnet-4-6", "", true},
 		{"anthropic.claude-opus-4-6-v1", "claude-opus-4-6", "", true},
 		{"anthropic.claude-haiku-4-5", "claude-haiku-4-5", "", true},
-		// Foundation model shape mustn't swallow the region prefix.
-		{"us.anthropic.claude-sonnet-4-6", "", "", false},
+		// Region-prefixed dateless inference-profile IDs: AWS started
+		// shipping these for Claude 4.6/4.7 under type=APPLICATION.
+		// The pattern must accept them so discovery indexes them.
+		{"us.anthropic.claude-sonnet-4-6", "claude-sonnet-4-6", "", true},
+		{"us.anthropic.claude-opus-4-7", "claude-opus-4-7", "", true},
+		{"global.anthropic.claude-opus-4-7", "claude-opus-4-7", "", true},
+		{"us.anthropic.claude-opus-4-6-v1", "claude-opus-4-6", "", true},
 		// Legacy "claude-v2": the `2` satisfies the digit requirement
 		// and the whole name is preserved — clients still send it.
 		{"anthropic.claude-v2", "claude-v2", "", true},
@@ -426,6 +432,176 @@ func TestProfileDiscovererPartialFailure(t *testing.T) {
 	id, ok := d.Lookup(context.Background(), "claude-sonnet-4-6")
 	if !ok || id != "anthropic.claude-sonnet-4-6" {
 		t.Errorf("partial discovery must still return FM hits; got (%q,%v)", id, ok)
+	}
+}
+
+// fakeRepo is a deterministic in-memory BedrockDiscoveryRepository for
+// unit tests. It ignores providerID — the discoverer always passes its
+// own providerID (0 in tests), but the repo contract is about persisting
+// per-provider catalogs, not multiplexing them in a single fake.
+type fakeRepo struct {
+	loaded    []*domain.BedrockDiscoveryEntry
+	loadedAt  time.Time
+	loadErr   error
+	saved     []*domain.BedrockDiscoveryEntry
+	savedAt   time.Time
+	saveCount int
+	saveErr   error
+}
+
+func (s *fakeRepo) Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
+	return s.loaded, s.loadedAt, s.loadErr
+}
+func (s *fakeRepo) Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
+	s.saveCount++
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.saved = append([]*domain.BedrockDiscoveryEntry(nil), entries...)
+	s.savedAt = fetchedAt
+	return nil
+}
+
+func TestProfileDiscovererLoadsFromStore(t *testing.T) {
+	// Pre-populated store simulates a process restart: the in-memory
+	// cache must be seeded before any Lookup() so the first request
+	// doesn't pay the AWS round-trip. The stored FetchedAt sits well
+	// within the TTL, so no refresh should fire.
+	repo := &fakeRepo{
+		loaded: []*domain.BedrockDiscoveryEntry{
+			{ShortName: "claude-sonnet-4-5", BedrockID: "us.anthropic.claude-sonnet-4-5-20250929-v1:0", Source: "inference-profile"},
+			{ShortName: "claude-opus-4", BedrockID: "anthropic.claude-opus-4-v1", Source: "foundation-model"},
+		},
+		loadedAt: time.Now().Add(-1 * time.Minute),
+	}
+	// Server would be a bug — if discovery hits AWS we want the test to
+	// fail loudly, not silently "pass" because both sources return the
+	// same data.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected AWS call to %s — load-from-store should have served the hit", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	d := newDiscovererForTest(srv.URL)
+	d.repo = repo
+	d.loadFromStore()
+
+	if !d.Available() {
+		t.Error("Available() must be true after rehydration from store")
+	}
+	if id, ok := d.Lookup(context.Background(), "claude-sonnet-4-5"); !ok || id != "us.anthropic.claude-sonnet-4-5-20250929-v1:0" {
+		t.Errorf("rehydrated lookup got (%q,%v)", id, ok)
+	}
+	if e := d.entries["claude-opus-4"]; e.source != sourceFoundation {
+		t.Errorf("rehydrated source = %v; want sourceFoundation", e.source)
+	}
+}
+
+func TestProfileDiscovererSavesToStoreAfterFetch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/inference-profiles":
+			fmt.Fprint(w, `{"inferenceProfileSummaries":[
+				{"inferenceProfileId":"us.anthropic.claude-sonnet-4-5-20250929-v1:0","status":"ACTIVE"}
+			]}`)
+		case "/foundation-models":
+			fmt.Fprint(w, `{"modelSummaries":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	repo := &fakeRepo{}
+	d := newDiscovererForTest(srv.URL)
+	d.repo = repo
+
+	if _, _ = d.Lookup(context.Background(), "claude-sonnet-4-5"); repo.saveCount != 1 {
+		t.Fatalf("Save should be called exactly once after fetch; got %d", repo.saveCount)
+	}
+	// Expect exactly the short-name entry persisted — the internal
+	// dated-name index must not be saved.
+	var saw map[string]string = map[string]string{}
+	for _, e := range repo.saved {
+		saw[e.ShortName] = e.BedrockID
+	}
+	if got, ok := saw["claude-sonnet-4-5"]; !ok || got != "us.anthropic.claude-sonnet-4-5-20250929-v1:0" {
+		t.Errorf("expected claude-sonnet-4-5 saved; got %v", saw)
+	}
+	if _, ok := saw["claude-sonnet-4-5-20250929"]; ok {
+		t.Error("dated-name index must not be persisted")
+	}
+}
+
+func TestProfileDiscovererForceRefreshBypassesRateLimit(t *testing.T) {
+	// The hit counter proves the admin-path refresh really re-fetches,
+	// not just returns whatever sits in the cache.
+	var profileHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/inference-profiles":
+			atomic.AddInt32(&profileHits, 1)
+			fmt.Fprint(w, `{"inferenceProfileSummaries":[]}`)
+		case "/foundation-models":
+			fmt.Fprint(w, `{"modelSummaries":[]}`)
+		}
+	}))
+	defer srv.Close()
+
+	d := newDiscovererForTest(srv.URL)
+	// Initial fetch.
+	_, _ = d.Lookup(context.Background(), "__seed__")
+	// Invalidate's 60s rate-limit kicks in; a plain Invalidate would be a no-op.
+	d.Invalidate()
+	// ForceRefresh must still trigger a second fetch.
+	if err := d.ForceRefresh(context.Background()); err != nil {
+		t.Fatalf("ForceRefresh: %v", err)
+	}
+	if got := atomic.LoadInt32(&profileHits); got < 2 {
+		t.Errorf("ForceRefresh should have re-fetched; profileHits=%d", got)
+	}
+}
+
+func TestProfileDiscovererSkipsFoundationModelsWithoutOnDemand(t *testing.T) {
+	// AWS lists Claude 4.x foundation models but sets
+	// inferenceTypesSupported to ["INFERENCE_PROFILE"] only — direct
+	// InvokeModel on the bare FM ID returns "on-demand throughput isn't
+	// supported". Discovery must skip those so resolveModelID doesn't
+	// route a request to a target that cannot be invoked.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/inference-profiles":
+			fmt.Fprint(w, `{"inferenceProfileSummaries":[]}`)
+		case "/foundation-models":
+			fmt.Fprint(w, `{"modelSummaries":[
+				{"modelId":"anthropic.claude-sonnet-4-6","modelLifecycle":{"status":"ACTIVE"},"inferenceTypesSupported":["INFERENCE_PROFILE"]},
+				{"modelId":"anthropic.claude-opus-4-6-v1","modelLifecycle":{"status":"ACTIVE"},"inferenceTypesSupported":["INFERENCE_PROFILE"]},
+				{"modelId":"anthropic.claude-3-5-sonnet-20241022-v2:0","modelLifecycle":{"status":"ACTIVE"},"inferenceTypesSupported":["ON_DEMAND","INFERENCE_PROFILE"]},
+				{"modelId":"anthropic.claude-v2","modelLifecycle":{"status":"ACTIVE"},"inferenceTypesSupported":["ON_DEMAND"]}
+			]}`)
+		}
+	}))
+	defer srv.Close()
+
+	d := newDiscovererForTest(srv.URL)
+
+	// FM-only 4.x entries must NOT be indexed — letting them through
+	// is exactly the regression this test pins down.
+	if _, ok := d.Lookup(context.Background(), "claude-sonnet-4-6"); ok {
+		t.Error("claude-sonnet-4-6 has no ON_DEMAND support; must be filtered out")
+	}
+	if _, ok := d.Lookup(context.Background(), "claude-opus-4-6"); ok {
+		t.Error("claude-opus-4-6 has no ON_DEMAND support; must be filtered out")
+	}
+
+	// Entries that do advertise ON_DEMAND still pass through, including
+	// the mixed case where ON_DEMAND sits alongside INFERENCE_PROFILE.
+	if id, ok := d.Lookup(context.Background(), "claude-3-5-sonnet"); !ok || id != "anthropic.claude-3-5-sonnet-20241022-v2:0" {
+		t.Errorf("mixed ON_DEMAND+INFERENCE_PROFILE must be indexed; got (%q,%v)", id, ok)
+	}
+	if id, ok := d.Lookup(context.Background(), "claude-v2"); !ok || id != "anthropic.claude-v2" {
+		t.Errorf("ON_DEMAND-only FM must be indexed; got (%q,%v)", id, ok)
 	}
 }
 

--- a/internal/adapter/provider/bedrock/discovery_test.go
+++ b/internal/adapter/provider/bedrock/discovery_test.go
@@ -302,6 +302,14 @@ func TestExtractNameAndDateAcceptsFoundationModels(t *testing.T) {
 		{"anthropic.claude-v2", "claude-v2", "", true},
 		// Inference-profile shape still works.
 		{"us.anthropic.claude-opus-4-7-20260115-v1:0", "claude-opus-4-7", "20260115", true},
+		// Legacy "claude-instant-v1": pin the current behaviour. The
+		// regex's non-greedy inner capture does NOT peel off the
+		// trailing "-v1" for this shape because the version suffix's
+		// digit satisfies the `\d` requirement inside the capture. The
+		// short name is therefore "claude-instant-v1" as-is. Harmless
+		// in practice (clients request the full name), but pinned so a
+		// future regex rework doesn't silently change it.
+		{"anthropic.claude-instant-v1", "claude-instant-v1", "", true},
 	}
 	for _, c := range cases {
 		short, date, ok := extractNameAndDate(c.id)
@@ -494,6 +502,14 @@ func TestProfileDiscovererLoadsFromStore(t *testing.T) {
 	}
 	if e := d.entries["claude-opus-4"]; e.source != sourceFoundation {
 		t.Errorf("rehydrated source = %v; want sourceFoundation", e.source)
+	}
+	// Dated-name alias must be reconstructed from the stored Bedrock
+	// ID so clients sending explicit release-dated names keep resolving
+	// after a restart — without this, the cold discoverer would miss on
+	// the dated lookup and resolveModelID would synthesise a wrong
+	// -v1:0 target for models whose real profile is -v2:0.
+	if id, ok := d.Lookup(context.Background(), "claude-sonnet-4-5-20250929"); !ok || id != "us.anthropic.claude-sonnet-4-5-20250929-v1:0" {
+		t.Errorf("dated-name alias not reconstructed: got (%q,%v)", id, ok)
 	}
 }
 

--- a/internal/adapter/provider/bedrock/invoke_live_test.go
+++ b/internal/adapter/provider/bedrock/invoke_live_test.go
@@ -1,0 +1,144 @@
+package bedrock
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+// TestLiveInvoke exercises the full resolve + sign + invoke path against
+// real AWS. For every model in the MAXX_BEDROCK_LIVE_MODELS list (or the
+// default set below) it:
+//   - discovers the Bedrock ID via the real catalog
+//   - signs a 1-token non-stream Messages request
+//   - asserts HTTP 200 and a non-empty content block
+//
+// Gated by MAXX_BEDROCK_LIVE=1. Generates a few cents of token cost at
+// most — a 1-token max-tokens response stays under $0.01 even on Opus.
+func TestLiveInvoke(t *testing.T) {
+	if os.Getenv("MAXX_BEDROCK_LIVE") != "1" {
+		t.Skip("set MAXX_BEDROCK_LIVE=1 to run against real AWS")
+	}
+	ak := os.Getenv("AWS_ACCESS_KEY_ID")
+	sk := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	if ak == "" || sk == "" {
+		t.Fatal("missing AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY")
+	}
+	creds := credentials.NewStaticCredentialsProvider(ak, sk, "")
+	httpClient := newHTTPClient()
+	d := newProfileDiscoverer(httpClient, creds, region)
+
+	// Force discovery to populate the cache before we start resolving.
+	warmCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	_, _ = d.Lookup(warmCtx, "__force_load__")
+	cancel()
+
+	// Models we care about most — newly-shipped 4.6/4.7 plus one known-
+	// good classic profile as a control. Operator can override via env
+	// if they want to test something specific.
+	models := []string{"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5"}
+	if override := os.Getenv("MAXX_BEDROCK_LIVE_MODELS"); override != "" {
+		models = nil
+		for _, m := range splitCSV(override) {
+			if m != "" {
+				models = append(models, m)
+			}
+		}
+	}
+
+	for _, requested := range models {
+		t.Run(requested, func(t *testing.T) {
+			// Use the same resolver the adapter uses in production.
+			lookup := func(name string) (string, bool) {
+				ctx, cancel := context.WithTimeout(context.Background(), discoveryLookupTimeout)
+				defer cancel()
+				return d.Lookup(ctx, name)
+			}
+			resolved, ok := resolveModelID(requested, nil, "us", lookup)
+			if !ok {
+				t.Fatalf("resolveModelID(%q) = not ok — catalog: %v", requested, d.Names())
+			}
+			t.Logf("resolved %s -> %s", requested, resolved)
+
+			// Minimal Claude Messages request: 1 user turn, cap at 1
+			// output token. We don't care about the reply content, only
+			// that the upstream accepts the request and returns a
+			// stop_reason (meaning end-to-end plumbing worked).
+			reqBody, err := json.Marshal(map[string]any{
+				"anthropic_version": "bedrock-2023-05-31",
+				"max_tokens":        1,
+				"messages":          []map[string]any{{"role": "user", "content": "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			upstreamURL := buildBedrockURL(region, resolved, false)
+			invokeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(invokeCtx, http.MethodPost, upstreamURL, bytes.NewReader(reqBody))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json")
+			if err := signRequest(invokeCtx, req, reqBody, creds, region); err != nil {
+				t.Fatalf("sign: %v", err)
+			}
+
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				t.Fatalf("do: %v", err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, truncate(string(body), 400))
+			}
+
+			var parsed struct {
+				StopReason string `json:"stop_reason"`
+				Content    []struct {
+					Type string `json:"type"`
+				} `json:"content"`
+				Usage struct {
+					InputTokens  int `json:"input_tokens"`
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			}
+			if err := json.Unmarshal(body, &parsed); err != nil {
+				t.Fatalf("decode: %v body=%s", err, truncate(string(body), 400))
+			}
+			if parsed.StopReason == "" {
+				t.Errorf("expected stop_reason in response; body=%s", truncate(string(body), 400))
+			}
+			t.Logf("url=%s stop_reason=%s in_tokens=%d out_tokens=%d",
+				upstreamURL, parsed.StopReason, parsed.Usage.InputTokens, parsed.Usage.OutputTokens)
+		})
+	}
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	return out
+}
+

--- a/internal/adapter/provider/bedrock/invoke_live_test.go
+++ b/internal/adapter/provider/bedrock/invoke_live_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestLiveInvoke(t *testing.T) {
 	models := []string{"claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5"}
 	if override := os.Getenv("MAXX_BEDROCK_LIVE_MODELS"); override != "" {
 		models = nil
-		for _, m := range splitCSV(override) {
+		for _, m := range strings.Split(override, ",") {
 			if m != "" {
 				models = append(models, m)
 			}
@@ -130,15 +131,4 @@ func TestLiveInvoke(t *testing.T) {
 	}
 }
 
-func splitCSV(s string) []string {
-	var out []string
-	start := 0
-	for i := 0; i <= len(s); i++ {
-		if i == len(s) || s[i] == ',' {
-			out = append(out, s[start:i])
-			start = i + 1
-		}
-	}
-	return out
-}
 

--- a/internal/adapter/provider/bedrock/model_mapping.go
+++ b/internal/adapter/provider/bedrock/model_mapping.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // modelDatePattern matches an Anthropic short name that already carries an
@@ -67,11 +68,22 @@ func degradeCandidates(short string) []string {
 	return out
 }
 
+// degradeLog deduplicates degrade warnings so a high-QPS client
+// requesting an unshipped model doesn't flood the log with one line per
+// request. Logging once per (requested, fallback) pair is enough to
+// surface the substitution to an operator; the pair changes only when
+// AWS ships or retires a profile, at which point we want the next
+// occurrence logged again.
+var degradeLog struct {
+	sync.Mutex
+	seen map[string]struct{}
+}
+
 // lookupWithFallback queries discovery for the exact short name and, on a
-// miss, walks degradeCandidates until one hits. Logs a WARN on a degrade
-// hit so operators notice that a request for 4.6/4.7 was silently served
-// by 4.5 — otherwise a user debugging "why does my response look like a
-// different model" has nothing to grep for.
+// miss, walks degradeCandidates until one hits. Logs a WARN on the first
+// occurrence of each degrade pair so operators notice that a request for
+// 4.6/4.7 was silently served by 4.5 — without flooding the log on a
+// busy endpoint.
 func lookupWithFallback(discovered discoveredLookup, short string) (string, bool) {
 	if discovered == nil {
 		return "", false
@@ -81,7 +93,19 @@ func lookupWithFallback(discovered discoveredLookup, short string) (string, bool
 	}
 	for _, cand := range degradeCandidates(short) {
 		if id, ok := discovered(cand); ok {
-			log.Printf("bedrock: no inference profile for %q, falling back to %q (%s)", short, cand, id)
+			key := short + "->" + cand
+			degradeLog.Lock()
+			if degradeLog.seen == nil {
+				degradeLog.seen = map[string]struct{}{}
+			}
+			_, already := degradeLog.seen[key]
+			if !already {
+				degradeLog.seen[key] = struct{}{}
+			}
+			degradeLog.Unlock()
+			if !already {
+				log.Printf("bedrock: no inference profile for %q, falling back to %q (%s)", short, cand, id)
+			}
 			return id, true
 		}
 	}

--- a/internal/adapter/provider/bedrock/model_mapping.go
+++ b/internal/adapter/provider/bedrock/model_mapping.go
@@ -1,7 +1,10 @@
 package bedrock
 
 import (
+	"fmt"
+	"log"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -34,6 +37,57 @@ var inferenceProfilePattern = regexp.MustCompile(`^anthropic\.claude-[a-z0-9-]+-
 // or ("", false) on miss. May be nil when no discoverer is wired up.
 type discoveredLookup func(shortName string) (id string, hit bool)
 
+// minorVersionPattern captures the new-style "claude-<family>-<major>-<minor>"
+// short names (e.g. "claude-sonnet-4-6", "claude-opus-4-1"). Used to drive
+// the degrade loop — we don't want it firing on old-style
+// "claude-3-5-sonnet" (version before family) or on dated names.
+var minorVersionPattern = regexp.MustCompile(`^(claude-[a-z]+)-(\d+)-(\d+)$`)
+
+// degradeCandidates yields progressively-older fallback short names for a
+// client-requested short name whose AWS inference profile has not yet
+// shipped. Given "claude-sonnet-4-6" it returns
+// ["claude-sonnet-4-5", "claude-sonnet-4-4", ..., "claude-sonnet-4-0",
+// "claude-sonnet-4"]. Inputs that don't match minorVersionPattern yield
+// nothing — so dated names, old-style names, and bare majors don't degrade.
+func degradeCandidates(short string) []string {
+	m := minorVersionPattern.FindStringSubmatch(short)
+	if len(m) != 4 {
+		return nil
+	}
+	family, major := m[1], m[2]
+	minor, err := strconv.Atoi(m[3])
+	if err != nil || minor <= 0 {
+		return []string{family + "-" + major}
+	}
+	out := make([]string, 0, minor+1)
+	for i := minor - 1; i >= 0; i-- {
+		out = append(out, fmt.Sprintf("%s-%s-%d", family, major, i))
+	}
+	out = append(out, family+"-"+major)
+	return out
+}
+
+// lookupWithFallback queries discovery for the exact short name and, on a
+// miss, walks degradeCandidates until one hits. Logs a WARN on a degrade
+// hit so operators notice that a request for 4.6/4.7 was silently served
+// by 4.5 — otherwise a user debugging "why does my response look like a
+// different model" has nothing to grep for.
+func lookupWithFallback(discovered discoveredLookup, short string) (string, bool) {
+	if discovered == nil {
+		return "", false
+	}
+	if id, ok := discovered(short); ok {
+		return id, true
+	}
+	for _, cand := range degradeCandidates(short) {
+		if id, ok := discovered(cand); ok {
+			log.Printf("bedrock: no inference profile for %q, falling back to %q (%s)", short, cand, id)
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // resolveModelID maps a request model to a fully-qualified Bedrock ID.
 // Returns ok=false for bare short names that cannot be resolved — the caller
 // must surface an error rather than guess a date, since Bedrock profile IDs
@@ -57,15 +111,13 @@ func resolveModelID(model string, configMapping map[string]string, modelPrefix s
 			return applyPrefix(mapped, modelPrefix), true
 		}
 	}
-	if discovered != nil {
-		if id, ok := discovered(model); ok {
-			// Discovery returns the exact invoke-ready ID: inference
-			// profiles already carry their region prefix, foundation
-			// models must not receive one (a region-prefixed foundation
-			// model ID like "us.anthropic.claude-sonnet-4-6" is not a
-			// valid Bedrock target).
-			return id, true
-		}
+	if id, ok := lookupWithFallback(discovered, model); ok {
+		// Discovery returns the exact invoke-ready ID: inference
+		// profiles already carry their region prefix, foundation
+		// models must not receive one (a region-prefixed foundation
+		// model ID like "us.anthropic.claude-sonnet-4-6" is not a
+		// valid Bedrock target).
+		return id, true
 	}
 	if modelDatePattern.MatchString(model) {
 		return applyPrefix("anthropic."+model+"-v1:0", modelPrefix), true
@@ -82,7 +134,7 @@ func resolveModelID(model string, configMapping map[string]string, modelPrefix s
 			!regionPrefixedPattern.MatchString(model) &&
 			!inferenceProfilePattern.MatchString(model) {
 			if short, ok := strings.CutPrefix(model, "anthropic."); ok && short != "" {
-				if id, hit := discovered(short); hit {
+				if id, hit := lookupWithFallback(discovered, short); hit {
 					return id, true
 				}
 			}

--- a/internal/adapter/provider/bedrock/model_mapping_test.go
+++ b/internal/adapter/provider/bedrock/model_mapping_test.go
@@ -254,3 +254,66 @@ func TestResolveModelIDPriority(t *testing.T) {
 		})
 	}
 }
+
+func TestDegradeCandidates(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"claude-sonnet-4-6", []string{"claude-sonnet-4-5", "claude-sonnet-4-4", "claude-sonnet-4-3", "claude-sonnet-4-2", "claude-sonnet-4-1", "claude-sonnet-4-0", "claude-sonnet-4"}},
+		{"claude-opus-4-1", []string{"claude-opus-4-0", "claude-opus-4"}},
+		{"claude-opus-4-0", []string{"claude-opus-4"}},
+		// No minor: nothing to degrade to; we never downshift across majors.
+		{"claude-sonnet-4", nil},
+		// Old-style "claude-3-5-sonnet": version before family, no degrade.
+		{"claude-3-5-sonnet", nil},
+		// Dated name: authoritative, no degrade.
+		{"claude-sonnet-4-5-20250929", nil},
+		{"gpt-4-1", nil},
+	}
+	for _, c := range cases {
+		got := degradeCandidates(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("degradeCandidates(%q) = %v; want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("degradeCandidates(%q)[%d] = %q; want %q", c.in, i, got[i], c.want[i])
+			}
+		}
+	}
+}
+
+func TestResolveModelIDDegradesOnDiscoveryMiss(t *testing.T) {
+	// Only claude-sonnet-4-5 and claude-opus-4 are discoverable; requests
+	// for newer minor versions must degrade to the nearest available.
+	lookup := func(name string) (string, bool) {
+		switch name {
+		case "claude-sonnet-4-5":
+			return "us.anthropic.claude-sonnet-4-5-20250929-v1:0", true
+		case "claude-opus-4":
+			return "us.anthropic.claude-opus-4-20250514-v1:0", true
+		}
+		return "", false
+	}
+
+	cases := []struct {
+		name   string
+		model  string
+		wantID string
+	}{
+		{"sonnet-4-6 degrades to sonnet-4-5", "claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+		{"sonnet-4-7 degrades past missing 4-6 to 4-5", "claude-sonnet-4-7", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+		{"opus-4-6 degrades all the way to bare opus-4", "claude-opus-4-6", "us.anthropic.claude-opus-4-20250514-v1:0"},
+		{"bare anthropic.<short> also degrades", "anthropic.claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := resolveModelID(c.model, nil, "us", lookup)
+			if !ok || got != c.wantID {
+				t.Errorf("got (%q,%v); want (%q,true)", got, ok, c.wantID)
+			}
+		})
+	}
+}

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -1,0 +1,87 @@
+package bedrock
+
+import (
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Claude's extended-thinking config has evolved through two incompatible
+// shapes:
+//
+//   classic  — thinking.type="enabled" + thinking.budget_tokens=N
+//   adaptive — thinking.type="adaptive" + output_config.effort="low|medium|high"
+//
+// Models split into three camps:
+//
+//   adaptive-only   — Opus 4.7: rejects thinking.type="enabled" with
+//                     "\"thinking.type.enabled\" is not supported"
+//   classic-only    — Sonnet/Opus 4.x pre-4.6, 3.7 and older: reject adaptive
+//   either         — Opus 4.6, Sonnet 4.6: accept both (adaptive recommended)
+//
+// The sanitizer already handles classic-only (it rewrites adaptive →
+// enabled). What's new is the adaptive-only tier. adaptThinkingForModel
+// performs the inverse rewrite when the resolved short name requires it,
+// so clients that only speak the classic shape (Claude Code CLI on
+// Bedrock) can still hit Opus 4.7.
+
+// adaptiveOnlyModels is the set of short names that reject classic
+// extended-thinking. Kept as a small hand-maintained list because
+// neither Bedrock's ListFoundationModels nor Anthropic's /v1/models
+// exposes the capability flag — there's no authoritative source to
+// derive it from.
+var adaptiveOnlyModels = map[string]bool{
+	"claude-opus-4-7": true,
+}
+
+// requiresAdaptiveThinking reports whether the model identified by
+// shortName refuses the classic thinking.type="enabled" shape.
+func requiresAdaptiveThinking(shortName string) bool {
+	return adaptiveOnlyModels[shortName]
+}
+
+// adaptThinkingForModel rewrites a classic extended-thinking config into
+// adaptive form when the target model demands it. Idempotent: if the
+// payload already uses adaptive, or the model doesn't require it, or
+// there's no thinking config at all, the body is returned unchanged.
+//
+// Budget → effort translation is conservative:
+//   - budget_tokens >= 32k → "high"
+//   - budget_tokens >= 8k  → "medium"
+//   - otherwise            → "low"
+//
+// We don't bother trying to back out of the payload exactly how much
+// thinking the client asked for. Adaptive's whole point is that Claude
+// decides dynamically; we just need to land in the same ballpark so
+// clients that crank budget_tokens up don't silently get capped to a
+// tiny thinking allotment.
+func adaptThinkingForModel(body []byte, shortName string) []byte {
+	if !requiresAdaptiveThinking(shortName) {
+		return body
+	}
+	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+	if thinkingType == "" || thinkingType == "adaptive" || thinkingType == "disabled" {
+		return body
+	}
+
+	budget := gjson.GetBytes(body, "thinking.budget_tokens").Int()
+	effort := "low"
+	switch {
+	case budget >= 32000:
+		effort = "high"
+	case budget >= 8000:
+		effort = "medium"
+	}
+
+	// Replace the thinking block with just {type: adaptive}. budget_tokens
+	// is not valid under adaptive and would be rejected; the effort
+	// signal moves to output_config.effort.
+	body, _ = sjson.SetBytes(body, "thinking.type", "adaptive")
+	body, _ = sjson.DeleteBytes(body, "thinking.budget_tokens")
+
+	// Preserve any effort the client already set on output_config; only
+	// fill it in when absent, so a caller who knows what they want wins.
+	if !gjson.GetBytes(body, "output_config.effort").Exists() {
+		body, _ = sjson.SetBytes(body, "output_config.effort", effort)
+	}
+	return body
+}

--- a/internal/adapter/provider/bedrock/thinking_policy_test.go
+++ b/internal/adapter/provider/bedrock/thinking_policy_test.go
@@ -1,0 +1,98 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestAdaptThinkingForModel(t *testing.T) {
+	cases := []struct {
+		name      string
+		shortName string
+		input     string
+		// Expected post-rewrite fields. Empty string = not asserted.
+		wantType   string
+		wantBudget bool // expected presence of thinking.budget_tokens
+		wantEffort string
+	}{
+		{
+			name:       "opus-4-7 rewrites enabled to adaptive",
+			shortName:  "claude-opus-4-7",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000}}`,
+			wantType:   "adaptive",
+			wantBudget: false,
+			wantEffort: "medium",
+		},
+		{
+			name:       "opus-4-7 maps large budget to high effort",
+			shortName:  "claude-opus-4-7",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":40000}}`,
+			wantType:   "adaptive",
+			wantEffort: "high",
+		},
+		{
+			name:       "opus-4-7 maps small budget to low effort",
+			shortName:  "claude-opus-4-7",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":2000}}`,
+			wantType:   "adaptive",
+			wantEffort: "low",
+		},
+		{
+			name:       "opus-4-7 leaves adaptive untouched",
+			shortName:  "claude-opus-4-7",
+			input:      `{"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"}}`,
+			wantType:   "adaptive",
+			wantBudget: false,
+			wantEffort: "medium",
+		},
+		{
+			name:      "opus-4-7 leaves body without thinking untouched",
+			shortName: "claude-opus-4-7",
+			input:     `{"max_tokens":1024}`,
+			wantType:  "",
+		},
+		{
+			name:       "opus-4-5 does not rewrite (classic-only model)",
+			shortName:  "claude-opus-4-5",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000}}`,
+			wantType:   "enabled",
+			wantBudget: true,
+			wantEffort: "",
+		},
+		{
+			name:       "opus-4-6 does not rewrite (both supported, leave as-is)",
+			shortName:  "claude-opus-4-6",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000}}`,
+			wantType:   "enabled",
+			wantBudget: true,
+			wantEffort: "",
+		},
+		{
+			name:       "opus-4-7 preserves caller-set effort",
+			shortName:  "claude-opus-4-7",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":1000},"output_config":{"effort":"high"}}`,
+			wantType:   "adaptive",
+			wantEffort: "high",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := adaptThinkingForModel([]byte(c.input), c.shortName)
+			if c.wantType != "" {
+				if gt := gjson.GetBytes(got, "thinking.type").String(); gt != c.wantType {
+					t.Errorf("thinking.type = %q; want %q (body=%s)", gt, c.wantType, string(got))
+				}
+			}
+			if c.wantEffort != "" {
+				if ge := gjson.GetBytes(got, "output_config.effort").String(); ge != c.wantEffort {
+					t.Errorf("output_config.effort = %q; want %q (body=%s)", ge, c.wantEffort, string(got))
+				}
+			}
+			budgetExists := gjson.GetBytes(got, "thinking.budget_tokens").Exists()
+			if budgetExists != c.wantBudget {
+				t.Errorf("budget_tokens exists = %v; want %v (body=%s)", budgetExists, c.wantBudget, string(got))
+			}
+		})
+	}
+}

--- a/internal/domain/bedrock_discovery.go
+++ b/internal/domain/bedrock_discovery.go
@@ -1,0 +1,13 @@
+package domain
+
+// BedrockDiscoveryEntry is one row of a Bedrock provider's discovered
+// model catalog — the short name clients send mapped to the invoke-ready
+// Bedrock ID, plus which AWS catalog (inference-profile or
+// foundation-model) supplied it. Persisted per provider so the
+// profileDiscoverer can warm its cache at startup instead of paying
+// the AWS round-trip on the first request.
+type BedrockDiscoveryEntry struct {
+	ShortName string
+	BedrockID string
+	Source    string // "inference-profile" or "foundation-model"
+}

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -252,7 +252,10 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 // table. Available=false means discovery hasn't succeeded (typically
 // missing bedrock:ListInferenceProfiles IAM permission).
 func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *http.Request, id uint64) {
-	if r.Method != http.MethodGet {
+	// GET returns the current catalog (triggers a lazy refresh on TTL
+	// expiry). POST forces an immediate fetch bypassing the TTL and the
+	// Invalidate() rate-limit — used by the admin UI's refresh button.
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
@@ -274,6 +277,23 @@ func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *h
 	bedrockA, ok := adapter.(*bedrock.BedrockAdapter)
 	if !ok {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "bedrock adapter type mismatch"})
+		return
+	}
+	if r.Method == http.MethodPost {
+		result, refreshErr := bedrockA.RefreshDiscoveredModels(r.Context())
+		if refreshErr != nil {
+			// Return 200 with the payload + error field so the UI can show
+			// the stale list alongside the refresh failure reason (missing
+			// IAM, throttling, etc.) without a separate error endpoint.
+			writeJSON(w, http.StatusOK, map[string]any{
+				"available":    result.Available,
+				"region":       result.Region,
+				"models":       result.Models,
+				"refreshError": refreshErr.Error(),
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
 		return
 	}
 	writeJSON(w, http.StatusOK, bedrockA.DiscoveredModels(r.Context()))

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -280,20 +280,21 @@ func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *h
 		return
 	}
 	if r.Method == http.MethodPost {
+		// POST always returns the same shape — available/region/models
+		// plus refreshError (empty string on success). Keeping the key
+		// present regardless of outcome means the UI doesn't have to
+		// branch on its existence.
 		result, refreshErr := bedrockA.RefreshDiscoveredModels(r.Context())
+		errStr := ""
 		if refreshErr != nil {
-			// Return 200 with the payload + error field so the UI can show
-			// the stale list alongside the refresh failure reason (missing
-			// IAM, throttling, etc.) without a separate error endpoint.
-			writeJSON(w, http.StatusOK, map[string]any{
-				"available":    result.Available,
-				"region":       result.Region,
-				"models":       result.Models,
-				"refreshError": refreshErr.Error(),
-			})
-			return
+			errStr = refreshErr.Error()
 		}
-		writeJSON(w, http.StatusOK, result)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"available":    result.Available,
+			"region":       result.Region,
+			"models":       result.Models,
+			"refreshError": errStr,
+		})
 		return
 	}
 	writeJSON(w, http.StatusOK, bedrockA.DiscoveredModels(r.Context()))

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -362,3 +362,22 @@ type FailureCountRepository interface {
 	// DeleteExpired deletes failure counts where last failure was too long ago
 	DeleteExpired(olderThan int64) error
 }
+
+// BedrockDiscoveryRepository persists per-provider Bedrock discovery
+// catalogs across process restarts so the profileDiscoverer can warm its
+// in-memory cache at startup and skip the ~1-5s
+// ListInferenceProfiles + ListFoundationModels round-trip on the first
+// request. Scoped per provider: different Bedrock providers may hold
+// different IAM permissions and therefore see different catalogs.
+type BedrockDiscoveryRepository interface {
+	// Load returns every cached entry for a provider plus the timestamp
+	// of the most recent successful fetch, used to decide whether the
+	// rehydrated cache is still within TTL. Zero entries + zero time
+	// means no cache; nil error.
+	Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error)
+
+	// Replace atomically swaps the stored catalog for a provider. Empty
+	// entries is valid — it clears the cache, matching what the adapter
+	// sees after a discovery run that returned nothing.
+	Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -369,15 +369,23 @@ type FailureCountRepository interface {
 // ListInferenceProfiles + ListFoundationModels round-trip on the first
 // request. Scoped per provider: different Bedrock providers may hold
 // different IAM permissions and therefore see different catalogs.
+//
+// Rows are fingerprinted with (region, accessKeyID) so a config edit
+// that retargets the provider at a new region or IAM principal
+// invalidates the cache — the adapter would otherwise happily serve
+// profile IDs from the old region until the next TTL refresh.
 type BedrockDiscoveryRepository interface {
-	// Load returns every cached entry for a provider plus the timestamp
-	// of the most recent successful fetch, used to decide whether the
-	// rehydrated cache is still within TTL. Zero entries + zero time
-	// means no cache; nil error.
-	Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error)
+	// Load returns cached entries for a provider that match the current
+	// (region, accessKeyID) pair, plus the timestamp of the most recent
+	// matching fetch. Rows that don't match are silently ignored (they
+	// will be overwritten on the next Replace). Zero entries + zero time
+	// means no usable cache; nil error.
+	Load(providerID uint64, region, accessKeyID string) ([]*domain.BedrockDiscoveryEntry, time.Time, error)
 
-	// Replace atomically swaps the stored catalog for a provider. Empty
-	// entries is valid — it clears the cache, matching what the adapter
-	// sees after a discovery run that returned nothing.
-	Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error
+	// Replace atomically swaps the stored catalog for a provider and
+	// stamps every row with the supplied (region, accessKeyID).
+	// Clears any pre-existing rows for this provider regardless of
+	// their stored region/accessKeyID, so a config edit doesn't leave
+	// orphan rows behind.
+	Replace(providerID uint64, region, accessKeyID string, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error
 }

--- a/internal/repository/sqlite/bedrock_discovery.go
+++ b/internal/repository/sqlite/bedrock_discovery.go
@@ -16,9 +16,16 @@ func NewBedrockDiscoveryRepository(db *DB) repository.BedrockDiscoveryRepository
 	return &BedrockDiscoveryRepository{db: db}
 }
 
-func (r *BedrockDiscoveryRepository) Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
+// Load returns cached entries for a provider whose stored (region,
+// access_key_id) matches the supplied live config. Rows from a previous
+// region or IAM principal are silently ignored — they'll be wiped on
+// the next Replace so we don't accumulate orphan rows over time.
+func (r *BedrockDiscoveryRepository) Load(providerID uint64, region, accessKeyID string) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
 	var rows []BedrockDiscoveryEntry
-	if err := r.db.gorm.Where("provider_id = ?", providerID).Find(&rows).Error; err != nil {
+	if err := r.db.gorm.Where(
+		"provider_id = ? AND region = ? AND access_key_id = ?",
+		providerID, region, accessKeyID,
+	).Find(&rows).Error; err != nil {
 		return nil, time.Time{}, err
 	}
 	out := make([]*domain.BedrockDiscoveryEntry, 0, len(rows))
@@ -40,9 +47,13 @@ func (r *BedrockDiscoveryRepository) Load(providerID uint64) ([]*domain.BedrockD
 	return out, newest, nil
 }
 
-func (r *BedrockDiscoveryRepository) Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
+func (r *BedrockDiscoveryRepository) Replace(providerID uint64, region, accessKeyID string, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
 	fetchedMs := fetchedAt.UnixMilli()
 	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		// Delete every row for this provider, regardless of its stored
+		// region/accessKeyID — a config edit that retargets the
+		// provider would otherwise leave orphan rows that silently
+		// accumulate forever.
 		if err := tx.Where("provider_id = ?", providerID).Delete(&BedrockDiscoveryEntry{}).Error; err != nil {
 			return err
 		}
@@ -52,11 +63,13 @@ func (r *BedrockDiscoveryRepository) Replace(providerID uint64, entries []*domai
 		rows := make([]BedrockDiscoveryEntry, 0, len(entries))
 		for _, e := range entries {
 			rows = append(rows, BedrockDiscoveryEntry{
-				ProviderID: providerID,
-				ShortName:  e.ShortName,
-				BedrockID:  e.BedrockID,
-				Source:     e.Source,
-				FetchedAt:  fetchedMs,
+				ProviderID:  providerID,
+				ShortName:   e.ShortName,
+				BedrockID:   e.BedrockID,
+				Source:      e.Source,
+				Region:      region,
+				AccessKeyID: accessKeyID,
+				FetchedAt:   fetchedMs,
 			})
 		}
 		// No OnConflict clause — the preceding Delete already cleared

--- a/internal/repository/sqlite/bedrock_discovery.go
+++ b/internal/repository/sqlite/bedrock_discovery.go
@@ -1,0 +1,65 @@
+package sqlite
+
+import (
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type BedrockDiscoveryRepository struct {
+	db *DB
+}
+
+func NewBedrockDiscoveryRepository(db *DB) repository.BedrockDiscoveryRepository {
+	return &BedrockDiscoveryRepository{db: db}
+}
+
+func (r *BedrockDiscoveryRepository) Load(providerID uint64) ([]*domain.BedrockDiscoveryEntry, time.Time, error) {
+	var rows []BedrockDiscoveryEntry
+	if err := r.db.gorm.Where("provider_id = ?", providerID).Find(&rows).Error; err != nil {
+		return nil, time.Time{}, err
+	}
+	out := make([]*domain.BedrockDiscoveryEntry, 0, len(rows))
+	var newest time.Time
+	for _, row := range rows {
+		out = append(out, &domain.BedrockDiscoveryEntry{
+			ShortName: row.ShortName,
+			BedrockID: row.BedrockID,
+			Source:    row.Source,
+		})
+		// All rows for one provider share a FetchedAt (Replace writes
+		// them as a batch), but stay defensive — an old row left by a
+		// partial write must not extend the TTL clock beyond the most
+		// recent successful fetch.
+		if ts := time.UnixMilli(row.FetchedAt); ts.After(newest) {
+			newest = ts
+		}
+	}
+	return out, newest, nil
+}
+
+func (r *BedrockDiscoveryRepository) Replace(providerID uint64, entries []*domain.BedrockDiscoveryEntry, fetchedAt time.Time) error {
+	fetchedMs := fetchedAt.UnixMilli()
+	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("provider_id = ?", providerID).Delete(&BedrockDiscoveryEntry{}).Error; err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+		rows := make([]BedrockDiscoveryEntry, 0, len(entries))
+		for _, e := range entries {
+			rows = append(rows, BedrockDiscoveryEntry{
+				ProviderID: providerID,
+				ShortName:  e.ShortName,
+				BedrockID:  e.BedrockID,
+				Source:     e.Source,
+				FetchedAt:  fetchedMs,
+			})
+		}
+		return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+	})
+}

--- a/internal/repository/sqlite/bedrock_discovery.go
+++ b/internal/repository/sqlite/bedrock_discovery.go
@@ -6,7 +6,6 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type BedrockDiscoveryRepository struct {
@@ -60,6 +59,11 @@ func (r *BedrockDiscoveryRepository) Replace(providerID uint64, entries []*domai
 				FetchedAt:  fetchedMs,
 			})
 		}
-		return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+		// No OnConflict clause — the preceding Delete already cleared
+		// every (provider_id, short_name) row for this provider, so a
+		// unique-index violation here would indicate a caller passed
+		// duplicates in `entries` and should surface as an error rather
+		// than be silently dropped.
+		return tx.Create(&rows).Error
 	})
 }

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -447,6 +447,25 @@ type ModelPrice struct {
 
 func (ModelPrice) TableName() string { return "model_prices" }
 
+// BedrockDiscoveryEntry caches one short-name → Bedrock-ID mapping that
+// discovery resolved for a given Bedrock provider. Persisted so process
+// restarts don't pay the ~5s cold-start ListInferenceProfiles +
+// ListFoundationModels round-trip on the first request. Keyed by
+// provider_id (not region alone) because different providers in the same
+// region may have different IAM permissions and therefore see different
+// catalogs. FetchedAt tracks when the row was written so the loader can
+// decide whether the cache is still within TTL.
+type BedrockDiscoveryEntry struct {
+	ID         uint64 `gorm:"primaryKey;autoIncrement"`
+	ProviderID uint64 `gorm:"uniqueIndex:idx_bedrock_disc_provider_short"`
+	ShortName  string `gorm:"size:128;uniqueIndex:idx_bedrock_disc_provider_short"`
+	BedrockID  string `gorm:"size:255"`
+	Source     string `gorm:"size:32"` // "inference-profile" or "foundation-model"
+	FetchedAt  int64  `gorm:"index"`   // unix ms
+}
+
+func (BedrockDiscoveryEntry) TableName() string { return "bedrock_discovery_entries" }
+
 // ==================== All Models for AutoMigrate ====================
 
 // AllModels returns all GORM models for auto-migration
@@ -474,6 +493,7 @@ func AllModels() []any {
 		&UsageStats{},
 		&ResponseModel{},
 		&ModelPrice{},
+		&BedrockDiscoveryEntry{},
 		&SchemaMigration{},
 	}
 }

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -455,13 +455,22 @@ func (ModelPrice) TableName() string { return "model_prices" }
 // region may have different IAM permissions and therefore see different
 // catalogs. FetchedAt tracks when the row was written so the loader can
 // decide whether the cache is still within TTL.
+//
+// Region + AccessKeyID are recorded alongside so a later config edit
+// that retargets the provider at a different region or IAM principal
+// invalidates the cache: loadFromStore filters to rows whose (region,
+// access_key_id) still match the live config, so a stale catalog from
+// the previous region never gets served post-edit. AccessKeyID is only
+// the public ID ("AKIA..."), not the secret.
 type BedrockDiscoveryEntry struct {
-	ID         uint64 `gorm:"primaryKey;autoIncrement"`
-	ProviderID uint64 `gorm:"uniqueIndex:idx_bedrock_disc_provider_short"`
-	ShortName  string `gorm:"size:128;uniqueIndex:idx_bedrock_disc_provider_short"`
-	BedrockID  string `gorm:"size:255"`
-	Source     string `gorm:"size:32"` // "inference-profile" or "foundation-model"
-	FetchedAt  int64  `gorm:"index"`   // unix ms
+	ID           uint64 `gorm:"primaryKey;autoIncrement"`
+	ProviderID   uint64 `gorm:"uniqueIndex:idx_bedrock_disc_provider_short"`
+	ShortName    string `gorm:"size:128;uniqueIndex:idx_bedrock_disc_provider_short"`
+	BedrockID    string `gorm:"size:255"`
+	Source       string `gorm:"size:32"` // "inference-profile" or "foundation-model"
+	Region       string `gorm:"size:64"`
+	AccessKeyID  string `gorm:"size:128"`
+	FetchedAt    int64  `gorm:"index"` // unix ms
 }
 
 func (BedrockDiscoveryEntry) TableName() string { return "bedrock_discovery_entries" }

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -563,6 +563,19 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async refreshBedrockDiscoveredModels(
+    providerId: number,
+  ): Promise<BedrockDiscoveredModelsResult> {
+    // POST forces a fresh ListInferenceProfiles + ListFoundationModels
+    // round-trip, bypassing the server-side TTL. Use this only when the
+    // operator clicks the refresh button — routine page loads should
+    // stick with GET to avoid burning AWS API quota on every nav.
+    const { data } = await this.client.post<BedrockDiscoveredModelsResult>(
+      `/providers/${providerId}/bedrock-models`,
+    );
+    return data;
+  }
+
   async getAntigravityProviderQuota(
     providerId: number,
     forceRefresh?: boolean,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -177,6 +177,9 @@ export interface Transport {
   // ListInferenceProfiles + ListFoundationModels with the provider's
   // credentials and returns what's actually invocable in its region.
   getBedrockDiscoveredModels(providerId: number): Promise<BedrockDiscoveredModelsResult>;
+  // Force a fresh AWS round-trip (bypasses the server-side TTL). Use
+  // only in response to an explicit operator refresh action.
+  refreshBedrockDiscoveredModels(providerId: number): Promise<BedrockDiscoveredModelsResult>;
 
   // ===== Model Mapping API =====
   getModelMappings(): Promise<ModelMapping[]>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -116,6 +116,11 @@ export interface BedrockDiscoveredModelsResult {
   available: boolean;
   region: string;
   models: BedrockDiscoveredModel[];
+  // Populated by the force-refresh endpoint (POST) when the AWS
+  // round-trip failed; the server returns the stale catalog alongside
+  // this message so the UI can show both. Empty or absent on the GET
+  // read path.
+  refreshError?: string;
 }
 
 export interface ProviderConfig {

--- a/web/src/pages/providers/components/bedrock-provider-view.tsx
+++ b/web/src/pages/providers/components/bedrock-provider-view.tsx
@@ -56,10 +56,8 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
         // field when the forced AWS round-trip itself failed. Surface
         // it as a non-fatal error so the operator sees both the old
         // list and why the new one couldn't land.
-        const refreshErr = (result as BedrockDiscoveredModelsResult & { refreshError?: string })
-          .refreshError;
-        if (refreshErr) {
-          setDiscoveryError(refreshErr);
+        if (result.refreshError) {
+          setDiscoveryError(result.refreshError);
         }
       } catch (err) {
         // 503 from the admin endpoint means the adapter hasn't been

--- a/web/src/pages/providers/components/bedrock-provider-view.tsx
+++ b/web/src/pages/providers/components/bedrock-provider-view.tsx
@@ -43,28 +43,48 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
   const [discoveryLoading, setDiscoveryLoading] = useState(false);
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
 
-  const loadDiscoveredModels = useCallback(async () => {
-    setDiscoveryLoading(true);
-    setDiscoveryError(null);
-    try {
-      const result = await getTransport().getBedrockDiscoveredModels(provider.id);
-      setDiscovered(result);
-    } catch (err) {
-      // 503 from the admin endpoint means the adapter hasn't been
-      // initialized yet — from the operator's perspective that is
-      // another flavour of "discovery isn't working right now", so
-      // treat it the same as an Available=false response rather than
-      // a red transport error.
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      if (status === 503) {
-        setDiscovered({ available: false, region: provider.config?.bedrock?.region || '', models: [] });
-      } else {
-        setDiscoveryError(err instanceof Error ? err.message : String(err));
+  const fetchDiscovery = useCallback(
+    async (force: boolean) => {
+      setDiscoveryLoading(true);
+      setDiscoveryError(null);
+      try {
+        const result = force
+          ? await getTransport().refreshBedrockDiscoveredModels(provider.id)
+          : await getTransport().getBedrockDiscoveredModels(provider.id);
+        setDiscovered(result);
+        // The refresh endpoint may return the stale catalog + an error
+        // field when the forced AWS round-trip itself failed. Surface
+        // it as a non-fatal error so the operator sees both the old
+        // list and why the new one couldn't land.
+        const refreshErr = (result as BedrockDiscoveredModelsResult & { refreshError?: string })
+          .refreshError;
+        if (refreshErr) {
+          setDiscoveryError(refreshErr);
+        }
+      } catch (err) {
+        // 503 from the admin endpoint means the adapter hasn't been
+        // initialized yet — from the operator's perspective that is
+        // another flavour of "discovery isn't working right now", so
+        // treat it the same as an Available=false response rather than
+        // a red transport error.
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 503) {
+          setDiscovered({ available: false, region: provider.config?.bedrock?.region || '', models: [] });
+        } else {
+          setDiscoveryError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        setDiscoveryLoading(false);
       }
-    } finally {
-      setDiscoveryLoading(false);
-    }
-  }, [provider.id, provider.config?.bedrock?.region]);
+    },
+    [provider.id, provider.config?.bedrock?.region],
+  );
+
+  // Mount: cheap GET that returns the persisted/cached catalog. The
+  // refresh button (below) is the only path that triggers a live AWS
+  // round-trip so routine navigation doesn't burn API quota.
+  const loadDiscoveredModels = useCallback(() => fetchDiscovery(false), [fetchDiscovery]);
+  const refreshDiscoveredModels = useCallback(() => fetchDiscovery(true), [fetchDiscovery]);
 
   useEffect(() => {
     loadDiscoveredModels();
@@ -224,7 +244,7 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={loadDiscoveredModels}
+                onClick={refreshDiscoveredModels}
                 disabled={discoveryLoading}
               >
                 <RefreshCw size={14} className={discoveryLoading ? 'animate-spin' : ''} />


### PR DESCRIPTION
## Summary

Fixes a cluster of Bedrock-side regressions exposed when AWS shipped Claude Opus 4.6 / 4.7 and Sonnet 4.6:

- **Discovery found none of the new profiles.** AWS serves them under `type=APPLICATION` (not `SYSTEM_DEFINED`) with bare short-name IDs (`us.anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-6-v1`). Dropped the type filter; unified `profileIDPattern` + `foundationModelPattern` into one `bedrockAnthropicPattern` that accepts region-prefixed dateless shapes.
- **FM-only 4.x entries were being indexed** as direct-invoke targets and then failing at request time with "on-demand throughput isn't supported". Skip entries whose `inferenceTypesSupported` lacks `ON_DEMAND`.
- **Graceful degrade** when a model is entitled but its profile hasn't landed yet: `claude-opus-4-7` → `4-6` → `4-5` → `4`, logging a WARN so operators see the substitution.
- **Persist the catalog in SQLite** (`bedrock_discovery_entries`, keyed per-provider). Restart no longer pays the ~1–5s `ListInferenceProfiles` cold-start. Admin refresh button now POSTs to force-refresh (bypasses rate-limit); page loads stay cheap GETs.
- **Opus 4.7 rejects classic thinking** (`thinking.type=enabled`). Added `adaptThinkingForModel`: for the adaptive-only set (currently just `claude-opus-4-7`), rewrite to `thinking.type=adaptive` + `output_config.effort` with a budget→effort mapping so classic-shape clients (Claude Code CLI) can still hit it.
- Layering follows existing repo convention (`domain.BedrockDiscoveryEntry` + `repository.BedrockDiscoveryRepository` interface + sqlite impl, one-line wire-up in `cmd/maxx`, no shims).

## Test plan

- [x] `go test ./...` green
- [x] `MAXX_BEDROCK_LIVE=1` live tests pass (discovery list + direct invoke on 4-5/4-6/4-7)
- [x] Docker Claude Code CLI → maxx → Bedrock end-to-end: `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-sonnet-4-5` all return real model output
- [x] Restart of maxx: GET `/bedrock-models` served from DB in ~5ms; POST forces a ~4s AWS re-fetch
- [x] 4-6/4-7 catalog rows persist in `bedrock_discovery_entries` across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 添加了手动刷新 AWS Bedrock 模型发现的功能
  * 启用 Bedrock 发现缓存持久化，加速重启后的模型目录加载

* **改进**
  * 扩展了模型短名称解析，支持优雅的版本降级（当较新版本不可用时回退到旧版本）
  * 优化了思维策略处理，改进了 Claude 模型的请求兼容性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->