### PR TITLE
fix(bedrock): normalize tool_use ids and names to match Bedrock's regex

### DIFF
--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -338,9 +338,10 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 		if mapped, ok := idMap[original]; ok {
 			return mapped
 		}
-		candidate := toolIdentifierInvalidChar.ReplaceAllString(original, "_")
+		base := toolIdentifierInvalidChar.ReplaceAllString(original, "_")
+		candidate := base
 		for n := 1; used[candidate]; n++ {
-			candidate = fmt.Sprintf("%s_%d", toolIdentifierInvalidChar.ReplaceAllString(original, "_"), n)
+			candidate = fmt.Sprintf("%s_%d", base, n)
 		}
 		idMap[original] = candidate
 		used[candidate] = true

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -302,18 +302,38 @@ func RemoveOrphanedToolResults(body []byte) []byte {
 // Some clients/SDKs synthesize ids like "functions.foo:0" which fail this regex.
 var toolIdentifierInvalidChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
-// normalizeToolName substitutes disallowed characters and applies Bedrock's
-// 128-char cap. Used for `tool_use.name` and `tools[].name`, which are not
-// references and don't need uniqueness across a request.
-func normalizeToolName(s string) string {
-	if s == "" {
-		return s
+// newToolIdentifierResolver returns a resolver closure that maps an original
+// identifier to a Bedrock-valid form, disambiguating collisions across a
+// single request. maxLen > 0 enforces a length cap; suffix allocation
+// re-truncates the base so the final candidate (base + "_<n>") stays
+// within the cap.
+func newToolIdentifierResolver(maxLen int) func(string) string {
+	mapping := make(map[string]string)
+	used := make(map[string]bool)
+	return func(original string) string {
+		if original == "" {
+			return original
+		}
+		if mapped, ok := mapping[original]; ok {
+			return mapped
+		}
+		base := toolIdentifierInvalidChar.ReplaceAllString(original, "_")
+		if maxLen > 0 && len(base) > maxLen {
+			base = base[:maxLen]
+		}
+		candidate := base
+		for n := 1; used[candidate]; n++ {
+			suffix := fmt.Sprintf("_%d", n)
+			trunc := base
+			if maxLen > 0 && len(trunc)+len(suffix) > maxLen {
+				trunc = base[:maxLen-len(suffix)]
+			}
+			candidate = trunc + suffix
+		}
+		mapping[original] = candidate
+		used[candidate] = true
+		return candidate
 	}
-	out := toolIdentifierInvalidChar.ReplaceAllString(s, "_")
-	if len(out) > 128 {
-		out = out[:128]
-	}
-	return out
 }
 
 // NormalizeToolIdentifiers replaces characters that Bedrock rejects in tool
@@ -323,36 +343,34 @@ func normalizeToolName(s string) string {
 //   - messages[*].content[*].tool_use_id (tool_result)
 //   - tools[*].name
 //
-// Reference pairs (tool_use.id ↔ tool_result.tool_use_id) stay consistent
-// because we build a single request-wide original→normalized id map and apply
-// it to both ends. The map disambiguates collisions: if two distinct originals
-// (e.g. `foo.bar` and `foo_bar`) would collapse to the same value, the second
-// one gets a `_<n>` suffix so Bedrock still sees unique ids.
+// Reference pairs stay consistent because we build request-wide
+// original→normalized maps and apply them on both ends:
+//   - id map links tool_use.id ↔ tool_result.tool_use_id
+//   - name map links tools[].name (definition) ↔ tool_use.name (reference)
+//
+// Collisions get a stable `_<n>` suffix so two distinct originals (e.g.
+// `functions.foo` and `functions/foo`, both collapsing to `functions_foo`)
+// stay distinguishable on the wire. Names are capped at Bedrock's 128-char
+// limit, and suffix allocation truncates the base if needed to keep the
+// total within that cap.
 func NormalizeToolIdentifiers(body []byte) []byte {
-	idMap := make(map[string]string)
-	used := make(map[string]bool)
-	resolve := func(original string) string {
-		if original == "" {
-			return original
+	resolveID := newToolIdentifierResolver(0)
+	resolveName := newToolIdentifierResolver(128)
+
+	// First pass (forward order, definitions before references): build maps.
+	// tools[] is walked before messages so tool definitions own canonical
+	// names; tool_use.name references then resolve through the same map.
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		tn := int(tools.Get("#").Int())
+		for i := 0; i < tn; i++ {
+			path := fmt.Sprintf("tools.%d.name", i)
+			if name := gjson.GetBytes(body, path).String(); name != "" {
+				_ = resolveName(name)
+			}
 		}
-		if mapped, ok := idMap[original]; ok {
-			return mapped
-		}
-		base := toolIdentifierInvalidChar.ReplaceAllString(original, "_")
-		candidate := base
-		for n := 1; used[candidate]; n++ {
-			candidate = fmt.Sprintf("%s_%d", base, n)
-		}
-		idMap[original] = candidate
-		used[candidate] = true
-		return candidate
 	}
-
 	messages := gjson.GetBytes(body, "messages")
-
-	// First pass (forward order): build a stable original→normalized id map.
-	// Walking forward ensures the first occurrence of a colliding original keeps
-	// the canonical normalized form; later collisions get suffixed.
 	if messages.IsArray() {
 		n := int(messages.Get("#").Int())
 		for i := 0; i < n; i++ {
@@ -366,20 +384,23 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 				switch gjson.GetBytes(body, blockPath+".type").String() {
 				case "tool_use":
 					if id := gjson.GetBytes(body, blockPath+".id").String(); id != "" {
-						_ = resolve(id)
+						_ = resolveID(id)
+					}
+					if name := gjson.GetBytes(body, blockPath+".name").String(); name != "" {
+						_ = resolveName(name)
 					}
 				case "tool_result":
 					if id := gjson.GetBytes(body, blockPath+".tool_use_id").String(); id != "" {
-						_ = resolve(id)
+						_ = resolveID(id)
 					}
 				}
 			}
 		}
 	}
 
-	// Second pass: apply the mapping. Order doesn't matter for correctness
+	// Second pass: apply mappings. Order doesn't matter for correctness
 	// (only scalar fields are rewritten), but reverse iteration keeps the
-	// pattern consistent with the other sanitizer helpers in this file.
+	// pattern consistent with other sanitizer helpers in this file.
 	if messages.IsArray() {
 		for i := int(messages.Get("#").Int()) - 1; i >= 0; i-- {
 			content := gjson.GetBytes(body, fmt.Sprintf("messages.%d.content", i))
@@ -391,18 +412,18 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 				switch gjson.GetBytes(body, blockPath+".type").String() {
 				case "tool_use":
 					if id := gjson.GetBytes(body, blockPath+".id").String(); id != "" {
-						if mapped := idMap[id]; mapped != "" && mapped != id {
+						if mapped := resolveID(id); mapped != id {
 							body, _ = sjson.SetBytes(body, blockPath+".id", mapped)
 						}
 					}
 					if name := gjson.GetBytes(body, blockPath+".name").String(); name != "" {
-						if fixed := normalizeToolName(name); fixed != name {
-							body, _ = sjson.SetBytes(body, blockPath+".name", fixed)
+						if mapped := resolveName(name); mapped != name {
+							body, _ = sjson.SetBytes(body, blockPath+".name", mapped)
 						}
 					}
 				case "tool_result":
 					if id := gjson.GetBytes(body, blockPath+".tool_use_id").String(); id != "" {
-						if mapped := idMap[id]; mapped != "" && mapped != id {
+						if mapped := resolveID(id); mapped != id {
 							body, _ = sjson.SetBytes(body, blockPath+".tool_use_id", mapped)
 						}
 					}
@@ -411,14 +432,12 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 		}
 	}
 
-	// Walk tools[*].name
-	tools := gjson.GetBytes(body, "tools")
 	if tools.IsArray() {
 		for i := int(tools.Get("#").Int()) - 1; i >= 0; i-- {
 			path := fmt.Sprintf("tools.%d.name", i)
 			if name := gjson.GetBytes(body, path).String(); name != "" {
-				if fixed := normalizeToolName(name); fixed != name {
-					body, _ = sjson.SetBytes(body, path, fixed)
+				if mapped := resolveName(name); mapped != name {
+					body, _ = sjson.SetBytes(body, path, mapped)
 				}
 			}
 		}

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -302,16 +302,15 @@ func RemoveOrphanedToolResults(body []byte) []byte {
 // Some clients/SDKs synthesize ids like "functions.foo:0" which fail this regex.
 var toolIdentifierInvalidChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 
-// normalizeToolIdentifier replaces every disallowed character with `_`. The
-// substitution is deterministic, so tool_use.id and the matching
-// tool_result.tool_use_id collapse to the same value without needing a map.
-// Name fields are additionally truncated to 128 bytes (Bedrock's max).
-func normalizeToolIdentifier(s string, capLen bool) string {
+// normalizeToolName substitutes disallowed characters and applies Bedrock's
+// 128-char cap. Used for `tool_use.name` and `tools[].name`, which are not
+// references and don't need uniqueness across a request.
+func normalizeToolName(s string) string {
 	if s == "" {
 		return s
 	}
 	out := toolIdentifierInvalidChar.ReplaceAllString(s, "_")
-	if capLen && len(out) > 128 {
+	if len(out) > 128 {
 		out = out[:128]
 	}
 	return out
@@ -325,10 +324,61 @@ func normalizeToolIdentifier(s string, capLen bool) string {
 //   - tools[*].name
 //
 // Reference pairs (tool_use.id ↔ tool_result.tool_use_id) stay consistent
-// because both sides go through the same deterministic substitution.
+// because we build a single request-wide original→normalized id map and apply
+// it to both ends. The map disambiguates collisions: if two distinct originals
+// (e.g. `foo.bar` and `foo_bar`) would collapse to the same value, the second
+// one gets a `_<n>` suffix so Bedrock still sees unique ids.
 func NormalizeToolIdentifiers(body []byte) []byte {
-	// Walk messages[*].content[*]
+	idMap := make(map[string]string)
+	used := make(map[string]bool)
+	resolve := func(original string) string {
+		if original == "" {
+			return original
+		}
+		if mapped, ok := idMap[original]; ok {
+			return mapped
+		}
+		candidate := toolIdentifierInvalidChar.ReplaceAllString(original, "_")
+		for n := 1; used[candidate]; n++ {
+			candidate = fmt.Sprintf("%s_%d", toolIdentifierInvalidChar.ReplaceAllString(original, "_"), n)
+		}
+		idMap[original] = candidate
+		used[candidate] = true
+		return candidate
+	}
+
 	messages := gjson.GetBytes(body, "messages")
+
+	// First pass (forward order): build a stable original→normalized id map.
+	// Walking forward ensures the first occurrence of a colliding original keeps
+	// the canonical normalized form; later collisions get suffixed.
+	if messages.IsArray() {
+		n := int(messages.Get("#").Int())
+		for i := 0; i < n; i++ {
+			content := gjson.GetBytes(body, fmt.Sprintf("messages.%d.content", i))
+			if !content.IsArray() {
+				continue
+			}
+			cn := int(content.Get("#").Int())
+			for j := 0; j < cn; j++ {
+				blockPath := fmt.Sprintf("messages.%d.content.%d", i, j)
+				switch gjson.GetBytes(body, blockPath+".type").String() {
+				case "tool_use":
+					if id := gjson.GetBytes(body, blockPath+".id").String(); id != "" {
+						_ = resolve(id)
+					}
+				case "tool_result":
+					if id := gjson.GetBytes(body, blockPath+".tool_use_id").String(); id != "" {
+						_ = resolve(id)
+					}
+				}
+			}
+		}
+	}
+
+	// Second pass: apply the mapping. Order doesn't matter for correctness
+	// (only scalar fields are rewritten), but reverse iteration keeps the
+	// pattern consistent with the other sanitizer helpers in this file.
 	if messages.IsArray() {
 		for i := int(messages.Get("#").Int()) - 1; i >= 0; i-- {
 			content := gjson.GetBytes(body, fmt.Sprintf("messages.%d.content", i))
@@ -340,19 +390,19 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 				switch gjson.GetBytes(body, blockPath+".type").String() {
 				case "tool_use":
 					if id := gjson.GetBytes(body, blockPath+".id").String(); id != "" {
-						if fixed := normalizeToolIdentifier(id, false); fixed != id {
-							body, _ = sjson.SetBytes(body, blockPath+".id", fixed)
+						if mapped := idMap[id]; mapped != "" && mapped != id {
+							body, _ = sjson.SetBytes(body, blockPath+".id", mapped)
 						}
 					}
 					if name := gjson.GetBytes(body, blockPath+".name").String(); name != "" {
-						if fixed := normalizeToolIdentifier(name, true); fixed != name {
+						if fixed := normalizeToolName(name); fixed != name {
 							body, _ = sjson.SetBytes(body, blockPath+".name", fixed)
 						}
 					}
 				case "tool_result":
 					if id := gjson.GetBytes(body, blockPath+".tool_use_id").String(); id != "" {
-						if fixed := normalizeToolIdentifier(id, false); fixed != id {
-							body, _ = sjson.SetBytes(body, blockPath+".tool_use_id", fixed)
+						if mapped := idMap[id]; mapped != "" && mapped != id {
+							body, _ = sjson.SetBytes(body, blockPath+".tool_use_id", mapped)
 						}
 					}
 				}
@@ -366,7 +416,7 @@ func NormalizeToolIdentifiers(body []byte) []byte {
 		for i := int(tools.Get("#").Int()) - 1; i >= 0; i-- {
 			path := fmt.Sprintf("tools.%d.name", i)
 			if name := gjson.GetBytes(body, path).String(); name != "" {
-				if fixed := normalizeToolIdentifier(name, true); fixed != name {
+				if fixed := normalizeToolName(name); fixed != name {
 					body, _ = sjson.SetBytes(body, path, fixed)
 				}
 			}

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -17,9 +17,10 @@ import (
 // - Then runs the relay-safe transformations via SanitizeForBedrockCompat.
 //
 // Bedrock feature support (verified via real API tests):
-//   ACCEPTED: cache_control (system/tools/messages), thinking(enabled), tools, tool_use
-//   REJECTED: stream, output_config, context_management, reasoning, betas,
-//             thinking(adaptive), tools[].custom, cache_control.scope
+//
+//	ACCEPTED: cache_control (system/tools/messages), thinking(enabled), tools, tool_use
+//	REJECTED: stream, output_config, context_management, reasoning, betas,
+//	          thinking(adaptive), tools[].custom, cache_control.scope
 func sanitizeRequestBody(body []byte) []byte {
 	// Remove `model` field (Bedrock uses URL path)
 	body, _ = sjson.DeleteBytes(body, "model")
@@ -96,6 +97,8 @@ func SanitizeForBedrockCompat(body []byte) []byte {
 			}
 		}
 	}
+
+	body = NormalizeToolIdentifiers(body)
 
 	// Remove empty top-level arrays that Bedrock rejects with ValidationException.
 	// Clients sometimes send `"system":[]` or `"tools":[]` which Anthropic API
@@ -290,6 +293,87 @@ func RemoveOrphanedToolResults(body []byte) []byte {
 		return body
 	}
 	return updatedBody
+}
+
+// toolIdentifierInvalidChar matches any character disallowed in Bedrock's
+// tool identifier pattern. Bedrock validates tool_use.id, tool_result.tool_use_id,
+// tool_use.name, and tools[].name against `^[a-zA-Z0-9_-]+$` (name additionally
+// capped at 128 chars), and rejects requests with characters like `.` or `:`.
+// Some clients/SDKs synthesize ids like "functions.foo:0" which fail this regex.
+var toolIdentifierInvalidChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+// normalizeToolIdentifier replaces every disallowed character with `_`. The
+// substitution is deterministic, so tool_use.id and the matching
+// tool_result.tool_use_id collapse to the same value without needing a map.
+// Name fields are additionally truncated to 128 bytes (Bedrock's max).
+func normalizeToolIdentifier(s string, capLen bool) string {
+	if s == "" {
+		return s
+	}
+	out := toolIdentifierInvalidChar.ReplaceAllString(s, "_")
+	if capLen && len(out) > 128 {
+		out = out[:128]
+	}
+	return out
+}
+
+// NormalizeToolIdentifiers replaces characters that Bedrock rejects in tool
+// identifier fields. Covers:
+//   - messages[*].content[*].id (tool_use)
+//   - messages[*].content[*].name (tool_use)
+//   - messages[*].content[*].tool_use_id (tool_result)
+//   - tools[*].name
+//
+// Reference pairs (tool_use.id ↔ tool_result.tool_use_id) stay consistent
+// because both sides go through the same deterministic substitution.
+func NormalizeToolIdentifiers(body []byte) []byte {
+	// Walk messages[*].content[*]
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		for i := int(messages.Get("#").Int()) - 1; i >= 0; i-- {
+			content := gjson.GetBytes(body, fmt.Sprintf("messages.%d.content", i))
+			if !content.IsArray() {
+				continue
+			}
+			for j := int(content.Get("#").Int()) - 1; j >= 0; j-- {
+				blockPath := fmt.Sprintf("messages.%d.content.%d", i, j)
+				switch gjson.GetBytes(body, blockPath+".type").String() {
+				case "tool_use":
+					if id := gjson.GetBytes(body, blockPath+".id").String(); id != "" {
+						if fixed := normalizeToolIdentifier(id, false); fixed != id {
+							body, _ = sjson.SetBytes(body, blockPath+".id", fixed)
+						}
+					}
+					if name := gjson.GetBytes(body, blockPath+".name").String(); name != "" {
+						if fixed := normalizeToolIdentifier(name, true); fixed != name {
+							body, _ = sjson.SetBytes(body, blockPath+".name", fixed)
+						}
+					}
+				case "tool_result":
+					if id := gjson.GetBytes(body, blockPath+".tool_use_id").String(); id != "" {
+						if fixed := normalizeToolIdentifier(id, false); fixed != id {
+							body, _ = sjson.SetBytes(body, blockPath+".tool_use_id", fixed)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Walk tools[*].name
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		for i := int(tools.Get("#").Int()) - 1; i >= 0; i-- {
+			path := fmt.Sprintf("tools.%d.name", i)
+			if name := gjson.GetBytes(body, path).String(); name != "" {
+				if fixed := normalizeToolIdentifier(name, true); fixed != name {
+					body, _ = sjson.SetBytes(body, path, fixed)
+				}
+			}
+		}
+	}
+
+	return body
 }
 
 // stripCacheControlScope removes the "scope" sub-field from all cache_control objects.

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -487,4 +488,102 @@ func TestSanitizeRequestBodyRemovesModelAndStream(t *testing.T) {
 	if got := gjson.GetBytes(result, "anthropic_version").String(); got != BedrockAPIVersion {
 		t.Errorf("anthropic_version = %q, want %q", got, BedrockAPIVersion)
 	}
+}
+
+func TestNormalizeToolIdentifiers(t *testing.T) {
+	t.Run("rewrites tool_use.id and matching tool_result.tool_use_id", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"functions.foo:0","name":"functions.foo","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"functions.foo:0","content":"ok"}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		gotID := gjson.GetBytes(result, "messages.0.content.0.id").String()
+		if gotID != "functions_foo_0" {
+			t.Errorf("tool_use.id = %q, want functions_foo_0", gotID)
+		}
+		gotName := gjson.GetBytes(result, "messages.0.content.0.name").String()
+		if gotName != "functions_foo" {
+			t.Errorf("tool_use.name = %q, want functions_foo", gotName)
+		}
+		gotRefID := gjson.GetBytes(result, "messages.1.content.0.tool_use_id").String()
+		if gotRefID != gotID {
+			t.Errorf("tool_result.tool_use_id = %q, want matching %q", gotRefID, gotID)
+		}
+	})
+
+	t.Run("preserves already-valid identifiers", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"toolu_abc-123","name":"my_tool","input":{}}
+				]}
+			]
+		}`)
+		original := string(body)
+
+		result := NormalizeToolIdentifiers(body)
+
+		if gjson.GetBytes(result, "messages.0.content.0.id").String() != "toolu_abc-123" {
+			t.Errorf("valid id mutated: %s", result)
+		}
+		if gjson.GetBytes(result, "messages.0.content.0.name").String() != "my_tool" {
+			t.Errorf("valid name mutated: %s", result)
+		}
+		_ = original
+	})
+
+	t.Run("normalizes tools[].name", func(t *testing.T) {
+		body := []byte(`{
+			"tools":[{"name":"functions.bar","description":"d","input_schema":{}}],
+			"messages":[{"role":"user","content":"hi"}]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		if got := gjson.GetBytes(result, "tools.0.name").String(); got != "functions_bar" {
+			t.Errorf("tools[0].name = %q, want functions_bar", got)
+		}
+	})
+
+	t.Run("caps name at 128 chars", func(t *testing.T) {
+		longName := strings.Repeat("a", 150)
+		body := []byte(`{"tools":[{"name":"` + longName + `"}],"messages":[{"role":"user","content":"hi"}]}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		got := gjson.GetBytes(result, "tools.0.name").String()
+		if len(got) != 128 {
+			t.Errorf("tools[0].name length = %d, want 128", len(got))
+		}
+	})
+
+	t.Run("integrates via SanitizeForBedrockCompat", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"functions.x:1","name":"functions.x","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"functions.x:1","content":"ok"}
+				]}
+			]
+		}`)
+
+		result := SanitizeForBedrockCompat(body)
+
+		if got := gjson.GetBytes(result, "messages.0.content.0.id").String(); got != "functions_x_1" {
+			t.Errorf("SanitizeForBedrockCompat did not normalize tool_use.id: %q", got)
+		}
+		if got := gjson.GetBytes(result, "messages.1.content.0.tool_use_id").String(); got != "functions_x_1" {
+			t.Errorf("SanitizeForBedrockCompat did not normalize tool_result.tool_use_id: %q", got)
+		}
+	})
 }

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -666,21 +666,6 @@ func TestNormalizeToolIdentifiers(t *testing.T) {
 		}
 	})
 
-	t.Run("empty id is left alone", func(t *testing.T) {
-		body := []byte(`{
-			"messages":[
-				{"role":"assistant","content":[
-					{"type":"tool_use","id":"","name":"a","input":{}}
-				]}
-			]
-		}`)
-
-		result := NormalizeToolIdentifiers(body)
-		if got := gjson.GetBytes(result, "messages.0.content.0.id").String(); got != "" {
-			t.Errorf("empty id should stay empty, got %q", got)
-		}
-	})
-
 	t.Run("ignores non-array message content", func(t *testing.T) {
 		body := []byte(`{"messages":[{"role":"user","content":"plain string"}]}`)
 		result := NormalizeToolIdentifiers(body)

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -689,6 +689,70 @@ func TestNormalizeToolIdentifiers(t *testing.T) {
 		}
 	})
 
+	t.Run("disambiguates colliding tool names across tools[] and tool_use", func(t *testing.T) {
+		// Regression: two distinct tool definitions whose names collapse to
+		// the same Bedrock-valid form must stay distinguishable on the wire,
+		// and tool_use.name references must follow the same mapping so that
+		// each tool_use points to the right (renamed) definition.
+		body := []byte(`{
+			"tools":[
+				{"name":"functions.foo","description":"a","input_schema":{}},
+				{"name":"functions/foo","description":"b","input_schema":{}}
+			],
+			"messages":[{"role":"assistant","content":[
+				{"type":"tool_use","id":"id1","name":"functions.foo","input":{}},
+				{"type":"tool_use","id":"id2","name":"functions/foo","input":{}}
+			]}]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		t0 := gjson.GetBytes(result, "tools.0.name").String()
+		t1 := gjson.GetBytes(result, "tools.1.name").String()
+		u0 := gjson.GetBytes(result, "messages.0.content.0.name").String()
+		u1 := gjson.GetBytes(result, "messages.0.content.1.name").String()
+
+		if t0 == t1 {
+			t.Errorf("tools[] names must not collide, both = %q", t0)
+		}
+		if u0 == u1 {
+			t.Errorf("tool_use names must not collide, both = %q", u0)
+		}
+		if t0 != u0 {
+			t.Errorf("tool_use[0].name should match tools[0].name: %q vs %q", u0, t0)
+		}
+		if t1 != u1 {
+			t.Errorf("tool_use[1].name should match tools[1].name: %q vs %q", u1, t1)
+		}
+		// And the first-occurrence original wins canonical form.
+		if t0 != "functions_foo" {
+			t.Errorf("tools[0].name should keep canonical form, got %q", t0)
+		}
+	})
+
+	t.Run("suffix respects 128-char name cap", func(t *testing.T) {
+		// Two long names that collapse to the same 128-char base. Suffix
+		// allocation must re-truncate the base so `base + "_1"` stays ≤ 128.
+		long := strings.Repeat("a", 130)
+		body := []byte(`{
+			"tools":[
+				{"name":"` + long + `.x"},
+				{"name":"` + long + `/x"}
+			],
+			"messages":[{"role":"user","content":"hi"}]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+		t0 := gjson.GetBytes(result, "tools.0.name").String()
+		t1 := gjson.GetBytes(result, "tools.1.name").String()
+		if len(t0) > 128 || len(t1) > 128 {
+			t.Errorf("names exceed 128-char cap: %d, %d", len(t0), len(t1))
+		}
+		if t0 == t1 {
+			t.Errorf("names should be distinct after suffix, both = %q", t0)
+		}
+	})
+
 	t.Run("normalizes tools[].name", func(t *testing.T) {
 		body := []byte(`{
 			"tools":[{"name":"functions.bar","description":"d","input_schema":{}}],

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -527,7 +527,6 @@ func TestNormalizeToolIdentifiers(t *testing.T) {
 				]}
 			]
 		}`)
-		original := string(body)
 
 		result := NormalizeToolIdentifiers(body)
 
@@ -537,7 +536,92 @@ func TestNormalizeToolIdentifiers(t *testing.T) {
 		if gjson.GetBytes(result, "messages.0.content.0.name").String() != "my_tool" {
 			t.Errorf("valid name mutated: %s", result)
 		}
-		_ = original
+	})
+
+	t.Run("disambiguates colliding originals", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"foo_bar","name":"a","input":{}},
+					{"type":"tool_use","id":"foo.bar","name":"b","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"foo_bar","content":"r0"},
+					{"type":"tool_result","tool_use_id":"foo.bar","content":"r1"}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		id0 := gjson.GetBytes(result, "messages.0.content.0.id").String()
+		id1 := gjson.GetBytes(result, "messages.0.content.1.id").String()
+		ref0 := gjson.GetBytes(result, "messages.1.content.0.tool_use_id").String()
+		ref1 := gjson.GetBytes(result, "messages.1.content.1.tool_use_id").String()
+
+		if id0 != "foo_bar" {
+			t.Errorf("first id should keep canonical form, got %q", id0)
+		}
+		if id1 == id0 {
+			t.Errorf("colliding ids must disambiguate, both got %q", id0)
+		}
+		if ref0 != id0 {
+			t.Errorf("tool_result[0] should match tool_use[0]: %q vs %q", ref0, id0)
+		}
+		if ref1 != id1 {
+			t.Errorf("tool_result[1] should match tool_use[1]: %q vs %q", ref1, id1)
+		}
+	})
+
+	t.Run("handles multiple tool_use blocks in one message", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"text","text":"thinking..."},
+					{"type":"tool_use","id":"a.1","name":"f.x","input":{}},
+					{"type":"tool_use","id":"a.2","name":"f.y","input":{}},
+					{"type":"tool_use","id":"a.3","name":"f.z","input":{}}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		for j, want := range []string{"a_1", "a_2", "a_3"} {
+			path := fmt.Sprintf("messages.0.content.%d.id", j+1)
+			if got := gjson.GetBytes(result, path).String(); got != want {
+				t.Errorf("content.%d.id = %q, want %q", j+1, got, want)
+			}
+		}
+	})
+
+	t.Run("caps tool_use.name in messages content", func(t *testing.T) {
+		longName := strings.Repeat("a.", 80) // 160 chars, also contains invalid `.`
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"toolu_1","name":"` + longName + `","input":{}}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+
+		got := gjson.GetBytes(result, "messages.0.content.0.name").String()
+		if len(got) != 128 {
+			t.Errorf("tool_use.name length = %d, want 128", len(got))
+		}
+		if toolIdentifierInvalidChar.MatchString(got) {
+			t.Errorf("tool_use.name still contains invalid chars: %q", got)
+		}
+	})
+
+	t.Run("ignores non-array message content", func(t *testing.T) {
+		body := []byte(`{"messages":[{"role":"user","content":"plain string"}]}`)
+		result := NormalizeToolIdentifiers(body)
+		if gjson.GetBytes(result, "messages.0.content").String() != "plain string" {
+			t.Errorf("plain-string content should be untouched: %s", result)
+		}
 	})
 
 	t.Run("normalizes tools[].name", func(t *testing.T) {

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -616,6 +616,71 @@ func TestNormalizeToolIdentifiers(t *testing.T) {
 		}
 	})
 
+	t.Run("suffix skips slots already taken by a valid id", func(t *testing.T) {
+		// `foo_bar_1` is already valid; `foo_bar` is already valid;
+		// `foo.bar` would collapse onto `foo_bar` → suffixed to `foo_bar_1` (taken)
+		// → must bump to `foo_bar_2`.
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"foo_bar_1","name":"a","input":{}},
+					{"type":"tool_use","id":"foo_bar","name":"b","input":{}},
+					{"type":"tool_use","id":"foo.bar","name":"c","input":{}}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+		ids := []string{
+			gjson.GetBytes(result, "messages.0.content.0.id").String(),
+			gjson.GetBytes(result, "messages.0.content.1.id").String(),
+			gjson.GetBytes(result, "messages.0.content.2.id").String(),
+		}
+		want := []string{"foo_bar_1", "foo_bar", "foo_bar_2"}
+		for i, w := range want {
+			if ids[i] != w {
+				t.Errorf("ids[%d] = %q, want %q (all=%v)", i, ids[i], w, ids)
+			}
+		}
+	})
+
+	t.Run("repeated original id maps to same normalized value", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"x.1","name":"a","input":{}}
+				]},
+				{"role":"user","content":[
+					{"type":"tool_result","tool_use_id":"x.1","content":"r1"},
+					{"type":"tool_result","tool_use_id":"x.1","content":"r2"}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+		id := gjson.GetBytes(result, "messages.0.content.0.id").String()
+		ref0 := gjson.GetBytes(result, "messages.1.content.0.tool_use_id").String()
+		ref1 := gjson.GetBytes(result, "messages.1.content.1.tool_use_id").String()
+		if id == "" || id != ref0 || id != ref1 {
+			t.Errorf("repeated original should map identically: id=%q ref0=%q ref1=%q", id, ref0, ref1)
+		}
+	})
+
+	t.Run("empty id is left alone", func(t *testing.T) {
+		body := []byte(`{
+			"messages":[
+				{"role":"assistant","content":[
+					{"type":"tool_use","id":"","name":"a","input":{}}
+				]}
+			]
+		}`)
+
+		result := NormalizeToolIdentifiers(body)
+		if got := gjson.GetBytes(result, "messages.0.content.0.id").String(); got != "" {
+			t.Errorf("empty id should stay empty, got %q", got)
+		}
+	})
+
 	t.Run("ignores non-array message content", func(t *testing.T) {
 		body := []byte(`{"messages":[{"role":"user","content":"plain string"}]}`)
 		result := NormalizeToolIdentifiers(body)


### PR DESCRIPTION
## Summary
- Some clients send tool identifiers like `functions.foo:0` which Bedrock rejects: ``tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'``
- Add `NormalizeToolIdentifiers` to substitute disallowed chars with `_` across `tool_use.id`, `tool_result.tool_use_id`, `tool_use.name`, and `tools[].name`
- Wire into `SanitizeForBedrockCompat` so both direct-Bedrock and custom-adapter bedrock-disguise paths pick it up

## Why
Reviewing last few days of FAILED requests on the gateway:
- **23** `tool_use.id` pattern rejections
- **2** `tools[].name` pattern rejections

Substitution is deterministic, so `tool_use.id` and the matching `tool_result.tool_use_id` collapse to the same value without needing a remap. This is a pure compatibility cleanup — no semantic change.

## Test plan
- [x] Unit tests for tool_use.id + matching tool_result.tool_use_id stay paired
- [x] Already-valid identifiers untouched
- [x] tools[].name normalized
- [x] Name capped at 128 chars
- [x] Integration test via `SanitizeForBedrockCompat`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 强化与 Bedrock 的兼容性：自动规范化工具标识符与名称（只保留允许字符、将不合法字符替换、长度上限 128），保证规范化后相关使用与结果标识符保持一致且幂等，冲突时自动消解以避免重复。

* **测试**
  * 新增全面测试，覆盖标识符重写、名称截断、冲突解消、幂等性及与兼容化流程的集成验证。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/557)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->