### PR TITLE
fix: bridge OpenRouter Codex tools via chat completions

### DIFF
--- a/internal/converter/codex_openai_more_test.go
+++ b/internal/converter/codex_openai_more_test.go
@@ -27,10 +27,12 @@ func TestCodexToOpenAIRequest_ResponseInputString(t *testing.T) {
 
 func TestCodexToOpenAIRequest_ConvertsResponseToolsToFunctionTools(t *testing.T) {
 	req := CodexRequest{
-		Model: "codex-test",
+		Model:        "codex-test",
+		Instructions: "prefer safe edits",
 		Input: []interface{}{
 			map[string]interface{}{"type": "message", "role": "developer", "content": "follow instructions"},
 			map[string]interface{}{"type": "message", "role": "user", "content": "use a tool"},
+			map[string]interface{}{"type": "message", "role": "", "content": "missing role defaults to user"},
 		},
 		Tools: []CodexTool{{
 			Type:        "function",
@@ -43,7 +45,15 @@ func TestCodexToOpenAIRequest_ConvertsResponseToolsToFunctionTools(t *testing.T)
 				},
 			},
 		}, {
+			Type:        "FUNCTION",
+			Name:        "read_file",
+			Description: "read a file",
+		}, {
 			Type: "web_search",
+		}, {
+			Type: "image_generation",
+		}, {
+			Type: "function",
 		}},
 	}
 	body, _ := json.Marshal(req)
@@ -59,15 +69,66 @@ func TestCodexToOpenAIRequest_ConvertsResponseToolsToFunctionTools(t *testing.T)
 	if got.Model != "deepseek-test" || !got.Stream {
 		t.Fatalf("unexpected model/stream: %#v", got)
 	}
-	if len(got.Messages) != 2 || got.Messages[0].Role != "system" || got.Messages[1].Role != "user" {
-		t.Fatalf("unexpected converted roles: %#v", got.Messages)
+	if len(got.Messages) != 4 {
+		t.Fatalf("messages len = %d, want 4: %#v", len(got.Messages), got.Messages)
 	}
-	if len(got.Tools) != 1 {
-		t.Fatalf("tools len = %d, want only the function tool", len(got.Tools))
+	wantRoles := []string{"system", "system", "user", "user"}
+	for i, want := range wantRoles {
+		if got.Messages[i].Role != want {
+			t.Fatalf("message[%d].Role = %q, want %q; messages=%#v", i, got.Messages[i].Role, want, got.Messages)
+		}
 	}
-	tool := got.Tools[0]
-	if tool.Type != "function" || tool.Function.Name != "shell" {
-		t.Fatalf("unexpected converted tool: %#v", tool)
+	if len(got.Tools) != 2 {
+		t.Fatalf("tools len = %d, want only the two named function tools: %#v", len(got.Tools), got.Tools)
+	}
+	if got.Tools[0].Type != "function" || got.Tools[0].Function.Name != "shell" {
+		t.Fatalf("unexpected first converted tool: %#v", got.Tools[0])
+	}
+	if got.Tools[1].Type != "function" || got.Tools[1].Function.Name != "read_file" {
+		t.Fatalf("unexpected second converted tool: %#v", got.Tools[1])
+	}
+}
+
+func TestCodexToOpenAIRequest_PreservesToolCallRoundTripShape(t *testing.T) {
+	req := CodexRequest{
+		Model: "codex-test",
+		Input: []interface{}{
+			map[string]interface{}{
+				"type":      "function_call",
+				"call_id":   "call_shell_1",
+				"name":      "shell",
+				"arguments": `{"cmd":"pwd"}`,
+			},
+			map[string]interface{}{
+				"type":    "function_call_output",
+				"call_id": "call_shell_1",
+				"output":  "workspace",
+			},
+		},
+	}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "deepseek-test", false)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	var got OpenAIRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2: %#v", len(got.Messages), got.Messages)
+	}
+	assistant := got.Messages[0]
+	if assistant.Role != "assistant" || len(assistant.ToolCalls) != 1 {
+		t.Fatalf("unexpected assistant tool call message: %#v", assistant)
+	}
+	if assistant.ToolCalls[0].ID != "call_shell_1" || assistant.ToolCalls[0].Function.Name != "shell" || assistant.ToolCalls[0].Function.Arguments != `{"cmd":"pwd"}` {
+		t.Fatalf("unexpected tool call: %#v", assistant.ToolCalls[0])
+	}
+	tool := got.Messages[1]
+	if tool.Role != "tool" || tool.ToolCallID != "call_shell_1" || tool.Content != "workspace" {
+		t.Fatalf("unexpected tool output message: %#v", tool)
 	}
 }
 

--- a/internal/converter/codex_openai_more_test.go
+++ b/internal/converter/codex_openai_more_test.go
@@ -59,7 +59,7 @@ func TestCodexToOpenAIRequest_ConvertsResponseToolsToFunctionTools(t *testing.T)
 	if got.Model != "deepseek-test" || !got.Stream {
 		t.Fatalf("unexpected model/stream: %#v", got)
 	}
-	if len(got.Messages) < 2 || got.Messages[0].Role != "system" || got.Messages[1].Role != "user" {
+	if len(got.Messages) != 2 || got.Messages[0].Role != "system" || got.Messages[1].Role != "user" {
 		t.Fatalf("unexpected converted roles: %#v", got.Messages)
 	}
 	if len(got.Tools) != 1 {

--- a/internal/converter/codex_openai_more_test.go
+++ b/internal/converter/codex_openai_more_test.go
@@ -25,6 +25,52 @@ func TestCodexToOpenAIRequest_ResponseInputString(t *testing.T) {
 	}
 }
 
+func TestCodexToOpenAIRequest_ConvertsResponseToolsToFunctionTools(t *testing.T) {
+	req := CodexRequest{
+		Model: "codex-test",
+		Input: []interface{}{
+			map[string]interface{}{"type": "message", "role": "developer", "content": "follow instructions"},
+			map[string]interface{}{"type": "message", "role": "user", "content": "use a tool"},
+		},
+		Tools: []CodexTool{{
+			Type:        "function",
+			Name:        "shell",
+			Description: "run shell command",
+			Parameters: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cmd": map[string]interface{}{"type": "string"},
+				},
+			},
+		}, {
+			Type: "web_search",
+		}},
+	}
+	body, _ := json.Marshal(req)
+	conv := &codexToOpenAIRequest{}
+	out, err := conv.Transform(body, "deepseek-test", true)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	var got OpenAIRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Model != "deepseek-test" || !got.Stream {
+		t.Fatalf("unexpected model/stream: %#v", got)
+	}
+	if len(got.Messages) < 2 || got.Messages[0].Role != "system" || got.Messages[1].Role != "user" {
+		t.Fatalf("unexpected converted roles: %#v", got.Messages)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("tools len = %d, want only the function tool", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if tool.Type != "function" || tool.Function.Name != "shell" {
+		t.Fatalf("unexpected converted tool: %#v", tool)
+	}
+}
+
 func TestCodexToOpenAIResponse_StreamMore(t *testing.T) {
 	conv := &codexToOpenAIResponse{}
 	state := NewTransformState()

--- a/internal/converter/codex_to_openai.go
+++ b/internal/converter/codex_to_openai.go
@@ -79,11 +79,8 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 				role, _ := m["role"].(string)
 				switch itemType {
 				case "message":
-					if role == "" {
-						role = "user"
-					}
 					openaiReq.Messages = append(openaiReq.Messages, OpenAIMessage{
-						Role:    role,
+						Role:    codexMessageRoleToOpenAI(role),
 						Content: codexContentToOpenAI(m["content"]),
 					})
 				case "function_call":
@@ -119,8 +116,14 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 		}
 	}
 
-	// Convert tools
+	// Convert tools. Chat Completions can carry function tools, but Responses-only
+	// built-ins such as web_search do not have an OpenAI Chat function shape.
+	// Dropping those keeps Codex/OpenRouter-compatible fallbacks from sending
+	// invalid {type:"web_search"} or empty function names upstream.
 	for _, tool := range req.Tools {
+		if !strings.EqualFold(strings.TrimSpace(tool.Type), "function") || strings.TrimSpace(tool.Name) == "" {
+			continue
+		}
 		openaiReq.Tools = append(openaiReq.Tools, OpenAITool{
 			Type: "function",
 			Function: OpenAIFunction{
@@ -132,6 +135,17 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 	}
 
 	return json.Marshal(openaiReq)
+}
+
+func codexMessageRoleToOpenAI(role string) string {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "developer", "system":
+		return "system"
+	case "assistant", "user", "tool", "function":
+		return strings.ToLower(strings.TrimSpace(role))
+	default:
+		return "user"
+	}
 }
 
 func codexContentToOpenAI(content interface{}) interface{} {

--- a/internal/converter/codex_to_openai.go
+++ b/internal/converter/codex_to_openai.go
@@ -138,11 +138,12 @@ func (c *codexToOpenAIRequest) Transform(body []byte, model string, stream bool)
 }
 
 func codexMessageRoleToOpenAI(role string) string {
-	switch strings.ToLower(strings.TrimSpace(role)) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
 	case "developer", "system":
 		return "system"
 	case "assistant", "user", "tool", "function":
-		return strings.ToLower(strings.TrimSpace(role))
+		return normalized
 	default:
 		return "user"
 	}

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -75,7 +75,29 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 		requestURI := state.requestURI
 
 		supportedTypes := matchedRoute.ProviderAdapter.SupportedClientTypes()
-		if e.converter.NeedConvert(clientType, supportedTypes) {
+		if shouldBridgeCustomCodexViaOpenAI(matchedRoute.Provider, clientType, supportedTypes) {
+			currentClientType = domain.ClientTypeOpenAI
+			needsConversion = true
+			log.Printf("[Executor] OpenRouter-compatible custom provider %s: bridging Codex request through OpenAI Chat Completions",
+				matchedRoute.Provider.Name)
+
+			convertedBody, convErr = e.converter.TransformRequest(
+				clientType, currentClientType, requestBody, mappedModel, state.isStream)
+			if convErr != nil {
+				log.Printf("[Executor] OpenRouter Codex->OpenAI conversion failed: %v, proceeding with original format", convErr)
+				needsConversion = false
+				currentClientType = clientType
+			} else {
+				requestBody = convertedBody
+
+				originalURI := requestURI
+				convertedURI := ConvertRequestURI(requestURI, clientType, currentClientType, mappedModel, state.isStream)
+				if convertedURI != originalURI {
+					requestURI = convertedURI
+					log.Printf("[Executor] URI converted: %s -> %s", originalURI, convertedURI)
+				}
+			}
+		} else if e.converter.NeedConvert(clientType, supportedTypes) {
 			currentClientType = GetPreferredTargetType(supportedTypes, clientType, matchedRoute.Provider.Type)
 			if currentClientType != clientType {
 				needsConversion = true

--- a/internal/executor/openrouter_bridge.go
+++ b/internal/executor/openrouter_bridge.go
@@ -55,13 +55,11 @@ func isOpenRouterCompatibleURL(rawURL string) bool {
 		return false
 	}
 	parsed, err := url.Parse(trimmed)
-	if err == nil {
-		host := strings.TrimPrefix(parsed.Hostname(), "www.")
-		if host == "openrouter.ai" || strings.HasSuffix(host, ".openrouter.ai") {
-			return true
-		}
+	if err != nil {
+		return false
 	}
-	return strings.Contains(trimmed, "openrouter.ai")
+	host := strings.TrimPrefix(parsed.Hostname(), "www.")
+	return host == "openrouter.ai" || strings.HasSuffix(host, ".openrouter.ai")
 }
 
 func isOpenRouterCompatibleProviderName(name string) bool {

--- a/internal/executor/openrouter_bridge.go
+++ b/internal/executor/openrouter_bridge.go
@@ -1,0 +1,69 @@
+package executor
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// shouldBridgeCustomCodexViaOpenAI returns true for custom OpenRouter-style
+// providers that are reachable through OpenAI Chat Completions but reject Codex
+// Responses API tool schemas. Codex CLI sends Responses-shaped tool definitions
+// such as web_search/image_generation, while OpenRouter accepts only its own
+// openrouter:* built-in tool types on /responses. Routing through OpenAI keeps
+// user-defined function tools compatible and avoids breaking normal Codex
+// providers.
+func shouldBridgeCustomCodexViaOpenAI(provider *domain.Provider, clientType domain.ClientType, supportedTypes []domain.ClientType) bool {
+	if provider == nil || clientType != domain.ClientTypeCodex || provider.Type != "custom" {
+		return false
+	}
+	if !supportsClientType(supportedTypes, domain.ClientTypeOpenAI) {
+		return false
+	}
+	if provider.Config == nil || provider.Config.Custom == nil {
+		return false
+	}
+
+	custom := provider.Config.Custom
+	if isOpenRouterCompatibleURL(custom.BaseURL) {
+		return true
+	}
+	if custom.ClientBaseURL != nil {
+		if isOpenRouterCompatibleURL(custom.ClientBaseURL[domain.ClientTypeCodex]) {
+			return true
+		}
+		if isOpenRouterCompatibleURL(custom.ClientBaseURL[domain.ClientTypeOpenAI]) {
+			return true
+		}
+	}
+	return isOpenRouterCompatibleProviderName(provider.Name)
+}
+
+func supportsClientType(types []domain.ClientType, target domain.ClientType) bool {
+	for _, candidate := range types {
+		if candidate == target {
+			return true
+		}
+	}
+	return false
+}
+
+func isOpenRouterCompatibleURL(rawURL string) bool {
+	trimmed := strings.TrimSpace(strings.ToLower(rawURL))
+	if trimmed == "" {
+		return false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err == nil {
+		host := strings.TrimPrefix(parsed.Hostname(), "www.")
+		if host == "openrouter.ai" || strings.HasSuffix(host, ".openrouter.ai") {
+			return true
+		}
+	}
+	return strings.Contains(trimmed, "openrouter.ai")
+}
+
+func isOpenRouterCompatibleProviderName(name string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(name)), "openrouter")
+}

--- a/internal/executor/openrouter_bridge_e2e_test.go
+++ b/internal/executor/openrouter_bridge_e2e_test.go
@@ -1,0 +1,112 @@
+package executor
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestOpenRouterCodexBridge_EndToEndMockUpstream(t *testing.T) {
+	var capturedPath string
+	var capturedBody []byte
+	mockOpenRouter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedBody, _ = io.ReadAll(r.Body)
+		if capturedPath != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %q, want /v1/chat/completions", capturedPath)
+		}
+
+		var got converter.OpenAIRequest
+		if err := json.Unmarshal(capturedBody, &got); err != nil {
+			t.Fatalf("upstream received invalid OpenAI request JSON: %v\n%s", err, capturedBody)
+		}
+		if got.Model != "openrouter/codex-target" || !got.Stream {
+			t.Fatalf("unexpected model/stream at mock upstream: %#v", got)
+		}
+		if len(got.Messages) != 3 {
+			t.Fatalf("messages len = %d, want 3: %#v", len(got.Messages), got.Messages)
+		}
+		wantRoles := []string{"system", "system", "user"}
+		for i, want := range wantRoles {
+			if got.Messages[i].Role != want {
+				t.Fatalf("message[%d].role = %q, want %q; messages=%#v", i, got.Messages[i].Role, want, got.Messages)
+			}
+		}
+		if len(got.Tools) != 1 {
+			t.Fatalf("tools len = %d, want only one function tool after dropping Responses-only built-ins: %#v", len(got.Tools), got.Tools)
+		}
+		if got.Tools[0].Type != "function" || got.Tools[0].Function.Name != "shell" {
+			t.Fatalf("unexpected function tool at mock upstream: %#v", got.Tools[0])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl_mock","object":"chat.completion","created":1,"model":"openrouter/codex-target","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"completion_tokens":2,"total_tokens":9}}`))
+	}))
+	defer mockOpenRouter.Close()
+
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "openrouter",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: mockOpenRouter.URL,
+			ClientBaseURL: map[domain.ClientType]string{
+				domain.ClientTypeOpenAI: mockOpenRouter.URL,
+				domain.ClientTypeCodex:  "https://openrouter.ai/api/v1",
+			},
+		}},
+	}
+	if !shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+		t.Fatal("expected OpenRouter-compatible custom provider to bridge Codex through OpenAI")
+	}
+
+	codexReq := converter.CodexRequest{
+		Model:        "codex-source",
+		Instructions: "be careful",
+		Input: []interface{}{
+			map[string]interface{}{"type": "message", "role": "developer", "content": "follow project rules"},
+			map[string]interface{}{"type": "message", "role": "user", "content": "run pwd"},
+		},
+		Tools: []converter.CodexTool{{
+			Type:        "function",
+			Name:        "shell",
+			Description: "run a shell command",
+			Parameters:  map[string]interface{}{"type": "object"},
+		}, {
+			Type: "web_search",
+		}, {
+			Type: "image_generation",
+		}},
+	}
+	body, err := json.Marshal(codexReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	convertedBody, err := converter.GetGlobalRegistry().TransformRequest(domain.ClientTypeCodex, domain.ClientTypeOpenAI, body, "openrouter/codex-target", true)
+	if err != nil {
+		t.Fatalf("TransformRequest: %v", err)
+	}
+	convertedURI := ConvertRequestURI("/responses", domain.ClientTypeCodex, domain.ClientTypeOpenAI, "openrouter/codex-target", true)
+	if convertedURI != "/v1/chat/completions" {
+		t.Fatalf("converted URI = %q, want /v1/chat/completions", convertedURI)
+	}
+
+	resp, err := http.Post(mockOpenRouter.URL+convertedURI, "application/json", bytes.NewReader(convertedBody))
+	if err != nil {
+		t.Fatalf("mock upstream post: %v", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mock upstream status = %d body=%s", resp.StatusCode, respBody)
+	}
+	if len(capturedBody) == 0 {
+		t.Fatal("mock upstream did not capture converted request body")
+	}
+}

--- a/internal/executor/openrouter_bridge_test.go
+++ b/internal/executor/openrouter_bridge_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestShouldBridgeCustomCodexViaOpenAIForOpenRouter(t *testing.T) {
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "openrouter",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://openrouter.ai/api/v1",
+		}},
+	}
+
+	if !shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+		t.Fatal("expected OpenRouter custom Codex route to bridge through OpenAI")
+	}
+}
+
+func TestShouldNotBridgeOpenRouterWithoutOpenAISupport(t *testing.T) {
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "openrouter",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://openrouter.ai/api/v1",
+		}},
+	}
+
+	if shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex}) {
+		t.Fatal("must not bridge when provider cannot accept OpenAI Chat Completions")
+	}
+}
+
+func TestShouldNotBridgeNonOpenRouterCustomCodex(t *testing.T) {
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "generic-relay",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://relay.example.com/v1",
+		}},
+	}
+
+	if shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+		t.Fatal("generic custom Codex routes should keep their declared Codex Responses path")
+	}
+}
+
+func TestShouldBridgeOpenRouterClientBaseURL(t *testing.T) {
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "relay",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://relay.example.com/v1",
+			ClientBaseURL: map[domain.ClientType]string{
+				domain.ClientTypeCodex: "https://openrouter.ai/api/v1",
+			},
+		}},
+	}
+
+	if !shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+		t.Fatal("expected OpenRouter Codex client base URL to bridge through OpenAI")
+	}
+}
+
+func TestOpenRouterCodexBridgeUsesChatCompletionsPath(t *testing.T) {
+	if got := ConvertRequestURI("/responses", domain.ClientTypeCodex, domain.ClientTypeOpenAI, "", true); got != "/v1/chat/completions" {
+		t.Fatalf("ConvertRequestURI(/responses) = %q, want /v1/chat/completions", got)
+	}
+	if got := ConvertRequestURI("/v1/responses", domain.ClientTypeCodex, domain.ClientTypeOpenAI, "", true); got != "/v1/chat/completions" {
+		t.Fatalf("ConvertRequestURI(/v1/responses) = %q, want /v1/chat/completions", got)
+	}
+}

--- a/internal/executor/openrouter_bridge_test.go
+++ b/internal/executor/openrouter_bridge_test.go
@@ -49,19 +49,52 @@ func TestShouldNotBridgeNonOpenRouterCustomCodex(t *testing.T) {
 }
 
 func TestShouldBridgeOpenRouterClientBaseURL(t *testing.T) {
-	provider := &domain.Provider{
-		Type: "custom",
-		Name: "relay",
-		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
-			BaseURL: "https://relay.example.com/v1",
-			ClientBaseURL: map[domain.ClientType]string{
+	tests := []struct {
+		name          string
+		clientBaseURL map[domain.ClientType]string
+	}{
+		{
+			name: "codex client base URL",
+			clientBaseURL: map[domain.ClientType]string{
 				domain.ClientTypeCodex: "https://openrouter.ai/api/v1",
 			},
+		},
+		{
+			name: "openai client base URL",
+			clientBaseURL: map[domain.ClientType]string{
+				domain.ClientTypeOpenAI: "https://openrouter.ai/api/v1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &domain.Provider{
+				Type: "custom",
+				Name: "relay",
+				Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+					BaseURL:       "https://relay.example.com/v1",
+					ClientBaseURL: tt.clientBaseURL,
+				}},
+			}
+
+			if !shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+				t.Fatal("expected OpenRouter client base URL to bridge through OpenAI")
+			}
+		})
+	}
+}
+
+func TestShouldNotBridgeLookalikeOpenRouterHost(t *testing.T) {
+	provider := &domain.Provider{
+		Type: "custom",
+		Name: "generic-relay",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://openrouter.ai.evil.example/api/v1",
 		}},
 	}
 
-	if !shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
-		t.Fatal("expected OpenRouter Codex client base URL to bridge through OpenAI")
+	if shouldBridgeCustomCodexViaOpenAI(provider, domain.ClientTypeCodex, []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI}) {
+		t.Fatal("must not bridge OpenRouter lookalike hosts")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #537 by routing custom OpenRouter-compatible Codex requests through OpenAI Chat Completions when the provider also supports OpenAI format.

This avoids sending Codex Responses API tool schemas directly to OpenRouter-compatible `/responses` endpoints, where non-`openrouter:*` tool types are rejected.

## Changes

- Detect custom OpenRouter-compatible Codex routes by OpenRouter base URL / client base URL / provider name.
- Convert those requests from Codex Responses shape to OpenAI Chat Completions before dispatch.
- Normalize Codex `developer` messages to Chat-compatible `system` messages during Codex → OpenAI conversion.
- Preserve function tools while dropping Responses-only built-in tools such as `web_search` that cannot be represented as Chat Completions function tools.
- Add regression tests for the bridge detection, `/responses` → `/v1/chat/completions` path, role normalization, and tool filtering.

## Validation

- `go test ./internal/converter ./internal/executor ./internal/adapter/provider/custom`
- `go test ./internal/...`
- Real local smoke test with maxx `/responses` → telepub `DeepSeek-V4-pro`, including a function tool payload, returned HTTP 200 and `maxx537-ok`.
- Real `codexmate codex exec` smoke test through local maxx using telepub `DeepSeek-V4-pro`; Codex CLI request included 44 tools including `web_search`, and returned `maxx537-codexmate-ok`.

No API keys are included in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进消息角色标准化，避免因异常角色导致的请求行为不一致。
  * 工具处理更严格：仅保留符合预期的函数类工具，减少兼容性问题。

* **New Features**
  * 自动对 OpenRouter 兼容的自定义 Codex 请求进行桥接，并稳定使用对应的聊天补全端点路径。

* **Tests**
  * 新增 OpenRouter 桥接判定与路径转换测试。
  * 新增工具转换/筛除与工具调用回传形状的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->