### PR TITLE
feat: multitenant ui toggle and sync theme tab

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -18,6 +18,7 @@ var publicSettingsAllowlist = map[string]struct{}{
 	"force_project_timeout":  {},
 	"auto_sort_antigravity":  {},
 	"auto_sort_codex":        {},
+	"ui_multitenant_enabled": {},
 }
 
 // SelfServiceHandler exposes tenant-scoped provider/project APIs for authenticated users.

--- a/web/src/components/layout/app-sidebar/nav-user.tsx
+++ b/web/src/components/layout/app-sidebar/nav-user.tsx
@@ -29,6 +29,7 @@ import {
   useChangeMyPassword,
   useDeletePasskeyCredential,
   usePasskeyCredentials,
+  usePublicSettings,
   useRegisterPasskey,
 } from '@/hooks/queries';
 import type { Theme } from '@/lib/theme';
@@ -77,6 +78,7 @@ export function NavUser() {
   const { transport } = useTransport();
   const { theme, setTheme } = useTheme();
   const { user, authEnabled, logout } = useAuth();
+  const publicSettings = usePublicSettings(authEnabled);
   const changePassword = useChangeMyPassword();
   const isCollapsed = !isMobile && state === 'collapsed';
 
@@ -315,11 +317,15 @@ export function NavUser() {
       ? t('users.roleAdmin')
       : t('users.roleMember')
     : t('nav.accountFallback');
-  const tenantLabel = user?.tenantName?.trim()
-    ? user.tenantName.trim()
-    : user?.tenantID && user.tenantID > 0
-      ? t('nav.tenantFallback', { id: user.tenantID })
-      : t('nav.tenantUnknown');
+  const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
+  const tenantLabel =
+    multiTenantUIEnabled && user
+      ? user.tenantName?.trim()
+        ? user.tenantName.trim()
+        : user.tenantID > 0
+          ? t('nav.tenantFallback', { id: user.tenantID })
+          : t('nav.tenantUnknown')
+      : '';
   const accountName = username || t('nav.accountFallback');
   const accountStatusLabel = authEnabled
     ? t('nav.accountStatusProtected')
@@ -328,7 +334,9 @@ export function NavUser() {
     ? [roleLabel, tenantLabel].filter(Boolean).join(' · ')
     : t('nav.accountIdentityUnknown');
   const accountIdentity = user
-    ? `${t('nav.identityMaskUser', { value: maskNumericIdentity(user.id) })} · ${t('nav.identityMaskTenant', { value: maskNumericIdentity(user.tenantID) })}`
+    ? multiTenantUIEnabled
+      ? `${t('nav.identityMaskUser', { value: maskNumericIdentity(user.id) })} · ${t('nav.identityMaskTenant', { value: maskNumericIdentity(user.tenantID) })}`
+      : t('nav.identityMaskUser', { value: maskNumericIdentity(user.id) })
     : t('nav.accountIdentityUnknown');
   const displayUser = {
     name: accountName,

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -950,6 +950,9 @@
       "en": "English",
       "zh": "简体中文"
     },
+    "ui": "UI",
+    "enableMultiTenantUI": "Enable Multi-tenant UI",
+    "enableMultiTenantUIDesc": "Show workspace / tenant identifiers in the interface.",
     "forceProjectBinding": "Force Project Binding",
     "enableForceProjectBinding": "Enable Force Project Binding",
     "forceProjectBindingDesc": "When enabled, new sessions must select a project before executing requests",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -949,6 +949,9 @@
       "en": "English",
       "zh": "简体中文"
     },
+    "ui": "界面",
+    "enableMultiTenantUI": "启用多租户界面",
+    "enableMultiTenantUIDesc": "开启后显示工作区/租户标识等多租户相关界面。",
     "forceProjectBinding": "强制项目绑定",
     "enableForceProjectBinding": "启用强制项目绑定",
     "forceProjectBindingDesc": "开启后，新会话必须选择项目才能继续执行请求",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -305,13 +305,7 @@ function GeneralSection() {
 
   const defaultThemes = getDefaultThemes();
   const luxuryThemes = getLuxuryThemes();
-  const [themeCategoryTab, setThemeCategoryTab] = useState<'default' | 'luxury'>(
-    isLuxuryTheme(theme) ? 'luxury' : 'default',
-  );
-
-  useEffect(() => {
-    setThemeCategoryTab(isLuxuryTheme(theme) ? 'luxury' : 'default');
-  }, [theme]);
+  const themeCategoryTab = isLuxuryTheme(theme) ? 'luxury' : 'default';
 
   const languages = [
     { value: 'en', label: t('settings.languages.en') },
@@ -330,8 +324,8 @@ function GeneralSection() {
         {/* Theme Selection */}
         <div className="space-y-3">
           <Tabs
-            value={themeCategoryTab}
-            onValueChange={(value) => setThemeCategoryTab(value as 'default' | 'luxury')}
+            key={themeCategoryTab}
+            defaultValue={themeCategoryTab}
             className="w-full"
           >
             <div className="flex items-center justify-between mb-3 ">

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -282,6 +282,7 @@ export function SettingsPage() {
           <GeneralSection />
           {isAdmin && (
             <>
+              <MultiTenantUISection />
               <TimezoneSection />
               <DataRetentionSection />
               <ForceProjectSection />
@@ -1715,3 +1716,40 @@ function BackupSection() {
 }
 
 export default SettingsPage;
+
+function MultiTenantUISection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+
+  const enabled = settings?.ui_multitenant_enabled === 'true';
+
+  const handleToggle = async (checked: boolean) => {
+    await updateSetting.mutateAsync({
+      key: 'ui_multitenant_enabled',
+      value: checked ? 'true' : 'false',
+    });
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Monitor className="h-4 w-4 text-muted-foreground" />
+          {t('settings.ui')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium text-foreground">{t('settings.enableMultiTenantUI')}</div>
+            <p className="text-xs text-muted-foreground mt-1">{t('settings.enableMultiTenantUIDesc')}</p>
+          </div>
+          <Switch checked={enabled} onCheckedChange={handleToggle} disabled={updateSetting.isPending} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Add multitenant ui toggle default off to hide tenant workspace identifiers
- Add admin settings toggle for multitenant ui
- Fix settings theme category tab to follow active theme
- Fixes #511

## Tests
- go test ./internal/... ./tests/...
- pnpm -C web typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* 新增多租户用户界面设置，管理员可在设置页面中启用或禁用该功能，以控制工作区/租户标识符在界面中的显示。

## Localization
* 新增英文和中文本地化字符串支持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->