### PR TITLE
chore: update CLIProxyAPI replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,4 +114,4 @@ require (
 	modernc.org/sqlite v1.23.1 // indirect
 )
 
-replace github.com/router-for-me/CLIProxyAPI/v6 => github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260428052458-45e50ef6d7b1
+replace github.com/router-for-me/CLIProxyAPI/v6 => github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260505045601-11bf5adba145

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260428052458-45e50ef6d7b1 h1:wKVVvfPvdMUREnSLvnqoMK9ZO3oE0aFsC4gIUw9u2ME=
-github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260428052458-45e50ef6d7b1/go.mod h1:P1jsIPFXorYGuS2N/3BlZYkpRKi/z7+oR3+1tdG0u4k=
+github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260505045601-11bf5adba145 h1:P3cbM1JoVzSkpYpGxvHEMH1rA4AT5rKsMmM04pQLdC0=
+github.com/awsl-project/CLIProxyAPI/v6 v6.0.0-20260505045601-11bf5adba145/go.mod h1:P1jsIPFXorYGuS2N/3BlZYkpRKi/z7+oR3+1tdG0u4k=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=


### PR DESCRIPTION
Automated dependency update by CLIProxyAPI Sync workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新依赖替换指向为新的伪版本以获取上游更新。仅调整了替换目标的版本标识，没有修改其他依赖声明、公共接口或代码行为。构建和本地复现将采用该新的替换指向，影响范围有限，通常无需额外操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->