### PR TITLE
fix(ui): hide multitenant admin controls when disabled

### DIFF
--- a/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
+++ b/tests/e2e/playwright/requests-auth-switch-isolation.spec.ts
@@ -141,6 +141,7 @@ test('requests page does not leak cached requests or token filters across tenant
         body: JSON.stringify({
           api_token_auth_enabled: 'true',
           force_project_binding: 'false',
+          ui_multitenant_enabled: 'true',
         }),
       });
       return;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useEffect, type ReactNode } from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AppLayout } from '@/components/layout';
 import { useTranslation } from 'react-i18next';
 import { OverviewPage } from '@/pages/overview';
@@ -26,6 +26,26 @@ import { UsersPage } from '@/pages/users';
 import { AdminRoute } from '@/components/auth/admin-route';
 import { InviteCodesPage } from '@/pages/invite-codes';
 import { AuthProvider, useAuth } from '@/lib/auth-context';
+import { usePublicSettings } from '@/hooks/queries';
+
+function MultiTenantUIRoute({ children }: { children: ReactNode }) {
+  const { t } = useTranslation();
+  const { data: settings, isLoading } = usePublicSettings();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <span className="text-muted-foreground">{t('common.loading')}</span>
+      </div>
+    );
+  }
+
+  if (settings?.ui_multitenant_enabled !== 'true') {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}
 
 function AppRoutes() {
   const { t } = useTranslation();
@@ -67,7 +87,14 @@ function AppRoutes() {
           <Route path="providers" element={<ProvidersPage />} />
           <Route path="providers/create/*" element={<ProviderCreateLayout />} />
           <Route path="providers/:id/edit" element={<ProviderEditPage />} />
-          <Route path="routes/:clientType" element={<ClientRoutesPage />} />
+          <Route
+            path="routes/:clientType"
+            element={
+              <MultiTenantUIRoute>
+                <ClientRoutesPage />
+              </MultiTenantUIRoute>
+            }
+          />
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="projects/:id" element={<ProjectDetailPage />} />
           <Route path="sessions" element={<SessionsPage />} />
@@ -83,7 +110,9 @@ function AppRoutes() {
             path="invite-codes"
             element={
               <AdminRoute>
-                <InviteCodesPage />
+                <MultiTenantUIRoute>
+                  <InviteCodesPage />
+                </MultiTenantUIRoute>
               </AdminRoute>
             }
           />
@@ -104,7 +133,9 @@ function AppRoutes() {
             path="users"
             element={
               <AdminRoute>
-                <UsersPage />
+                <MultiTenantUIRoute>
+                  <UsersPage />
+                </MultiTenantUIRoute>
               </AdminRoute>
             }
           />

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { SidebarConfig, MenuItem } from '@/types/sidebar';
 import { useAuth } from '@/lib/auth-context';
+import { usePublicSettings } from '@/hooks/queries';
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -65,12 +66,26 @@ function MenuItemRenderer({ item }: { item: MenuItem }) {
 export function SidebarRenderer({ config }: SidebarRendererProps) {
   const { t } = useTranslation();
   const { user, authEnabled } = useAuth();
+  const publicSettings = usePublicSettings();
   const isAdmin = !user || user.role === 'admin';
+  const multiTenantUIEnabled =
+    publicSettings.isLoading || publicSettings.data?.ui_multitenant_enabled === 'true';
 
   return (
     <>
       {config.sections.map((section) => {
+        if (!multiTenantUIEnabled && section.key === 'routes') {
+          return null;
+        }
+
         const filteredItems = section.items.filter((item) => {
+          if (
+            !multiTenantUIEnabled &&
+            item.type === 'standard' &&
+            (item.key === 'invite-codes' || item.key === 'users')
+          ) {
+            return false;
+          }
           if (item.type === 'standard' && item.adminOnly && !isAdmin) {
             return false;
           }

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -27,6 +27,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { AuthUser } from '@/lib/auth-context';
 import { getManagedPasswordError, getManagedPasswordRuleState } from '@/lib/managed-password';
 import { useTransport } from '@/lib/transport';
+import { usePublicSettings } from '@/hooks/queries';
 
 interface LoginPageProps {
   onSuccess: (token: string, user?: AuthUser) => void;
@@ -72,6 +73,9 @@ function mapRegisterError(
 export function LoginPage({ onSuccess }: LoginPageProps) {
   const { t } = useTranslation();
   const { transport } = useTransport();
+  const publicSettings = usePublicSettings();
+  const multiTenantUIEnabled =
+    publicSettings.isLoading || publicSettings.data?.ui_multitenant_enabled === 'true';
   const [authTab, setAuthTab] = useState<AuthTab>('login');
   const [passkeyExpanded, setPasskeyExpanded] = useState(false);
   const [showRegisterPasswordRules, setShowRegisterPasswordRules] = useState(false);
@@ -139,8 +143,9 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
     clearLoginMessages();
     clearPasskeyMessages();
 
+    const loginUsernameValue = multiTenantUIEnabled ? loginUsername.trim() : 'admin';
     const nextErrors: Partial<Record<LoginField, string>> = {};
-    if (!loginUsername.trim()) {
+    if (multiTenantUIEnabled && !loginUsernameValue) {
       nextErrors.username = t('login.usernameRequired');
     }
     if (!loginPassword.trim()) {
@@ -155,7 +160,7 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
     setIsLoginLoading(true);
 
     try {
-      const result = await transport.login(loginUsername.trim(), loginPassword);
+      const result = await transport.login(loginUsernameValue, loginPassword);
       if (result.success && result.token) {
         onSuccess(result.token, result.user as AuthUser | undefined);
         return;
@@ -332,7 +337,7 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                 )}
 
                 <Tabs
-                  value={authTab}
+                  value={multiTenantUIEnabled ? authTab : 'login'}
                   onValueChange={(value) => {
                     if (anyLoading) {
                       return;
@@ -349,18 +354,21 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                   }}
                   className="w-full"
                 >
-                  <TabsList className="grid h-11 w-full grid-cols-2 rounded-xl p-1">
+                  {multiTenantUIEnabled && (
+                    <TabsList className="grid h-11 w-full grid-cols-2 rounded-xl p-1">
                     <TabsTrigger value="login" className="rounded-lg text-sm" disabled={anyLoading}>
                       {t('login.primaryTitle')}
                     </TabsTrigger>
                     <TabsTrigger value="register" className="rounded-lg text-sm" disabled={anyLoading}>
                       {t('login.registerSummaryTitle')}
                     </TabsTrigger>
-                  </TabsList>
+                    </TabsList>
+                  )}
 
                   <TabsContent value="login" className="mt-6 space-y-5">
                     <form onSubmit={handleLogin} className="space-y-5">
-                      <div className="space-y-2">
+                      {multiTenantUIEnabled && (
+                        <div className="space-y-2">
                         <Label htmlFor="login-username">{t('login.usernameLabel')}</Label>
                         <Input
                           id="login-username"
@@ -380,7 +388,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                       }}
                     />
                         <FieldError message={loginFieldErrors.username} />
-                      </div>
+                        </div>
+                      )}
 
                       <div className="space-y-2">
                         <Label htmlFor="login-password">{t('login.passwordLabel')}</Label>
@@ -390,6 +399,7 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                           value={loginPassword}
                           placeholder={t('login.passwordPlaceholder')}
                           autoComplete="current-password"
+                          autoFocus={!multiTenantUIEnabled}
                           disabled={anyLoading}
                           className="h-11"
                           aria-invalid={loginFieldErrors.password ? 'true' : undefined}
@@ -399,7 +409,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                             setLoginFormError('');
                           }}
                         />
-                        <div className="flex justify-end">
+                        {multiTenantUIEnabled && (
+                          <div className="flex justify-end">
                           <Button
                             type="button"
                             variant="link"
@@ -408,7 +419,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                           >
                             {t('login.forgotPassword')}
                           </Button>
-                        </div>
+                          </div>
+                        )}
                         <FieldError message={loginFieldErrors.password} />
                       </div>
 
@@ -416,13 +428,18 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                         type="submit"
                         className="w-full"
                         size="lg"
-                        disabled={anyLoading || !loginUsername.trim() || !loginPassword.trim()}
+                        disabled={
+                          anyLoading ||
+                          (multiTenantUIEnabled && !loginUsername.trim()) ||
+                          !loginPassword.trim()
+                        }
                       >
                         {isLoginLoading ? t('login.verifying') : t('login.submit')}
                       </Button>
                     </form>
 
-                    <div className="space-y-3 border-t border-border/60 pt-4">
+                    {multiTenantUIEnabled && (
+                      <div className="space-y-3 border-t border-border/60 pt-4">
                       <button
                         type="button"
                         className="flex w-full items-start gap-3 rounded-2xl border border-border/70 bg-muted/25 px-4 py-4 text-left transition-colors hover:bg-muted/45"
@@ -484,10 +501,12 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                           </Button>
                         </div>
                       )}
-                    </div>
+                      </div>
+                    )}
                   </TabsContent>
 
-                  <TabsContent value="register" className="mt-6 space-y-5">
+                  {multiTenantUIEnabled && (
+                    <TabsContent value="register" className="mt-6 space-y-5">
                     <div className="rounded-2xl border border-border/70 bg-muted/25 p-4">
                       <p className="text-sm font-medium">{t('login.registerSummaryTitle')}</p>
                       <p className="text-muted-foreground mt-1 text-sm leading-6">
@@ -631,7 +650,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
                         {isRegisterLoading ? t('login.registering') : t('login.register')}
                       </Button>
                     </form>
-                  </TabsContent>
+                    </TabsContent>
+                  )}
                 </Tabs>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- use the public `ui_multitenant_enabled` setting to keep single-admin login to a password-only form that submits username `admin`
- hide users, invite codes, and routes from the sidebar when multitenant UI is disabled
- redirect direct visits to users, invite codes, and route pages back to the overview while the toggle is disabled
- update the mocked auth-switch Playwright fixture to opt into multitenant UI when it expects username-based tenant switching

## Validation
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- attempted `pnpm exec playwright test -c playwright.config.ts requests-auth-switch-isolation.spec.ts --project=e2e-chromium`, but local Playwright browser binary is not installed in this environment

## Notes
- This is intentionally limited to frontend UI/route guards and test fixture alignment; it does not change backend auth or settings semantics.