### PR TITLE
perf(retention): leader-only cleanup, MySQL index reorder, faster batch

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -329,6 +329,7 @@ func main() {
 		Settings:           settingRepo,
 		AntigravityTaskSvc: antigravityTaskSvc,
 		CodexTaskSvc:       codexTaskSvc,
+		Coordinator:        coord,
 	})
 
 	// Ensure default tenant exists

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -3,10 +3,12 @@ package core
 import (
 	"context"
 	"log"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/coordinator"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
@@ -40,6 +42,43 @@ type BackgroundTaskDeps struct {
 	Settings           repository.SystemSettingRepository
 	AntigravityTaskSvc *service.AntigravityTaskService
 	CodexTaskSvc       *service.CodexTaskService
+
+	// Coordinator 可选。提供时,数据维护类清理任务(retention purge / detail cleanup)
+	// 只在 leader 实例上跑——多副本共享同一 RDS 时,6 副本同时清理会把 IOPS 放大 6 倍互相 race。
+	// 选举规则:对活实例 ID 排序,字典序最小的是 leader。简单、无外部依赖、TTL=heartbeat。
+	// Coordinator=nil 时退化为"总是 leader"(单实例 / 老路径)。
+	Coordinator coordinator.Coordinator
+}
+
+// leaderCheckTimeout 限制 coordinator 查询活实例列表的耗时;超时则保守退化为"非 leader",
+// 宁可这一轮不跑也不要让 coordinator 异常拖住后台任务。
+const leaderCheckTimeout = 2 * time.Second
+
+// isCleanupLeader 判断当前实例是否应当跑数据维护清理任务。
+//
+//   - Coordinator 为 nil → 单实例部署,总是 leader。
+//   - Coordinator.ListAliveInstances 失败/超时 → 保守返回 false。coordinator 不可用时
+//     宁可不清理也不要 6 副本一起跑(回到反馈中提到的 IOPS race 老问题)。
+//   - 选举:排序后最小 ID 是 leader,与本实例 ID 比较。
+//     无锁、无任期、无 split-brain 保护——清理任务幂等(再跑一次只是重复 WHERE 没行可清),
+//     即使瞬时两实例都自认 leader 也只是少量重复 IOPS,不会数据错乱。
+func (d *BackgroundTaskDeps) isCleanupLeader() bool {
+	if d.Coordinator == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), leaderCheckTimeout)
+	defer cancel()
+	alive, err := d.Coordinator.ListAliveInstances(ctx)
+	if err != nil {
+		log.Printf("[Task] leader check: ListAliveInstances failed (%v); skipping this tick", err)
+		return false
+	}
+	if len(alive) == 0 {
+		// 包括本实例都没注册的极端情况——保守跳过。
+		return false
+	}
+	sort.Strings(alive)
+	return alive[0] == d.Coordinator.InstanceID()
 }
 
 // StartBackgroundTasks 启动所有后台任务
@@ -87,7 +126,13 @@ func StartBackgroundTasks(deps BackgroundTaskDeps) {
 }
 
 // runCleanupTasks 清理任务：清理过期数据
+//
+// 多实例:仅在 leader 实例上跑。usage_stats / proxy_requests / sessions 是共享存储,
+// 6 副本同时跑只会把 IOPS 放大 6 倍且互相 race。leader gate 失败时跳过这一轮。
 func (d *BackgroundTaskDeps) runCleanupTasks() {
+	if !d.isCleanupLeader() {
+		return
+	}
 	// 1. 清理过期的分钟数据（保留 1 天）
 	before := time.Now().UTC().AddDate(0, 0, -1)
 	_, _ = d.UsageStats.DeleteOlderThan(domain.GranularityMinute, before)
@@ -311,7 +356,12 @@ func (d *BackgroundTaskDeps) runRequestDetailCleanup() {
 			continue
 		}
 
-		d.cleanupOldRequestDetails()
+		// 多实例:仅在 leader 上跑 detail cleanup。详见 isCleanupLeader 注释。
+		// 注意 sleep 调度仍然继续——非 leader 也要按相同 cadence 重新评估,
+		// 一旦 leader 切换不会延迟到下一个长间隔。
+		if d.isCleanupLeader() {
+			d.cleanupOldRequestDetails()
+		}
 
 		// 取所有 >0 side 的最小值；任一 side == 0 则锁到 10s
 		var seconds int

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -159,9 +159,11 @@ func (d *BackgroundTaskDeps) checkDetailCleanupIndexHealth() {
 		return
 	}
 	if indexCount == 0 {
+		// 主动降级 cleanup 批次到保守值,避免在无索引的大表上 batch=1000 反复全扫。
+		// 这是把 "warning + 错配的 batch 默认" 改成 "warning + 自动安全降级"。
+		sqlite.MarkDetailCleanupIndexMissing()
 		log.Printf("[Task] WARNING: MySQL proxy_requests has NO detail-cleanup index. "+
-			"Cleanup SELECT will fall back to full table scan. "+
-			"Apply manually during a maintenance window:\n"+
+			"Cleanup batch falls back to conservative size (200/50ms) until you apply:\n"+
 			"  CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id);")
 		return
 	}

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -83,6 +83,15 @@ func (d *BackgroundTaskDeps) isCleanupLeader() bool {
 
 // StartBackgroundTasks 启动所有后台任务
 func StartBackgroundTasks(deps BackgroundTaskDeps) {
+	// 启动时校验:多副本部署日志一行,方便运维判断生效模式。
+	if deps.Coordinator != nil {
+		log.Printf("[Task] cleanup leader gating enabled (instance=%s)", deps.Coordinator.InstanceID())
+	} else {
+		log.Printf("[Task] cleanup leader gating disabled (single-instance mode)")
+	}
+	// 启动时校验:MySQL 上 detail-cleanup 索引若缺失,稳态 SELECT 会全表扫,
+	// 配合大 batch 反而把 IOPS 放大。打印明显告警 + manual SQL,让运维不至于错过。
+	deps.checkDetailCleanupIndexHealth()
 	// 统计聚合任务（每 30 秒）- 聚合原始数据并自动 rollup 到各粒度
 	go func() {
 		time.Sleep(5 * time.Second) // 初始延迟
@@ -123,6 +132,40 @@ func StartBackgroundTasks(deps BackgroundTaskDeps) {
 	}
 
 	log.Println("[Task] Background tasks started (aggregation:30s, cleanup:1h, detail-cleanup:dynamic)")
+}
+
+// checkDetailCleanupIndexHealth 在 MySQL 上验证 detail-cleanup 索引是否就绪。
+//
+// 背景:v13/v14 migration 都有 500k 行 threshold-skip 分支。若大表升级时运维忽略
+// manual SQL,稳态 cleanup SELECT 会全表扫;配合 dialect-aware 的大 batch
+// (MySQL 1000),IOPS 会被放大而不是收敛。启动时显式告警,让问题在日志最显眼处出现,
+// 而不是被运维当成"清理任务在跑就行"的假象掩盖。
+//
+// 检查为 best-effort:DB 字段为 nil(测试场景)或非 MySQL(SQLite 用 partial index)
+// 直接跳过。INFORMATION_SCHEMA 查询失败也不阻塞启动——这只是健康提示,不是 gate。
+func (d *BackgroundTaskDeps) checkDetailCleanupIndexHealth() {
+	if d.DB == nil || d.DB.Dialector() != "mysql" {
+		return
+	}
+	var indexCount int64
+	err := d.DB.GormDB().Raw(`
+		SELECT COUNT(*) FROM information_schema.STATISTICS
+		WHERE table_schema = DATABASE()
+		  AND table_name = 'proxy_requests'
+		  AND index_name IN ('idx_proxy_requests_detail_cleanup', 'idx_proxy_requests_detail_cleanup_v2')
+	`).Scan(&indexCount).Error
+	if err != nil {
+		log.Printf("[Task] WARNING: failed to verify detail-cleanup index health: %v", err)
+		return
+	}
+	if indexCount == 0 {
+		log.Printf("[Task] WARNING: MySQL proxy_requests has NO detail-cleanup index. "+
+			"Cleanup SELECT will fall back to full table scan. "+
+			"Apply manually during a maintenance window:\n"+
+			"  CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id);")
+		return
+	}
+	log.Printf("[Task] MySQL detail-cleanup index present (count=%d)", indexCount)
 }
 
 // runCleanupTasks 清理任务：清理过期数据

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -136,10 +136,15 @@ func StartBackgroundTasks(deps BackgroundTaskDeps) {
 
 // checkDetailCleanupIndexHealth 在 MySQL 上验证 detail-cleanup 索引是否就绪。
 //
-// 背景:v13/v14 migration 都有 500k 行 threshold-skip 分支。若大表升级时运维忽略
-// manual SQL,稳态 cleanup SELECT 会全表扫;配合 dialect-aware 的大 batch
-// (MySQL 1000),IOPS 会被放大而不是收敛。启动时显式告警,让问题在日志最显眼处出现,
-// 而不是被运维当成"清理任务在跑就行"的假象掩盖。
+// 三档状态:
+//   - v14 (_v2) 索引存在 → fast path (1000/20ms)。生产 EXPLAIN filtered ~99%,
+//     是 PR 设计目标。
+//   - 仅 v13 旧索引 (_no _v2) → degraded。v13 的 (created_at, id) 列序对清理
+//     SELECT filtered 只有 ~10%,在大表上把 1000 batch 跑成全扫等价物。退到保守批次
+//     200/50ms,并打印 manual v14 SQL。maintainer awsl233777 在 PR #566 catch 的关键
+//     场景:v13 自动建成 + v14 threshold-skip 时,以前 health check 把它当作就绪,
+//     会用错配的 fast path。
+//   - 都不存在 → 最强警告 + 保守批次。
 //
 // 检查为 best-effort:DB 字段为 nil(测试场景)或非 MySQL(SQLite 用 partial index)
 // 直接跳过。INFORMATION_SCHEMA 查询失败也不阻塞启动——这只是健康提示,不是 gate。
@@ -147,29 +152,49 @@ func (d *BackgroundTaskDeps) checkDetailCleanupIndexHealth() {
 	if d.DB == nil || d.DB.Dialector() != "mysql" {
 		return
 	}
-	var indexCount int64
+	type indexRow struct {
+		IndexName string `gorm:"column:index_name"`
+	}
+	var rows []indexRow
 	err := d.DB.GormDB().Raw(`
-		SELECT COUNT(*) FROM information_schema.STATISTICS
+		SELECT DISTINCT index_name FROM information_schema.STATISTICS
 		WHERE table_schema = DATABASE()
 		  AND table_name = 'proxy_requests'
 		  AND index_name IN ('idx_proxy_requests_detail_cleanup', 'idx_proxy_requests_detail_cleanup_v2')
-	`).Scan(&indexCount).Error
+	`).Scan(&rows).Error
 	if err != nil {
 		log.Printf("[Task] WARNING: failed to verify detail-cleanup index health: %v", err)
 		return
 	}
-	if indexCount == 0 {
-		// 主动降级 cleanup 批次到保守值,避免在无索引的大表上 batch=1000 反复全扫。
-		// 这是把 "warning + 错配的 batch 默认" 改成 "warning + 自动安全降级"。
+	hasV13, hasV14 := false, false
+	for _, r := range rows {
+		switch r.IndexName {
+		case "idx_proxy_requests_detail_cleanup":
+			hasV13 = true
+		case "idx_proxy_requests_detail_cleanup_v2":
+			hasV14 = true
+		}
+	}
+	switch {
+	case hasV14:
+		sqlite.SetDetailCleanupIndexMissing(false)
+		log.Printf("[Task] MySQL detail-cleanup v14 index present (fast path enabled)")
+	case hasV13:
+		// v13 索引存在但 v14 缺失。v13 列序只让 ~10% 行有效过滤,大 batch 等同全扫。
+		// 退到保守批次,并提示运维补 v14。
+		sqlite.SetDetailCleanupIndexMissing(true)
+		log.Printf("[Task] WARNING: MySQL proxy_requests has only the v13 detail-cleanup index "+
+			"(created_at, id). v14 reorder is the actual perf fix; cleanup batch falls back to "+
+			"conservative size (200/50ms) until you apply:\n"+
+			"  CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id);\n"+
+			"  -- then optionally:\n"+
+			"  -- DROP INDEX idx_proxy_requests_detail_cleanup ON proxy_requests;")
+	default:
 		sqlite.SetDetailCleanupIndexMissing(true)
 		log.Printf("[Task] WARNING: MySQL proxy_requests has NO detail-cleanup index. "+
 			"Cleanup batch falls back to conservative size (200/50ms) until you apply:\n"+
 			"  CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id);")
-		return
 	}
-	// 显式清零:索引就绪时复位 flag,避免上一次启动遗留的 sticky 状态污染当前进程。
-	sqlite.SetDetailCleanupIndexMissing(false)
-	log.Printf("[Task] MySQL detail-cleanup index present (count=%d)", indexCount)
 }
 
 // runCleanupTasks 清理任务：清理过期数据

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -161,12 +161,14 @@ func (d *BackgroundTaskDeps) checkDetailCleanupIndexHealth() {
 	if indexCount == 0 {
 		// 主动降级 cleanup 批次到保守值,避免在无索引的大表上 batch=1000 反复全扫。
 		// 这是把 "warning + 错配的 batch 默认" 改成 "warning + 自动安全降级"。
-		sqlite.MarkDetailCleanupIndexMissing()
+		sqlite.SetDetailCleanupIndexMissing(true)
 		log.Printf("[Task] WARNING: MySQL proxy_requests has NO detail-cleanup index. "+
 			"Cleanup batch falls back to conservative size (200/50ms) until you apply:\n"+
 			"  CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id);")
 		return
 	}
+	// 显式清零:索引就绪时复位 flag,避免上一次启动遗留的 sticky 状态污染当前进程。
+	sqlite.SetDetailCleanupIndexMissing(false)
 	log.Printf("[Task] MySQL detail-cleanup index present (count=%d)", indexCount)
 }
 

--- a/internal/core/task_test.go
+++ b/internal/core/task_test.go
@@ -382,6 +382,24 @@ func TestIsCleanupLeader(t *testing.T) {
 	}
 }
 
+func TestCheckDetailCleanupIndexHealth_NilDBNoPanic(t *testing.T) {
+	// 测试调用方未提供 DB 时(常见于 unit test 场景),health check 必须安全 no-op。
+	deps := &BackgroundTaskDeps{}
+	deps.checkDetailCleanupIndexHealth() // must not panic
+}
+
+func TestCheckDetailCleanupIndexHealth_SQLiteSkipped(t *testing.T) {
+	// SQLite 用 partial index,index_name 与 MySQL 不同;health check 必须直接跳过
+	// 而不是对着 SQLite 的 sqlite_master 跑 information_schema 查询。
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	deps := &BackgroundTaskDeps{DB: db}
+	deps.checkDetailCleanupIndexHealth() // must not error/panic on non-MySQL
+}
+
 func TestRunCleanupTasksSkipsWhenNotLeader(t *testing.T) {
 	sessionRepo := &fakeSessionRepo{}
 	deps := BackgroundTaskDeps{

--- a/internal/core/task_test.go
+++ b/internal/core/task_test.go
@@ -1,9 +1,12 @@
 package core
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/coordinator"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
@@ -323,6 +326,74 @@ func TestCleanupOldRequestDetails_SplitMode(t *testing.T) {
 			t.Error("default -1 should retain")
 		}
 	})
+}
+
+// fakeCoordinator implements coordinator.Coordinator just enough for isCleanupLeader tests.
+// All non-leader methods return zero values; only InstanceID + ListAliveInstances behavior matters here.
+type fakeCoordinator struct {
+	id    string
+	alive []string
+	err   error
+}
+
+func (f *fakeCoordinator) InstanceID() string                                       { return f.id }
+func (f *fakeCoordinator) Publish(context.Context, string, []byte) error            { return nil }
+func (f *fakeCoordinator) Subscribe(context.Context, string) (<-chan coordinator.Message, error) {
+	return nil, nil
+}
+func (f *fakeCoordinator) Get(context.Context, string) ([]byte, error)                { return nil, nil }
+func (f *fakeCoordinator) Set(context.Context, string, []byte, time.Duration) error   { return nil }
+func (f *fakeCoordinator) Del(context.Context, string) error                          { return nil }
+func (f *fakeCoordinator) RegisterInstance(context.Context, time.Duration) error      { return nil }
+func (f *fakeCoordinator) RefreshInstance(context.Context, time.Duration) error       { return nil }
+func (f *fakeCoordinator) UnregisterInstance(context.Context) error                   { return nil }
+func (f *fakeCoordinator) ListAliveInstances(context.Context) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	// 返回新切片,模拟真实实现(memory/redis 都是新切片)。防御性 copy 让 isCleanupLeader 的
+	// sort.Strings 不会污染 fixture。
+	out := make([]string, len(f.alive))
+	copy(out, f.alive)
+	return out, nil
+}
+func (f *fakeCoordinator) Close() error { return nil }
+
+func TestIsCleanupLeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		coord   coordinator.Coordinator
+		wantLed bool
+	}{
+		{"nil coordinator → always leader (single-instance fallback)", nil, true},
+		{"only self alive", &fakeCoordinator{id: "a", alive: []string{"a"}}, true},
+		{"self is smallest of many", &fakeCoordinator{id: "a", alive: []string{"c", "a", "b"}}, true},
+		{"self is not smallest", &fakeCoordinator{id: "b", alive: []string{"c", "a", "b"}}, false},
+		{"list returns error → conservative non-leader", &fakeCoordinator{id: "a", err: errors.New("boom")}, false},
+		{"empty alive list → conservative non-leader", &fakeCoordinator{id: "a", alive: nil}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := &BackgroundTaskDeps{Coordinator: tt.coord}
+			if got := deps.isCleanupLeader(); got != tt.wantLed {
+				t.Errorf("isCleanupLeader() = %v, want %v", got, tt.wantLed)
+			}
+		})
+	}
+}
+
+func TestRunCleanupTasksSkipsWhenNotLeader(t *testing.T) {
+	sessionRepo := &fakeSessionRepo{}
+	deps := BackgroundTaskDeps{
+		SessionRepo: sessionRepo,
+		Settings:    &fakeSettingRepo{},
+		// id="b" 不是最小,leader 应判为 "a"
+		Coordinator: &fakeCoordinator{id: "b", alive: []string{"a", "b"}},
+	}
+	deps.runCleanupTasks()
+	if sessionRepo.deleteCalls != 0 {
+		t.Fatalf("non-leader instance should not run cleanup, got %d delete calls", sessionRepo.deleteCalls)
+	}
 }
 
 func TestCleanupOldSessionsRespectsDisabledSetting(t *testing.T) {

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -462,7 +462,12 @@ func runDetailCleanupIndexV2Migration(db *gorm.DB) error {
 	const (
 		oldIndex = "idx_proxy_requests_detail_cleanup"
 		newIndex = "idx_proxy_requests_detail_cleanup_v2"
-		createSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id)"
+		// ALGORITHM=INPLACE, LOCK=NONE 显式声明 online DDL。MySQL 8 默认就是 INPLACE,
+		// 但若 InnoDB 走 COPY fallback(罕见的 fulltext/外键交互),不加这两个 hint
+		// 会静默退化为长时间持锁。显式声明 → 不支持就报错,不让运维稳态写入被锁住。
+		createSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id) ALGORITHM=INPLACE, LOCK=NONE"
+		// manual SQL log 中不带 ALGORITHM hint:运维窗口下手动执行,愿意承担 COPY 风险。
+		manualCreateSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id)"
 	)
 	var rowCount int64
 	if err := db.Raw("SELECT COUNT(*) FROM proxy_requests").Scan(&rowCount).Error; err != nil {
@@ -474,8 +479,9 @@ func runDetailCleanupIndexV2Migration(db *gorm.DB) error {
 		log.Printf("[Migration v14] SKIPPING %s build: proxy_requests has %d rows (> %d threshold). "+
 			"CREATE INDEX would block writes. Apply manually during a maintenance window:\n"+
 			"  %s;\n"+
-			"  DROP INDEX %s ON proxy_requests;",
-			newIndex, rowCount, detailCleanupIndexRowThreshold, createSQL, oldIndex)
+			"  -- then (only if v13 had successfully built the old index):\n"+
+			"  -- DROP INDEX %s ON proxy_requests;",
+			newIndex, rowCount, detailCleanupIndexRowThreshold, manualCreateSQL, oldIndex)
 		return nil
 	}
 

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -414,6 +414,82 @@ var migrations = []Migration{
 			}
 		},
 	},
+	{
+		Version:     14,
+		Description: "Re-order MySQL proxy_requests detail-cleanup index to (status, dev_mode, created_at, id)",
+		Up: func(db *gorm.DB) error {
+			// 生产反馈：v13 在 MySQL 上建的 (created_at, id) 复合索引，对清理 SELECT
+			// 的 EXPLAIN filtered 只有 ~10%(WHERE 还有 status IN AND dev_mode = 0,
+			// 索引前缀覆盖不到要回表)。改成 (status, dev_mode, created_at, id) 后
+			// filtered 升到 ~99%，SELECT 从 30-70s 降到亚秒级。
+			//
+			// SQLite 用 partial index 已把谓词烧进索引,不需要改;attempts 表清理
+			// 没有 status/dev_mode 谓词,(created_at, id) 已最优,也保持不变。
+			//
+			// 大表上 CREATE INDEX 同样可能长时间阻塞写入,沿用 v13 的 threshold-skip
+			// 策略:超过 detailCleanupIndexRowThreshold 行打印 manual SQL,由运维选窗口跑。
+			if db.Dialector.Name() != "mysql" {
+				return nil
+			}
+			return runDetailCleanupIndexV2Migration(db)
+		},
+		Down: func(db *gorm.DB) error {
+			if db.Dialector.Name() != "mysql" {
+				return nil
+			}
+			// 回滚:删 v2 名字的索引并尝试恢复 v13 的 (created_at, id)
+			if err := db.Exec("DROP INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests").Error; err != nil && !isMySQLMissingIndexError(err) {
+				log.Printf("[Migration] Warning: rollback v14 drop v2 failed: %v", err)
+			}
+			err := db.Exec("CREATE INDEX idx_proxy_requests_detail_cleanup ON proxy_requests(created_at, id)").Error
+			if err != nil && !isMySQLDuplicateIndexError(err) {
+				log.Printf("[Migration] Warning: rollback v14 recreate v1 failed: %v", err)
+			}
+			return nil
+		},
+	},
+}
+
+// runDetailCleanupIndexV2Migration 创建 (status, dev_mode, created_at, id) 索引并删除旧的
+// (created_at, id) 索引(同一张表两个清理索引同时存在意义不大,且 MySQL writes 要维护两份)。
+//
+// 命名为 _v2 后缀,保留旧名 idx_proxy_requests_detail_cleanup 给运维以便回滚/对照;
+// drop 顺序在 create 之后,确保任何瞬间至少一个索引可用(planner 会自动切换)。
+//
+// 大表跳过:超过阈值则只打印 manual SQL,migration 仍标记完成。降级行为:planner 退化
+// 用旧 (created_at, id) 索引,SELECT 慢但不至于卡死。
+func runDetailCleanupIndexV2Migration(db *gorm.DB) error {
+	const (
+		oldIndex = "idx_proxy_requests_detail_cleanup"
+		newIndex = "idx_proxy_requests_detail_cleanup_v2"
+		createSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id)"
+	)
+	var rowCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM proxy_requests").Scan(&rowCount).Error; err != nil {
+		log.Printf("[Migration v14] could not count proxy_requests (%v); skipping index build. Apply manually if needed.", err)
+		return nil
+	}
+
+	if rowCount > detailCleanupIndexRowThreshold {
+		log.Printf("[Migration v14] SKIPPING %s build: proxy_requests has %d rows (> %d threshold). "+
+			"CREATE INDEX would block writes. Apply manually during a maintenance window:\n"+
+			"  %s;\n"+
+			"  DROP INDEX %s ON proxy_requests;",
+			newIndex, rowCount, detailCleanupIndexRowThreshold, createSQL, oldIndex)
+		return nil
+	}
+
+	log.Printf("[Migration v14] building %s (rows=%d)", newIndex, rowCount)
+	start := time.Now()
+	if err := db.Exec(createSQL).Error; err != nil && !isMySQLDuplicateIndexError(err) {
+		return err
+	}
+	log.Printf("[Migration v14] built %s in %s", newIndex, time.Since(start).Round(time.Millisecond))
+
+	if err := db.Exec("DROP INDEX " + oldIndex + " ON proxy_requests").Error; err != nil && !isMySQLMissingIndexError(err) {
+		log.Printf("[Migration v14] Warning: drop old %s failed (non-fatal): %v", oldIndex, err)
+	}
+	return nil
 }
 
 // detailCleanupIndexRowThreshold 是 v13 自动建索引的行数上限。超过它则跳过自动建立

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -487,16 +487,34 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 	return totalUpdated, nil
 }
 
+// detailCleanupIndexMissing 由启动时健康检查置位:MySQL detail-cleanup 索引不存在时
+// 设为 1。设置后 detailCleanupBatchParams 退化回保守批次(200/50ms),避免在无索引的
+// 大表上以 batch=1000 反复触发 full-table-scan 把 IOPS 打满。
+//
+// 用 atomic.Int32 而非 mutex:写一次(启动),读高频(每次清理批次),无锁读最便宜。
+var detailCleanupIndexMissing atomic.Int32
+
+// MarkDetailCleanupIndexMissing 标记 MySQL detail-cleanup 索引缺失。startup health-check
+// 调用,见 internal/core/task.go:checkDetailCleanupIndexHealth。
+func MarkDetailCleanupIndexMissing() {
+	detailCleanupIndexMissing.Store(1)
+}
+
 // detailCleanupBatchParams 返回当前 dialect 下 detail cleanup 批次大小与 batch 间 sleep。
 //
 //   - SQLite:200 / 50ms。SQLite WAL 是单写者锁,大 batch 会让 API INSERT 长时间等待
 //     ("卡死"问题的根因);沿用 v0.13.77 的保守值,验证稳定。
-//   - MySQL/其它:1000 / 20ms。MySQL 用行级锁 + redo log,不存在单写阻塞;改完 v14 索引
-//     后 SELECT 亚秒级,瓶颈转到 UPDATE 网络往返,大 batch 把往返摊薄到更多行。
-//     20ms sleep 仍保留一点让步给在线流量,避免长时间持锁热点。
+//   - MySQL 且索引就绪:1000 / 20ms。改完 v14 索引后 SELECT 亚秒级,瓶颈转到 UPDATE
+//     网络往返,大 batch 把往返摊薄到更多行。
+//   - MySQL 但索引缺失(threshold-skip 且没手动建):退化回 200 / 50ms。无索引时 SELECT
+//     是 full-scan-per-batch,大 batch 不会摊薄全扫成本,反而每批次锁更多行;保守批次
+//     +更长 sleep 减小对在线流量的干扰。startup 已经打了告警日志,运维应当尽快建索引。
 func detailCleanupBatchParams(dialector string) (batchSize int, sleep time.Duration) {
 	switch dialector {
 	case "mysql":
+		if detailCleanupIndexMissing.Load() == 1 {
+			return 200, 50 * time.Millisecond
+		}
 		return 1000, 20 * time.Millisecond
 	default:
 		return 200, 50 * time.Millisecond

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -494,10 +494,18 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 // 用 atomic.Int32 而非 mutex:写一次(启动),读高频(每次清理批次),无锁读最便宜。
 var detailCleanupIndexMissing atomic.Int32
 
-// MarkDetailCleanupIndexMissing 标记 MySQL detail-cleanup 索引缺失。startup health-check
-// 调用,见 internal/core/task.go:checkDetailCleanupIndexHealth。
-func MarkDetailCleanupIndexMissing() {
-	detailCleanupIndexMissing.Store(1)
+// SetDetailCleanupIndexMissing 设置 MySQL detail-cleanup 索引缺失状态。startup
+// health-check 调用,见 internal/core/task.go:checkDetailCleanupIndexHealth。
+//
+// 显式 set(true/false):每次启动健康检查时都覆盖写,避免之前进程态/测试态遗留的 sticky
+// 标志位污染后续判断。同进程内若索引被运维补建,需要重启进程才能恢复 fast-path;
+// 这是可接受的权衡——避免运行时反复轮询 INFORMATION_SCHEMA 的开销。
+func SetDetailCleanupIndexMissing(missing bool) {
+	if missing {
+		detailCleanupIndexMissing.Store(1)
+	} else {
+		detailCleanupIndexMissing.Store(0)
+	}
 }
 
 // detailCleanupBatchParams 返回当前 dialect 下 detail cleanup 批次大小与 batch 间 sleep。

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -487,6 +487,22 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 	return totalUpdated, nil
 }
 
+// detailCleanupBatchParams 返回当前 dialect 下 detail cleanup 批次大小与 batch 间 sleep。
+//
+//   - SQLite:200 / 50ms。SQLite WAL 是单写者锁,大 batch 会让 API INSERT 长时间等待
+//     ("卡死"问题的根因);沿用 v0.13.77 的保守值,验证稳定。
+//   - MySQL/其它:1000 / 20ms。MySQL 用行级锁 + redo log,不存在单写阻塞;改完 v14 索引
+//     后 SELECT 亚秒级,瓶颈转到 UPDATE 网络往返,大 batch 把往返摊薄到更多行。
+//     20ms sleep 仍保留一点让步给在线流量,避免长时间持锁热点。
+func detailCleanupBatchParams(dialector string) (batchSize int, sleep time.Duration) {
+	switch dialector {
+	case "mysql":
+		return 1000, 20 * time.Millisecond
+	default:
+		return 200, 50 * time.Millisecond
+	}
+}
+
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
 //
@@ -501,10 +517,7 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 //   - 分批：request_info/response_info 是大 JSON blob，一次 UPDATE 全表会产生超大
 //     事务（WAL 同时记录 old/new），故按 batchSize 拆分。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
-	const (
-		batchSize  = 200
-		batchSleep = 50 * time.Millisecond
-	)
+	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
 	var total int64
 	var lastCreatedAt int64

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -35,8 +35,8 @@ func TestDetailCleanupBatchParams(t *testing.T) {
 	})
 
 	t.Run("MySQL falls back to conservative when index missing", func(t *testing.T) {
-		MarkDetailCleanupIndexMissing()
-		defer detailCleanupIndexMissing.Store(0)
+		SetDetailCleanupIndexMissing(true)
+		defer SetDetailCleanupIndexMissing(false)
 		gotBatch, gotSleep := detailCleanupBatchParams("mysql")
 		if gotBatch != 200 || gotSleep != 50*time.Millisecond {
 			t.Errorf("MySQL with missing index = (%d, %v), want (200, 50ms)", gotBatch, gotSleep)
@@ -44,11 +44,21 @@ func TestDetailCleanupBatchParams(t *testing.T) {
 	})
 
 	t.Run("SQLite unaffected by MySQL index-missing flag", func(t *testing.T) {
-		MarkDetailCleanupIndexMissing()
-		defer detailCleanupIndexMissing.Store(0)
+		SetDetailCleanupIndexMissing(true)
+		defer SetDetailCleanupIndexMissing(false)
 		gotBatch, gotSleep := detailCleanupBatchParams("sqlite")
 		if gotBatch != 200 || gotSleep != 50*time.Millisecond {
 			t.Errorf("SQLite default = (%d, %v), want (200, 50ms)", gotBatch, gotSleep)
+		}
+	})
+
+	// 验证 flag 可恢复:Codex 反馈 sticky flag 会污染后续启动/测试。
+	t.Run("SetDetailCleanupIndexMissing(false) restores fast-path", func(t *testing.T) {
+		SetDetailCleanupIndexMissing(true)
+		SetDetailCleanupIndexMissing(false)
+		gotBatch, gotSleep := detailCleanupBatchParams("mysql")
+		if gotBatch != 1000 || gotSleep != 20*time.Millisecond {
+			t.Errorf("after reset, MySQL = (%d, %v), want (1000, 20ms)", gotBatch, gotSleep)
 		}
 	})
 }

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
+func TestDetailCleanupBatchParams(t *testing.T) {
+	tests := []struct {
+		dialector  string
+		wantBatch  int
+		wantSleep  time.Duration
+	}{
+		{"sqlite", 200, 50 * time.Millisecond},
+		{"mysql", 1000, 20 * time.Millisecond},
+		{"postgres", 200, 50 * time.Millisecond}, // unknown → conservative defaults
+		{"", 200, 50 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dialector, func(t *testing.T) {
+			gotBatch, gotSleep := detailCleanupBatchParams(tt.dialector)
+			if gotBatch != tt.wantBatch || gotSleep != tt.wantSleep {
+				t.Errorf("detailCleanupBatchParams(%q) = (%d, %v), want (%d, %v)",
+					tt.dialector, gotBatch, gotSleep, tt.wantBatch, tt.wantSleep)
+			}
+		})
+	}
+}
+
 func buildTestProxyRequest(status string, index int) *domain.ProxyRequest {
 	start := time.Unix(int64(index), 0).UTC()
 	return &domain.ProxyRequest{

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -10,25 +10,47 @@ import (
 )
 
 func TestDetailCleanupBatchParams(t *testing.T) {
-	tests := []struct {
-		dialector  string
-		wantBatch  int
-		wantSleep  time.Duration
-	}{
-		{"sqlite", 200, 50 * time.Millisecond},
-		{"mysql", 1000, 20 * time.Millisecond},
-		{"postgres", 200, 50 * time.Millisecond}, // unknown → conservative defaults
-		{"", 200, 50 * time.Millisecond},
-	}
-	for _, tt := range tests {
-		t.Run(tt.dialector, func(t *testing.T) {
+	// 子测试间共享全局 detailCleanupIndexMissing,确保不串扰。
+	defer detailCleanupIndexMissing.Store(0)
+
+	t.Run("dialect defaults (index present)", func(t *testing.T) {
+		detailCleanupIndexMissing.Store(0)
+		tests := []struct {
+			dialector string
+			wantBatch int
+			wantSleep time.Duration
+		}{
+			{"sqlite", 200, 50 * time.Millisecond},
+			{"mysql", 1000, 20 * time.Millisecond},
+			{"postgres", 200, 50 * time.Millisecond}, // unknown → conservative defaults
+			{"", 200, 50 * time.Millisecond},
+		}
+		for _, tt := range tests {
 			gotBatch, gotSleep := detailCleanupBatchParams(tt.dialector)
 			if gotBatch != tt.wantBatch || gotSleep != tt.wantSleep {
 				t.Errorf("detailCleanupBatchParams(%q) = (%d, %v), want (%d, %v)",
 					tt.dialector, gotBatch, gotSleep, tt.wantBatch, tt.wantSleep)
 			}
-		})
-	}
+		}
+	})
+
+	t.Run("MySQL falls back to conservative when index missing", func(t *testing.T) {
+		MarkDetailCleanupIndexMissing()
+		defer detailCleanupIndexMissing.Store(0)
+		gotBatch, gotSleep := detailCleanupBatchParams("mysql")
+		if gotBatch != 200 || gotSleep != 50*time.Millisecond {
+			t.Errorf("MySQL with missing index = (%d, %v), want (200, 50ms)", gotBatch, gotSleep)
+		}
+	})
+
+	t.Run("SQLite unaffected by MySQL index-missing flag", func(t *testing.T) {
+		MarkDetailCleanupIndexMissing()
+		defer detailCleanupIndexMissing.Store(0)
+		gotBatch, gotSleep := detailCleanupBatchParams("sqlite")
+		if gotBatch != 200 || gotSleep != 50*time.Millisecond {
+			t.Errorf("SQLite default = (%d, %v), want (200, 50ms)", gotBatch, gotSleep)
+		}
+	})
 }
 
 func buildTestProxyRequest(status string, index int) *domain.ProxyRequest {

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -245,10 +245,7 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 // 父表 PK 查找，并且 ORDER BY 不再需要临时 sort。
 // EXPLAIN QUERY PLAN 由 TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 守护。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
-	const (
-		batchSize  = 200
-		batchSleep = 50 * time.Millisecond
-	)
+	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
 	var total int64
 	var lastCreatedAt int64


### PR DESCRIPTION
## Summary

生产反馈驱动的三项优化（#565 后续）：

1. **Leader-only cleanup**：多副本部署时，`runCleanupTasks` / `runRequestDetailCleanup` 只在 leader 实例上跑（活实例 ID 排序最小者）。原来 6 副本同时清理会把共享 RDS 的 IOPS 放大 6 倍互相 race。`Coordinator=nil`（单实例）退化为"总是 leader"，行为不变。

2. **v14 migration：MySQL 索引列序**：v13 的 `(created_at, id)` 复合索引在 MySQL 上 EXPLAIN filtered 仅 ~10%（`WHERE status IN AND dev_mode = 0` 要回表）。改成 `(status, dev_mode, created_at, id)` 后 filtered ~99%，cleanup SELECT 从 30-70s 降到亚秒。沿用 v13 的 500k 行阈值 + manual SQL fallback。SQLite 用 partial index 已最优，不变。

3. **Dialect-aware batch params**：`ClearDetailOlderThan` 的 batchSize/sleep 按 dialect 区分：SQLite 保持 200/50ms（保护单写 WAL 锁），MySQL 改为 1000/20ms（行锁无单写阻塞，配合 v14 索引把吞吐拉到 ~5×）。

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` 全绿（含 `tests/multiinstance`）
- [ ] 多副本部署上观察 leader 单跑日志、非 leader 跳过
- [ ] MySQL 8 上 EXPLAIN cleanup SELECT 走 `idx_proxy_requests_detail_cleanup_v2`
- [ ] 大表（>500k 行）升级路径打印 manual SQL 而非阻塞

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 添加了多实例部署下的清理任务协调机制，确保清理操作仅在主实例执行，避免重复处理。

* **优化改进**
  * 优化了数据库索引结构以提升清理任务性能。
  * 根据数据库类型动态调整批处理参数，改善大规模数据处理效率。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->