### PR TITLE
fix(bedrock): catch "temperature is deprecated" wording for retry

### DIFF
--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -162,27 +162,36 @@ func StripSamplingParams(body []byte) []byte {
 // samplingParamRejectedPattern matches Bedrock 400 validation messages that
 // reject `temperature` / `top_p` / `top_k` because the target model is in
 // (possibly always-on) extended-thinking mode. Wording shifts across
-// releases — the Anthropic-style format wraps the field in backticks
-// ("`temperature` may only be set to 1 when thinking is enabled") while
-// the Bedrock-native format drops them — and the field may appear before
-// or after the thinking clause.
+// releases:
 //
-// The pattern requires both (a) one of the rejected field names and
-// (b) a phrase that anchors "thinking" to its rejection role: either a
-// preposition + "thinking" (e.g. "when thinking", "with extended
-// thinking") or "thinking is enabled/active/on" / "thinking mode".
-// Bare co-occurrence is intentionally NOT enough — a message like
-// "temperature must be between 0 and 1; thinking budget exceeds
-// max_tokens" mentions both but is not a thinking-mode rejection;
-// "thinking" there is a noun modifier of "budget", not the verb
-// describing the model state, so it must not trigger a body-mutating
-// retry.
+//  1. Thinking-anchored: "temperature may only be set to 1 when thinking
+//     is enabled" / "with extended thinking" / etc. The Anthropic-style
+//     format wraps the field in backticks while the Bedrock-native format
+//     drops them; the field may appear before or after the thinking clause.
+//  2. Deprecation-style (observed in production starting 2026-05-12 for
+//     `claude-opus-4-7`): "`temperature` is deprecated for this model."
+//     No mention of "thinking" at all. The same body mutation (strip
+//     sampling params and replay) is the right recovery.
+//
+// The thinking-anchored alternation deliberately rejects bare
+// co-occurrence — a message like "temperature must be between 0 and 1;
+// thinking budget exceeds max_tokens" mentions both words but is not a
+// thinking-mode rejection. The deprecation alternation has no such
+// ambiguity: a 400 saying a sampling param "is deprecated for this model"
+// is exactly the case we want to recover from.
 var samplingParamRejectedPattern = regexp.MustCompile(
+	// (1a) field-then-thinking
 	`\b(?:temperature|top_p|top_k)\b[^\n]{0,200}` +
 		`(?:\b(?:when|with|during|while|in)\s+(?:extended\s+|adaptive\s+)?thinking\b|\bthinking\s+(?:is\s+(?:enabled|active|on)|mode)\b)` +
 		`|` +
+		// (1b) thinking-then-field
 		`(?:\b(?:when|with|during|while|in)\s+(?:extended\s+|adaptive\s+)?thinking\b|\bthinking\s+(?:is\s+(?:enabled|active|on)|mode)\b)` +
-		`[^\n]{0,200}\b(?:temperature|top_p|top_k)\b`,
+		`[^\n]{0,200}\b(?:temperature|top_p|top_k)\b` +
+		`|` +
+		// (2) deprecation wording (no thinking phrase)
+		`\b(?:temperature|top_p|top_k)\b[^\n]{0,60}\b(?:is\s+)?deprecated\b` +
+		`|` +
+		`\bdeprecated\b[^\n]{0,60}\b(?:temperature|top_p|top_k)\b`,
 )
 
 // IsSamplingParamRejectedError reports whether the upstream error body is

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -188,10 +188,16 @@ var samplingParamRejectedPattern = regexp.MustCompile(
 		`(?:\b(?:when|with|during|while|in)\s+(?:extended\s+|adaptive\s+)?thinking\b|\bthinking\s+(?:is\s+(?:enabled|active|on)|mode)\b)` +
 		`[^\n]{0,200}\b(?:temperature|top_p|top_k)\b` +
 		`|` +
-		// (2) deprecation wording (no thinking phrase)
-		`\b(?:temperature|top_p|top_k)\b[^\n]{0,60}\b(?:is\s+)?deprecated\b` +
+		// (2) deprecation wording (no thinking phrase). The 200-char window
+		// matches the thinking-anchored branch — "deprecated" near a
+		// sampling field name is itself a strong anchor, so we tolerate
+		// longer prose like "`temperature` is deprecated for this model
+		// when X; use default behavior instead." A spurious match would
+		// just waste a single replay (the stripped body either succeeds
+		// or fails the same way), so the failure mode is self-correcting.
+		`\b(?:temperature|top_p|top_k)\b[^\n]{0,200}\b(?:is\s+)?deprecated\b` +
 		`|` +
-		`\bdeprecated\b[^\n]{0,60}\b(?:temperature|top_p|top_k)\b`,
+		`\bdeprecated\b[^\n]{0,200}\b(?:temperature|top_p|top_k)\b`,
 )
 
 // IsSamplingParamRejectedError reports whether the upstream error body is

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -482,6 +482,20 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 			body: `{"message":"` + "`temperature`" + ` is deprecated for this model when extended thinking is used; use the default behavior instead."}`,
 			want: true,
 		},
+		{
+			// Boundary: field and `deprecated` separated by ~190 chars of
+			// filler to exercise the 200-char proximity window.
+			name: "deprecation wording near 200-char boundary",
+			body: `{"message":"temperature ` + strings.Repeat("x", 190) + ` is deprecated."}`,
+			want: true,
+		},
+		{
+			// Boundary: same shape but pushed past 200 chars between the
+			// field and `deprecated` — should NOT match.
+			name: "deprecation wording beyond 200-char boundary",
+			body: `{"message":"temperature ` + strings.Repeat("x", 220) + ` is deprecated."}`,
+			want: false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -471,6 +471,17 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 			body: `{"message":"this endpoint is deprecated, use v2"}`,
 			want: false,
 		},
+		{
+			name: "deprecation wording for top_k",
+			body: `{"message":"top_k is deprecated for this model."}`,
+			want: true,
+		},
+		{
+			// Defensive: longer prose wording within the 200-char window.
+			name: "deprecation wording with extended prose",
+			body: `{"message":"` + "`temperature`" + ` is deprecated for this model when extended thinking is used; use the default behavior instead."}`,
+			want: true,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -446,6 +446,31 @@ func TestIsSamplingParamRejectedError(t *testing.T) {
 			body: `{"message":"thinking budget too low; temperature was 0.7"}`,
 			want: false,
 		},
+		{
+			// Production regression captured 2026-05-12 onward: Bedrock now
+			// emits this wording for claude-opus-4-7 instead of the older
+			// "may only be set to 1 when thinking is enabled" form. No
+			// mention of thinking, but the recovery (strip + replay) is
+			// the same.
+			name: "deprecation wording (backticks)",
+			body: `{"message":"` + "`temperature`" + ` is deprecated for this model."}`,
+			want: true,
+		},
+		{
+			name: "deprecation wording (no backticks)",
+			body: `{"message":"top_p is deprecated for this model."}`,
+			want: true,
+		},
+		{
+			name: "deprecation wording (reversed clause)",
+			body: `{"message":"deprecated parameter: temperature"}`,
+			want: true,
+		},
+		{
+			name: "false-positive guard: unrelated deprecation",
+			body: `{"message":"this endpoint is deprecated, use v2"}`,
+			want: false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Bedrock changed its sampling-param rejection wording for \`claude-opus-4-7\`. Production logs since 2026-05-12 show 87+ requests failing with \`\`\`\`\`temperature\`\`\` is deprecated for this model.\`\`\`\` — no mention of \"thinking\".
- The PR #555 regex was tightened to require a thinking-state phrase (to avoid false-positives on \`temperature must be between 0 and 1; thinking budget exceeds max_tokens\`), which made the new deprecation wording slip through.
- Add a separate alternation that triggers on \`is deprecated\` in proximity to a sampling field name. Same recovery (strip + replay).

## Why this is safe
Unlike the bare-co-occurrence case, \"X is deprecated for this model\" near a sampling field name is unambiguous — it can only be the case we want to recover from. Added a guard test for an unrelated \"this endpoint is deprecated\" message to verify the regex doesn't over-match.

## Test plan
- [x] New cases in \`TestIsSamplingParamRejectedError\`: backticks, no-backticks, reversed clause, unrelated-deprecation guard
- [x] All existing cases still pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了系统对来自服务端的采样参数相关错误消息的识别，新增对多种“已弃用”格式的识别规则，提升错误分类的准确性与稳健性。

* **Tests**
  * 扩展了测试用例，覆盖新增的弃用消息变体并加入防误报场景，增强回归保护与可靠性验证。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/558)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->