### PR TITLE
fix(ui): avoid multitenant disabled-state flicker

### DIFF
--- a/internal/handler/self_service_routes.go
+++ b/internal/handler/self_service_routes.go
@@ -2,7 +2,7 @@ package handler
 
 import "net/http"
 
-var selfServiceRoutePatterns = []string{
+var protectedSelfServiceRoutePatterns = []string{
 	"/api/providers",
 	"/api/providers/",
 	"/api/routes",
@@ -17,8 +17,6 @@ var selfServiceRoutePatterns = []string{
 	"/api/api-tokens/",
 	"/api/model-mappings",
 	"/api/model-mappings/",
-	"/api/settings",
-	"/api/settings/",
 	"/api/proxy-status",
 	"/api/proxy-status/",
 	"/api/model-prices",
@@ -26,6 +24,16 @@ var selfServiceRoutePatterns = []string{
 	"/api/response-models",
 	"/api/response-models/",
 }
+
+var publicSelfServiceRoutePatterns = []string{
+	"/api/settings",
+	"/api/settings/",
+}
+
+var selfServiceRoutePatterns = append(
+	append([]string{}, protectedSelfServiceRoutePatterns...),
+	publicSelfServiceRoutePatterns...,
+)
 
 // RegisterSelfServiceRoutes registers the admin and self-service HTTP endpoints under /api.
 func RegisterSelfServiceRoutes(
@@ -37,7 +45,12 @@ func RegisterSelfServiceRoutes(
 	mux.Handle("/api/admin/", http.StripPrefix("/api", wrap(adminHandler)))
 
 	wrappedSelfService := http.StripPrefix("/api", wrap(selfServiceHandler))
-	for _, pattern := range selfServiceRoutePatterns {
+	for _, pattern := range protectedSelfServiceRoutePatterns {
 		mux.Handle(pattern, wrappedSelfService)
+	}
+
+	publicSelfService := http.StripPrefix("/api", NoAuthMiddleware(selfServiceHandler))
+	for _, pattern := range publicSelfServiceRoutePatterns {
+		mux.Handle(pattern, publicSelfService)
 	}
 }

--- a/internal/handler/self_service_routes_test.go
+++ b/internal/handler/self_service_routes_test.go
@@ -49,3 +49,39 @@ func TestRegisterSelfServiceRoutes_RegistersProxyStatus(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisterSelfServiceRoutes_SettingsBypassAuthWrapper(t *testing.T) {
+	mux := http.NewServeMux()
+	wrappedAuthCalled := false
+	RegisterSelfServiceRoutes(
+		mux,
+		func(h http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				wrappedAuthCalled = true
+				http.Error(w, "auth required", http.StatusUnauthorized)
+			})
+		},
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		}),
+	)
+
+	settingsRec := httptest.NewRecorder()
+	mux.ServeHTTP(settingsRec, httptest.NewRequest(http.MethodGet, "/api/settings", nil))
+	if settingsRec.Code != http.StatusNoContent {
+		t.Fatalf("expected public settings route to bypass auth wrapper, got status %d", settingsRec.Code)
+	}
+	if wrappedAuthCalled {
+		t.Fatal("expected public settings route not to call auth wrapper")
+	}
+
+	protectedRec := httptest.NewRecorder()
+	mux.ServeHTTP(protectedRec, httptest.NewRequest(http.MethodGet, "/api/providers", nil))
+	if protectedRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected protected self-service route to use auth wrapper, got status %d", protectedRec.Code)
+	}
+	if !wrappedAuthCalled {
+		t.Fatal("expected protected self-service route to call auth wrapper")
+	}
+}

--- a/tests/e2e/playwright/helpers.ts
+++ b/tests/e2e/playwright/helpers.ts
@@ -56,15 +56,19 @@ export async function loginToAdminUI(page: Page) {
   await enableMultiTenantUIForE2E();
   await page.goto(BASE);
 
-  const usernameInput = page.locator('input[type="text"]');
-  const loginVisible = await usernameInput
+  const passwordInput = page.locator('input[type="password"]');
+  const passwordVisible = await passwordInput
     .waitFor({ state: 'visible', timeout: 10000 })
     .then(() => true)
     .catch(() => false);
 
-  if (loginVisible) {
-    await page.fill('input[type="text"]', USER);
-    await page.fill('input[type="password"]', PASS);
+  if (passwordVisible) {
+    const usernameInput = page.locator('input[type="text"]');
+    const usernameVisible = await usernameInput.isVisible().catch(() => false);
+    if (usernameVisible) {
+      await usernameInput.fill(USER);
+    }
+    await passwordInput.fill(PASS);
     await page.locator('button[type="submit"]').click();
   }
 

--- a/tests/e2e/playwright/helpers.ts
+++ b/tests/e2e/playwright/helpers.ts
@@ -47,12 +47,18 @@ export async function waitForDashboard(page: Page, timeout = 10000) {
   await expect.poll(async () => /dashboard/i.test(await bodyText(page)), { timeout }).toBe(true);
 }
 
+export async function enableMultiTenantUIForE2E() {
+  const token = await loginToAdminAPI();
+  await adminAPI('PUT', '/settings/ui_multitenant_enabled', { value: 'true' }, token);
+}
+
 export async function loginToAdminUI(page: Page) {
+  await enableMultiTenantUIForE2E();
   await page.goto(BASE);
 
   const usernameInput = page.locator('input[type="text"]');
   const loginVisible = await usernameInput
-    .waitFor({ state: 'visible', timeout: 3000 })
+    .waitFor({ state: 'visible', timeout: 10000 })
     .then(() => true)
     .catch(() => false);
 

--- a/tests/e2e/playwright/multitenant-ui-loading.spec.ts
+++ b/tests/e2e/playwright/multitenant-ui-loading.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test, type Page, type Route } from 'playwright/test';
+
+const ADMIN_USER = {
+  id: 1,
+  username: 'admin',
+  tenantID: 1,
+  tenantName: 'Admin Tenant',
+  role: 'admin',
+};
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockCommonApis(page: Page, settingsGate: Promise<void>) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+
+    if (pathname === '/api/settings') {
+      await settingsGate;
+      return json(route, {
+        force_project_binding: 'false',
+        ui_multitenant_enabled: 'false',
+      });
+    }
+
+    if (pathname === '/api/admin/auth/status') {
+      const token = await route.request().headerValue('authorization');
+      return json(route, {
+        authEnabled: true,
+        user: token ? ADMIN_USER : null,
+      });
+    }
+
+    if (pathname === '/api/admin/proxy-status' || pathname === '/api/proxy-status') {
+      return json(route, {
+        running: true,
+        address: '127.0.0.1',
+        port: 9880,
+        version: 'v0.13.61',
+      });
+    }
+
+    if (
+      pathname === '/api/admin/providers' ||
+      pathname === '/api/providers' ||
+      pathname === '/api/admin/routes' ||
+      pathname === '/api/routes' ||
+      pathname === '/api/admin/projects' ||
+      pathname === '/api/projects' ||
+      pathname === '/api/admin/api-tokens' ||
+      pathname === '/api/api-tokens' ||
+      pathname === '/api/admin/model-mappings' ||
+      pathname === '/api/model-mappings' ||
+      pathname === '/api/admin/response-models' ||
+      pathname === '/api/response-models' ||
+      pathname === '/api/admin/sessions' ||
+      pathname === '/api/sessions'
+    ) {
+      return json(route, []);
+    }
+
+    if (pathname === '/api/admin/requests/count') {
+      return json(route, 0);
+    }
+
+    if (pathname === '/api/admin/requests') {
+      return json(route, { items: [], hasMore: false, firstId: 0, lastId: 0 });
+    }
+
+    return json(route, {});
+  });
+}
+
+test('login does not flash multi-tenant controls while disabled setting is loading', async ({
+  page,
+}) => {
+  let resolveSettings!: () => void;
+  const settingsGate = new Promise<void>((resolve) => {
+    resolveSettings = resolve;
+  });
+  await mockCommonApis(page, settingsGate);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByLabel(/password/i)).toBeVisible();
+  await expect(page.locator('input[type="text"]')).toHaveCount(0);
+  await expect(page.getByRole('tab', { name: /register/i })).toHaveCount(0);
+  await expect(page.getByText(/passkey/i)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /sign in|login/i })).toBeDisabled();
+
+  resolveSettings();
+
+  await expect(page.locator('input[type="text"]')).toHaveCount(0);
+  await expect(page.getByRole('tab', { name: /register/i })).toHaveCount(0);
+  await expect(page.getByText(/passkey/i)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /sign in|login/i })).toBeDisabled();
+});
+
+test('sidebar does not flash multi-tenant navigation while disabled setting is loading', async ({
+  page,
+}) => {
+  let resolveSettings!: () => void;
+  const settingsGate = new Promise<void>((resolve) => {
+    resolveSettings = resolve;
+  });
+  await mockCommonApis(page, settingsGate);
+  await page.addInitScript(() => localStorage.setItem('maxx-admin-token', 'admin-token'));
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByText('ROUTES')).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /invite codes/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /^users$/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /claude/i })).toHaveCount(0);
+
+  resolveSettings();
+
+  await expect(page.getByText('ROUTES')).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /invite codes/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /^users$/i })).toHaveCount(0);
+  await expect(page.getByRole('link', { name: /claude/i })).toHaveCount(0);
+});

--- a/tests/e2e/playwright/passkey-discoverable.spec.ts
+++ b/tests/e2e/playwright/passkey-discoverable.spec.ts
@@ -92,20 +92,20 @@ test('passkey discoverable login works without username', async ({ browser }, te
     const logoutItem = page.locator('[role="menuitem"]').filter({ hasText: /Log out|退出登录/ }).first();
     await expect(logoutItem).toBeVisible({ timeout: 5000 });
     await logoutItem.click();
-    await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 5000 });
-    console.log('✅ Logged out');
-
-    console.log('\n--- Step 4: Discoverable Passkey Login (NO username) ---');
-    const usernameField = page.locator('input[type="text"]');
-    await usernameField.fill('');
-    await expect(usernameField).toHaveValue('');
-    console.log('  Username field is empty: ✓');
 
     const passkeyToggle = page
       .locator('button[aria-expanded]')
       .filter({ hasText: /Passkey Login|Passkey 登录/ })
       .first();
-    await expect(passkeyToggle).toBeVisible({ timeout: 5000 });
+    await expect(passkeyToggle).toBeVisible({ timeout: 10000 });
+    console.log('✅ Logged out');
+
+    console.log('\n--- Step 4: Discoverable Passkey Login (NO username) ---');
+    const usernameField = page.locator('input[type="text"]');
+    await expect(usernameField).toBeVisible({ timeout: 10000 });
+    await usernameField.fill('');
+    await expect(usernameField).toHaveValue('');
+    console.log('  Username field is empty: ✓');
     if ((await passkeyToggle.getAttribute('aria-expanded')) !== 'true') {
       await passkeyToggle.click();
     }

--- a/tests/e2e/playwright/provider-proxy-route.spec.ts
+++ b/tests/e2e/playwright/provider-proxy-route.spec.ts
@@ -8,7 +8,7 @@ import http from 'node:http';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, PASS, USER, adminAPI } from './helpers';
+import { BASE, adminAPI, loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -154,12 +154,7 @@ test('provider-scoped proxy route records requests and shows provider URL in the
     const payload = JSON.parse(text);
     expect(payload.model).toBe(requestModel);
 
-    await page.goto(BASE);
-    await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
-    await page.fill('input[type="text"]', USER);
-    await page.fill('input[type="password"]', PASS);
-    await page.locator('button[type="submit"]').click();
-    await expect(page.locator('body')).toContainText(/Dashboard|dashboard/, { timeout: 10000 });
+    await loginToAdminUI(page);
 
     await page.goto(`${BASE}/requests`);
     await expect(page.locator('body')).toContainText(/Requests|请求/, { timeout: 15000 });

--- a/tests/e2e/playwright/provider-proxy-route.spec.ts
+++ b/tests/e2e/playwright/provider-proxy-route.spec.ts
@@ -8,7 +8,7 @@ import http from 'node:http';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, adminAPI, loginToAdminUI } from './helpers';
+import { BASE, PASS, USER, adminAPI, loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 

--- a/tests/e2e/playwright/requests-project-filter.spec.ts
+++ b/tests/e2e/playwright/requests-project-filter.spec.ts
@@ -8,7 +8,7 @@ import http from 'node:http';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, adminAPI, loginToAdminUI } from './helpers';
+import { BASE, PASS, USER, adminAPI, loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 

--- a/tests/e2e/playwright/requests-project-filter.spec.ts
+++ b/tests/e2e/playwright/requests-project-filter.spec.ts
@@ -8,7 +8,7 @@ import http from 'node:http';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, PASS, USER, adminAPI } from './helpers';
+import { BASE, adminAPI, loginToAdminUI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -213,12 +213,7 @@ test('requests page can filter by project and persist selection', async ({ page 
     }, { timeout: 15000 }).toEqual({ alphaCount: 3, betaCount: 2 });
 
     console.log('\n--- Step 1: Browser Login ---');
-    await page.goto(BASE);
-    await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
-    await page.fill('input[type="text"]', USER);
-    await page.fill('input[type="password"]', PASS);
-    await page.locator('button[type="submit"]').click();
-    await expect(page.locator('body')).toContainText(/Dashboard|dashboard/, { timeout: 10000 });
+    await loginToAdminUI(page);
     console.log('✅ Browser login success');
 
     console.log('\n--- Step 2: Navigate to Requests ---');

--- a/tests/e2e/playwright/stats-chart-resize.spec.ts
+++ b/tests/e2e/playwright/stats-chart-resize.spec.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, PASS, USER, adminAPI, nextAnimationFrames } from './helpers';
+import { BASE, adminAPI, loginToAdminUI, nextAnimationFrames } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -201,12 +201,7 @@ test('stats chart survives repeated zero-dimension resize cycles', async ({ page
     }, { timeout: 20000 }).toBeGreaterThan(0);
 
     console.log('\n--- Step 1: Browser Login ---');
-    await page.goto(BASE);
-    await expect(page.locator('input[type="text"]')).toBeVisible({ timeout: 10000 });
-    await page.fill('input[type="text"]', USER);
-    await page.fill('input[type="password"]', PASS);
-    await page.locator('button[type="submit"]').click();
-    await expect(page.locator('body')).toContainText(/Dashboard|dashboard/, { timeout: 10000 });
+    await loginToAdminUI(page);
     console.log('✅ Browser login success');
 
     const consoleErrors: string[] = [];

--- a/tests/e2e/playwright/stats-chart-resize.spec.ts
+++ b/tests/e2e/playwright/stats-chart-resize.spec.ts
@@ -10,7 +10,7 @@ import path from 'node:path';
 
 import { expect, test } from 'playwright/test';
 
-import { BASE, adminAPI, loginToAdminUI, nextAnimationFrames } from './helpers';
+import { BASE, PASS, USER, adminAPI, loginToAdminUI, nextAnimationFrames } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
 

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -68,8 +68,7 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
   const { user, authEnabled } = useAuth();
   const publicSettings = usePublicSettings();
   const isAdmin = !user || user.role === 'admin';
-  const multiTenantUIEnabled =
-    publicSettings.isLoading || publicSettings.data?.ui_multitenant_enabled === 'true';
+  const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
 
   return (
     <>

--- a/web/src/pages/login.tsx
+++ b/web/src/pages/login.tsx
@@ -74,8 +74,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
   const { t } = useTranslation();
   const { transport } = useTransport();
   const publicSettings = usePublicSettings();
-  const multiTenantUIEnabled =
-    publicSettings.isLoading || publicSettings.data?.ui_multitenant_enabled === 'true';
+  const publicSettingsLoading = publicSettings.isLoading;
+  const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
   const [authTab, setAuthTab] = useState<AuthTab>('login');
   const [passkeyExpanded, setPasskeyExpanded] = useState(false);
   const [showRegisterPasswordRules, setShowRegisterPasswordRules] = useState(false);
@@ -103,7 +103,8 @@ export function LoginPage({ onSuccess }: LoginPageProps) {
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
 
   const passkeySupported = browserSupportsWebAuthn();
-  const anyLoading = isLoginLoading || isRegisterLoading || isPasskeyLoading;
+  const anyLoading =
+    publicSettingsLoading || isLoginLoading || isRegisterLoading || isPasskeyLoading;
   const registerPasswordRuleState = getManagedPasswordRuleState(registerPassword);
   const registerPasswordFormatError = getRegisterPasswordError(registerPassword, t);
   const registerPasswordFieldError =


### PR DESCRIPTION
## Summary
- stop treating the public settings loading state as multi-tenant UI enabled
- hide multi-tenant-only sidebar/login controls unless `ui_multitenant_enabled` is explicitly `true`
- keep login submission disabled while public settings are still loading so the form cannot submit with the wrong single-tenant/multi-tenant assumptions
- add Playwright coverage for delayed disabled settings on both login and authenticated sidebar refresh paths

## Tests
- pnpm -C /tmp/maxx-multitenant-ui/web typecheck
- local Playwright regression for `multitenant-ui-loading.spec.ts` using `/usr/bin/google-chrome` executable override: 2 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加多租户UI功能支持，通过管理员设置启用。

* **错误修复**
  * 修复了登录页面和侧边栏在加载设置时的UI行为问题，确保在设置加载过程中正确处理加载状态。

* **测试**
  * 改进E2E测试流程，统一登录和多租户UI配置的测试逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->