### PR TITLE
feat: add provider response model mapping and codex openai compatibility

### DIFF
--- a/internal/converter/codex_openai_stream_test.go
+++ b/internal/converter/codex_openai_stream_test.go
@@ -222,3 +222,85 @@ func TestClaudeToCodexToolShortening(t *testing.T) {
 		t.Fatalf("missing server tool type in codex tools")
 	}
 }
+
+func TestCodexToOpenAIStreamToolCallArgumentDeltas(t *testing.T) {
+	state := NewTransformState()
+	conv := &codexToOpenAIResponse{}
+
+	eventsIn := []interface{}{
+		map[string]interface{}{"type": "response.created", "response": map[string]interface{}{"id": "resp_stream_delta"}},
+		map[string]interface{}{
+			"type":         "response.output_item.added",
+			"output_index": 0,
+			"item": map[string]interface{}{
+				"id":      "fc_1",
+				"type":    "function_call",
+				"call_id": "call_1",
+				"name":    "tool_alpha",
+			},
+		},
+		map[string]interface{}{"type": "response.function_call_arguments.delta", "output_index": 0, "delta": `{"a"`},
+		map[string]interface{}{"type": "response.function_call_arguments.delta", "output_index": 0, "delta": `:1}`},
+		map[string]interface{}{
+			"type":         "response.output_item.done",
+			"output_index": 0,
+			"item": map[string]interface{}{
+				"type":      "function_call",
+				"call_id":   "call_1",
+				"name":      "tool_alpha",
+				"arguments": `{"a":1}`,
+			},
+		},
+		map[string]interface{}{"type": "response.completed", "response": map[string]interface{}{"id": "resp_stream_delta"}},
+	}
+
+	var out []byte
+	for _, ev := range eventsIn {
+		next, err := conv.TransformChunk(FormatSSE("", ev), state)
+		if err != nil {
+			t.Fatalf("transform chunk error: %v", err)
+		}
+		out = append(out, next...)
+	}
+
+	events, _ := ParseSSE(string(out))
+	var nameChunk, firstArgDelta, secondArgDelta, duplicatedDoneArgs, finishToolCalls bool
+	for _, ev := range events {
+		if ev.Event == "done" {
+			continue
+		}
+		var chunk OpenAIStreamChunk
+		if err := json.Unmarshal(ev.Data, &chunk); err != nil {
+			t.Fatalf("invalid chunk JSON: %v", err)
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		choice := chunk.Choices[0]
+		if choice.FinishReason == "tool_calls" {
+			finishToolCalls = true
+		}
+		if choice.Delta == nil || len(choice.Delta.ToolCalls) == 0 {
+			continue
+		}
+		call := choice.Delta.ToolCalls[0]
+		if call.ID == "call_1" && call.Function.Name == "tool_alpha" {
+			nameChunk = true
+		}
+		if call.Function.Arguments == `{"a"` {
+			firstArgDelta = true
+		}
+		if call.Function.Arguments == `:1}` {
+			secondArgDelta = true
+		}
+		if call.Function.Arguments == `{"a":1}` {
+			duplicatedDoneArgs = true
+		}
+	}
+	if !nameChunk || !firstArgDelta || !secondArgDelta || !finishToolCalls {
+		t.Fatalf("missing expected stream tool call chunks; name=%v first=%v second=%v finish=%v output=%s", nameChunk, firstArgDelta, secondArgDelta, finishToolCalls, string(out))
+	}
+	if duplicatedDoneArgs {
+		t.Fatalf("expected output_item.done not to duplicate completed arguments after deltas: %s", string(out))
+	}
+}

--- a/internal/converter/codex_to_openai.go
+++ b/internal/converter/codex_to_openai.go
@@ -30,10 +30,11 @@ type openaiStreamState struct {
 }
 
 type openaiToolCallState struct {
-	ID       string
-	CallID   string
-	Name     string
-	NameSent bool
+	ID            string
+	CallID        string
+	Name          string
+	NameSent      bool
+	ArgsDeltaSent bool
 }
 
 func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool) ([]byte, error) {
@@ -312,8 +313,8 @@ func (c *codexToOpenAIResponse) TransformWithState(body []byte, state *Transform
 
 	outputResult := response.Get("output")
 	if outputResult.IsArray() {
-		var contentText string
-		var reasoningText string
+		var contentParts []string
+		var reasoningParts []string
 		var toolCalls []string
 		rev := buildReverseMapFromOriginalOpenAI(nil)
 		if state != nil && len(state.OriginalRequestBody) > 0 {
@@ -326,8 +327,9 @@ func (c *codexToOpenAIResponse) TransformWithState(body []byte, state *Transform
 				if summaryResult := outputItem.Get("summary"); summaryResult.IsArray() {
 					summaryResult.ForEach(func(_, summaryItem gjson.Result) bool {
 						if summaryItem.Get("type").String() == "summary_text" {
-							reasoningText = summaryItem.Get("text").String()
-							return false
+							if text := summaryItem.Get("text").String(); text != "" {
+								reasoningParts = append(reasoningParts, text)
+							}
 						}
 						return true
 					})
@@ -335,9 +337,15 @@ func (c *codexToOpenAIResponse) TransformWithState(body []byte, state *Transform
 			case "message":
 				if contentResult := outputItem.Get("content"); contentResult.IsArray() {
 					contentResult.ForEach(func(_, contentItem gjson.Result) bool {
-						if contentItem.Get("type").String() == "output_text" {
-							contentText = contentItem.Get("text").String()
-							return false
+						switch contentItem.Get("type").String() {
+						case "output_text":
+							if text := contentItem.Get("text").String(); text != "" {
+								contentParts = append(contentParts, text)
+							}
+						case "refusal":
+							if text := contentItem.Get("refusal").String(); text != "" {
+								contentParts = append(contentParts, text)
+							}
 						}
 						return true
 					})
@@ -362,12 +370,12 @@ func (c *codexToOpenAIResponse) TransformWithState(body []byte, state *Transform
 			return true
 		})
 
-		if contentText != "" {
-			template, _ = sjson.Set(template, "choices.0.message.content", contentText)
+		if len(contentParts) > 0 {
+			template, _ = sjson.Set(template, "choices.0.message.content", strings.Join(contentParts, ""))
 			template, _ = sjson.Set(template, "choices.0.message.role", "assistant")
 		}
-		if reasoningText != "" {
-			template, _ = sjson.Set(template, "choices.0.message.reasoning_content", reasoningText)
+		if len(reasoningParts) > 0 {
+			template, _ = sjson.Set(template, "choices.0.message.reasoning_content", strings.Join(reasoningParts, ""))
 			template, _ = sjson.Set(template, "choices.0.message.role", "assistant")
 		}
 		if len(toolCalls) > 0 {
@@ -379,9 +387,21 @@ func (c *codexToOpenAIResponse) TransformWithState(body []byte, state *Transform
 		}
 	}
 
-	if statusResult := response.Get("status"); statusResult.Exists() && statusResult.String() == "completed" {
-		template, _ = sjson.Set(template, "choices.0.finish_reason", "stop")
-		template, _ = sjson.Set(template, "choices.0.native_finish_reason", "stop")
+	if statusResult := response.Get("status"); statusResult.Exists() {
+		finishReason := ""
+		switch statusResult.String() {
+		case "completed":
+			finishReason = "stop"
+			if strings.Contains(template, `"tool_calls":[`) {
+				finishReason = "tool_calls"
+			}
+		case "incomplete":
+			finishReason = codexIncompleteReasonToOpenAI(response.Get("incomplete_details.reason").String())
+		}
+		if finishReason != "" {
+			template, _ = sjson.Set(template, "choices.0.finish_reason", finishReason)
+			template, _ = sjson.Set(template, "choices.0.native_finish_reason", finishReason)
+		}
 	}
 
 	return []byte(template), nil
@@ -445,24 +465,77 @@ func (c *codexToOpenAIResponse) TransformChunk(chunk []byte, state *TransformSta
 				output = append(output, FormatSSE("", []byte(chunk))...)
 			}
 
+		case "response.output_item.added":
+			item := root.Get("item")
+			if item.Exists() && item.Get("type").String() == "function_call" {
+				index := openAIStreamToolIndex(root, st)
+				st.HasToolCall = true
+
+				id := item.Get("call_id").String()
+				if id == "" {
+					id = item.Get("id").String()
+				}
+				name := openAIStreamToolName(item.Get("name").String(), state, st)
+
+				toolState := st.ToolCalls[index]
+				if toolState == nil {
+					toolState = &openaiToolCallState{}
+					st.ToolCalls[index] = toolState
+				}
+				toolState.ID = id
+				toolState.CallID = item.Get("call_id").String()
+				toolState.Name = name
+				toolState.NameSent = true
+
+				functionCallItemTemplate := `{"index":0,"id":"","type":"function","function":{"name":"","arguments":""}}`
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", index)
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "id", id)
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.name", name)
+
+				chunk := newOpenAIStreamTemplate(state.MessageID, st)
+				chunk, _ = sjson.Set(chunk, "choices.0.delta.role", "assistant")
+				chunk, _ = sjson.SetRaw(chunk, "choices.0.delta.tool_calls", `[]`)
+				chunk, _ = sjson.SetRaw(chunk, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
+				chunk = applyOpenAIUsageFromResponse(chunk, root.Get("response.usage"))
+				output = append(output, FormatSSE("", []byte(chunk))...)
+			}
+
+		case "response.function_call_arguments.delta":
+			if delta := root.Get("delta"); delta.Exists() {
+				index := openAIStreamToolIndex(root, st)
+				st.HasToolCall = true
+				toolState := st.ToolCalls[index]
+				if toolState == nil {
+					toolState = &openaiToolCallState{}
+					st.ToolCalls[index] = toolState
+				}
+				toolState.ArgsDeltaSent = true
+
+				functionCallItemTemplate := `{"index":0,"function":{"arguments":""}}`
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", index)
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", delta.String())
+
+				chunk := newOpenAIStreamTemplate(state.MessageID, st)
+				chunk, _ = sjson.Set(chunk, "choices.0.delta.role", "assistant")
+				chunk, _ = sjson.SetRaw(chunk, "choices.0.delta.tool_calls", `[]`)
+				chunk, _ = sjson.SetRaw(chunk, "choices.0.delta.tool_calls.-1", functionCallItemTemplate)
+				chunk = applyOpenAIUsageFromResponse(chunk, root.Get("response.usage"))
+				output = append(output, FormatSSE("", []byte(chunk))...)
+			}
+
 		case "response.output_item.done":
 			item := root.Get("item")
 			if item.Exists() && item.Get("type").String() == "function_call" {
-				st.Index++
+				index := openAIStreamToolIndex(root, st)
+				if toolState := st.ToolCalls[index]; toolState != nil && toolState.ArgsDeltaSent {
+					continue
+				}
 				st.HasToolCall = true
 				functionCallItemTemplate := `{"index":0,"id":"","type":"function","function":{"name":"","arguments":""}}`
-				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", st.Index)
+				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "index", index)
 				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "id", item.Get("call_id").String())
 
-				name := item.Get("name").String()
-				rev := st.ShortToOrig
-				if rev == nil {
-					rev = buildReverseMapFromOriginalOpenAI(state.OriginalRequestBody)
-					st.ShortToOrig = rev
-				}
-				if orig, ok := rev[name]; ok {
-					name = orig
-				}
+				name := openAIStreamToolName(item.Get("name").String(), state, st)
 				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.name", name)
 				functionCallItemTemplate, _ = sjson.Set(functionCallItemTemplate, "function.arguments", item.Get("arguments").String())
 
@@ -491,6 +564,37 @@ func (c *codexToOpenAIResponse) TransformChunk(chunk []byte, state *TransformSta
 	}
 
 	return output, nil
+}
+
+func codexIncompleteReasonToOpenAI(reason string) string {
+	switch reason {
+	case "max_output_tokens", "max_tokens":
+		return "length"
+	case "content_filter":
+		return "content_filter"
+	default:
+		return "stop"
+	}
+}
+
+func openAIStreamToolIndex(root gjson.Result, st *openaiStreamState) int {
+	if index := root.Get("output_index"); index.Exists() {
+		return int(index.Int())
+	}
+	st.Index++
+	return st.Index
+}
+
+func openAIStreamToolName(name string, state *TransformState, st *openaiStreamState) string {
+	rev := st.ShortToOrig
+	if rev == nil {
+		rev = buildReverseMapFromOriginalOpenAI(state.OriginalRequestBody)
+		st.ShortToOrig = rev
+	}
+	if orig, ok := rev[name]; ok {
+		return orig
+	}
+	return name
 }
 
 func getOpenAIStreamState(state *TransformState) *openaiStreamState {

--- a/internal/converter/codex_to_openai.go
+++ b/internal/converter/codex_to_openai.go
@@ -105,10 +105,12 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 					})
 				case "function_call_output":
 					callID, _ := m["call_id"].(string)
-					outputStr, _ := m["output"].(string)
+					if callID == "" {
+						continue
+					}
 					openaiReq.Messages = append(openaiReq.Messages, OpenAIMessage{
 						Role:       "tool",
-						Content:    outputStr,
+						Content:    codexToolOutputToOpenAI(m["output"]),
 						ToolCallID: callID,
 					})
 				}
@@ -139,6 +141,18 @@ func codexContentToOpenAI(content interface{}) interface{} {
 		onlyText := true
 		sawCodexPart := false
 		for _, rawPart := range value {
+			if text, ok := rawPart.(string); ok {
+				if text == "" {
+					continue
+				}
+				textParts = append(textParts, text)
+				parts = append(parts, map[string]interface{}{
+					"type": "text",
+					"text": text,
+				})
+				continue
+			}
+
 			part, ok := rawPart.(map[string]interface{})
 			if !ok {
 				onlyText = false
@@ -156,17 +170,29 @@ func codexContentToOpenAI(content interface{}) interface{} {
 					"type": "text",
 					"text": text,
 				})
-			case "input_image":
+			case "input_image", "output_image", "image_url":
 				sawCodexPart = true
 				onlyText = false
-				imageURL := codexImageURLToOpenAI(part["image_url"])
+				imageURL := codexImageURLToOpenAI(part["image_url"], part["detail"])
 				if imageURL == nil {
-					imageURL = codexImageURLToOpenAI(part["image"])
+					imageURL = codexImageURLToOpenAI(part["image"], part["detail"])
+				}
+				if imageURL == nil {
+					imageURL = codexImageURLToOpenAI(part["url"], part["detail"])
 				}
 				if imageURL != nil {
 					parts = append(parts, map[string]interface{}{
 						"type":      "image_url",
 						"image_url": imageURL,
+					})
+				}
+			case "input_file", "file":
+				sawCodexPart = true
+				onlyText = false
+				if file := codexFileToOpenAI(part); file != nil {
+					parts = append(parts, map[string]interface{}{
+						"type": "file",
+						"file": file,
 					})
 				}
 			default:
@@ -186,19 +212,69 @@ func codexContentToOpenAI(content interface{}) interface{} {
 	return content
 }
 
-func codexImageURLToOpenAI(raw interface{}) map[string]interface{} {
+func codexToolOutputToOpenAI(output interface{}) interface{} {
+	if output == nil {
+		return ""
+	}
+	if text, ok := output.(string); ok {
+		return text
+	}
+	if _, ok := output.([]interface{}); ok {
+		switch normalized := codexContentToOpenAI(output).(type) {
+		case string:
+			return normalized
+		case []map[string]interface{}:
+			return normalized
+		}
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func codexImageURLToOpenAI(raw interface{}, detailRaw interface{}) map[string]interface{} {
+	var imageURL map[string]interface{}
 	switch image := raw.(type) {
 	case string:
 		if image == "" {
 			return nil
 		}
-		return map[string]interface{}{"url": image}
+		imageURL = map[string]interface{}{"url": image}
 	case map[string]interface{}:
 		if _, ok := image["url"].(string); ok {
-			return image
+			imageURL = image
 		}
 	}
-	return nil
+	if imageURL == nil {
+		return nil
+	}
+	if detail, ok := detailRaw.(string); ok && detail != "" {
+		if _, exists := imageURL["detail"]; !exists {
+			imageURL["detail"] = detail
+		}
+	}
+	return imageURL
+}
+
+func codexFileToOpenAI(part map[string]interface{}) map[string]interface{} {
+	file := map[string]interface{}{}
+	if fileID, ok := part["file_id"].(string); ok && fileID != "" {
+		file["file_id"] = fileID
+	} else if fileURL, ok := part["file_url"].(string); ok && fileURL != "" {
+		file["file_id"] = fileURL
+	}
+	if fileData, ok := part["file_data"].(string); ok && fileData != "" {
+		file["file_data"] = fileData
+	}
+	if filename, ok := part["filename"].(string); ok && filename != "" {
+		file["filename"] = filename
+	}
+	if len(file) == 0 {
+		return nil
+	}
+	return file
 }
 
 func (c *codexToOpenAIResponse) Transform(body []byte) ([]byte, error) {

--- a/internal/converter/codex_to_openai.go
+++ b/internal/converter/codex_to_openai.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -82,7 +83,7 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 					}
 					openaiReq.Messages = append(openaiReq.Messages, OpenAIMessage{
 						Role:    role,
-						Content: m["content"],
+						Content: codexContentToOpenAI(m["content"]),
 					})
 				case "function_call":
 					id, _ := m["id"].(string)
@@ -128,6 +129,76 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 	}
 
 	return json.Marshal(openaiReq)
+}
+
+func codexContentToOpenAI(content interface{}) interface{} {
+	switch value := content.(type) {
+	case []interface{}:
+		parts := make([]map[string]interface{}, 0, len(value))
+		var textParts []string
+		onlyText := true
+		sawCodexPart := false
+		for _, rawPart := range value {
+			part, ok := rawPart.(map[string]interface{})
+			if !ok {
+				onlyText = false
+				continue
+			}
+			switch part["type"] {
+			case "input_text", "output_text", "text":
+				sawCodexPart = true
+				text, _ := part["text"].(string)
+				if text == "" {
+					continue
+				}
+				textParts = append(textParts, text)
+				parts = append(parts, map[string]interface{}{
+					"type": "text",
+					"text": text,
+				})
+			case "input_image":
+				sawCodexPart = true
+				onlyText = false
+				imageURL := codexImageURLToOpenAI(part["image_url"])
+				if imageURL == nil {
+					imageURL = codexImageURLToOpenAI(part["image"])
+				}
+				if imageURL != nil {
+					parts = append(parts, map[string]interface{}{
+						"type":      "image_url",
+						"image_url": imageURL,
+					})
+				}
+			default:
+				onlyText = false
+			}
+		}
+		if onlyText {
+			return strings.Join(textParts, "")
+		}
+		if len(parts) > 0 {
+			return parts
+		}
+		if sawCodexPart {
+			return ""
+		}
+	}
+	return content
+}
+
+func codexImageURLToOpenAI(raw interface{}) map[string]interface{} {
+	switch image := raw.(type) {
+	case string:
+		if image == "" {
+			return nil
+		}
+		return map[string]interface{}{"url": image}
+	case map[string]interface{}:
+		if _, ok := image["url"].(string); ok {
+			return image
+		}
+	}
+	return nil
 }
 
 func (c *codexToOpenAIResponse) Transform(body []byte) ([]byte, error) {

--- a/internal/converter/coverage_openai_request_test.go
+++ b/internal/converter/coverage_openai_request_test.go
@@ -945,3 +945,62 @@ func TestCodexToOpenAIRequestInstructions(t *testing.T) {
 		t.Fatalf("expected system message from instructions")
 	}
 }
+
+func TestCodexToOpenAIRequestNormalizesResponsesContentParts(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []interface{}{
+				map[string]interface{}{"type": "input_text", "text": "look"},
+				map[string]interface{}{"type": "input_image", "image_url": "data:image/png;base64,Zm9v"},
+			},
+		},
+		map[string]interface{}{
+			"type": "message",
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "output_text", "text": "done"},
+			},
+		},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if strings.Contains(string(out), "input_text") || strings.Contains(string(out), "output_text") || strings.Contains(string(out), "input_image") {
+		t.Fatalf("Codex content part types leaked into OpenAI request: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"type":"image_url"`) {
+		t.Fatalf("expected OpenAI image_url content part: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"content":"done"`) {
+		t.Fatalf("expected assistant output_text to collapse to text content: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIRequestDoesNotLeakMalformedResponsesImagePart(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []interface{}{
+				map[string]interface{}{"type": "input_image"},
+			},
+		},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if strings.Contains(string(out), "input_image") {
+		t.Fatalf("malformed Codex image part leaked into OpenAI request: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"content":""`) {
+		t.Fatalf("expected malformed known Codex part to collapse to empty content: %s", string(out))
+	}
+}

--- a/internal/converter/coverage_openai_request_test.go
+++ b/internal/converter/coverage_openai_request_test.go
@@ -1004,3 +1004,96 @@ func TestCodexToOpenAIRequestDoesNotLeakMalformedResponsesImagePart(t *testing.T
 		t.Fatalf("expected malformed known Codex part to collapse to empty content: %s", string(out))
 	}
 }
+
+func TestCodexToOpenAIRequestNormalizesToolOutputParts(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{
+			"type":    "function_call_output",
+			"call_id": "call_1",
+			"output": []interface{}{
+				map[string]interface{}{"type": "input_text", "text": "a"},
+				map[string]interface{}{"type": "output_text", "text": "b"},
+			},
+		},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if strings.Contains(string(out), "input_text") || strings.Contains(string(out), "output_text") {
+		t.Fatalf("Responses tool output part type leaked into OpenAI request: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"content":"ab"`) {
+		t.Fatalf("expected text-only tool output parts to collapse to string: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIRequestSkipsToolOutputWithoutCallID(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{"type": "function_call_output", "output": "orphan"},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if strings.Contains(string(out), `"role":"tool"`) || strings.Contains(string(out), "orphan") {
+		t.Fatalf("expected orphan tool output to be skipped: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIRequestJSONEncodesUnknownStructuredToolOutput(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{
+			"type":    "function_call_output",
+			"call_id": "call_1",
+			"output": []interface{}{
+				map[string]interface{}{"unknown": "value"},
+			},
+		},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if !strings.Contains(string(out), `"content":"[{\"unknown\":\"value\"}]"`) {
+		t.Fatalf("expected unknown structured tool output to be JSON encoded: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIRequestNormalizesFilesImagesAndBareTextParts(t *testing.T) {
+	req := CodexRequest{Input: []interface{}{
+		map[string]interface{}{
+			"type": "message",
+			"role": "user",
+			"content": []interface{}{
+				"prefix",
+				map[string]interface{}{"type": "input_text", "text": " body"},
+				map[string]interface{}{"type": "input_image", "image_url": "https://example.com/a.png", "detail": "low"},
+				map[string]interface{}{"type": "input_file", "file_url": "https://example.com/a.pdf", "file_data": "data"},
+			},
+		},
+	}}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "gpt", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	outStr := string(out)
+	for _, leaked := range []string{"input_text", "input_image", "input_file"} {
+		if strings.Contains(outStr, leaked) {
+			t.Fatalf("Responses content part type %q leaked into OpenAI request: %s", leaked, outStr)
+		}
+	}
+	for _, expected := range []string{`"text":"prefix"`, `"text":" body"`, `"type":"image_url"`, `"detail":"low"`, `"type":"file"`, `"file_id":"https://example.com/a.pdf"`, `"file_data":"data"`} {
+		if !strings.Contains(outStr, expected) {
+			t.Fatalf("expected %s in converted request: %s", expected, outStr)
+		}
+	}
+}

--- a/internal/converter/coverage_openai_response_test.go
+++ b/internal/converter/coverage_openai_response_test.go
@@ -797,3 +797,36 @@ func TestGeminiToOpenAIRequestFunctionResponseFallback(t *testing.T) {
 		t.Fatalf("expected tool_call_id fallback to name")
 	}
 }
+
+func TestCodexToOpenAIResponseJoinsMultipleOutputTextAndRefusal(t *testing.T) {
+	body := []byte(`{"id":"resp_1","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"a"},{"type":"output_text","text":"b"},{"type":"refusal","refusal":"c"}]}]}`)
+	out, err := (&codexToOpenAIResponse{}).Transform(body)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if !strings.Contains(string(out), `"content":"abc"`) {
+		t.Fatalf("expected joined content/refusal text: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIResponseCompletedToolCallsFinishReason(t *testing.T) {
+	body := []byte(`{"id":"resp_1","status":"completed","output":[{"type":"function_call","call_id":"call_1","name":"tool","arguments":"{}"}]}`)
+	out, err := (&codexToOpenAIResponse{}).Transform(body)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if !strings.Contains(string(out), `"finish_reason":"tool_calls"`) {
+		t.Fatalf("expected tool_calls finish reason: %s", string(out))
+	}
+}
+
+func TestCodexToOpenAIResponseIncompleteFinishReason(t *testing.T) {
+	body := []byte(`{"id":"resp_1","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}]}`)
+	out, err := (&codexToOpenAIResponse{}).Transform(body)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	if !strings.Contains(string(out), `"finish_reason":"length"`) {
+		t.Fatalf("expected length finish reason: %s", string(out))
+	}
+}

--- a/internal/converter/more_converter_extra_test.go
+++ b/internal/converter/more_converter_extra_test.go
@@ -34,8 +34,8 @@ func TestCodexToOpenAIResponse_ToolCallsFinishReason(t *testing.T) {
 	if err := json.Unmarshal(out, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(got.Choices) == 0 || got.Choices[0].FinishReason != "stop" {
-		t.Fatalf("expected finish_reason stop, got %#v", got.Choices)
+	if len(got.Choices) == 0 || got.Choices[0].FinishReason != "tool_calls" {
+		t.Fatalf("expected finish_reason tool_calls, got %#v", got.Choices)
 	}
 }
 

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -176,6 +176,9 @@ type ProviderConfigClaude struct {
 
 	// Model 映射: RequestModel → MappedModel
 	ModelMapping map[string]string `json:"modelMapping,omitempty"`
+
+	// 响应 Model 映射: ResponseModelPattern → MappedModelConstant
+	ResponseModelMapping map[string]string `json:"responseModelMapping,omitempty"`
 }
 
 type ProviderConfigCodex struct {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/pricing"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -157,7 +158,14 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 
 			var responseWriter http.ResponseWriter
 			var convertingWriter *ConvertingResponseWriter
-			responseCapture := NewResponseCapture(c.Writer)
+			modifierWriter := responsemodifier.NewResponseModifierWriter(c.Writer, matchedRoute.Provider, originalClientType, state.isStream)
+			captureWriter := http.ResponseWriter(c.Writer)
+			if modifierWriter != nil {
+				captureWriter = modifierWriter
+			}
+			// Keep capture before modifier so stored response details remain upstream-visible,
+			// while only the client-facing writer receives response modifications.
+			responseCapture := NewResponseCapture(captureWriter)
 			if needsConversion {
 				convertingWriter = NewConvertingResponseWriter(
 					responseCapture, e.converter, originalClientType, currentClientType, state.isStream, state.originalRequestBody)
@@ -174,6 +182,11 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			if needsConversion && convertingWriter != nil && !state.isStream {
 				if finalizeErr := convertingWriter.Finalize(); finalizeErr != nil {
 					log.Printf("[Executor] Response conversion finalize failed: %v", finalizeErr)
+				}
+			}
+			if err == nil && modifierWriter != nil {
+				if finalizeErr := modifierWriter.Finalize(); finalizeErr != nil {
+					log.Printf("[Executor] Response modifier finalize failed: %v", finalizeErr)
 				}
 			}
 

--- a/internal/executor/response_modifier_capture_test.go
+++ b/internal/executor/response_modifier_capture_test.go
@@ -1,0 +1,54 @@
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
+)
+
+func TestResponseCaptureRecordsUnmodifiedBodyBeforeModifier(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	provider := &domain.Provider{
+		Type: "claude",
+		Config: &domain.ProviderConfig{Claude: &domain.ProviderConfigClaude{
+			ResponseModelMapping: map[string]string{"upstream-model": "client-model"},
+		}},
+	}
+	modifierWriter := responsemodifier.NewResponseModifierWriter(recorder, provider, domain.ClientTypeClaude, false)
+	if modifierWriter == nil {
+		t.Fatal("expected modifier writer")
+	}
+
+	responseCapture := NewResponseCapture(modifierWriter)
+	upstreamBody := `{"model":"upstream-model","content":[{"type":"text","text":"ok"}]}`
+
+	responseCapture.WriteHeader(http.StatusOK)
+	if _, err := responseCapture.Write([]byte(upstreamBody)); err != nil {
+		t.Fatalf("capture write failed: %v", err)
+	}
+	if got := responseCapture.Body(); got != upstreamBody {
+		t.Fatalf("capture body = %s, want %s", got, upstreamBody)
+	}
+	if got := recorder.Body.String(); got != "" {
+		t.Fatalf("client body should stay buffered before modifier finalize, got %s", got)
+	}
+
+	if err := modifierWriter.Finalize(); err != nil {
+		t.Fatalf("modifier finalize failed: %v", err)
+	}
+
+	clientBody := recorder.Body.String()
+	if !strings.Contains(clientBody, `"model":"client-model"`) {
+		t.Fatalf("client body was not modified: %s", clientBody)
+	}
+	if strings.Contains(clientBody, `"model":"upstream-model"`) {
+		t.Fatalf("client body still contains upstream model: %s", clientBody)
+	}
+	if got := responseCapture.Body(); got != upstreamBody {
+		t.Fatalf("capture body changed after modifier finalize = %s, want %s", got, upstreamBody)
+	}
+}

--- a/internal/executor/responsemodifier/claude_response_modifier.go
+++ b/internal/executor/responsemodifier/claude_response_modifier.go
@@ -116,7 +116,10 @@ func sortedMappingPatterns(mapping map[string]string) []string {
 		if leftWildcards != rightWildcards {
 			return leftWildcards < rightWildcards
 		}
-		return len(left) > len(right)
+		if len(left) != len(right) {
+			return len(left) > len(right)
+		}
+		return left < right
 	})
 	return patterns
 }

--- a/internal/executor/responsemodifier/claude_response_modifier.go
+++ b/internal/executor/responsemodifier/claude_response_modifier.go
@@ -1,0 +1,122 @@
+package responsemodifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+var claudeSSEDataLineRE = regexp.MustCompile(`(?m)^(\s*data:\s*)(.*?)(\r?\n?)$`)
+
+type claudeResponseModifier struct {
+	mapping  map[string]string
+	patterns []string
+}
+
+func newClaudeResponseModifier(provider *domain.Provider, clientType domain.ClientType) *claudeResponseModifier {
+	if clientType != domain.ClientTypeClaude || provider.Config == nil || provider.Config.Claude == nil {
+		return nil
+	}
+	mapping := provider.Config.Claude.ResponseModelMapping
+	if len(mapping) == 0 {
+		return nil
+	}
+	return &claudeResponseModifier{mapping: mapping, patterns: sortedMappingPatterns(mapping)}
+}
+
+func (m *claudeResponseModifier) modifyBody(body []byte) []byte {
+	return m.rewriteJSON(body)
+}
+
+func (m *claudeResponseModifier) modifyStreamEvent(body []byte) []byte {
+	return claudeSSEDataLineRE.ReplaceAllFunc(body, func(line []byte) []byte {
+		parts := claudeSSEDataLineRE.FindSubmatch(line)
+		if len(parts) != 4 || bytes.Equal(bytes.TrimSpace(parts[2]), []byte("[DONE]")) {
+			return line
+		}
+		payload := m.rewriteJSON(parts[2])
+		if bytes.Equal(payload, parts[2]) {
+			return line
+		}
+		out := make([]byte, 0, len(parts[1])+len(payload)+len(parts[3]))
+		out = append(out, parts[1]...)
+		out = append(out, payload...)
+		out = append(out, parts[3]...)
+		return out
+	})
+}
+
+func (m *claudeResponseModifier) rewriteJSON(body []byte) []byte {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return body
+	}
+	var object map[string]any
+	if err := json.Unmarshal(body, &object); err != nil {
+		return body
+	}
+	changed := m.rewriteModel(object, "model")
+	if message, ok := object["message"].(map[string]any); ok {
+		changed = m.rewriteModel(message, "model") || changed
+	}
+	if !changed {
+		return body
+	}
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(object); err != nil {
+		return body
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
+}
+
+func (m *claudeResponseModifier) rewriteModel(object map[string]any, key string) bool {
+	value, ok := object[key].(string)
+	if !ok {
+		return false
+	}
+	mapped := m.mapModel(value)
+	if mapped == value {
+		return false
+	}
+	object[key] = mapped
+	return true
+}
+
+func (m *claudeResponseModifier) mapModel(model string) string {
+	model = strings.TrimSpace(model)
+	patterns := m.patterns
+	if patterns == nil {
+		patterns = sortedMappingPatterns(m.mapping)
+	}
+	for _, pattern := range patterns {
+		target := strings.TrimSpace(m.mapping[pattern])
+		if target == "" || strings.Contains(target, "*") {
+			continue
+		}
+		if domain.MatchWildcard(pattern, model) {
+			return target
+		}
+	}
+	return model
+}
+
+func sortedMappingPatterns(mapping map[string]string) []string {
+	patterns := make([]string, 0, len(mapping))
+	for pattern := range mapping {
+		patterns = append(patterns, pattern)
+	}
+	sort.SliceStable(patterns, func(i, j int) bool {
+		left, right := patterns[i], patterns[j]
+		leftWildcards, rightWildcards := strings.Count(left, "*"), strings.Count(right, "*")
+		if leftWildcards != rightWildcards {
+			return leftWildcards < rightWildcards
+		}
+		return len(left) > len(right)
+	})
+	return patterns
+}

--- a/internal/executor/responsemodifier/response_modifier_writer.go
+++ b/internal/executor/responsemodifier/response_modifier_writer.go
@@ -1,0 +1,149 @@
+package responsemodifier
+
+import (
+	"bytes"
+	"net/http"
+	"strconv"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type responseModifier interface {
+	modifyBody(body []byte) []byte
+	modifyStreamEvent(event []byte) []byte
+}
+
+// ResponseModifierWriter buffers a response and applies provider-specific response modifications before sending it.
+type ResponseModifierWriter struct {
+	underlying  http.ResponseWriter
+	modifier    responseModifier
+	isStream    bool
+	statusCode  int
+	buffer      bytes.Buffer
+	headersSent bool
+}
+
+func NewResponseModifierWriter(w http.ResponseWriter, provider *domain.Provider, clientType domain.ClientType, isStream bool) *ResponseModifierWriter {
+	modifier := newResponseModifier(provider, clientType)
+	if modifier == nil {
+		return nil
+	}
+	return &ResponseModifierWriter{underlying: w, modifier: modifier, isStream: isStream, statusCode: http.StatusOK}
+}
+
+func newResponseModifier(provider *domain.Provider, clientType domain.ClientType) responseModifier {
+	if provider == nil {
+		return nil
+	}
+	switch provider.Type {
+	case "claude":
+		modifier := newClaudeResponseModifier(provider, clientType)
+		if modifier == nil {
+			return nil
+		}
+		return modifier
+	default:
+		return nil
+	}
+}
+
+func (w *ResponseModifierWriter) Header() http.Header {
+	return w.underlying.Header()
+}
+
+func (w *ResponseModifierWriter) WriteHeader(code int) {
+	w.statusCode = code
+	if w.isStream {
+		w.writeHeaderIfNeeded()
+	}
+}
+
+func (w *ResponseModifierWriter) Write(b []byte) (int, error) {
+	if !w.isStream {
+		_, err := w.buffer.Write(b)
+		return len(b), err
+	}
+	if _, err := w.buffer.Write(b); err != nil {
+		return 0, err
+	}
+	if err := w.flushCompleteStreamEvents(false); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (w *ResponseModifierWriter) Flush() {
+	if w.isStream {
+		_ = w.flushCompleteStreamEvents(false)
+	}
+	if f, ok := w.underlying.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *ResponseModifierWriter) Finalize() error {
+	if w.isStream {
+		return w.flushCompleteStreamEvents(true)
+	}
+	body := w.modifier.modifyBody(w.buffer.Bytes())
+	if w.underlying.Header().Get("Content-Length") != "" {
+		w.underlying.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	}
+	w.writeHeaderIfNeeded()
+	_, err := w.underlying.Write(body)
+	return err
+}
+
+func (w *ResponseModifierWriter) flushCompleteStreamEvents(final bool) error {
+	for {
+		eventLen := completeSSEEventLen(w.buffer.Bytes())
+		if eventLen == 0 {
+			break
+		}
+		if err := w.writeStreamEvent(w.buffer.Next(eventLen)); err != nil {
+			return err
+		}
+	}
+	if final && w.buffer.Len() > 0 {
+		if err := w.writeStreamEvent(w.buffer.Next(w.buffer.Len())); err != nil {
+			return err
+		}
+	}
+	if final {
+		w.writeHeaderIfNeeded()
+	}
+	return nil
+}
+
+func (w *ResponseModifierWriter) writeStreamEvent(event []byte) error {
+	body := w.modifier.modifyStreamEvent(event)
+	w.writeHeaderIfNeeded()
+	_, err := w.underlying.Write(body)
+	if err != nil {
+		return err
+	}
+	if f, ok := w.underlying.(http.Flusher); ok {
+		f.Flush()
+	}
+	return nil
+}
+
+func (w *ResponseModifierWriter) writeHeaderIfNeeded() {
+	if w.headersSent {
+		return
+	}
+	w.underlying.WriteHeader(w.statusCode)
+	w.headersSent = true
+}
+
+func completeSSEEventLen(data []byte) int {
+	lf := bytes.Index(data, []byte("\n\n"))
+	crlf := bytes.Index(data, []byte("\r\n\r\n"))
+	if lf == -1 && crlf == -1 {
+		return 0
+	}
+	if lf == -1 || (crlf != -1 && crlf < lf) {
+		return crlf + len("\r\n\r\n")
+	}
+	return lf + len("\n\n")
+}

--- a/internal/executor/responsemodifier/response_modifier_writer_test.go
+++ b/internal/executor/responsemodifier/response_modifier_writer_test.go
@@ -29,6 +29,20 @@ func TestMapModel(t *testing.T) {
 	}
 }
 
+func TestSortedMappingPatternsUsesDeterministicTieBreaker(t *testing.T) {
+	mapping := map[string]string{
+		"claude-3-*": "older",
+		"claude-4-*": "newer",
+		"claude-*":   "fallback",
+		"*":          "global",
+	}
+	got := sortedMappingPatterns(mapping)
+	want := []string{"claude-3-*", "claude-4-*", "claude-*", "*"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("sortedMappingPatterns() = %v, want %v", got, want)
+	}
+}
+
 func TestResponseModifierWriterModifiesNonStreamingClaudeResponse(t *testing.T) {
 	rr := httptest.NewRecorder()
 	writer := NewResponseModifierWriter(rr, claudeProvider(map[string]string{"upstream": "alias", "nested": "nested-alias"}), domain.ClientTypeClaude, false)

--- a/internal/executor/responsemodifier/response_modifier_writer_test.go
+++ b/internal/executor/responsemodifier/response_modifier_writer_test.go
@@ -1,0 +1,111 @@
+package responsemodifier
+
+import (
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func claudeProvider(mapping map[string]string) *domain.Provider {
+	return &domain.Provider{Type: "claude", Config: &domain.ProviderConfig{Claude: &domain.ProviderConfigClaude{ResponseModelMapping: mapping}}}
+}
+
+func TestMapModel(t *testing.T) {
+	mapping := map[string]string{"*": "fallback", "claude-*": "claude-alias", "bad": "client-*", "empty": " "}
+	cases := map[string]string{
+		"claude-sonnet-4": "claude-alias",
+		"gpt-5":           "fallback",
+		"bad":             "fallback",
+		"empty":           "fallback",
+	}
+	modifier := &claudeResponseModifier{mapping: mapping}
+	for model, want := range cases {
+		if got := modifier.mapModel(model); got != want {
+			t.Fatalf("mapModel(%q) = %q, want %q", model, got, want)
+		}
+	}
+}
+
+func TestResponseModifierWriterModifiesNonStreamingClaudeResponse(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writer := NewResponseModifierWriter(rr, claudeProvider(map[string]string{"upstream": "alias", "nested": "nested-alias"}), domain.ClientTypeClaude, false)
+	if writer == nil {
+		t.Fatal("expected writer")
+	}
+	writer.Header().Set("Content-Length", "20")
+	writer.WriteHeader(200)
+	_, _ = writer.Write([]byte(`{"model":"upstream","message":{"model":"nested"},"text":"<b>hi</b>"}`))
+	if err := writer.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	got := rr.Body.String()
+	for _, want := range []string{`"model":"alias"`, `"message":{"model":"nested-alias"}`, `<b>hi</b>`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %s in %s", want, got)
+		}
+	}
+	if rr.Header().Get("Content-Length") != strconv.Itoa(len(got)) {
+		t.Fatalf("unexpected Content-Length: %s", rr.Header().Get("Content-Length"))
+	}
+}
+
+func TestResponseModifierWriterModifiesStreamingClaudeResponse(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writer := NewResponseModifierWriter(rr, claudeProvider(map[string]string{"upstream": "alias", "nested": "nested-alias"}), domain.ClientTypeClaude, true)
+	if writer == nil {
+		t.Fatal("expected writer")
+	}
+	_, _ = writer.Write([]byte("event: message\ndata: {\"model\":"))
+	if got := rr.Body.String(); got != "" {
+		t.Fatalf("expected incomplete SSE event to stay buffered, got %s", got)
+	}
+	_, _ = writer.Write([]byte("\"upstream\"}\n\n"))
+	if got := rr.Body.String(); !strings.Contains(got, `data: {"model":"alias"}`) {
+		t.Fatalf("expected first complete SSE event to flush immediately, got %s", got)
+	}
+	if !rr.Flushed {
+		t.Fatal("expected complete SSE event to flush before finalize")
+	}
+	_, _ = writer.Write([]byte("data: {\"message\":{\"model\":\"nested\"}}\n\ndata: [DONE]\n"))
+	if err := writer.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	got := rr.Body.String()
+	for _, want := range []string{`data: {"model":"alias"}`, `data: {"message":{"model":"nested-alias"}}`, "data: [DONE]"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %s in %s", want, got)
+		}
+	}
+}
+
+func TestResponseModifierWriterLeavesMalformedStreamEventUnchanged(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writer := NewResponseModifierWriter(rr, claudeProvider(map[string]string{"upstream": "alias"}), domain.ClientTypeClaude, true)
+	if writer == nil {
+		t.Fatal("expected writer")
+	}
+	event := "data: {\"model\":\"upstream\"\n\n"
+	_, _ = writer.Write([]byte(event))
+	if err := writer.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	if got := rr.Body.String(); got != event {
+		t.Fatalf("expected malformed SSE event to pass through unchanged, got %s", got)
+	}
+}
+
+func TestResponseModifierWriterDisabled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	if NewResponseModifierWriter(rr, &domain.Provider{Type: "codex"}, domain.ClientTypeCodex, false) != nil {
+		t.Fatal("expected non-claude provider to be disabled")
+	}
+	if NewResponseModifierWriter(rr, claudeProvider(nil), domain.ClientTypeClaude, false) != nil {
+		t.Fatal("expected empty mapping to be disabled")
+	}
+	if NewResponseModifierWriter(rr, claudeProvider(map[string]string{"a": "b"}), domain.ClientTypeCodex, false) != nil {
+		t.Fatal("expected non-claude client shape to be disabled")
+	}
+}

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -511,6 +511,178 @@ type conversionTestCase struct {
 	respAssert func(t *testing.T, respBody []byte)
 }
 
+func startStrictOpenAICompatibleProxyServer(t *testing.T, captured *capturedRequest) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Set(r)
+		if r.Method != http.MethodPost || r.URL.Path != "/compatible/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer ***" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "missing provider auth"}})
+			return
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(captured.Body, &body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": err.Error()}})
+			return
+		}
+		messages, ok := body["messages"].([]any)
+		if !ok || len(messages) < 2 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "messages missing"}})
+			return
+		}
+		if leaked := findCodexContentPartType(body); leaked != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "invalid OpenAI chat content part: " + leaked}})
+			return
+		}
+		if !gjson.GetBytes(captured.Body, "messages.0.content.1.image_url.url").Exists() {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "image_url part missing"}})
+			return
+		}
+		if got := gjson.GetBytes(captured.Body, "messages.1.content").String(); got != "previous answer" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"message": "assistant output_text was not normalized"}})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-openai-compatible",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   body["model"],
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "strict OpenAI-compatible provider ok",
+				},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{
+				"prompt_tokens":     10,
+				"completion_tokens": 4,
+				"total_tokens":      14,
+			},
+		})
+	}))
+}
+
+func findCodexContentPartType(value any) string {
+	switch v := value.(type) {
+	case map[string]any:
+		if typ, _ := v["type"].(string); typ == "input_text" || typ == "output_text" || typ == "input_image" {
+			return typ
+		}
+		for _, child := range v {
+			if leaked := findCodexContentPartType(child); leaked != "" {
+				return leaked
+			}
+		}
+	case []any:
+		for _, child := range v {
+			if leaked := findCodexContentPartType(child); leaked != "" {
+				return leaked
+			}
+		}
+	}
+	return ""
+}
+
+func TestProxyCodexRouteToLegacyOpenAICompatibleProviderConfig(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := startStrictOpenAICompatibleProxyServer(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	legacyProviderConfig := map[string]any{
+		"name": "Legacy OpenAI Compatible Provider",
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "http://unused.invalid/base",
+				"apiKey":  "***",
+				"clientBaseURL": map[string]any{
+					"openai": mock.URL + "/compatible",
+				},
+			},
+		},
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        []string{"*"},
+	}
+	providerResp := env.AdminPost("/api/admin/providers", legacyProviderConfig)
+	AssertStatus(t, providerResp, http.StatusCreated)
+	var provider map[string]any
+	DecodeJSON(t, providerResp, &provider)
+	providerID := uint64(provider["id"].(float64))
+	createRoute(t, env, "codex", providerID)
+
+	resp := env.ProxyPost("/responses?source=codex-cli", map[string]any{
+		"model": "gpt-5-codex",
+		"input": []map[string]any{{
+			"type": "message",
+			"role": "user",
+			"content": []map[string]any{{
+				"type": "input_text",
+				"text": "describe this",
+			}, {
+				"type":      "input_image",
+				"image_url": "data:image/png;base64,Zm9v",
+			}},
+		}, {
+			"type": "message",
+			"role": "assistant",
+			"content": []map[string]any{{
+				"type": "output_text",
+				"text": "previous answer",
+			}},
+		}},
+		"max_output_tokens": 128,
+	}, map[string]string{
+		"User-Agent":    "codex_cli_rs/0.50.0 (Mac OS 26.0.1; arm64)",
+		"Authorization": "Bearer client-token-must-not-leak",
+	})
+	defer resp.Body.Close()
+	AssertStatus(t, resp, http.StatusOK)
+
+	_, path, headers, upstreamBody := captured.Get()
+	if path != "/compatible/v1/chat/completions" {
+		t.Fatalf("upstream path = %s, want /compatible/v1/chat/completions", path)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer ***" {
+		t.Fatalf("Authorization = %q, want provider credential", got)
+	}
+	if strings.Contains(string(upstreamBody), "client-token-must-not-leak") {
+		t.Fatalf("client auth leaked to upstream body/headers")
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.0.content.0.type").String(); got != "text" {
+		t.Fatalf("first OpenAI content part type = %q, want text; body=%s", got, string(upstreamBody))
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.0.content.1.type").String(); got != "image_url" {
+		t.Fatalf("second OpenAI content part type = %q, want image_url; body=%s", got, string(upstreamBody))
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.1.content").String(); got != "previous answer" {
+		t.Fatalf("assistant content = %q, want previous answer; body=%s", got, string(upstreamBody))
+	}
+
+	respBody := ReadBody(t, resp)
+	if got := gjson.Get(respBody, "object").String(); got != "response" {
+		t.Fatalf("response object = %q, want response; body=%s", got, respBody)
+	}
+	if got := gjson.Get(respBody, "output.0.content.0.text").String(); got != "strict OpenAI-compatible provider ok" {
+		t.Fatalf("converted response text = %q; body=%s", got, respBody)
+	}
+}
+
 func TestProxyCrossProtocolConversions(t *testing.T) {
 	tests := []conversionTestCase{
 		// === Claude ↔ OpenAI ===

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -89,6 +89,7 @@ export interface ProviderConfigClaude {
   expiresAt?: string; // RFC3339 format
   organizationId?: string;
   modelMapping?: Record<string, string>;
+  responseModelMapping?: Record<string, string>;
 }
 
 export interface ProviderConfigBedrock {

--- a/web/src/pages/providers/components/claude-provider-view.tsx
+++ b/web/src/pages/providers/components/claude-provider-view.tsx
@@ -215,6 +215,161 @@ function ProviderModelMappings({ provider }: { provider: Provider }) {
   );
 }
 
+function ResponseModelMappings({ provider }: { provider: Provider }) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+  const enabled = provider.type === 'claude';
+  const config = enabled ? provider.config?.claude : undefined;
+  const [newPattern, setNewPattern] = useState('');
+  const [newTarget, setNewTarget] = useState('');
+
+  const mappings = useMemo(
+    () => Object.entries(config?.responseModelMapping || {}),
+    [config?.responseModelMapping],
+  );
+  const isValidTarget = (target: string) => !target.trim().includes('*');
+
+  const saveMappings = async (next: Record<string, string>) => {
+    if (!config) return;
+    await updateProvider.mutateAsync({
+      id: provider.id,
+      data: {
+        ...provider,
+        config: {
+          ...provider.config,
+          claude: {
+            ...config,
+            responseModelMapping: Object.keys(next).length > 0 ? next : undefined,
+          },
+        },
+      },
+    });
+  };
+
+  const handleAddMapping = async () => {
+    const pattern = newPattern.trim();
+    const target = newTarget.trim();
+    if (!pattern || !target || !isValidTarget(target)) return;
+    const next = { ...(config?.responseModelMapping || {}), [pattern]: target };
+    await saveMappings(next);
+    setNewPattern('');
+    setNewTarget('');
+  };
+
+  const handleUpdateMapping = async (oldPattern: string, pattern: string, target: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of mappings) {
+      if (key === oldPattern) continue;
+      next[key] = value;
+    }
+    const nextPattern = pattern.trim();
+    const nextTarget = target.trim();
+    if (nextTarget && !isValidTarget(nextTarget)) return;
+    if (nextPattern && nextTarget) {
+      next[nextPattern] = nextTarget;
+    }
+    await saveMappings(next);
+  };
+
+  const handleDeleteMapping = async (pattern: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of mappings) {
+      if (key === pattern) continue;
+      next[key] = value;
+    }
+    await saveMappings(next);
+  };
+
+  if (!enabled) return null;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4 border-b border-border pb-2">
+        <Zap size={18} className="text-yellow-500" />
+        <h4 className="text-lg font-semibold text-foreground">Response Model Mapping</h4>
+        <span className="text-sm text-muted-foreground">({mappings.length})</span>
+      </div>
+
+      <div className="bg-card border border-border rounded-xl p-4">
+        <p className="text-xs text-muted-foreground mb-4">
+          Enabled for Claude providers in this rollout. ResponseModel pattern → constant MappedModel, applied only to final API responses.
+        </p>
+
+        {mappings.length > 0 && (
+          <div className="space-y-2 mb-4">
+            {mappings.map(([pattern, target], index) => (
+              <div key={pattern} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
+                <ModelInput
+                  value={pattern}
+                  onChange={(value) => handleUpdateMapping(pattern, value, target)}
+                  placeholder="ResponseModel pattern"
+                  disabled={updateProvider.isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                <ModelInput
+                  value={target}
+                  onChange={(value) => handleUpdateMapping(pattern, pattern, value)}
+                  placeholder="Mapped model"
+                  disabled={updateProvider.isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleDeleteMapping(pattern)}
+                  disabled={updateProvider.isPending}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {mappings.length === 0 && (
+          <div className="text-center py-6 mb-4">
+            <p className="text-muted-foreground text-sm">No response model mappings configured.</p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-4 border-t border-border">
+          <ModelInput
+            value={newPattern}
+            onChange={setNewPattern}
+            placeholder="ResponseModel pattern"
+            disabled={updateProvider.isPending}
+            className="flex-1 min-w-0 h-8 text-sm"
+          />
+          <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          <ModelInput
+            value={newTarget}
+            onChange={setNewTarget}
+            placeholder="Mapped model"
+            disabled={updateProvider.isPending}
+            className="flex-1 min-w-0 h-8 text-sm"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAddMapping}
+            disabled={
+              !newPattern.trim() ||
+              !newTarget.trim() ||
+              !isValidTarget(newTarget) ||
+              updateProvider.isPending
+            }
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            {t('common.add')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProviderViewProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -440,6 +595,8 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
 
           {/* Provider Model Mappings */}
           <ProviderModelMappings provider={provider} />
+
+          <ResponseModelMappings provider={provider} />
 
           {/* Supported Clients */}
           <div>


### PR DESCRIPTION
# Summary
- Add Claude-provider `responseModelMapping` alongside existing Claude `modelMapping`.
- Implement response model mapping as one generic writer/dispatcher plus provider-specific mapping files.
- Fix Codex `/responses` routing into OpenAI-compatible custom providers by normalizing Codex Responses request/response parts into OpenAI Chat-compatible shapes.
- Make response-model mapping pattern ordering deterministic when patterns have equal wildcard count and length.

# Changes
- Enable `responseModelMapping` only for Claude providers and Claude client responses.
- Keep generic writer/dispatch in `internal/executor/responsemodelmapping/response_model_mapping.go`.
- Keep Claude-specific rewrite logic in `internal/executor/responsemodifier/claude_response_modifier.go`.
- Rewrite non-streaming responses at finalize time and update `Content-Length` when present.
- Rewrite streaming SSE responses per complete SSE event and flush immediately to preserve streaming TTFT.
- Skip flushing buffered mapped responses on failed provider attempts to avoid polluted error responses.
- Interpret Claude response mapping keys as wildcard-capable source model patterns and values as constant mapped model names.
- Sort response-model mapping patterns by fewer wildcards, longer pattern, then lexicographic tiebreaker for stable priority across process restarts.
- Rewrite Claude top-level `model` and Claude stream `message.model` in final API responses.
- Keep persisted upstream records and captured response bodies on the upstream-original model details.
- Expose response model mapping controls on the Claude provider page.
- Convert Codex `input_text` / `output_text` / `input_image` / `output_image` / `input_file` message content into OpenAI-compatible `text` / `image_url` / `file` content when a Codex route targets an OpenAI custom provider.
- Preserve image `detail`, normalize tool output content parts, JSON-encode unknown structured tool outputs, and skip orphan tool outputs without `call_id`.
- Improve Codex Responses→OpenAI Chat response conversion for multiple `output_text` blocks, refusal text, incomplete finish reasons, tool-call finish reasons, and streaming function-call argument deltas.
- Add a strict E2E covering a legacy custom provider config shape with `supportedClientTypes: ["openai"]` and `custom.clientBaseURL.openai`, including path, auth override, request body, and response conversion checks.

# Tests
- `go test ./internal/converter -run 'TestCodexToOpenAIRequest(NormalizesResponsesContentParts|DoesNotLeakMalformedResponsesImagePart|NormalizesToolOutputParts|SkipsToolOutputWithoutCallID|JSONEncodesUnknownStructuredToolOutput|NormalizesFilesImagesAndBareTextParts)' -count=1` — pass
- `go test ./internal/converter -run 'TestCodexToOpenAI(ResponseJoinsMultipleOutputTextAndRefusal|ResponseCompletedToolCallsFinishReason|ResponseIncompleteFinishReason|StreamToolCallArgumentDeltas|StreamToolCalls)$' -count=1` — pass
- `go test ./tests/e2e -run 'TestProxyCodexRouteToLegacyOpenAICompatibleProviderConfig' -count=1` — pass
- `go test ./internal/executor/responsemodifier -count=1` — pass
- `go test ./internal/converter ./internal/executor ./internal/adapter/provider/custom ./tests/e2e -count=1` — pass
- `go test ./... -count=1` — pass
- `pnpm --dir web typecheck` — pass before the latest Go-only converter hardening
- `pnpm --dir web lint` — pass before the latest Go-only converter hardening
- `git diff --check` — pass

# Research notes
- Compared with public Responses/OpenAI/Claude conversion implementations in `cc-switch`, `claude-code-router`, `LiteLLM`, and the additional GitHub samples collected during review.
- The PR now covers the concrete low-risk gaps found in that comparison: request content part normalization, tool output normalization, multiple output text/refusal handling, incomplete/tool-call finish reasons, and streaming tool-call argument deltas.

# Risks
- Low: providers without enabled `responseModelMapping` keep the existing response path.
- Medium: response model mapping support is currently limited to Claude top-level `model` and Claude stream `message.model`.
- Low/Medium: Codex→OpenAI normalization intentionally maps known Responses content parts to OpenAI Chat equivalents, JSON-encodes unknown structured tool outputs, skips orphan tool outputs without `call_id`, and collapses malformed known Codex parts instead of leaking unsupported part types upstream.
