### PR TITLE
fix(proxy): expose global Gemini model list

### DIFF
--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -27,12 +27,13 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 		mux.Handle("/responses/", handlers.ProxyHandler)
 		mux.Handle("/v1/responses", handlers.ProxyHandler)
 		mux.Handle("/v1/responses/", handlers.ProxyHandler)
-		// Gemini API (Google AI Studio style)
+		// Gemini API (Google AI Studio style generation endpoints)
 		mux.Handle("/v1beta/models/", handlers.ProxyHandler)
 	}
 
 	if handlers.ModelsHandler != nil {
 		mux.Handle("/v1/models", handlers.ModelsHandler)
+		mux.Handle("/v1beta/models", handlers.ModelsHandler)
 	}
 
 	if handlers.ProviderProxyHandler != nil {

--- a/internal/core/proxy_routes_test.go
+++ b/internal/core/proxy_routes_test.go
@@ -26,8 +26,16 @@ func TestRegisterProxyRoutes_RegistersModelsRoute(t *testing.T) {
 			t.Fatalf("%s status = %d, want %d", path, rec.Code, http.StatusNoContent)
 		}
 	}
-	if len(calledPaths) != 2 {
-		t.Fatalf("models handler calls = %v, want both model-list routes", calledPaths)
+	wantPaths := map[string]bool{"/v1/models": false, "/v1beta/models": false}
+	for _, path := range calledPaths {
+		if _, ok := wantPaths[path]; ok {
+			wantPaths[path] = true
+		}
+	}
+	for path, called := range wantPaths {
+		if !called {
+			t.Fatalf("models handler calls = %v, missing %s", calledPaths, path)
+		}
 	}
 }
 

--- a/internal/core/proxy_routes_test.go
+++ b/internal/core/proxy_routes_test.go
@@ -8,21 +8,49 @@ import (
 
 func TestRegisterProxyRoutes_RegistersModelsRoute(t *testing.T) {
 	mux := http.NewServeMux()
-	called := false
+	calledPaths := make([]string, 0, 2)
 
 	RegisterProxyRoutes(mux, ProxyRouteHandlers{
 		ModelsHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			called = true
+			calledPaths = append(calledPaths, r.URL.Path)
 			w.WriteHeader(http.StatusNoContent)
 		}),
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	for _, path := range []string{"/v1/models", "/v1beta/models"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("%s status = %d, want %d", path, rec.Code, http.StatusNoContent)
+		}
+	}
+	if len(calledPaths) != 2 {
+		t.Fatalf("models handler calls = %v, want both model-list routes", calledPaths)
+	}
+}
+
+func TestRegisterProxyRoutes_RoutesGeminiGenerationToProxy(t *testing.T) {
+	mux := http.NewServeMux()
+	proxyCalled := false
+
+	RegisterProxyRoutes(mux, ProxyRouteHandlers{
+		ProxyHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			proxyCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		}),
+		ModelsHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("did not expect Gemini generation path to hit ModelsHandler")
+		}),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
-	if !called {
-		t.Fatal("expected /v1/models to be routed to ModelsHandler")
+	if !proxyCalled {
+		t.Fatal("expected Gemini generation path to be routed to ProxyHandler")
 	}
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -39,19 +39,27 @@ func (h *ModelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	tenantID := maxxctx.GetTenantID(r.Context())
 	userAgent := r.Header.Get("User-Agent")
-	names, err := h.collectModelNamesForUserAgent(tenantID, userAgent)
+	isGeminiModels := isGeminiModelsPath(r.URL.Path)
+
+	var names []string
+	var err error
+	if isGeminiModels {
+		names, err = h.collectModelNames(tenantID)
+	} else {
+		names, err = h.collectModelNamesForUserAgent(tenantID, userAgent)
+	}
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 
-	if strings.HasPrefix(userAgent, "claude-cli") {
-		writeJSON(w, http.StatusOK, buildClaudeModelsResponse(names))
+	if isGeminiModels {
+		writeJSON(w, http.StatusOK, buildGeminiModelsResponse(names))
 		return
 	}
 
-	if isGeminiModelsPath(r.URL.Path) {
-		writeJSON(w, http.StatusOK, buildGeminiModelsResponse(names))
+	if strings.HasPrefix(userAgent, "claude-cli") {
+		writeJSON(w, http.StatusOK, buildClaudeModelsResponse(names))
 		return
 	}
 

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -10,7 +10,7 @@ import (
 	"github.com/awsl-project/maxx/internal/repository"
 )
 
-// ModelsHandler serves GET /v1/models with a lightweight model list.
+// ModelsHandler serves model-list endpoints with a lightweight model list.
 type ModelsHandler struct {
 	responseModelRepo repository.ResponseModelRepository
 	providerRepo      repository.ProviderRepository
@@ -30,7 +30,7 @@ func NewModelsHandler(
 	}
 }
 
-// ServeHTTP handles GET /v1/models.
+// ServeHTTP handles model-list requests.
 func (h *ModelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
@@ -50,7 +50,20 @@ func (h *ModelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if isGeminiModelsPath(r.URL.Path) {
+		writeJSON(w, http.StatusOK, buildGeminiModelsResponse(names))
+		return
+	}
+
 	writeJSON(w, http.StatusOK, buildOpenAIModelsResponse(names))
+}
+
+func isModelListAPIPath(path string) bool {
+	return path == "/v1/models" || isGeminiModelsPath(path)
+}
+
+func isGeminiModelsPath(path string) bool {
+	return path == "/v1beta/models"
 }
 
 func (h *ModelsHandler) collectModelNames(tenantID uint64) ([]string, error) {
@@ -178,5 +191,30 @@ func buildClaudeModelsResponse(names []string) map[string]interface{} {
 	return map[string]interface{}{
 		"data":     data,
 		"has_more": false,
+	}
+}
+
+func buildGeminiModelsResponse(names []string) map[string]interface{} {
+	models := make([]map[string]interface{}, 0, len(names))
+	for _, name := range names {
+		modelName := name
+		if !strings.HasPrefix(modelName, "models/") {
+			modelName = "models/" + modelName
+		}
+		baseModelID := strings.TrimPrefix(modelName, "models/")
+		models = append(models, map[string]interface{}{
+			"name":                       modelName,
+			"baseModelId":                baseModelID,
+			"version":                    "",
+			"displayName":                baseModelID,
+			"description":                "",
+			"inputTokenLimit":            0,
+			"outputTokenLimit":           0,
+			"supportedGenerationMethods": []string{"generateContent", "streamGenerateContent"},
+		})
+	}
+
+	return map[string]interface{}{
+		"models": models,
 	}
 }

--- a/internal/handler/models_test.go
+++ b/internal/handler/models_test.go
@@ -176,6 +176,26 @@ func TestModelsHandlerFormats(t *testing.T) {
 	if !containsModel(geminiResp.Models[0].SupportedGenerationMethods, "generateContent") {
 		t.Fatalf("Gemini response missing generateContent support")
 	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.0")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var geminiWithClaudeUA struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &geminiWithClaudeUA); err != nil {
+		t.Fatalf("invalid Gemini payload with Claude UA: %v", err)
+	}
+	if len(geminiWithClaudeUA.Models) != 1 || geminiWithClaudeUA.Models[0].Name != "models/gpt-1" {
+		t.Fatalf("Gemini path with Claude UA returned wrong payload: %+v", geminiWithClaudeUA.Models)
+	}
 }
 
 func TestModelsHandlerPricingSupplementByUserAgent(t *testing.T) {

--- a/internal/handler/models_test.go
+++ b/internal/handler/models_test.go
@@ -146,6 +146,36 @@ func TestModelsHandlerFormats(t *testing.T) {
 	if openaiResp["object"] != "list" {
 		t.Fatalf("openai response object = %v, want list", openaiResp["object"])
 	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var geminiResp struct {
+		Models []struct {
+			Name                       string   `json:"name"`
+			BaseModelID                string   `json:"baseModelId"`
+			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &geminiResp); err != nil {
+		t.Fatalf("invalid Gemini payload: %v", err)
+	}
+	if len(geminiResp.Models) != 1 {
+		t.Fatalf("Gemini model count = %d, want 1", len(geminiResp.Models))
+	}
+	if geminiResp.Models[0].Name != "models/gpt-1" {
+		t.Fatalf("Gemini model name = %q, want models/gpt-1", geminiResp.Models[0].Name)
+	}
+	if geminiResp.Models[0].BaseModelID != "gpt-1" {
+		t.Fatalf("Gemini baseModelId = %q, want gpt-1", geminiResp.Models[0].BaseModelID)
+	}
+	if !containsModel(geminiResp.Models[0].SupportedGenerationMethods, "generateContent") {
+		t.Fatalf("Gemini response missing generateContent support")
+	}
 }
 
 func TestModelsHandlerPricingSupplementByUserAgent(t *testing.T) {

--- a/internal/handler/project_proxy.go
+++ b/internal/handler/project_proxy.go
@@ -58,7 +58,7 @@ func (h *ProjectProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	r.URL.Path = apiPath
 
 	// Forward to the appropriate handler
-	if apiPath == "/v1/models" {
+	if isModelListAPIPath(apiPath) {
 		h.modelsHandler.ServeHTTP(w, r)
 		return
 	}
@@ -115,7 +115,7 @@ func isValidAPIPath(path string) bool {
 		return true
 	}
 	// Gemini API
-	if strings.HasPrefix(path, "/v1beta/models/") {
+	if path == "/v1beta/models" || strings.HasPrefix(path, "/v1beta/models/") {
 		return true
 	}
 	return false

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -70,7 +70,7 @@ func (h *ProviderProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if apiPath == "/v1/models" {
+	if isModelListAPIPath(apiPath) {
 		r.URL.Path = apiPath
 		h.modelsHandler.ServeHTTP(w, r)
 		return

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -77,3 +77,27 @@ func TestIsProviderProxyPath(t *testing.T) {
 		t.Fatal("did not expect regular web route to be detected")
 	}
 }
+
+func TestIsModelListAPIPath(t *testing.T) {
+	for _, path := range []string{"/v1/models", "/v1beta/models"} {
+		if !isModelListAPIPath(path) {
+			t.Fatalf("expected %q to be a model-list API path", path)
+		}
+	}
+
+	for _, path := range []string{
+		"/v1/models/list",
+		"/v1beta/models/gemini-2.5-pro:generateContent",
+		"/v1beta/models/gemini-2.5-pro:streamGenerateContent",
+	} {
+		if isModelListAPIPath(path) {
+			t.Fatalf("did not expect %q to be a model-list API path", path)
+		}
+	}
+}
+
+func TestProjectAPIPathAllowsExactGeminiModelList(t *testing.T) {
+	if !isValidAPIPath("/v1beta/models") {
+		t.Fatal("expected exact Gemini model-list path to be valid for project proxy URLs")
+	}
+}

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -1,6 +1,65 @@
 package handler
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type fakeProjectRepo struct {
+	project *domain.Project
+}
+
+func (f *fakeProjectRepo) Create(project *domain.Project) error    { return nil }
+func (f *fakeProjectRepo) Update(project *domain.Project) error    { return nil }
+func (f *fakeProjectRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (f *fakeProjectRepo) GetByID(tenantID uint64, id uint64) (*domain.Project, error) {
+	return f.project, nil
+}
+func (f *fakeProjectRepo) GetBySlug(tenantID uint64, slug string) (*domain.Project, error) {
+	return f.project, nil
+}
+func (f *fakeProjectRepo) List(tenantID uint64) ([]*domain.Project, error) {
+	if f.project == nil {
+		return nil, nil
+	}
+	return []*domain.Project{f.project}, nil
+}
+
+type fakeProviderByIDRepo struct {
+	provider *domain.Provider
+}
+
+func (f *fakeProviderByIDRepo) Create(provider *domain.Provider) error  { return nil }
+func (f *fakeProviderByIDRepo) Update(provider *domain.Provider) error  { return nil }
+func (f *fakeProviderByIDRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (f *fakeProviderByIDRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
+	return f.provider, nil
+}
+func (f *fakeProviderByIDRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	if f.provider == nil {
+		return nil, nil
+	}
+	return []*domain.Provider{f.provider}, nil
+}
+
+func assertGeminiModelsPayload(t *testing.T, body []byte) {
+	t.Helper()
+	var payload struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("invalid Gemini models payload: %v", err)
+	}
+	if len(payload.Models) != 1 || payload.Models[0].Name != "models/gpt-1" {
+		t.Fatalf("Gemini models payload = %+v, want only models/gpt-1", payload.Models)
+	}
+}
 
 func TestParseProviderPath(t *testing.T) {
 	h := &ProviderProxyHandler{}
@@ -100,4 +159,38 @@ func TestProjectAPIPathAllowsExactGeminiModelList(t *testing.T) {
 	if !isValidAPIPath("/v1beta/models") {
 		t.Fatal("expected exact Gemini model-list path to be valid for project proxy URLs")
 	}
+}
+
+func TestProjectProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
+	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
+	handler := NewProjectProxyHandler(nil, modelsHandler, &fakeProjectRepo{
+		project: &domain.Project{ID: 42, Name: "Demo", Slug: "demo"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/project/demo/v1beta/models", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.0")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	assertGeminiModelsPayload(t, rec.Body.Bytes())
+}
+
+func TestProviderProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
+	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
+	handler := NewProviderProxyHandler(nil, modelsHandler, &fakeProviderByIDRepo{
+		provider: &domain.Provider{ID: 1, Name: "Provider"},
+	}, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/provider/1/v1beta/models", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.0")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	assertGeminiModelsPayload(t, rec.Body.Bytes())
 }


### PR DESCRIPTION
## Summary
- route global `GET /v1beta/models` to the model-list handler while keeping Gemini generation subpaths on the proxy handler
- return a Gemini-compatible `models` payload for `/v1beta/models`
- make the Gemini model-list path authoritative over `User-Agent` so `claude-cli` cannot force Claude-format/model supplement responses on `/v1beta/models`
- make project/provider-prefixed model-list paths use the shared model-list handler consistently
- add regression coverage for all three model-list entrypoints: global, project URL, and provider URL

## Tests
- `go test ./internal/core ./internal/handler`
- `go test ./internal/... ./cmd/maxx ./cmd/mockserver ./tests/e2e`

Note: `go test ./...` still cannot run from this checkout before building `web/dist`; the root package fails with `pattern all:web/dist: no matching files found`.