### PR TITLE
fix(retention): clear rejected request details

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -216,7 +216,7 @@ func (e *Executor) RecordRejectedProxyRequest(c *flow.Ctx, apiToken *domain.APIT
 		DevMode:      devMode,
 	}
 
-	clearDetail := e.shouldClearRequestDetailFor(&execState{apiTokenDevMode: devMode})
+	clearDetail := e.shouldClearFailedRequestDetailFor(&execState{apiTokenDevMode: devMode})
 	if !clearDetail {
 		requestHeaders := flattenHeaders(flow.GetRequestHeaders(c))
 		requestURI := flow.GetRequestURI(c)
@@ -450,6 +450,14 @@ func (e *Executor) shouldClearRequestDetailFor(state *execState) bool {
 	return e.shouldClearRequestDetail()
 }
 
+// shouldClearFailedRequestDetailFor 检查已知失败状态的请求详情是否应该立即清理。
+func (e *Executor) shouldClearFailedRequestDetailFor(state *execState) bool {
+	if state != nil && state.apiTokenDevMode {
+		return false
+	}
+	return e.shouldClearFailedRequestDetail()
+}
+
 // shouldClearRequestDetail 检查是否应该立即清理请求详情（全局配置）
 //
 // 决策时机在 ingress / dispatch，此时 status 未知，因此不能按状态分别决策。
@@ -458,8 +466,40 @@ func (e *Executor) shouldClearRequestDetailFor(state *execState) bool {
 //   - split=true：仅当 success 和 failed 两个键都解析为 0 时才立即清理
 //     （只要任一侧需要保留，就先存到 DB，后台 task 再按状态分别清理）
 func (e *Executor) shouldClearRequestDetail() bool {
-	if e.settingsRepo == nil {
+	cfg, ok := e.requestDetailRetentionConfig()
+	if !ok {
 		return false
+	}
+	if !cfg.split {
+		return cfg.unified == 0
+	}
+	return cfg.successSec == 0 && cfg.failedSec == 0
+}
+
+// shouldClearFailedRequestDetail 检查已知失败/拒绝请求是否应该立即清理详情。
+// 对 early rejection 这类已知失败状态，可以使用 failed 桶，而不是退化成
+// “success 和 failed 都为 0 才清理”的未知状态策略。
+func (e *Executor) shouldClearFailedRequestDetail() bool {
+	cfg, ok := e.requestDetailRetentionConfig()
+	if !ok {
+		return false
+	}
+	if !cfg.split {
+		return cfg.unified == 0
+	}
+	return cfg.failedSec == 0
+}
+
+type requestDetailRetentionConfig struct {
+	unified    int
+	split      bool
+	successSec int
+	failedSec  int
+}
+
+func (e *Executor) requestDetailRetentionConfig() (requestDetailRetentionConfig, bool) {
+	if e.settingsRepo == nil {
+		return requestDetailRetentionConfig{}, false
 	}
 
 	parse := func(key string, fallback int) int {
@@ -475,14 +515,18 @@ func (e *Executor) shouldClearRequestDetail() bool {
 	}
 
 	unified := parse(domain.SettingKeyRequestDetailRetentionSeconds, -1)
-
 	splitVal, _ := e.settingsRepo.Get(domain.SettingKeyRequestDetailRetentionSplitEnabled)
-	if splitVal != "true" {
-		return unified == 0
+	cfg := requestDetailRetentionConfig{
+		unified:    unified,
+		split:      splitVal == "true",
+		successSec: unified,
+		failedSec:  unified,
 	}
-	successSec := parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, unified)
-	failedSec := parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, unified)
-	return successSec == 0 && failedSec == 0
+	if cfg.split {
+		cfg.successSec = parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, unified)
+		cfg.failedSec = parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, unified)
+	}
+	return cfg, true
 }
 
 // ShouldClearRequestDetailByConfig 检查是否应该按全局配置立即清理请求详情

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -216,24 +216,27 @@ func (e *Executor) RecordRejectedProxyRequest(c *flow.Ctx, apiToken *domain.APIT
 		DevMode:      devMode,
 	}
 
-	requestHeaders := flattenHeaders(flow.GetRequestHeaders(c))
-	requestURI := flow.GetRequestURI(c)
-	requestBody := flow.GetRequestBody(c)
-	if c.Request != nil {
-		if c.Request.Host != "" {
-			if requestHeaders == nil {
-				requestHeaders = make(map[string]string)
+	clearDetail := e.shouldClearRequestDetailFor(&execState{apiTokenDevMode: devMode})
+	if !clearDetail {
+		requestHeaders := flattenHeaders(flow.GetRequestHeaders(c))
+		requestURI := flow.GetRequestURI(c)
+		requestBody := flow.GetRequestBody(c)
+		if c.Request != nil {
+			if c.Request.Host != "" {
+				if requestHeaders == nil {
+					requestHeaders = make(map[string]string)
+				}
+				requestHeaders["Host"] = c.Request.Host
 			}
-			requestHeaders["Host"] = c.Request.Host
+			proxyReq.RequestInfo = &domain.RequestInfo{
+				Method:  c.Request.Method,
+				URL:     requestURI,
+				Headers: requestHeaders,
+				Body:    string(requestBody),
+			}
 		}
-		proxyReq.RequestInfo = &domain.RequestInfo{
-			Method:  c.Request.Method,
-			URL:     requestURI,
-			Headers: requestHeaders,
-			Body:    string(requestBody),
-		}
+		proxyReq.ResponseInfo = &domain.ResponseInfo{Status: statusCode}
 	}
-	proxyReq.ResponseInfo = &domain.ResponseInfo{Status: statusCode}
 
 	if err := e.proxyRequestRepo.Create(proxyReq); err != nil {
 		log.Printf("[Executor] Failed to create rejected proxy request: %v", err)

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1201,7 +1201,11 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 	providerID := createProvider(t, env, "mock-openai", mock.URL, []string{"openai"})
 	createRoute(t, env, "openai", providerID)
 
-	resp := env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	resp := env.AdminPut("/api/admin/settings/request_detail_retention_seconds", map[string]any{"value": "0"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	resp = env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
 	AssertStatus(t, resp, http.StatusOK)
 	resp.Body.Close()
 
@@ -1246,7 +1250,14 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 		t.Fatal("timed out waiting for first request to reach upstream")
 	}
 
-	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), map[string]string{
+	secretPayload := map[string]any{
+		"model": "gpt-4o",
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "do not persist rejected payload",
+		}},
+	}
+	resp = env.ProxyPost("/v1/chat/completions", secretPayload, map[string]string{
 		"Authorization": "Bearer " + tokenStr,
 	})
 	AssertStatus(t, resp, http.StatusTooManyRequests)
@@ -1262,6 +1273,7 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	foundRejected := false
 	foundActive := false
+	rejectedID := 0
 	for {
 		resp = env.AdminGet(fmt.Sprintf("/api/admin/requests?limit=20&apiTokenId=%d", apiTokenID))
 		AssertStatus(t, resp, http.StatusOK)
@@ -1284,6 +1296,7 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 			errorMsg, _ := request["error"].(string)
 			if status == "REJECTED" && int(statusCode) == http.StatusTooManyRequests && strings.Contains(errorMsg, "concurrent request limit") {
 				foundRejected = true
+				rejectedID = int(request["id"].(float64))
 			}
 			if status == "PENDING" || status == "IN_PROGRESS" || status == "COMPLETED" {
 				foundActive = true
@@ -1296,6 +1309,17 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 			t.Fatalf("expected rejected+active requests, got items=%v", items)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+
+	resp = env.AdminGet(fmt.Sprintf("/api/admin/requests/%d", rejectedID))
+	AssertStatus(t, resp, http.StatusOK)
+	var rejected map[string]any
+	DecodeJSON(t, resp, &rejected)
+	if rejected["requestInfo"] != nil {
+		t.Fatalf("requestInfo must be nil when retention=0 for rejected request, got %#v", rejected["requestInfo"])
+	}
+	if rejected["responseInfo"] != nil {
+		t.Fatalf("responseInfo must be nil when retention=0 for rejected request, got %#v", rejected["responseInfo"])
 	}
 
 	close(blocked)

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1171,6 +1171,42 @@ func TestProxyAllProtocolsCoexist(t *testing.T) {
 // ============================================================
 
 func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
+	cases := []struct {
+		name               string
+		configureRetention func(t *testing.T, env *ProxyTestEnv)
+	}{
+		{
+			name: "unified retention zero",
+			configureRetention: func(t *testing.T, env *ProxyTestEnv) {
+				setRequestDetailRetentionSetting(t, env, "request_detail_retention_seconds", "0")
+			},
+		},
+		{
+			name: "split failed retention zero",
+			configureRetention: func(t *testing.T, env *ProxyTestEnv) {
+				setRequestDetailRetentionSetting(t, env, "request_detail_retention_seconds", "86400")
+				setRequestDetailRetentionSetting(t, env, "request_detail_retention_split_enabled", "true")
+				setRequestDetailRetentionSetting(t, env, "request_detail_retention_seconds_success", "86400")
+				setRequestDetailRetentionSetting(t, env, "request_detail_retention_seconds_failed", "0")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runTokenConcurrencyLimitRecordsRejectedRequest(t, tc.configureRetention)
+		})
+	}
+}
+
+func setRequestDetailRetentionSetting(t *testing.T, env *ProxyTestEnv, key, value string) {
+	t.Helper()
+	resp := env.AdminPut("/api/admin/settings/"+key, map[string]any{"value": value})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}
+
+func runTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T, configureRetention func(t *testing.T, env *ProxyTestEnv)) {
 	blocked := make(chan struct{})
 	entered := make(chan struct{}, 1)
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1201,11 +1237,9 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 	providerID := createProvider(t, env, "mock-openai", mock.URL, []string{"openai"})
 	createRoute(t, env, "openai", providerID)
 
-	resp := env.AdminPut("/api/admin/settings/request_detail_retention_seconds", map[string]any{"value": "0"})
-	AssertStatus(t, resp, http.StatusOK)
-	resp.Body.Close()
+	configureRetention(t, env)
 
-	resp = env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	resp := env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
 	AssertStatus(t, resp, http.StatusOK)
 	resp.Body.Close()
 
@@ -1316,10 +1350,10 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 	var rejected map[string]any
 	DecodeJSON(t, resp, &rejected)
 	if rejected["requestInfo"] != nil {
-		t.Fatalf("requestInfo must be nil when retention=0 for rejected request, got %#v", rejected["requestInfo"])
+		t.Fatalf("requestInfo must be nil when retention clears failed requests, got %#v", rejected["requestInfo"])
 	}
 	if rejected["responseInfo"] != nil {
-		t.Fatalf("responseInfo must be nil when retention=0 for rejected request, got %#v", rejected["responseInfo"])
+		t.Fatalf("responseInfo must be nil when retention clears failed requests, got %#v", rejected["responseInfo"])
 	}
 
 	close(blocked)


### PR DESCRIPTION
## Summary
- make early rejected proxy requests respect request detail retention settings
- avoid persisting request/response detail for token concurrency rejections when `request_detail_retention_seconds=0`
- extend the concurrency rejection e2e test to assert rejected request details are nil under retention zero

## Validation
- `go test ./tests/e2e -run 'TestTokenConcurrencyLimitRecordsRejectedRequest|TestRequestDetailRetentionZero_AlignedAcrossProxyPaths' -count=1 -v`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增请求详情保留时间配置，允许用户控制被拒绝的代理请求是否保存详细的请求和响应信息。

* **改进**
  * 完善被拒绝请求的数据持久化机制，高级别信息（状态、错误）始终保留，详细信息可根据配置灵活清除，提升隐私保护能力。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->