### PR TITLE
fix(bedrock): strip temperature/top_p/top_k when thinking is on

### DIFF
--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -255,6 +255,7 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// not handleStreamResponse.
 	var resp *http.Response
 	thinkingRetried := false
+	samplingRetried := false
 	for {
 		var attemptErr error
 		resp, attemptErr = a.sendBedrockRequest(ctx, c, upstreamURL, requestBody, region, clientWantsStream)
@@ -281,6 +282,20 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 				// schema, which is out of scope for this change.
 				requestBody = stripped
 				thinkingRetried = true
+				continue
+			}
+		}
+
+		// Bedrock sometimes rejects temperature/top_p/top_k for models that
+		// are (always-on) thinking-mode beyond the static list in
+		// thinking_policy.go. Strip and retry once so we don't need to know
+		// every adaptive-only SKU up front. Same single-attempt-slot caveat
+		// as the thinking-envelope retry above.
+		if !samplingRetried && resp.StatusCode == 400 && IsSamplingParamRejectedError(body) {
+			stripped := StripSamplingParams(requestBody)
+			if !bytes.Equal(stripped, requestBody) {
+				requestBody = stripped
+				samplingRetried = true
 				continue
 			}
 		}

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -234,16 +234,19 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// on the resolved Bedrock ID's short name, so classic-shape clients
 	// (e.g. Claude Code CLI) can still hit adaptive-only models.
 	if short, _, ok := extractNameAndDate(bedrockModelID); ok {
-		requestBody = adaptThinkingForModel(requestBody, short)
+		requestBody = AdaptThinkingForModel(requestBody, short)
 	}
 
 	// Build upstream URL
 	upstreamURL := buildBedrockURL(region, bedrockModelID, clientWantsStream)
 
-	// Up to two attempts: a Bedrock 400 that rejects a thinking-block
+	// Up to three attempts: two independent retry paths each fire at
+	// most once. (1) a Bedrock 400 that rejects a thinking-block
 	// envelope (signature on `thinking`, opaque `data` on
 	// `redacted_thinking`) is recoverable by stripping those blocks
-	// and replaying once. Cross-deployment replays produced by
+	// and replaying once. (2) a 400 rejecting temperature/top_p/top_k
+	// (extended-thinking mode) is recoverable by stripping those
+	// fields and replaying once. Cross-deployment replays produced by
 	// clients that captured a transcript against Anthropic and now
 	// hit Bedrock are the common cause; retry preserves the rest of
 	// the conversation rather than failing the whole request.

--- a/internal/adapter/provider/bedrock/discovery.go
+++ b/internal/adapter/provider/bedrock/discovery.go
@@ -597,6 +597,22 @@ func extractShortName(profileID string) (string, bool) {
 	return short, ok
 }
 
+// ShortNameForModel returns the Anthropic short name for a model identifier.
+// If the input is a Bedrock ID / inference profile (e.g.
+// "us.anthropic.claude-opus-4-7-20260115-v1:0") it returns the embedded
+// short name ("claude-opus-4-7"); otherwise the input is returned unchanged.
+//
+// Exposed so the custom adapter's bedrock disguise path — which is fed a
+// caller-supplied `model` field that may already be a Bedrock-qualified ID
+// after model mapping — can normalize before calling AdaptThinkingForModel,
+// which keys on the short name.
+func ShortNameForModel(model string) string {
+	if short, _, ok := extractNameAndDate(model); ok {
+		return short
+	}
+	return model
+}
+
 // newerProfile returns true when a should replace b for the same indexed
 // key. Dates are compared numerically via the YYYYMMDD capture; same-date
 // collisions fall back to the higher version suffix ("v2:0" > "v1:0"),

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -158,12 +158,18 @@ func StripSamplingParams(body []byte) []byte {
 
 // samplingParamRejectedPattern matches Bedrock 400 validation messages that
 // reject `temperature` / `top_p` / `top_k` because the target model is in
-// (possibly always-on) extended-thinking mode. The exact wording has
-// shifted across Bedrock releases, so the pattern is deliberately loose:
-// the offending field name appears in backticks alongside a mention of
-// thinking. Backticks are required to avoid matching unrelated 400s whose
-// prose happens to include the word "temperature".
-var samplingParamRejectedPattern = regexp.MustCompile("`(?:temperature|top_p|top_k)`[^`]*thinking|thinking[^`]*`(?:temperature|top_p|top_k)`")
+// (possibly always-on) extended-thinking mode. The exact wording shifts
+// across Bedrock releases — the Anthropic-style format wraps the field
+// in backticks (e.g. "`temperature` may only be set to 1 when thinking
+// is enabled") while the Bedrock-native format drops them (e.g.
+// "temperature may only be set to 1 when thinking is enabled"). The
+// pattern matches both by using word boundaries on the field name and
+// requiring the literal word "thinking" within 200 chars on the same
+// line. Co-occurrence of a sampling-field name and the word "thinking"
+// in a single 400 message is a strong enough signal to retry with the
+// fields stripped; an unrelated 400 that happens to mention "thinking"
+// without naming one of these three fields will not match.
+var samplingParamRejectedPattern = regexp.MustCompile(`\b(?:temperature|top_p|top_k)\b[^\n]{0,200}\bthinking\b|\bthinking\b[^\n]{0,200}\b(?:temperature|top_p|top_k)\b`)
 
 // IsSamplingParamRejectedError reports whether the upstream error body is
 // a Bedrock rejection of temperature / top_p / top_k that can be recovered

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -158,18 +158,29 @@ func StripSamplingParams(body []byte) []byte {
 
 // samplingParamRejectedPattern matches Bedrock 400 validation messages that
 // reject `temperature` / `top_p` / `top_k` because the target model is in
-// (possibly always-on) extended-thinking mode. The exact wording shifts
-// across Bedrock releases — the Anthropic-style format wraps the field
-// in backticks (e.g. "`temperature` may only be set to 1 when thinking
-// is enabled") while the Bedrock-native format drops them (e.g.
-// "temperature may only be set to 1 when thinking is enabled"). The
-// pattern matches both by using word boundaries on the field name and
-// requiring the literal word "thinking" within 200 chars on the same
-// line. Co-occurrence of a sampling-field name and the word "thinking"
-// in a single 400 message is a strong enough signal to retry with the
-// fields stripped; an unrelated 400 that happens to mention "thinking"
-// without naming one of these three fields will not match.
-var samplingParamRejectedPattern = regexp.MustCompile(`\b(?:temperature|top_p|top_k)\b[^\n]{0,200}\bthinking\b|\bthinking\b[^\n]{0,200}\b(?:temperature|top_p|top_k)\b`)
+// (possibly always-on) extended-thinking mode. Wording shifts across
+// releases — the Anthropic-style format wraps the field in backticks
+// ("`temperature` may only be set to 1 when thinking is enabled") while
+// the Bedrock-native format drops them — and the field may appear before
+// or after the thinking clause.
+//
+// The pattern requires both (a) one of the rejected field names and
+// (b) a phrase that anchors "thinking" to its rejection role: either a
+// preposition + "thinking" (e.g. "when thinking", "with extended
+// thinking") or "thinking is enabled/active/on" / "thinking mode".
+// Bare co-occurrence is intentionally NOT enough — a message like
+// "temperature must be between 0 and 1; thinking budget exceeds
+// max_tokens" mentions both but is not a thinking-mode rejection;
+// "thinking" there is a noun modifier of "budget", not the verb
+// describing the model state, so it must not trigger a body-mutating
+// retry.
+var samplingParamRejectedPattern = regexp.MustCompile(
+	`\b(?:temperature|top_p|top_k)\b[^\n]{0,200}` +
+		`(?:\b(?:when|with|during|while|in)\s+(?:extended\s+|adaptive\s+)?thinking\b|\bthinking\s+(?:is\s+(?:enabled|active|on)|mode)\b)` +
+		`|` +
+		`(?:\b(?:when|with|during|while|in)\s+(?:extended\s+|adaptive\s+)?thinking\b|\bthinking\s+(?:is\s+(?:enabled|active|on)|mode)\b)` +
+		`[^\n]{0,200}\b(?:temperature|top_p|top_k)\b`,
+)
 
 // IsSamplingParamRejectedError reports whether the upstream error body is
 // a Bedrock rejection of temperature / top_p / top_k that can be recovered

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -68,6 +69,18 @@ func SanitizeForBedrockCompat(body []byte) []byte {
 
 	body = EnsureMaxTokensAboveThinkingBudget(body)
 
+	// Anthropic rule (enforced by Bedrock): when extended thinking is on,
+	// `temperature` must be 1 and `top_p` / `top_k` are not allowed. Rather
+	// than try to clamp temperature, strip all three — the model picks
+	// sensible defaults and the caller's intent of "no sampling override"
+	// is preserved. The model-specific always-on adaptive case (Opus 4.7
+	// without an explicit thinking block) is handled later by
+	// adaptThinkingForModel, which calls StripSamplingParams again.
+	switch gjson.GetBytes(body, "thinking.type").String() {
+	case "enabled", "adaptive":
+		body = StripSamplingParams(body)
+	}
+
 	// cache_control is SUPPORTED by Bedrock, but the "scope" sub-field is NOT.
 	// Claude Code CLI sends cache_control like {"type":"ephemeral","scope":"turn"}
 	// Bedrock only accepts {"type":"ephemeral"}, so strip just the scope field.
@@ -124,6 +137,39 @@ func EnsureMaxTokensAboveThinkingBudget(body []byte) []byte {
 		body, _ = sjson.SetBytes(body, "max_tokens", newMax)
 	}
 	return body
+}
+
+// samplingParamFields lists the sampling-control fields that Anthropic's
+// extended-thinking mode rejects. Kept as a package-level slice so the
+// error-driven retry path can iterate the same set without drift.
+var samplingParamFields = []string{"temperature", "top_p", "top_k"}
+
+// StripSamplingParams removes `temperature`, `top_p`, and `top_k` from the
+// request body. Exported for reuse by adaptThinkingForModel (model-specific
+// always-on adaptive) and the adapter's error-driven retry path.
+func StripSamplingParams(body []byte) []byte {
+	for _, field := range samplingParamFields {
+		if gjson.GetBytes(body, field).Exists() {
+			body, _ = sjson.DeleteBytes(body, field)
+		}
+	}
+	return body
+}
+
+// samplingParamRejectedPattern matches Bedrock 400 validation messages that
+// reject `temperature` / `top_p` / `top_k` because the target model is in
+// (possibly always-on) extended-thinking mode. The exact wording has
+// shifted across Bedrock releases, so the pattern is deliberately loose:
+// the offending field name appears in backticks alongside a mention of
+// thinking. Backticks are required to avoid matching unrelated 400s whose
+// prose happens to include the word "temperature".
+var samplingParamRejectedPattern = regexp.MustCompile("`(?:temperature|top_p|top_k)`[^`]*thinking|thinking[^`]*`(?:temperature|top_p|top_k)`")
+
+// IsSamplingParamRejectedError reports whether the upstream error body is
+// a Bedrock rejection of temperature / top_p / top_k that can be recovered
+// from by stripping those fields and replaying once.
+func IsSamplingParamRejectedError(body []byte) bool {
+	return samplingParamRejectedPattern.Match(body)
 }
 
 // RemoveOrphanedToolResults removes tool_result blocks from user messages

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -75,7 +75,7 @@ func SanitizeForBedrockCompat(body []byte) []byte {
 	// sensible defaults and the caller's intent of "no sampling override"
 	// is preserved. The model-specific always-on adaptive case (Opus 4.7
 	// without an explicit thinking block) is handled later by
-	// adaptThinkingForModel, which calls StripSamplingParams again.
+	// AdaptThinkingForModel, which calls StripSamplingParams again.
 	switch gjson.GetBytes(body, "thinking.type").String() {
 	case "enabled", "adaptive":
 		body = StripSamplingParams(body)
@@ -145,7 +145,7 @@ func EnsureMaxTokensAboveThinkingBudget(body []byte) []byte {
 var samplingParamFields = []string{"temperature", "top_p", "top_k"}
 
 // StripSamplingParams removes `temperature`, `top_p`, and `top_k` from the
-// request body. Exported for reuse by adaptThinkingForModel (model-specific
+// request body. Exported for reuse by AdaptThinkingForModel (model-specific
 // always-on adaptive) and the adapter's error-driven retry path.
 func StripSamplingParams(body []byte) []byte {
 	for _, field := range samplingParamFields {

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -342,6 +342,102 @@ func TestSanitizeForBedrockCompatPreservesNonEmptyArrays(t *testing.T) {
 	}
 }
 
+func TestSanitizeForBedrockCompatStripsSamplingParamsWhenThinking(t *testing.T) {
+	cases := []struct {
+		name         string
+		body         string
+		wantStripped bool
+	}{
+		{
+			name:         "thinking enabled strips sampling",
+			body:         `{"thinking":{"type":"enabled","budget_tokens":2048},"max_tokens":4096,"temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`,
+			wantStripped: true,
+		},
+		{
+			name:         "thinking adaptive strips sampling",
+			body:         `{"thinking":{"type":"adaptive"},"temperature":0.5,"top_p":0.8,"messages":[{"role":"user","content":"hi"}]}`,
+			wantStripped: true,
+		},
+		{
+			name:         "no thinking preserves sampling",
+			body:         `{"temperature":0.7,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`,
+			wantStripped: false,
+		},
+		{
+			name:         "thinking disabled preserves sampling",
+			body:         `{"thinking":{"type":"disabled"},"temperature":0.7,"messages":[{"role":"user","content":"hi"}]}`,
+			wantStripped: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := SanitizeForBedrockCompat([]byte(c.body))
+			for _, f := range []string{"temperature", "top_p", "top_k"} {
+				exists := gjson.GetBytes(result, f).Exists()
+				inInput := gjson.GetBytes([]byte(c.body), f).Exists()
+				if !inInput {
+					continue
+				}
+				if c.wantStripped && exists {
+					t.Errorf("%s should be stripped, still present", f)
+				}
+				if !c.wantStripped && !exists {
+					t.Errorf("%s should be preserved, was stripped", f)
+				}
+			}
+		})
+	}
+}
+
+func TestIsSamplingParamRejectedError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "temperature rejected with thinking mention",
+			body: `{"message":"`+"`temperature`"+` may only be set to 1 when thinking is enabled"}`,
+			want: true,
+		},
+		{
+			name: "top_p rejected with thinking mention",
+			body: `{"message":"`+"`top_p`"+` is not supported when thinking is enabled"}`,
+			want: true,
+		},
+		{
+			name: "unrelated 400 (no thinking mention)",
+			body: `{"message":"`+"`temperature`"+` must be between 0 and 1"}`,
+			want: false,
+		},
+		{
+			name: "unrelated 400 (no backticks)",
+			body: `{"message":"temperature thinking error"}`,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsSamplingParamRejectedError([]byte(c.body)); got != c.want {
+				t.Errorf("IsSamplingParamRejectedError = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestStripSamplingParams(t *testing.T) {
+	body := []byte(`{"temperature":0.7,"top_p":0.9,"top_k":40,"max_tokens":1024}`)
+	got := StripSamplingParams(body)
+	for _, f := range []string{"temperature", "top_p", "top_k"} {
+		if gjson.GetBytes(got, f).Exists() {
+			t.Errorf("%s should be stripped", f)
+		}
+	}
+	if !gjson.GetBytes(got, "max_tokens").Exists() {
+		t.Error("max_tokens should be preserved")
+	}
+}
+
 func TestSanitizeRequestBodyRemovesModelAndStream(t *testing.T) {
 	// The direct-Bedrock helper should strip both fields and set anthropic_version.
 	body := []byte(`{

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -396,23 +396,38 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "temperature rejected with thinking mention",
-			body: `{"message":"`+"`temperature`"+` may only be set to 1 when thinking is enabled"}`,
+			name: "anthropic-style (with backticks) temperature",
+			body: `{"message":"` + "`temperature`" + ` may only be set to 1 when thinking is enabled"}`,
 			want: true,
 		},
 		{
-			name: "top_p rejected with thinking mention",
-			body: `{"message":"`+"`top_p`"+` is not supported when thinking is enabled"}`,
+			name: "anthropic-style (with backticks) top_p",
+			body: `{"message":"` + "`top_p`" + ` is not supported when thinking is enabled"}`,
+			want: true,
+		},
+		{
+			name: "bedrock-native (no backticks) temperature",
+			body: `{"message":"temperature may only be set to 1 when thinking is enabled"}`,
+			want: true,
+		},
+		{
+			name: "bedrock-native (no backticks) top_k",
+			body: `{"message":"top_k is not supported when thinking is enabled"}`,
+			want: true,
+		},
+		{
+			name: "thinking mentioned first, then field",
+			body: `{"message":"thinking mode is active so top_p is not allowed"}`,
 			want: true,
 		},
 		{
 			name: "unrelated 400 (no thinking mention)",
-			body: `{"message":"`+"`temperature`"+` must be between 0 and 1"}`,
+			body: `{"message":"temperature must be between 0 and 1"}`,
 			want: false,
 		},
 		{
-			name: "unrelated 400 (no backticks)",
-			body: `{"message":"temperature thinking error"}`,
+			name: "unrelated 400 (thinking mentioned but no sampling field)",
+			body: `{"message":"thinking budget exceeds max_tokens"}`,
 			want: false,
 		},
 	}

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -421,6 +421,11 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "with extended thinking phrasing",
+			body: `{"message":"temperature cannot be set with extended thinking"}`,
+			want: true,
+		},
+		{
 			name: "unrelated 400 (no thinking mention)",
 			body: `{"message":"temperature must be between 0 and 1"}`,
 			want: false,
@@ -428,6 +433,16 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 		{
 			name: "unrelated 400 (thinking mentioned but no sampling field)",
 			body: `{"message":"thinking budget exceeds max_tokens"}`,
+			want: false,
+		},
+		{
+			name: "false-positive guard: bare co-occurrence is not rejection",
+			body: `{"message":"temperature must be between 0 and 1; thinking budget exceeds max_tokens"}`,
+			want: false,
+		},
+		{
+			name: "false-positive guard: thinking as noun modifier near field",
+			body: `{"message":"thinking budget too low; temperature was 0.7"}`,
 			want: false,
 		},
 	}

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -94,4 +94,3 @@ func adaptThinkingForModel(body []byte, shortName string) []byte {
 	}
 	return body
 }
-

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -19,7 +19,7 @@ import (
 //   either         — Opus 4.6, Sonnet 4.6: accept both (adaptive recommended)
 //
 // The sanitizer already handles classic-only (it rewrites adaptive →
-// enabled). What's new is the adaptive-only tier. adaptThinkingForModel
+// enabled). What's new is the adaptive-only tier. AdaptThinkingForModel
 // performs the inverse rewrite when the resolved short name requires it,
 // so clients that only speak the classic shape (Claude Code CLI on
 // Bedrock) can still hit Opus 4.7.
@@ -39,7 +39,7 @@ func requiresAdaptiveThinking(shortName string) bool {
 	return adaptiveOnlyModels[shortName]
 }
 
-// adaptThinkingForModel rewrites a classic extended-thinking config into
+// AdaptThinkingForModel rewrites a classic extended-thinking config into
 // adaptive form when the target model demands it. Idempotent: if the
 // payload already uses adaptive, or the model doesn't require it, or
 // there's no thinking config at all, the body is returned unchanged.
@@ -54,7 +54,7 @@ func requiresAdaptiveThinking(shortName string) bool {
 // decides dynamically; we just need to land in the same ballpark so
 // clients that crank budget_tokens up don't silently get capped to a
 // tiny thinking allotment.
-func adaptThinkingForModel(body []byte, shortName string) []byte {
+func AdaptThinkingForModel(body []byte, shortName string) []byte {
 	if !requiresAdaptiveThinking(shortName) {
 		return body
 	}

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -58,6 +58,15 @@ func adaptThinkingForModel(body []byte, shortName string) []byte {
 	if !requiresAdaptiveThinking(shortName) {
 		return body
 	}
+
+	// Adaptive-thinking-only models (e.g. Opus 4.7) treat *every* request
+	// as a thinking request, even when the caller didn't set thinking.type.
+	// Bedrock therefore rejects temperature / top_p / top_k unconditionally
+	// on these SKUs. SanitizeForBedrockCompat already strips sampling params
+	// when thinking is enabled in the body, but it has no way to know about
+	// always-on adaptive — so we re-strip here, with model context.
+	body = StripSamplingParams(body)
+
 	thinkingType := gjson.GetBytes(body, "thinking.type").String()
 	if thinkingType == "" || thinkingType == "adaptive" || thinkingType == "disabled" {
 		return body
@@ -85,3 +94,4 @@ func adaptThinkingForModel(body []byte, shortName string) []byte {
 	}
 	return body
 }
+

--- a/internal/adapter/provider/bedrock/thinking_policy_test.go
+++ b/internal/adapter/provider/bedrock/thinking_policy_test.go
@@ -78,7 +78,7 @@ func TestAdaptThinkingForModel(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := adaptThinkingForModel([]byte(c.input), c.shortName)
+			got := AdaptThinkingForModel([]byte(c.input), c.shortName)
 			if c.wantType != "" {
 				if gt := gjson.GetBytes(got, "thinking.type").String(); gt != c.wantType {
 					t.Errorf("thinking.type = %q; want %q (body=%s)", gt, c.wantType, string(got))
@@ -134,7 +134,7 @@ func TestAdaptThinkingForModelStripsSamplingParams(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := adaptThinkingForModel([]byte(c.input), c.shortName)
+			got := AdaptThinkingForModel([]byte(c.input), c.shortName)
 			check := func(field string, wantStripped bool) {
 				exists := gjson.GetBytes(got, field).Exists()
 				if wantStripped && exists {

--- a/internal/adapter/provider/bedrock/thinking_policy_test.go
+++ b/internal/adapter/provider/bedrock/thinking_policy_test.go
@@ -96,3 +96,57 @@ func TestAdaptThinkingForModel(t *testing.T) {
 		})
 	}
 }
+
+func TestAdaptThinkingForModelStripsSamplingParams(t *testing.T) {
+	cases := []struct {
+		name      string
+		shortName string
+		input     string
+		// true => the field must be stripped from the output.
+		wantStripTemperature bool
+		wantStripTopP        bool
+		wantStripTopK        bool
+	}{
+		{
+			name:                 "opus-4-7 strips sampling params even without thinking",
+			shortName:            "claude-opus-4-7",
+			input:                `{"max_tokens":1024,"temperature":0.7,"top_p":0.9,"top_k":40}`,
+			wantStripTemperature: true,
+			wantStripTopP:        true,
+			wantStripTopK:        true,
+		},
+		{
+			name:                 "opus-4-7 strips sampling params when thinking enabled",
+			shortName:            "claude-opus-4-7",
+			input:                `{"thinking":{"type":"enabled","budget_tokens":4000},"temperature":0.5,"top_p":0.8,"top_k":20}`,
+			wantStripTemperature: true,
+			wantStripTopP:        true,
+			wantStripTopK:        true,
+		},
+		{
+			name:                 "opus-4-5 preserves sampling params (classic-only model)",
+			shortName:            "claude-opus-4-5",
+			input:                `{"temperature":0.7,"top_p":0.9,"top_k":40}`,
+			wantStripTemperature: false,
+			wantStripTopP:        false,
+			wantStripTopK:        false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := adaptThinkingForModel([]byte(c.input), c.shortName)
+			check := func(field string, wantStripped bool) {
+				exists := gjson.GetBytes(got, field).Exists()
+				if wantStripped && exists {
+					t.Errorf("%s should be stripped, still present (body=%s)", field, string(got))
+				}
+				if !wantStripped && !exists {
+					t.Errorf("%s should be preserved, was stripped (body=%s)", field, string(got))
+				}
+			}
+			check("temperature", c.wantStripTemperature)
+			check("top_p", c.wantStripTopP)
+			check("top_k", c.wantStripTopK)
+		})
+	}
+}

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -70,11 +70,13 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 		body = bedrock.SanitizeForBedrockCompat(body)
 		// Model-aware adaptive thinking: Opus 4.7 and other adaptive-only
 		// SKUs treat every request as a thinking request and reject sampling
-		// params even when the caller never set thinking.type. The direct
-		// Bedrock adapter resolves the short name from a Bedrock-qualified
-		// ID; under custom-bedrock disguise the upstream is a relay and the
-		// short name is already in `model`, so pass it through directly.
-		body = bedrock.AdaptThinkingForModel(body, modelName)
+		// params even when the caller never set thinking.type. The `model`
+		// field may already carry a Bedrock-qualified ID after the custom
+		// provider's model-mapping rewrite (e.g.
+		// "us.anthropic.claude-opus-4-7-20260115-v1:0"), so normalize it to
+		// the Anthropic short name first — AdaptThinkingForModel keys on
+		// "claude-opus-4-7", not on inference-profile IDs.
+		body = bedrock.AdaptThinkingForModel(body, bedrock.ShortNameForModel(modelName))
 		bedrockMode = true
 	case domain.DisguiseTypeNone:
 		// Explicit opt-out: no body transformation.

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -68,6 +68,13 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 		// Strip Claude Code identifying fields so the upstream relay's Bedrock
 		// backend won't reject the request with "invalid beta flag" etc.
 		body = bedrock.SanitizeForBedrockCompat(body)
+		// Model-aware adaptive thinking: Opus 4.7 and other adaptive-only
+		// SKUs treat every request as a thinking request and reject sampling
+		// params even when the caller never set thinking.type. The direct
+		// Bedrock adapter resolves the short name from a Bedrock-qualified
+		// ID; under custom-bedrock disguise the upstream is a relay and the
+		// short name is already in `model`, so pass it through directly.
+		body = bedrock.AdaptThinkingForModel(body, modelName)
 		bedrockMode = true
 	case domain.DisguiseTypeNone:
 		// Explicit opt-out: no body transformation.

--- a/internal/adapter/provider/custom/claude_body_test.go
+++ b/internal/adapter/provider/custom/claude_body_test.go
@@ -844,6 +844,40 @@ func TestProcessClaudeRequestBodyBedrockDisguiseStripsSamplingForAdaptiveOnly(t 
 	}
 }
 
+// TestProcessClaudeRequestBodyBedrockDisguiseStripsSamplingForBedrockID
+// guards the case where a custom provider's model mapping has already
+// rewritten `model` into a Bedrock-qualified inference-profile ID — the
+// adaptive-only strip must still fire because the short name is
+// embedded in the ID. Without normalization, a custom relay fronting
+// Bedrock would hit the same Opus 4.7 sampling-param rejection the
+// short-name path already recovers from.
+func TestProcessClaudeRequestBodyBedrockDisguiseStripsSamplingForBedrockID(t *testing.T) {
+	for _, modelID := range []string{
+		"us.anthropic.claude-opus-4-7-20260115-v1:0",
+		"anthropic.claude-opus-4-7-20260115-v1:0",
+		"eu.anthropic.claude-opus-4-7-20260115-v1:0",
+	} {
+		t.Run(modelID, func(t *testing.T) {
+			body := []byte(`{
+				"model":"` + modelID + `",
+				"max_tokens":1024,
+				"temperature":0.7,
+				"top_p":0.9,
+				"top_k":40,
+				"messages":[{"role":"user","content":"hi"}]
+			}`)
+
+			result, _ := processClaudeRequestBody(body, "claude-cli/2.1.23 (external, cli)", bedrockDisguiseCustomCfg())
+
+			for _, f := range []string{"temperature", "top_p", "top_k"} {
+				if gjson.GetBytes(result, f).Exists() {
+					t.Errorf("expected %s to be stripped when model is %q under bedrock disguise", f, modelID)
+				}
+			}
+		})
+	}
+}
+
 // TestProcessClaudeRequestBodyBedrockDisguisePreservesSamplingForClassic
 // confirms the model-aware strip only fires for adaptive-only models —
 // a classic-thinking model with no thinking block must keep its sampling

--- a/internal/adapter/provider/custom/claude_body_test.go
+++ b/internal/adapter/provider/custom/claude_body_test.go
@@ -818,6 +818,51 @@ func TestProcessClaudeRequestBodyBedrockDisguiseStripsUnsupportedFields(t *testi
 	}
 }
 
+// TestProcessClaudeRequestBodyBedrockDisguiseStripsSamplingForAdaptiveOnly
+// guards that custom-bedrock disguise applies the adaptive-only model
+// strip too: Opus 4.7 rejects temperature/top_p/top_k even without an
+// explicit thinking block, so the relay path needs the same model-aware
+// handling as the direct Bedrock adapter — otherwise a custom relay
+// fronting Bedrock fails on the same class of requests the direct path
+// already recovers from.
+func TestProcessClaudeRequestBodyBedrockDisguiseStripsSamplingForAdaptiveOnly(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-opus-4-7",
+		"max_tokens":1024,
+		"temperature":0.7,
+		"top_p":0.9,
+		"top_k":40,
+		"messages":[{"role":"user","content":"hi"}]
+	}`)
+
+	result, _ := processClaudeRequestBody(body, "claude-cli/2.1.23 (external, cli)", bedrockDisguiseCustomCfg())
+
+	for _, f := range []string{"temperature", "top_p", "top_k"} {
+		if gjson.GetBytes(result, f).Exists() {
+			t.Errorf("expected %s to be stripped on claude-opus-4-7 under bedrock disguise", f)
+		}
+	}
+}
+
+// TestProcessClaudeRequestBodyBedrockDisguisePreservesSamplingForClassic
+// confirms the model-aware strip only fires for adaptive-only models —
+// a classic-thinking model with no thinking block must keep its sampling
+// params under the bedrock disguise.
+func TestProcessClaudeRequestBodyBedrockDisguisePreservesSamplingForClassic(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-opus-4-5",
+		"max_tokens":1024,
+		"temperature":0.7,
+		"messages":[{"role":"user","content":"hi"}]
+	}`)
+
+	result, _ := processClaudeRequestBody(body, "claude-cli/2.1.23 (external, cli)", bedrockDisguiseCustomCfg())
+
+	if !gjson.GetBytes(result, "temperature").Exists() {
+		t.Error("expected temperature to be preserved on classic model under bedrock disguise")
+	}
+}
+
 // TestProcessClaudeRequestBodyBedrockDisguiseRecheckMaxTokensAfterMinBudget
 // guards against a subtle ordering bug: SanitizeForBedrockCompat enforces
 // `max_tokens > thinking.budget_tokens` early, then ensureMinThinkingBudget


### PR DESCRIPTION
## Summary
- Bedrock rejects `temperature` / `top_p` / `top_k` whenever extended thinking is active. For always-on adaptive SKUs (e.g. Opus 4.7) this happens even without an explicit `thinking` block, so requests like `{model: claude-opus-4-7, temperature: 0.7}` 400'd.
- Three-layer defense rather than a model-list patch:
  1. **Rule-driven** — `SanitizeForBedrockCompat` strips the three params when `thinking.type` is `enabled` or `adaptive`.
  2. **Model-specific** — `adaptThinkingForModel` calls `StripSamplingParams` for adaptive-only models so always-on adaptive is covered.
  3. **Error-driven retry** — adapter retries once on Bedrock 400 matching `IsSamplingParamRejectedError`, mirroring the existing thinking-envelope retry. Future SKUs / message wording shifts recover automatically without a code change.

## Test plan
- [x] `go test ./internal/adapter/... -count=1`
- [x] `go build ./...`
- [x] New unit tests: `TestSanitizeForBedrockCompatStripsSamplingParamsWhenThinking`, `TestIsSamplingParamRejectedError`, `TestStripSamplingParams`, `TestAdaptThinkingForModelStripsSamplingParams`
- [ ] Manual: replay the failing request (`claude-opus-4-7` + `temperature: 0.7`) against Bedrock and confirm 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 增加模型短名归一化和思维策略适配，针对特定自适应模型自动调整或移除采样参数以确保兼容性。

* **Bug修复**
  * 在 400 响应路径新增针对采样参数被拒的独立重试逻辑：若检测到此类错误，则尝试移除采样参数并重试一次，提升请求成功率和鲁棒性。

* **测试**
  * 添加多项单元测试，覆盖采样参数清理、错误识别和思维策略适配行为。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/555)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->