### PR TITLE
fix: batch request retention cleanup to avoid huge transactions

### DIFF
--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -284,11 +284,12 @@ func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error
 	const batchSize = 500
 	beforeTs := toTimestamp(before)
 	var total int64
+	var lastID uint64
 
 	for {
 		var ids []uint64
 		if err := r.db.gorm.Model(&ProxyRequest{}).
-			Where("created_at < ?", beforeTs).
+			Where("created_at < ? AND id > ?", beforeTs, lastID).
 			Order("id").
 			Limit(batchSize).
 			Pluck("id", &ids).Error; err != nil {
@@ -297,10 +298,16 @@ func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error
 		if len(ids) == 0 {
 			return total, nil
 		}
+		// keyset 推进：即使本批写命中 0 行也保证下一批跳过这段 id 区间，不会 livelock
+		lastID = ids[len(ids)-1]
 
 		var batchAffected int64
 		if err := r.db.gorm.Transaction(func(tx *gorm.DB) error {
-			if err := tx.Where("proxy_request_id IN ?", ids).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
+			// 子删除限定到当前仍 eligible 的 parent（防止 parent 不可删时 attempts 成孤儿）
+			eligibleParents := tx.Model(&ProxyRequest{}).
+				Select("id").
+				Where("id IN ? AND created_at < ?", ids, beforeTs)
+			if err := tx.Where("proxy_request_id IN (?)", eligibleParents).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
 				return err
 			}
 			res := tx.Where("id IN ? AND created_at < ?", ids, beforeTs).Delete(&ProxyRequest{})
@@ -489,11 +496,12 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 	const batchSize = 500
 	beforeTs := toTimestamp(before)
 	var total int64
+	var lastID uint64
 
 	for {
 		var ids []uint64
 		q := r.db.gorm.Model(&ProxyRequest{}).
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", beforeTs)
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 AND id > ?", beforeTs, lastID)
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
 		}
@@ -503,6 +511,7 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		if len(ids) == 0 {
 			return total, nil
 		}
+		lastID = ids[len(ids)-1]
 
 		// 重应用谓词：Pluck 与 UPDATE 之间行可能因 status/dev_mode 变动而不再 eligible。
 		uq := r.db.gorm.Model(&ProxyRequest{}).

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -278,37 +278,42 @@ func (r *ProxyRequestRepository) UpdateProjectIDBySessionID(tenantID uint64, ses
 }
 
 // DeleteOlderThan 删除指定时间之前的请求记录
+//
+// 分批处理：避免一次性 pluck 海量 id + 两次大 IN DELETE 产生超大事务。
 func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error) {
+	const batchSize = 500
 	beforeTs := toTimestamp(before)
+	var total int64
 
-	// 先查询需要删除的请求ID列表（兼容MySQL）
-	var requestIDs []uint64
-	if err := r.db.gorm.Model(&ProxyRequest{}).Where("created_at < ?", beforeTs).Pluck("id", &requestIDs).Error; err != nil {
-		return 0, err
+	for {
+		var ids []uint64
+		if err := r.db.gorm.Model(&ProxyRequest{}).
+			Where("created_at < ?", beforeTs).
+			Limit(batchSize).
+			Pluck("id", &ids).Error; err != nil {
+			return total, err
+		}
+		if len(ids) == 0 {
+			return total, nil
+		}
+
+		if err := r.db.gorm.Where("proxy_request_id IN ?", ids).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
+			return total, err
+		}
+
+		result := r.db.gorm.Where("id IN ?", ids).Delete(&ProxyRequest{})
+		if result.Error != nil {
+			return total, result.Error
+		}
+		if result.RowsAffected > 0 {
+			atomic.AddInt64(&r.count, -result.RowsAffected)
+		}
+		total += result.RowsAffected
+
+		if len(ids) < batchSize {
+			return total, nil
+		}
 	}
-
-	if len(requestIDs) == 0 {
-		return 0, nil
-	}
-
-	// 删除关联的 attempts
-	if err := r.db.gorm.Where("proxy_request_id IN ?", requestIDs).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
-		return 0, err
-	}
-
-	// 删除 requests
-	result := r.db.gorm.Where("id IN ?", requestIDs).Delete(&ProxyRequest{})
-	if result.Error != nil {
-		return 0, result.Error
-	}
-
-	affected := result.RowsAffected
-	// 更新计数缓存
-	if affected > 0 {
-		atomic.AddInt64(&r.count, -affected)
-	}
-
-	return affected, nil
 }
 
 // HasRecentRequests 检查指定时间之后是否有请求记录
@@ -470,22 +475,44 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
+//
+// 分批处理：request_info/response_info 是大 JSON blob，一次性 UPDATE 会产生
+// 超大事务（WAL 同时记录 old/new value），故按 batchSize 拆分。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
+	const batchSize = 500
 	beforeTs := toTimestamp(before)
-	now := time.Now().UnixMilli()
+	var total int64
 
-	q := r.db.gorm.Model(&ProxyRequest{}).
-		Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", beforeTs)
-	if len(statuses) > 0 {
-		q = q.Where("status IN ?", statuses)
+	for {
+		var ids []uint64
+		q := r.db.gorm.Model(&ProxyRequest{}).
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", beforeTs)
+		if len(statuses) > 0 {
+			q = q.Where("status IN ?", statuses)
+		}
+		if err := q.Limit(batchSize).Pluck("id", &ids).Error; err != nil {
+			return total, err
+		}
+		if len(ids) == 0 {
+			return total, nil
+		}
+
+		result := r.db.gorm.Model(&ProxyRequest{}).
+			Where("id IN ?", ids).
+			Updates(map[string]any{
+				"request_info":  nil,
+				"response_info": nil,
+				"updated_at":    time.Now().UnixMilli(),
+			})
+		if result.Error != nil {
+			return total, result.Error
+		}
+		total += result.RowsAffected
+
+		if len(ids) < batchSize {
+			return total, nil
+		}
 	}
-	result := q.Updates(map[string]any{
-		"request_info":  nil,
-		"response_info": nil,
-		"updated_at":    now,
-	})
-
-	return result.RowsAffected, result.Error
 }
 
 func (r *ProxyRequestRepository) toModel(p *domain.ProxyRequest) *ProxyRequest {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -289,6 +289,7 @@ func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error
 		var ids []uint64
 		if err := r.db.gorm.Model(&ProxyRequest{}).
 			Where("created_at < ?", beforeTs).
+			Order("id").
 			Limit(batchSize).
 			Pluck("id", &ids).Error; err != nil {
 			return total, err
@@ -297,18 +298,24 @@ func (r *ProxyRequestRepository) DeleteOlderThan(before time.Time) (int64, error
 			return total, nil
 		}
 
-		if err := r.db.gorm.Where("proxy_request_id IN ?", ids).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
+		var batchAffected int64
+		if err := r.db.gorm.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Where("proxy_request_id IN ?", ids).Delete(&ProxyUpstreamAttempt{}).Error; err != nil {
+				return err
+			}
+			res := tx.Where("id IN ? AND created_at < ?", ids, beforeTs).Delete(&ProxyRequest{})
+			if res.Error != nil {
+				return res.Error
+			}
+			batchAffected = res.RowsAffected
+			return nil
+		}); err != nil {
 			return total, err
 		}
-
-		result := r.db.gorm.Where("id IN ?", ids).Delete(&ProxyRequest{})
-		if result.Error != nil {
-			return total, result.Error
+		if batchAffected > 0 {
+			atomic.AddInt64(&r.count, -batchAffected)
 		}
-		if result.RowsAffected > 0 {
-			atomic.AddInt64(&r.count, -result.RowsAffected)
-		}
-		total += result.RowsAffected
+		total += batchAffected
 
 		if len(ids) < batchSize {
 			return total, nil
@@ -490,20 +497,24 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
 		}
-		if err := q.Limit(batchSize).Pluck("id", &ids).Error; err != nil {
+		if err := q.Order("id").Limit(batchSize).Pluck("id", &ids).Error; err != nil {
 			return total, err
 		}
 		if len(ids) == 0 {
 			return total, nil
 		}
 
-		result := r.db.gorm.Model(&ProxyRequest{}).
-			Where("id IN ?", ids).
-			Updates(map[string]any{
-				"request_info":  nil,
-				"response_info": nil,
-				"updated_at":    time.Now().UnixMilli(),
-			})
+		// 重应用谓词：Pluck 与 UPDATE 之间行可能因 status/dev_mode 变动而不再 eligible。
+		uq := r.db.gorm.Model(&ProxyRequest{}).
+			Where("id IN ? AND created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", ids, beforeTs)
+		if len(statuses) > 0 {
+			uq = uq.Where("status IN ?", statuses)
+		}
+		result := uq.Updates(map[string]any{
+			"request_info":  nil,
+			"response_info": nil,
+			"updated_at":    time.Now().UnixMilli(),
+		})
 		if result.Error != nil {
 			return total, result.Error
 		}

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -258,6 +258,37 @@ func TestProxyRequestClearDetailOlderThan(t *testing.T) {
 		}
 	})
 
+	t.Run("clears across more than one batch", func(t *testing.T) {
+		// 验证分批循环：seed > batchSize(500) 条，保证至少触发两次迭代且终止条件正确
+		db, err := NewDBWithDSN("sqlite://:memory:")
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer db.Close()
+		repo := NewProxyRequestRepository(db)
+
+		const seedCount = 1200
+		ids := make([]uint64, 0, seedCount)
+		for i := 0; i < seedCount; i++ {
+			req := seedRequestWithDetail(t, repo, "COMPLETED", false, old, i)
+			ids = append(ids, req.ID)
+		}
+
+		n, err := repo.ClearDetailOlderThan(cutoff, nil)
+		if err != nil {
+			t.Fatalf("clear: %v", err)
+		}
+		if n != seedCount {
+			t.Fatalf("expected %d cleared, got %d", seedCount, n)
+		}
+		for _, id := range ids {
+			if !detailCleared(t, repo, id) {
+				t.Fatalf("req %d not cleared after multi-batch run", id)
+				break
+			}
+		}
+	})
+
 	t.Run("respects dev_mode and time cutoff", func(t *testing.T) {
 		db, err := NewDBWithDSN("sqlite://:memory:")
 		if err != nil {

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -244,6 +244,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 	const batchSize = 500
 	beforeTs := toTimestamp(before)
 	var total int64
+	var lastID uint64
 
 	parentReqBuilder := func() *gorm.DB {
 		q := r.db.gorm.Model(&ProxyRequest{}).
@@ -259,7 +260,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		var ids []uint64
 
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND id > ?", beforeTs, lastID).
 			Where("proxy_request_id IN (?)", parentReqBuilder()).
 			Order("id").
 			Limit(batchSize).
@@ -269,6 +270,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		if len(ids) == 0 {
 			return total, nil
 		}
+		lastID = ids[len(ids)-1]
 
 		// 重应用谓词与父表过滤：Pluck 与 UPDATE 之间父请求状态可能变动。
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -238,27 +238,50 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 
 // ClearDetailOlderThan 清理指定时间之前 attempt 的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理所属 ProxyRequest.status IN (statuses) 的 attempt
+//
+// 分批处理：详情字段是大 blob，且关联父表子查询代价不低，故按 batchSize 拆分。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
+	const batchSize = 500
 	beforeTs := toTimestamp(before)
-	now := time.Now().UnixMilli()
+	var total int64
 
-	parentReq := r.db.gorm.Model(&ProxyRequest{}).
-		Select("id").
-		Where("dev_mode = 0")
-	if len(statuses) > 0 {
-		parentReq = parentReq.Where("status IN ?", statuses)
+	for {
+		var ids []uint64
+
+		parentReq := r.db.gorm.Model(&ProxyRequest{}).
+			Select("id").
+			Where("dev_mode = 0")
+		if len(statuses) > 0 {
+			parentReq = parentReq.Where("status IN ?", statuses)
+		}
+
+		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
+			Where("proxy_request_id IN (?)", parentReq).
+			Limit(batchSize).
+			Pluck("id", &ids).Error; err != nil {
+			return total, err
+		}
+		if len(ids) == 0 {
+			return total, nil
+		}
+
+		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
+			Where("id IN ?", ids).
+			Updates(map[string]any{
+				"request_info":  nil,
+				"response_info": nil,
+				"updated_at":    time.Now().UnixMilli(),
+			})
+		if result.Error != nil {
+			return total, result.Error
+		}
+		total += result.RowsAffected
+
+		if len(ids) < batchSize {
+			return total, nil
+		}
 	}
-
-	result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-		Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
-		Where("proxy_request_id IN (?)", parentReq).
-		Updates(map[string]any{
-			"request_info":  nil,
-			"response_info": nil,
-			"updated_at":    now,
-		})
-
-	return result.RowsAffected, result.Error
 }
 
 func (r *ProxyUpstreamAttemptRepository) toModel(a *domain.ProxyUpstreamAttempt) *ProxyUpstreamAttempt {

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -245,19 +245,23 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 	beforeTs := toTimestamp(before)
 	var total int64
 
-	for {
-		var ids []uint64
-
-		parentReq := r.db.gorm.Model(&ProxyRequest{}).
+	parentReqBuilder := func() *gorm.DB {
+		q := r.db.gorm.Model(&ProxyRequest{}).
 			Select("id").
 			Where("dev_mode = 0")
 		if len(statuses) > 0 {
-			parentReq = parentReq.Where("status IN ?", statuses)
+			q = q.Where("status IN ?", statuses)
 		}
+		return q
+	}
+
+	for {
+		var ids []uint64
 
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
-			Where("proxy_request_id IN (?)", parentReq).
+			Where("proxy_request_id IN (?)", parentReqBuilder()).
+			Order("id").
 			Limit(batchSize).
 			Pluck("id", &ids).Error; err != nil {
 			return total, err
@@ -266,8 +270,10 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 			return total, nil
 		}
 
+		// 重应用谓词与父表过滤：Pluck 与 UPDATE 之间父请求状态可能变动。
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-			Where("id IN ?", ids).
+			Where("id IN ? AND created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", ids, beforeTs).
+			Where("proxy_request_id IN (?)", parentReqBuilder()).
 			Updates(map[string]any{
 				"request_info":  nil,
 				"response_info": nil,


### PR DESCRIPTION
## Summary
- `ClearDetailOlderThan` (proxy_request & proxy_upstream_attempt) and `DeleteOlderThan` (proxy_request) used to issue a single UPDATE/DELETE over every matching row. With large `request_info`/`response_info` blobs — or when a retention policy is applied for the first time to a long-lived DB — this produced one giant transaction with very large WAL writes.
- Now each function pulls ids in batches of 500 (`Limit + Pluck`) and applies UPDATE/DELETE per batch, keeping per-transaction footprint bounded.
- `DeleteOlderThan` count cache is still decremented batch-by-batch.

## Test plan
- [x] `go build ./internal/...`
- [x] `go test ./internal/repository/sqlite/ -run 'ClearDetailOlderThan|DeleteOlderThan' -count=1`
- [ ] Manual: run against a populated DB with retention enabled and confirm WAL no longer spikes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能改进**
  * 优化了历史数据删除和清理流程，采用分批处理机制，显著提升处理大规模数据时的效率和系统稳定性。
  * 改进了缓存计数的原子更新机制。

* **测试**
  * 新增测试用例验证多批处理场景下的数据清理正确性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/563)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->