### PR TITLE
fix(ui): scope multitenant UI toggle

### DIFF
--- a/tests/e2e/playwright/routes-multitenant-ui-toggle.spec.ts
+++ b/tests/e2e/playwright/routes-multitenant-ui-toggle.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type Page } from 'playwright/test';
+
+async function mockRouteApis(page: Page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+
+    if (pathname === '/api/admin/auth/status') {
+      return json({ authEnabled: false });
+    }
+
+    if (pathname === '/api/settings' || pathname === '/api/admin/settings') {
+      return json({ ui_multitenant_enabled: 'false' });
+    }
+
+    if (
+      pathname === '/api/admin/routes' ||
+      pathname === '/api/routes' ||
+      pathname === '/api/admin/projects' ||
+      pathname === '/api/projects' ||
+      pathname === '/api/admin/providers' ||
+      pathname === '/api/providers' ||
+      pathname === '/api/admin/requests/active'
+    ) {
+      return json([]);
+    }
+
+    return route.fulfill({
+      status: 404,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Unmocked endpoint', pathname }),
+    });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockRouteApis(page);
+});
+
+test('route client tabs stay visible when multi-tenant UI is disabled', async ({ page }) => {
+  await page.goto('/');
+
+  for (const clientType of ['claude', 'openai', 'codex', 'gemini']) {
+    await expect(page.locator(`a[href="/routes/${clientType}"]`)).toBeVisible({ timeout: 10000 });
+  }
+});
+
+test('route pages remain accessible when multi-tenant UI is disabled', async ({ page }) => {
+  await page.goto('/routes/claude');
+
+  await expect(page).toHaveURL(/\/routes\/claude$/);
+  await expect(page.locator('body')).toContainText(/Claude Routes|Claude 路由/i);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -87,14 +87,7 @@ function AppRoutes() {
           <Route path="providers" element={<ProvidersPage />} />
           <Route path="providers/create/*" element={<ProviderCreateLayout />} />
           <Route path="providers/:id/edit" element={<ProviderEditPage />} />
-          <Route
-            path="routes/:clientType"
-            element={
-              <MultiTenantUIRoute>
-                <ClientRoutesPage />
-              </MultiTenantUIRoute>
-            }
-          />
+          <Route path="routes/:clientType" element={<ClientRoutesPage />} />
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="projects/:id" element={<ProjectDetailPage />} />
           <Route path="sessions" element={<SessionsPage />} />

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -73,10 +73,6 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
   return (
     <>
       {config.sections.map((section) => {
-        if (!multiTenantUIEnabled && section.key === 'routes') {
-          return null;
-        }
-
         const filteredItems = section.items.filter((item) => {
           if (
             !multiTenantUIEnabled &&


### PR DESCRIPTION
## Summary
- Keep the base route client entries visible when `ui_multitenant_enabled` is disabled.
- Keep `/routes/:clientType` pages accessible outside the multi-tenant UI gate.
- Add Playwright regression coverage for disabled multi-tenant UI route visibility/accessibility.

## Validation
- `cd web && pnpm run lint && pnpm run typecheck && pnpm run build`
- `cd tests/e2e/playwright && pnpm exec playwright test -c playwright.config.ts routes-multitenant-ui-toggle.spec.ts --project=e2e-chromium`
- `go vet ./cmd/... ./internal/... && go test -count=1 -timeout 600s ./cmd/... ./internal/... && go build -o /tmp/maxx-ci-build ./cmd/maxx`
- `go test -v -count=1 -timeout 300s -race ./tests/e2e/...`

## Changed files
- `web/src/App.tsx`
- `web/src/components/layout/app-sidebar/sidebar-renderer.tsx`
- `tests/e2e/playwright/routes-multitenant-ui-toggle.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加端到端测试，验证禁用多租户UI时的路由行为

* **问题修复**
  * 修复了禁用多租户UI时客户端路由标签页保持可见的问题
  * 改进了侧边栏路由部分的可见性逻辑，现在基于实际内容而非全局设置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->