### PR TITLE
fix(bedrock): expose bedrock-models under self-service /api/providers

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/bedrock" // Register bedrock adapter
+	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"  // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"  // Register custom adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"    // Register kiro adapter
@@ -121,9 +121,13 @@ func main() {
 	inviteCodeRepo := sqlite.NewInviteCodeRepository(db)
 	inviteCodeUsageRepo := sqlite.NewInviteCodeUsageRepository(db)
 
-	// Bedrock discovery persistence is wired inside
-	// core.InitializeServerComponents so both the CLI and desktop
-	// startup paths pick it up (see internal/core/database.go).
+	// Wire Bedrock discovery persistence. The CLI entry point does not
+	// go through core.InitializeServerComponents (the desktop launcher
+	// does — the desktop path gets the same call from core/database.go),
+	// so it needs its own setter call; otherwise the server process
+	// leaves the repo unset and the first Bedrock request after every
+	// restart pays the full AWS discovery round-trip.
+	bedrock.SetDiscoveryRepository(sqlite.NewBedrockDiscoveryRepository(db))
 
 	// Initialize cooldown manager with database persistence
 	cooldown.Default().SetRepository(cooldownRepo)

--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
-	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/bedrock" // Register bedrock adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"  // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"  // Register custom adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"    // Register kiro adapter
@@ -121,11 +121,9 @@ func main() {
 	inviteCodeRepo := sqlite.NewInviteCodeRepository(db)
 	inviteCodeUsageRepo := sqlite.NewInviteCodeUsageRepository(db)
 
-	// Wire Bedrock discovery persistence: each BedrockAdapter will rehydrate
-	// its short-name → inference-profile catalog from SQLite at startup,
-	// avoiding the ~1-5s ListInferenceProfiles round-trip on the first
-	// request after a restart.
-	bedrock.SetDiscoveryRepository(sqlite.NewBedrockDiscoveryRepository(db))
+	// Bedrock discovery persistence is wired inside
+	// core.InitializeServerComponents so both the CLI and desktop
+	// startup paths pick it up (see internal/core/database.go).
 
 	// Initialize cooldown manager with database persistence
 	cooldown.Default().SetRepository(cooldownRepo)

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -126,13 +126,21 @@ func (a *BedrockAdapter) RefreshDiscoveredModels(ctx context.Context) (Discovere
 		defer cancel()
 		refreshErr = a.discoverer.ForceRefresh(lookupCtx)
 	}
-	return a.DiscoveredModels(ctx), refreshErr
+	// Refresh path already forced a fetch; pass false so DiscoveredModels
+	// doesn't do a redundant second Lookup.
+	return a.DiscoveredModels(ctx, false), refreshErr
 }
 
-// DiscoveredModels triggers a discovery refresh (subject to the normal
-// TTL) and returns the current catalog. Uses an isolated background
-// context so admin UI polling can't poison the shared cache.
-func (a *BedrockAdapter) DiscoveredModels(ctx context.Context) DiscoveredModelsResult {
+// DiscoveredModels returns the current catalog. When allowRefresh is
+// true, a TTL-expiry Lookup is triggered so the caller gets a fresh
+// list if the cache is stale; when false, the in-memory snapshot is
+// returned as-is. Admin GETs pass true (they're fine paying an
+// occasional AWS round-trip); non-admin GETs from the self-service
+// surface pass false, so an anonymous poller cannot wait out the TTL
+// to force a ListInferenceProfiles call. Uses an isolated background
+// context on the refresh path so admin UI polling can't poison the
+// shared cache if the client disconnects.
+func (a *BedrockAdapter) DiscoveredModels(ctx context.Context, allowRefresh bool) DiscoveredModelsResult {
 	region := DefaultRegion
 	if a.provider != nil && a.provider.Config != nil && a.provider.Config.Bedrock != nil && a.provider.Config.Bedrock.Region != "" {
 		region = a.provider.Config.Bedrock.Region
@@ -142,11 +150,13 @@ func (a *BedrockAdapter) DiscoveredModels(ctx context.Context) DiscoveredModelsR
 		return result
 	}
 
-	lookupCtx, cancel := context.WithTimeout(ctx, discoveryLookupTimeout)
-	defer cancel()
-	// Force a refresh if the cache is stale. Lookup's argument is a
-	// miss-on-purpose key — we only want the side effect.
-	_, _ = a.discoverer.Lookup(lookupCtx, "__admin_refresh__")
+	if allowRefresh {
+		lookupCtx, cancel := context.WithTimeout(ctx, discoveryLookupTimeout)
+		defer cancel()
+		// Force a refresh if the cache is stale. Lookup's argument is a
+		// miss-on-purpose key — we only want the side effect.
+		_, _ = a.discoverer.Lookup(lookupCtx, "__admin_refresh__")
+	}
 
 	entries := a.discoverer.Entries()
 	result.Available = a.discoverer.Available()

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/bedrock" // Register bedrock adapter
+	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"  // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/codex"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"
@@ -54,6 +54,7 @@ type DatabaseRepos struct {
 	CodexQuotaRepo            repository.CodexQuotaRepository
 	CooldownRepo              repository.CooldownRepository
 	FailureCountRepo          repository.FailureCountRepository
+	BedrockDiscoveryRepo      repository.BedrockDiscoveryRepository
 	CachedProviderRepo        *cached.ProviderRepository
 	CachedRouteRepo           *cached.RouteRepository
 	CachedRetryConfigRepo     *cached.RetryConfigRepository
@@ -130,6 +131,7 @@ func InitializeDatabase(config *DatabaseConfig) (*DatabaseRepos, error) {
 	codexQuotaRepo := sqlite.NewCodexQuotaRepository(db)
 	cooldownRepo := sqlite.NewCooldownRepository(db)
 	failureCountRepo := sqlite.NewFailureCountRepository(db)
+	bedrockDiscoveryRepo := sqlite.NewBedrockDiscoveryRepository(db)
 	apiTokenRepo := sqlite.NewAPITokenRepository(db)
 	modelMappingRepo := sqlite.NewModelMappingRepository(db)
 	usageStatsRepo := sqlite.NewUsageStatsRepository(db)
@@ -166,6 +168,7 @@ func InitializeDatabase(config *DatabaseConfig) (*DatabaseRepos, error) {
 		CodexQuotaRepo:            codexQuotaRepo,
 		CooldownRepo:              cooldownRepo,
 		FailureCountRepo:          failureCountRepo,
+		BedrockDiscoveryRepo:      bedrockDiscoveryRepo,
 		CachedProviderRepo:        cachedProviderRepo,
 		CachedRouteRepo:           cachedRouteRepo,
 		CachedRetryConfigRepo:     cachedRetryConfigRepo,
@@ -204,6 +207,14 @@ func InitializeServerComponents(
 	if err := cooldown.Default().LoadFromDatabase(); err != nil {
 		log.Printf("[Core] Warning: Failed to load cooldowns from database: %v", err)
 	}
+
+	// Wire Bedrock discovery persistence here (not in cmd/maxx/main.go)
+	// so both the CLI entrypoint and the desktop/Wails launcher — which
+	// shares this InitializeServerComponents path — benefit from the
+	// rehydrated catalog. Without this, desktop-mode restarts would pay
+	// the ~1-5s ListInferenceProfiles cold-start on the first Bedrock
+	// request even though the rows are on disk.
+	bedrock.SetDiscoveryRepository(repos.BedrockDiscoveryRepo)
 
 	log.Printf("[Core] Marking stale requests as failed")
 	if count, err := repos.ProxyRequestRepo.MarkStaleAsFailed(instanceID); err != nil {

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -252,7 +252,9 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 // table. Available=false means discovery hasn't succeeded (typically
 // missing bedrock:ListInferenceProfiles IAM permission).
 func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *http.Request, id uint64) {
-	serveBedrockDiscoveredModels(h.svc, w, r, id)
+	// Admin surface: callers are always admin, so GET may trigger a
+	// lazy AWS refresh on TTL expiry.
+	serveBedrockDiscoveredModels(h.svc, w, r, id, true)
 }
 
 // serveBedrockDiscoveredModels is the shared GET/POST handler for the
@@ -266,7 +268,7 @@ func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *h
 // GET returns the current catalog (triggers a lazy refresh on TTL
 // expiry). POST forces an immediate fetch bypassing the TTL and the
 // Invalidate() rate-limit — used by the admin UI's refresh button.
-func serveBedrockDiscoveredModels(svc *service.AdminService, w http.ResponseWriter, r *http.Request, id uint64) {
+func serveBedrockDiscoveredModels(svc *service.AdminService, w http.ResponseWriter, r *http.Request, id uint64, allowLazyRefresh bool) {
 	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
@@ -309,7 +311,7 @@ func serveBedrockDiscoveredModels(svc *service.AdminService, w http.ResponseWrit
 		})
 		return
 	}
-	writeJSON(w, http.StatusOK, bedrockA.DiscoveredModels(r.Context()))
+	writeJSON(w, http.StatusOK, bedrockA.DiscoveredModels(r.Context(), allowLazyRefresh))
 }
 
 // handleProvidersExport exports all providers as JSON

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -252,15 +252,27 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 // table. Available=false means discovery hasn't succeeded (typically
 // missing bedrock:ListInferenceProfiles IAM permission).
 func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *http.Request, id uint64) {
-	// GET returns the current catalog (triggers a lazy refresh on TTL
-	// expiry). POST forces an immediate fetch bypassing the TTL and the
-	// Invalidate() rate-limit — used by the admin UI's refresh button.
+	serveBedrockDiscoveredModels(h.svc, w, r, id)
+}
+
+// serveBedrockDiscoveredModels is the shared GET/POST handler for the
+// Bedrock discovery catalog surface, used by both the admin
+// (/api/admin/providers/{id}/bedrock-models) and self-service
+// (/api/providers/{id}/bedrock-models) paths. The self-service path is
+// what the frontend's default axios baseURL of /api actually hits —
+// without this shared handler, the admin-only registration used to 404
+// under non-admin deployments.
+//
+// GET returns the current catalog (triggers a lazy refresh on TTL
+// expiry). POST forces an immediate fetch bypassing the TTL and the
+// Invalidate() rate-limit — used by the admin UI's refresh button.
+func serveBedrockDiscoveredModels(svc *service.AdminService, w http.ResponseWriter, r *http.Request, id uint64) {
 	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
 	tenantID := maxxctx.GetTenantID(r.Context())
-	p, err := h.svc.GetProvider(tenantID, id)
+	p, err := svc.GetProvider(tenantID, id)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
 		return
@@ -269,7 +281,7 @@ func (h *AdminHandler) handleBedrockDiscoveredModels(w http.ResponseWriter, r *h
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider is not a bedrock provider"})
 		return
 	}
-	adapter, ok := h.svc.GetProviderAdapter(id)
+	adapter, ok := svc.GetProviderAdapter(id)
 	if !ok {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "adapter not initialized"})
 		return

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -74,6 +74,16 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			h.handleProviders(w, r, id)
+		case len(parts) == 4 && parts[3] == "bedrock-models":
+			// Mirror the admin endpoint (/api/admin/providers/{id}/bedrock-models)
+			// under /api/providers/{id}/bedrock-models so the frontend's
+			// default axios baseURL (/api) can read the discovery catalog
+			// without talking to the admin-only surface.
+			id, ok := parseSelfServiceID(w, "provider", parts[2])
+			if !ok {
+				return
+			}
+			serveBedrockDiscoveredModels(h.svc, w, r, id)
 		default:
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -79,8 +79,18 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// under /api/providers/{id}/bedrock-models so the frontend's
 			// default axios baseURL (/api) can read the discovery catalog
 			// without talking to the admin-only surface.
+			//
+			// GET is readable by any authenticated tenant member (same
+			// access posture as the providers list). POST forces a fresh
+			// ListInferenceProfiles + ListFoundationModels round-trip,
+			// bypassing the in-process TTL and Invalidate() rate-limit —
+			// gated on admin so a non-privileged member can't hammer it
+			// and burn the provider's AWS API quota.
 			id, ok := parseSelfServiceID(w, "provider", parts[2])
 			if !ok {
+				return
+			}
+			if r.Method == http.MethodPost && !h.requireAdmin(w, r) {
 				return
 			}
 			serveBedrockDiscoveredModels(h.svc, w, r, id)

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -93,7 +93,11 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodPost && !h.requireAdmin(w, r) {
 				return
 			}
-			serveBedrockDiscoveredModels(h.svc, w, r, id)
+			// Non-admin GET must not be able to trigger a ListInferenceProfiles
+			// refresh by polling past the TTL window — pass the caller's
+			// admin status through so DiscoveredModels only lazy-refreshes
+			// when an admin is on the other end.
+			serveBedrockDiscoveredModels(h.svc, w, r, id, h.isAdmin(r))
 		default:
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		}

--- a/web/src/pages/providers/components/bedrock-provider-view.tsx
+++ b/web/src/pages/providers/components/bedrock-provider-view.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import type { BedrockDiscoveredModelsResult, Provider } from '@/lib/transport';
 import { getTransport } from '@/lib/transport';
 import { useUpdateProvider } from '@/hooks/queries';
+import { useAuth } from '@/lib/auth-context';
 import { Button, Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { BEDROCK_COLOR } from '../types';
@@ -31,6 +32,11 @@ interface BedrockProviderViewProps {
 export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProviderViewProps) {
   const { t } = useTranslation();
   const updateProvider = useUpdateProvider();
+  const { user } = useAuth();
+  // Refresh triggers a POST that the backend gates behind admin role —
+  // non-admin tenant members would get a 403. Hide the button for them
+  // rather than let the UI advertise an action that will fail.
+  const isAdmin = user?.role === 'admin';
   const config = provider.config?.bedrock;
 
   const [showSecret, setShowSecret] = useState(false);
@@ -239,15 +245,17 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
                   </span>
                 )}
               </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={refreshDiscoveredModels}
-                disabled={discoveryLoading}
-              >
-                <RefreshCw size={14} className={discoveryLoading ? 'animate-spin' : ''} />
-                {t('common.refresh', 'Refresh')}
-              </Button>
+              {isAdmin && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={refreshDiscoveredModels}
+                  disabled={discoveryLoading}
+                >
+                  <RefreshCw size={14} className={discoveryLoading ? 'animate-spin' : ''} />
+                  {t('common.refresh', 'Refresh')}
+                </Button>
+              )}
             </div>
             <p className="text-xs text-muted-foreground">
               {t(


### PR DESCRIPTION
## Summary

After #533 merged, `GET /api/providers/{id}/bedrock-models` on production (maxx.gemini.skr.rocks) returned **404**. Root cause: the handler was only registered under `/api/admin/providers/{id}/bedrock-models`, but the frontend's default axios baseURL is `/api`, so every non-admin page-load hit the self-service path — which had no route for `bedrock-models`.

Fix:
- Add the 4-segment `providers/{id}/bedrock-models` case to `self_service.go`.
- Extract the shared GET/POST logic into `serveBedrockDiscoveredModels` so both handlers call the same code path (no duplication, no drift risk).

## Test plan

- [x] `go test ./...` green
- [x] Verified locally: with a real Bedrock provider, both `/api/admin/providers/{id}/bedrock-models` and `/api/providers/{id}/bedrock-models` return 200 OK + the same 14-model catalog; POST force-refresh returns 200 on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 为自助服务 API 添加了 Bedrock 模型端点。
  * 仅管理员用户可访问和执行模型发现刷新操作。

* **改进**
  * 优化了已发现模型的缓存机制，减少不必要的查询。
  * 管理员界面中的刷新功能现已受权限控制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->