### PR TITLE
fix(retention): unblock detail cleanup on large tables

### DIFF
--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -375,33 +375,30 @@ var migrations = []Migration{
 	},
 	{
 		Version:     13,
-		Description: "Add created_at indexes on proxy_requests and proxy_upstream_attempts for detail-cleanup",
+		Description: "Add detail-cleanup indexes on proxy_requests and proxy_upstream_attempts",
 		Up: func(db *gorm.DB) error {
-			// detail 清理 (ClearDetailOlderThan) 用 `WHERE created_at < ?` 过滤过期行；
-			// 在百万级以上的请求日志表上，没有 created_at 索引会导致每次清理都全表扫描，
-			// 进而长时间占用 SQLite 单写锁，表现为线上 API 写入"卡死"。
-			switch db.Dialector.Name() {
-			case "mysql":
-				if err := db.Exec("CREATE INDEX idx_proxy_requests_created_at ON proxy_requests(created_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
-					return err
-				}
-				if err := db.Exec("CREATE INDEX idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts(created_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
-					return err
-				}
-				return nil
-			default:
-				if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_proxy_requests_created_at ON proxy_requests(created_at)").Error; err != nil {
-					return err
-				}
-				return db.Exec("CREATE INDEX IF NOT EXISTS idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts(created_at)").Error
-			}
+			// detail 清理 (ClearDetailOlderThan) 用
+			//   WHERE created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) [AND dev_mode = 0]
+			//   ORDER BY id LIMIT ?
+			// 之前没索引时每次都全表扫，长时间占 SQLite 单写锁导致线上写入"卡死"。
+			//
+			// SQLite 用 **partial index**：WHERE 子句让只有"还没清理"的行进入索引；行被 null
+			// 后自动从索引移除，存量收敛后索引很小，scan 几乎免费。键设计 (created_at, id) 同
+			// 时服务 cleanup 的 ORDER BY id LIMIT。
+			//
+			// MySQL 不支持 partial index（functional index 语法又不同），退化为普通的
+			// (created_at, id) 复合索引。
+			//
+			// 注意：大表（>1M 行）首次 CREATE INDEX 会一次性扫描全表并阻塞写入数秒到几十秒，
+			// 这是一次性成本（之后清理快得多）。下面 log 行让运维能看到这段窗口。
+			return runDetailCleanupIndexMigration(db)
 		},
 		Down: func(db *gorm.DB) error {
 			switch db.Dialector.Name() {
 			case "mysql":
 				for _, sql := range []string{
-					"DROP INDEX idx_proxy_requests_created_at ON proxy_requests",
-					"DROP INDEX idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts",
+					"DROP INDEX idx_proxy_requests_detail_cleanup ON proxy_requests",
+					"DROP INDEX idx_proxy_upstream_attempts_detail_cleanup ON proxy_upstream_attempts",
 				} {
 					if err := db.Exec(sql).Error; err != nil && !isMySQLMissingIndexError(err) {
 						log.Printf("[Migration] Warning: rollback v13 failed sql=%q err=%v", sql, err)
@@ -409,13 +406,65 @@ var migrations = []Migration{
 				}
 				return nil
 			default:
-				if err := db.Exec("DROP INDEX IF EXISTS idx_proxy_requests_created_at").Error; err != nil {
+				if err := db.Exec("DROP INDEX IF EXISTS idx_proxy_requests_detail_cleanup").Error; err != nil {
 					return err
 				}
-				return db.Exec("DROP INDEX IF EXISTS idx_proxy_upstream_attempts_created_at").Error
+				return db.Exec("DROP INDEX IF EXISTS idx_proxy_upstream_attempts_detail_cleanup").Error
 			}
 		},
 	},
+}
+
+// runDetailCleanupIndexMigration 建立 v13 的清理索引并附带耗时/行数日志。
+// SQLite 在大表上 CREATE INDEX 会阻塞写入，提前打 log 让运维知道这段窗口。
+func runDetailCleanupIndexMigration(db *gorm.DB) error {
+	type tableSpec struct {
+		table     string
+		index     string
+		sqliteDDL string
+		mysqlDDL  string
+	}
+	specs := []tableSpec{
+		{
+			table:     "proxy_requests",
+			index:     "idx_proxy_requests_detail_cleanup",
+			sqliteDDL: "CREATE INDEX IF NOT EXISTS idx_proxy_requests_detail_cleanup ON proxy_requests(created_at, id) WHERE (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0",
+			mysqlDDL:  "CREATE INDEX idx_proxy_requests_detail_cleanup ON proxy_requests(created_at, id)",
+		},
+		{
+			table:     "proxy_upstream_attempts",
+			index:     "idx_proxy_upstream_attempts_detail_cleanup",
+			sqliteDDL: "CREATE INDEX IF NOT EXISTS idx_proxy_upstream_attempts_detail_cleanup ON proxy_upstream_attempts(created_at, id) WHERE request_info IS NOT NULL OR response_info IS NOT NULL",
+			mysqlDDL:  "CREATE INDEX idx_proxy_upstream_attempts_detail_cleanup ON proxy_upstream_attempts(created_at, id)",
+		},
+	}
+
+	for _, s := range specs {
+		var rowCount int64
+		if err := db.Raw("SELECT COUNT(*) FROM " + s.table).Scan(&rowCount).Error; err != nil {
+			// 计数失败不阻止迁移；日志少一行而已。
+			log.Printf("[Migration v13] could not count %s: %v", s.table, err)
+		}
+		log.Printf("[Migration v13] building %s (rows=%d). On large tables this briefly blocks writes; one-time cost.", s.index, rowCount)
+		start := time.Now()
+
+		var ddl string
+		switch db.Dialector.Name() {
+		case "mysql":
+			ddl = s.mysqlDDL
+		default:
+			ddl = s.sqliteDDL
+		}
+		if err := db.Exec(ddl).Error; err != nil {
+			if db.Dialector.Name() == "mysql" && isMySQLDuplicateIndexError(err) {
+				log.Printf("[Migration v13] %s already exists, skipped", s.index)
+				continue
+			}
+			return err
+		}
+		log.Printf("[Migration v13] built %s in %s", s.index, time.Since(start).Round(time.Millisecond))
+	}
+	return nil
 }
 
 func applyCodexQuotaIdentityMigration(db *gorm.DB) error {

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -389,8 +389,9 @@ var migrations = []Migration{
 			// MySQL 不支持 partial index（functional index 语法又不同），退化为普通的
 			// (created_at, id) 复合索引。
 			//
-			// 注意：大表（>1M 行）首次 CREATE INDEX 会一次性扫描全表并阻塞写入数秒到几十秒，
-			// 这是一次性成本（之后清理快得多）。下面 log 行让运维能看到这段窗口。
+			// 大表写锁规避：SQLite 没有 online CREATE INDEX。为不在升级路径上长时间阻塞
+			// 写入，runDetailCleanupIndexMigration 对超过 detailCleanupIndexRowThreshold
+			// 的表跳过自动建立，打印 manual SQL 由运维选维护窗口跑。
 			return runDetailCleanupIndexMigration(db)
 		},
 		Down: func(db *gorm.DB) error {
@@ -415,8 +416,18 @@ var migrations = []Migration{
 	},
 }
 
-// runDetailCleanupIndexMigration 建立 v13 的清理索引并附带耗时/行数日志。
-// SQLite 在大表上 CREATE INDEX 会阻塞写入，提前打 log 让运维知道这段窗口。
+// detailCleanupIndexRowThreshold 是 v13 自动建索引的行数上限。超过它则跳过自动建立
+// 并打印 manual SQL，由运维选维护窗口手动执行——避免大表升级时数据库被 CREATE INDEX
+// 长时间独占写锁（SQLite 没有 online DDL）。500k 行是经验值：低于此 SSD 上建索引秒级完成，
+// 远高于这个量级时建索引耗时可达数十秒到分钟级。
+const detailCleanupIndexRowThreshold = 500_000
+
+// runDetailCleanupIndexMigration 建立 v13 的清理索引：
+//   - 小表：直接同步建立（耗时可忽略）。
+//   - 大表：跳过，但打印明确的 manual SQL + 行数，让运维选窗口手动跑。
+//
+// 跳过分支下 migration 仍记为已应用——v14+ 不应依赖该索引存在。清理路径在缺索引时
+// 退化到全表扫，但 batch+sleep 的 yield 已经能避免"卡死"，只是稳态扫描成本高一些。
 func runDetailCleanupIndexMigration(db *gorm.DB) error {
 	type tableSpec struct {
 		table     string
@@ -441,12 +452,12 @@ func runDetailCleanupIndexMigration(db *gorm.DB) error {
 
 	for _, s := range specs {
 		var rowCount int64
+		// 表名是包内硬编码字面量，不存在注入面；GORM 占位符不支持表名。
 		if err := db.Raw("SELECT COUNT(*) FROM " + s.table).Scan(&rowCount).Error; err != nil {
-			// 计数失败不阻止迁移；日志少一行而已。
-			log.Printf("[Migration v13] could not count %s: %v", s.table, err)
+			// 计数失败时保守起见跳过——宁可慢，不要在升级路径上炸。
+			log.Printf("[Migration v13] could not count %s (%v); skipping index build. Apply manually if needed.", s.table, err)
+			continue
 		}
-		log.Printf("[Migration v13] building %s (rows=%d). On large tables this briefly blocks writes; one-time cost.", s.index, rowCount)
-		start := time.Now()
 
 		var ddl string
 		switch db.Dialector.Name() {
@@ -455,6 +466,17 @@ func runDetailCleanupIndexMigration(db *gorm.DB) error {
 		default:
 			ddl = s.sqliteDDL
 		}
+
+		if rowCount > detailCleanupIndexRowThreshold {
+			log.Printf("[Migration v13] SKIPPING %s build: %s has %d rows (> %d threshold). "+
+				"CREATE INDEX would block writes for tens of seconds. "+
+				"Apply manually during a maintenance window:\n  %s",
+				s.index, s.table, rowCount, detailCleanupIndexRowThreshold, ddl)
+			continue
+		}
+
+		log.Printf("[Migration v13] building %s (rows=%d)", s.index, rowCount)
+		start := time.Now()
 		if err := db.Exec(ddl).Error; err != nil {
 			if db.Dialector.Name() == "mysql" && isMySQLDuplicateIndexError(err) {
 				log.Printf("[Migration v13] %s already exists, skipped", s.index)

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -373,6 +373,49 @@ var migrations = []Migration{
 			return fmt.Errorf("migration v12 cannot be rolled back: dropping columns not supported in SQLite")
 		},
 	},
+	{
+		Version:     13,
+		Description: "Add created_at indexes on proxy_requests and proxy_upstream_attempts for detail-cleanup",
+		Up: func(db *gorm.DB) error {
+			// detail 清理 (ClearDetailOlderThan) 用 `WHERE created_at < ?` 过滤过期行；
+			// 在百万级以上的请求日志表上，没有 created_at 索引会导致每次清理都全表扫描，
+			// 进而长时间占用 SQLite 单写锁，表现为线上 API 写入"卡死"。
+			switch db.Dialector.Name() {
+			case "mysql":
+				if err := db.Exec("CREATE INDEX idx_proxy_requests_created_at ON proxy_requests(created_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+					return err
+				}
+				if err := db.Exec("CREATE INDEX idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts(created_at)").Error; err != nil && !isMySQLDuplicateIndexError(err) {
+					return err
+				}
+				return nil
+			default:
+				if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_proxy_requests_created_at ON proxy_requests(created_at)").Error; err != nil {
+					return err
+				}
+				return db.Exec("CREATE INDEX IF NOT EXISTS idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts(created_at)").Error
+			}
+		},
+		Down: func(db *gorm.DB) error {
+			switch db.Dialector.Name() {
+			case "mysql":
+				for _, sql := range []string{
+					"DROP INDEX idx_proxy_requests_created_at ON proxy_requests",
+					"DROP INDEX idx_proxy_upstream_attempts_created_at ON proxy_upstream_attempts",
+				} {
+					if err := db.Exec(sql).Error; err != nil && !isMySQLMissingIndexError(err) {
+						log.Printf("[Migration] Warning: rollback v13 failed sql=%q err=%v", sql, err)
+					}
+				}
+				return nil
+			default:
+				if err := db.Exec("DROP INDEX IF EXISTS idx_proxy_requests_created_at").Error; err != nil {
+					return err
+				}
+				return db.Exec("DROP INDEX IF EXISTS idx_proxy_upstream_attempts_created_at").Error
+			}
+		},
+	},
 }
 
 func applyCodexQuotaIdentityMigration(db *gorm.DB) error {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -490,15 +490,24 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
 //
-// 分批处理：request_info/response_info 是大 JSON blob，一次性 UPDATE 会产生
-// 超大事务（WAL 同时记录 old/new value），故按 batchSize 拆分。
+// 大数据量下的关键约束：
+//   - 分批：request_info/response_info 是大 JSON blob，一次性 UPDATE 会产生
+//     超大事务（WAL 同时记录 old/new value），故按 batchSize 拆分。
+//   - 批间 yield：SQLite 全库单写锁，连续不停的 UPDATE 会饿死正常请求写入（表现为
+//     线上 API "卡死"）。每批之间 sleep 一小段让真实流量的 INSERT 有机会拿到锁。
+//   - 单次调用封顶 maxBatchesPerCall 批：避免存量积压时一次清理占据整个 tick；
+//     剩余的部分由 runRequestDetailCleanup 的下一次 tick 继续推进。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
-	const batchSize = 500
+	const (
+		batchSize         = 200
+		maxBatchesPerCall = 200
+		batchSleep        = 50 * time.Millisecond
+	)
 	beforeTs := toTimestamp(before)
 	var total int64
 	var lastID uint64
 
-	for {
+	for batchIdx := 0; batchIdx < maxBatchesPerCall; batchIdx++ {
 		var ids []uint64
 		q := r.db.gorm.Model(&ProxyRequest{}).
 			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 AND id > ?", beforeTs, lastID)
@@ -532,7 +541,9 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		if len(ids) < batchSize {
 			return total, nil
 		}
+		time.Sleep(batchSleep)
 	}
+	return total, nil
 }
 
 func (r *ProxyRequestRepository) toModel(p *domain.ProxyRequest) *ProxyRequest {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -495,19 +495,20 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 //     超大事务（WAL 同时记录 old/new value），故按 batchSize 拆分。
 //   - 批间 yield：SQLite 全库单写锁，连续不停的 UPDATE 会饿死正常请求写入（表现为
 //     线上 API "卡死"）。每批之间 sleep 一小段让真实流量的 INSERT 有机会拿到锁。
-//   - 单次调用封顶 maxBatchesPerCall 批：避免存量积压时一次清理占据整个 tick；
-//     剩余的部分由 runRequestDetailCleanup 的下一次 tick 继续推进。
+//   - 不设单次调用封顶：之前的 cap 会在 backlog > cap 时产生回归——lastID 每次调用
+//     从 0 开始，下次 tick 还得重扫一遍上次已 null 的老区段。改回 drain-to-completion，
+//     由批间 sleep 保证写锁不被长期独占；partial index (v13) 让"已清理的行"自然从
+//     索引中移除，所以 backlog 收敛后扫描代价很小。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	const (
-		batchSize         = 200
-		maxBatchesPerCall = 200
-		batchSleep        = 50 * time.Millisecond
+		batchSize  = 200
+		batchSleep = 50 * time.Millisecond
 	)
 	beforeTs := toTimestamp(before)
 	var total int64
 	var lastID uint64
 
-	for batchIdx := 0; batchIdx < maxBatchesPerCall; batchIdx++ {
+	for {
 		var ids []uint64
 		q := r.db.gorm.Model(&ProxyRequest{}).
 			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 AND id > ?", beforeTs, lastID)
@@ -543,7 +544,6 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		}
 		time.Sleep(batchSleep)
 	}
-	return total, nil
 }
 
 func (r *ProxyRequestRepository) toModel(p *domain.ProxyRequest) *ProxyRequest {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -490,15 +490,16 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
 //
-// 大数据量下的关键约束：
-//   - 分批：request_info/response_info 是大 JSON blob，一次性 UPDATE 会产生
-//     超大事务（WAL 同时记录 old/new value），故按 batchSize 拆分。
-//   - 批间 yield：SQLite 全库单写锁，连续不停的 UPDATE 会饿死正常请求写入（表现为
-//     线上 API "卡死"）。每批之间 sleep 一小段让真实流量的 INSERT 有机会拿到锁。
-//   - 不设单次调用封顶：之前的 cap 会在 backlog > cap 时产生回归——lastID 每次调用
-//     从 0 开始，下次 tick 还得重扫一遍上次已 null 的老区段。改回 drain-to-completion，
-//     由批间 sleep 保证写锁不被长期独占；partial index (v13) 让"已清理的行"自然从
-//     索引中移除，所以 backlog 收敛后扫描代价很小。
+// Cursor / index 协作：
+//   - 用 (created_at, id) 二元组游标 + ORDER BY (created_at, id)，与 v13 的
+//     partial index idx_proxy_requests_detail_cleanup(created_at, id) 键顺序一致，
+//     EXPLAIN QUERY PLAN 验证：planner 走 SEARCH USING INDEX。若改用 id 游标 +
+//     ORDER BY id，planner 会回退到 PK 扫，索引失效，partial index 形同虚设。
+//   - drain-to-completion：50ms 批间 sleep 已经让出 SQLite 写锁，无需封顶批数。
+//     早期版本曾加 maxBatchesPerCall，但游标每次调用归零会导致 backlog 大于 cap 时
+//     下次 tick 重扫整段已 null 的老区，回退而不是改进。
+//   - 分批：request_info/response_info 是大 JSON blob，一次 UPDATE 全表会产生超大
+//     事务（WAL 同时记录 old/new），故按 batchSize 拆分。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	const (
 		batchSize  = 200
@@ -506,22 +507,37 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 	)
 	beforeTs := toTimestamp(before)
 	var total int64
+	var lastCreatedAt int64
 	var lastID uint64
 
+	type cursorRow struct {
+		ID        uint64 `gorm:"column:id"`
+		CreatedAt int64  `gorm:"column:created_at"`
+	}
+
 	for {
-		var ids []uint64
+		var rows []cursorRow
 		q := r.db.gorm.Model(&ProxyRequest{}).
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 AND id > ?", beforeTs, lastID)
+			Select("id, created_at").
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", beforeTs).
+			// 二元组游标：(created_at, id) > (lastCreatedAt, lastID)
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID)
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
 		}
-		if err := q.Order("id").Limit(batchSize).Pluck("id", &ids).Error; err != nil {
+		if err := q.Order("created_at, id").Limit(batchSize).Scan(&rows).Error; err != nil {
 			return total, err
 		}
-		if len(ids) == 0 {
+		if len(rows) == 0 {
 			return total, nil
 		}
-		lastID = ids[len(ids)-1]
+		ids := make([]uint64, len(rows))
+		for i, row := range rows {
+			ids[i] = row.ID
+		}
+		last := rows[len(rows)-1]
+		lastCreatedAt = last.CreatedAt
+		lastID = last.ID
 
 		// 重应用谓词：Pluck 与 UPDATE 之间行可能因 status/dev_mode 变动而不再 eligible。
 		uq := r.db.gorm.Model(&ProxyRequest{}).
@@ -539,7 +555,7 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		}
 		total += result.RowsAffected
 
-		if len(ids) < batchSize {
+		if len(rows) < batchSize {
 			return total, nil
 		}
 		time.Sleep(batchSleep)

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -318,4 +319,76 @@ func TestProxyRequestClearDetailOlderThan(t *testing.T) {
 			t.Error("fresh record must be retained")
 		}
 	})
+}
+
+// TestProxyRequestClearDetailOlderThan_UsesPartialIndex 锁定 cleanup 查询确实
+// 走 v13 partial index。回归守护：若有人改回 `id > ?` 游标 + `ORDER BY id`，
+// SQLite planner 会回退到 PK 扫，partial index 形同虚设，该测试会捕获。
+func TestProxyRequestClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	const sql = `SELECT id, created_at FROM proxy_requests ` +
+		`WHERE created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 ` +
+		`AND (created_at > ? OR (created_at = ? AND id > ?)) ` +
+		`ORDER BY created_at, id LIMIT 200`
+
+	rows, err := db.gorm.Raw("EXPLAIN QUERY PLAN "+sql, 0, 0, 0, 0).Rows()
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var planLines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		planLines = append(planLines, detail)
+	}
+	plan := strings.Join(planLines, "\n")
+	if !strings.Contains(plan, "idx_proxy_requests_detail_cleanup") {
+		t.Fatalf("expected plan to use idx_proxy_requests_detail_cleanup, got:\n%s", plan)
+	}
+}
+
+// TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 同上，针对
+// attempt 表的 cleanup 查询。
+func TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	const sql = `SELECT id, created_at FROM proxy_upstream_attempts ` +
+		`WHERE created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) ` +
+		`AND (created_at > ? OR (created_at = ? AND id > ?)) ` +
+		`AND EXISTS (SELECT 1 FROM proxy_requests WHERE proxy_requests.id = proxy_upstream_attempts.proxy_request_id AND proxy_requests.dev_mode = 0) ` +
+		`ORDER BY created_at, id LIMIT 200`
+
+	rows, err := db.gorm.Raw("EXPLAIN QUERY PLAN "+sql, 0, 0, 0, 0).Rows()
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+
+	var planLines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		planLines = append(planLines, detail)
+	}
+	plan := strings.Join(planLines, "\n")
+	if !strings.Contains(plan, "idx_proxy_upstream_attempts_detail_cleanup") {
+		t.Fatalf("expected plan to use idx_proxy_upstream_attempts_detail_cleanup, got:\n%s", plan)
+	}
 }

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -355,6 +355,11 @@ func TestProxyRequestClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
 	if !strings.Contains(plan, "idx_proxy_requests_detail_cleanup") {
 		t.Fatalf("expected plan to use idx_proxy_requests_detail_cleanup, got:\n%s", plan)
 	}
+	// 显式拒绝 TEMP B-TREE 排序：partial index 的键 (created_at, id) 已经匹配 ORDER BY，
+	// 出现 TEMP B-TREE 意味着 cursor 或 ORDER BY 形状变了，planner 退化到扫+排。
+	if strings.Contains(plan, "TEMP B-TREE") {
+		t.Fatalf("plan should not require TEMP B-TREE sort, got:\n%s", plan)
+	}
 }
 
 // TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 同上，针对
@@ -390,5 +395,10 @@ func TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex(t *testing.T)
 	plan := strings.Join(planLines, "\n")
 	if !strings.Contains(plan, "idx_proxy_upstream_attempts_detail_cleanup") {
 		t.Fatalf("expected plan to use idx_proxy_upstream_attempts_detail_cleanup, got:\n%s", plan)
+	}
+	// 显式拒绝 TEMP B-TREE 排序：EXISTS 改写的全部意义就是避免 planner 从父表驱动后
+	// 再做一次临时排序。若再次出现，说明有人把 EXISTS 改回了 IN 子查询。
+	if strings.Contains(plan, "TEMP B-TREE") {
+		t.Fatalf("plan should not require TEMP B-TREE sort, got:\n%s", plan)
 	}
 }

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -239,9 +239,14 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 // ClearDetailOlderThan 清理指定时间之前 attempt 的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理所属 ProxyRequest.status IN (statuses) 的 attempt
 //
-// 分批处理：详情字段是大 blob，且关联父表子查询代价不低，故按 batchSize 拆分。
+// 与 ProxyRequestRepository.ClearDetailOlderThan 同样的取舍：批间 sleep 让出写锁，
+// 单次调用封顶批数避免大数据量积压时占满整个 cleanup tick。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
-	const batchSize = 500
+	const (
+		batchSize         = 200
+		maxBatchesPerCall = 200
+		batchSleep        = 50 * time.Millisecond
+	)
 	beforeTs := toTimestamp(before)
 	var total int64
 	var lastID uint64
@@ -256,7 +261,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		return q
 	}
 
-	for {
+	for batchIdx := 0; batchIdx < maxBatchesPerCall; batchIdx++ {
 		var ids []uint64
 
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
@@ -289,7 +294,9 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		if len(ids) < batchSize {
 			return total, nil
 		}
+		time.Sleep(batchSleep)
 	}
+	return total, nil
 }
 
 func (r *ProxyUpstreamAttemptRepository) toModel(a *domain.ProxyUpstreamAttempt) *ProxyUpstreamAttempt {

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -239,8 +239,11 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 // ClearDetailOlderThan 清理指定时间之前 attempt 的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理所属 ProxyRequest.status IN (statuses) 的 attempt
 //
-// 与 ProxyRequestRepository.ClearDetailOlderThan 同样的取舍：批间 sleep 让出写锁，
-// drain-to-completion；partial index (v13) 让已清理的行不再参与扫描。
+// 关键点：父表过滤用 EXISTS 相关子查询（不是 IN）。SQLite planner 对 IN 子查询会从父表
+// 驱动 → 走 idx_proxy_upstream_attempts_proxy_request_id + USE TEMP B-TREE FOR ORDER BY，
+// partial index 形同虚设；改成 EXISTS 后 planner 走 partial index (created_at<?) +
+// 父表 PK 查找，并且 ORDER BY 不再需要临时 sort。
+// EXPLAIN QUERY PLAN 由 TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 守护。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	const (
 		batchSize  = 200
@@ -248,38 +251,55 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 	)
 	beforeTs := toTimestamp(before)
 	var total int64
+	var lastCreatedAt int64
 	var lastID uint64
 
-	parentReqBuilder := func() *gorm.DB {
-		q := r.db.gorm.Model(&ProxyRequest{}).
-			Select("id").
-			Where("dev_mode = 0")
+	// parentExistsClause 构造相关 EXISTS：通过 attempt.proxy_request_id 关联父行，
+	// 然后过滤父行 dev_mode/status。返回 SQL 片段 + 对应 args。
+	parentExistsClause := func() (string, []any) {
+		sql := "EXISTS (SELECT 1 FROM proxy_requests WHERE proxy_requests.id = proxy_upstream_attempts.proxy_request_id AND proxy_requests.dev_mode = 0"
+		args := []any{}
 		if len(statuses) > 0 {
-			q = q.Where("status IN ?", statuses)
+			sql += " AND proxy_requests.status IN ?"
+			args = append(args, statuses)
 		}
-		return q
+		sql += ")"
+		return sql, args
+	}
+
+	type cursorRow struct {
+		ID        uint64 `gorm:"column:id"`
+		CreatedAt int64  `gorm:"column:created_at"`
 	}
 
 	for {
-		var ids []uint64
-
+		var rows []cursorRow
+		existsSQL, existsArgs := parentExistsClause()
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND id > ?", beforeTs, lastID).
-			Where("proxy_request_id IN (?)", parentReqBuilder()).
-			Order("id").
+			Select("id, created_at").
+			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID).
+			Where(existsSQL, existsArgs...).
+			Order("created_at, id").
 			Limit(batchSize).
-			Pluck("id", &ids).Error; err != nil {
+			Scan(&rows).Error; err != nil {
 			return total, err
 		}
-		if len(ids) == 0 {
+		if len(rows) == 0 {
 			return total, nil
 		}
-		lastID = ids[len(ids)-1]
+		ids := make([]uint64, len(rows))
+		for i, row := range rows {
+			ids[i] = row.ID
+		}
+		last := rows[len(rows)-1]
+		lastCreatedAt = last.CreatedAt
+		lastID = last.ID
 
 		// 重应用谓词与父表过滤：Pluck 与 UPDATE 之间父请求状态可能变动。
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Where("id IN ? AND created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", ids, beforeTs).
-			Where("proxy_request_id IN (?)", parentReqBuilder()).
+			Where(existsSQL, existsArgs...).
 			Updates(map[string]any{
 				"request_info":  nil,
 				"response_info": nil,
@@ -290,7 +310,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		}
 		total += result.RowsAffected
 
-		if len(ids) < batchSize {
+		if len(rows) < batchSize {
 			return total, nil
 		}
 		time.Sleep(batchSleep)

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -240,12 +240,11 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 // statuses 为空时不按状态过滤；非空时仅清理所属 ProxyRequest.status IN (statuses) 的 attempt
 //
 // 与 ProxyRequestRepository.ClearDetailOlderThan 同样的取舍：批间 sleep 让出写锁，
-// 单次调用封顶批数避免大数据量积压时占满整个 cleanup tick。
+// drain-to-completion；partial index (v13) 让已清理的行不再参与扫描。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	const (
-		batchSize         = 200
-		maxBatchesPerCall = 200
-		batchSleep        = 50 * time.Millisecond
+		batchSize  = 200
+		batchSleep = 50 * time.Millisecond
 	)
 	beforeTs := toTimestamp(before)
 	var total int64
@@ -261,7 +260,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		return q
 	}
 
-	for batchIdx := 0; batchIdx < maxBatchesPerCall; batchIdx++ {
+	for {
 		var ids []uint64
 
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
@@ -296,7 +295,6 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		}
 		time.Sleep(batchSleep)
 	}
-	return total, nil
 }
 
 func (r *ProxyUpstreamAttemptRepository) toModel(a *domain.ProxyUpstreamAttempt) *ProxyUpstreamAttempt {


### PR DESCRIPTION
## Summary

Detail cleanup (`ClearDetailOlderThan`) was monopolizing the SQLite single-writer lock on million-row tables, starving normal API writes (线上 "卡死"). Fix has three parts:

### 1. Yield writer lock between batches
- Batch size 500 → 200 (smaller write transactions).
- 50ms sleep between batches.
- Drain-to-completion within a single invocation (no per-call batch cap — earlier cap caused regressions because the cursor reset each tick).

### 2. Index that actually gets used
Added migration v13 creating `idx_proxy_requests_detail_cleanup` and `idx_proxy_upstream_attempts_detail_cleanup`:
- **SQLite**: partial index `(created_at, id) WHERE (request_info IS NOT NULL OR response_info IS NOT NULL) [AND dev_mode = 0]` — rows leave the index when their details are nulled, so steady-state scans touch only eligible rows.
- **MySQL**: composite `(created_at, id)` (no partial index syntax).

Cleanup queries rewritten so the planner actually uses the index:
- Cursor switched from `id > ?` to `(created_at, id) > (lastCreatedAt, lastID)` and `ORDER BY (created_at, id)`. Without this, SQLite falls back to the PK btree and ignores the partial index.
- For attempt cleanup, parent filter switched from `IN (subquery)` to `EXISTS correlated subquery`. The IN form drove from the parent table via `idx_proxy_upstream_attempts_proxy_request_id` plus a TEMP B-TREE sort.

Two new tests (`TestProxyRequestClearDetailOlderThan_UsesPartialIndex`, `TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex`) run `EXPLAIN QUERY PLAN` and assert the cleanup query hits the partial index — regression guard against accidentally undoing the cursor/EXISTS shape.

### 3. Safe migration on huge tables ⚠️ operator action required
SQLite has no online `CREATE INDEX`; on a multi-million-row table the migration would block writes for tens of seconds (same class of issue the PR is fixing, just shifted to startup). To avoid that:

- `runDetailCleanupIndexMigration` checks `COUNT(*)`; tables ≤ 500k rows build the index inline (sub-second on SSD).
- Tables > 500k rows: **migration v13 is marked applied but the index is NOT built**. A clear log entry prints the exact SQL to run manually during a maintenance window.

When the index is missing, cleanup still works correctly — it falls back to a full scan, but the batch + sleep yielding from part 1 keeps writer-lock contention bounded, so 卡死 is resolved at the algorithm level regardless of index presence. Large-installation operators can apply the index at their convenience for the full performance benefit.

Log lines to watch for after upgrade on large installs:
```
[Migration v13] SKIPPING idx_proxy_requests_detail_cleanup build: proxy_requests has N rows ...
  CREATE INDEX IF NOT EXISTS idx_proxy_requests_detail_cleanup ON proxy_requests(...) WHERE ...
```

## Test plan

- [x] `go test ./internal/repository/sqlite/ ./internal/core/ ./tests/e2e/` — all pass
- [x] `EXPLAIN QUERY PLAN` confirms `idx_proxy_requests_detail_cleanup` and `idx_proxy_upstream_attempts_detail_cleanup` are both used by their respective cleanup queries (covered by the two new tests)
- [x] Existing `TestProxyRequestClearDetailOlderThan` multi-batch / dev-mode / status-filter cases still pass with the new tuple cursor
- [ ] On a production-sized DB:
  - confirm 卡死 is resolved (API writes are no longer starved by cleanup)
  - if `proxy_requests` > 500k rows, apply the printed manual CREATE INDEX during a maintenance window for the full speedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)