### PR TITLE
fix(migration v14): use ALTER TABLE for online DDL syntax (MySQL 1064 hotfix)

### DIFF
--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -462,11 +462,12 @@ func runDetailCleanupIndexV2Migration(db *gorm.DB) error {
 	const (
 		oldIndex = "idx_proxy_requests_detail_cleanup"
 		newIndex = "idx_proxy_requests_detail_cleanup_v2"
-		// ALGORITHM=INPLACE, LOCK=NONE 显式声明 online DDL。MySQL 8 默认就是 INPLACE,
-		// 但若 InnoDB 走 COPY fallback(罕见的 fulltext/外键交互),不加这两个 hint
-		// 会静默退化为长时间持锁。显式声明 → 不支持就报错,不让运维稳态写入被锁住。
-		createSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id) ALGORITHM=INPLACE, LOCK=NONE"
-		// manual SQL log 中不带 ALGORITHM hint:运维窗口下手动执行,愿意承担 COPY 风险。
+		// ALGORITHM=INPLACE, LOCK=NONE 显式声明 online DDL。这两个子句**只能用在
+		// ALTER TABLE ADD INDEX 上**;附在 CREATE INDEX 后面 MySQL 8 会报 1064 语法错。
+		// 之前用 CREATE INDEX 的版本在 v0.13.78 启动崩溃(生产报告)。
+		// 用 ALTER TABLE 等价表达,等价语义,但语法被 MySQL parser 接受。
+		createSQL = "ALTER TABLE proxy_requests ADD INDEX idx_proxy_requests_detail_cleanup_v2 (status, dev_mode, created_at, id), ALGORITHM=INPLACE, LOCK=NONE"
+		// manual SQL log 中保持 CREATE INDEX 形式:运维窗口下不需要 INPLACE/LOCK 提示。
 		manualCreateSQL = "CREATE INDEX idx_proxy_requests_detail_cleanup_v2 ON proxy_requests(status, dev_mode, created_at, id)"
 	)
 	var rowCount int64


### PR DESCRIPTION
## Summary

**Production hotfix for v0.13.78.** A downstream user reported that v14 migration crashes startup on MySQL 8.0.44 with error 1064 (syntax error).

Root cause: `ALGORITHM=INPLACE, LOCK=NONE` clauses are **only valid on \`ALTER TABLE\`**, not on \`CREATE INDEX\`. I added them at review time without verifying syntax — my fault. The MySQL parser rejects the combined form.

Impact: any MySQL cluster with \`proxy_requests\` row count **below** the 500k threshold-skip line will hit the auto-build branch on startup → SQL 1064 → process crash. Above-threshold clusters dodge it because they skip the auto-build entirely.

## Fix

Switch to equivalent ALTER TABLE syntax which MySQL accepts:

\`\`\`sql
ALTER TABLE proxy_requests
  ADD INDEX idx_proxy_requests_detail_cleanup_v2 (status, dev_mode, created_at, id),
  ALGORITHM=INPLACE, LOCK=NONE;
\`\`\`

Same online-DDL semantics, parser-valid syntax.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/repository/sqlite/... ./internal/core/...\`
- [ ] Verify on real MySQL 8 (no MySQL test container in repo — same validation pattern as PR #566)

cc @awsl233777 — sorry for the breakage. The MySQL DDL path remains the gap I called out earlier (no CI coverage), but the lesson is clear: ALTER TABLE syntax for any online-DDL hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化数据库迁移中索引创建的SQL语法执行方式。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->