### PR TITLE
perf(cleanup): sentinel column + persistent cursor + batch cap (fix 43-min stall)

### DIFF
--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -171,6 +171,9 @@ func (d *BackgroundTaskDeps) checkDetailClearedColumnHealth() {
 }
 
 // detailClearedColumnExists 跨 dialect 探测列是否存在。
+//
+// 注意 Postgres 分支:不能 fall through 到 SQLite PRAGMA 路径。Postgres 会以
+// SQLSTATE 42601 拒绝 PRAGMA 并 abort 当前事务,后续查询全部失败(multiinstance CI 抓到)。
 func detailClearedColumnExists(db *sqlite.DB, table string) (bool, error) {
 	switch db.Dialector() {
 	case "mysql":
@@ -180,7 +183,15 @@ func detailClearedColumnExists(db *sqlite.DB, table string) (bool, error) {
 			WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'detail_cleared'
 		`, table).Scan(&n).Error
 		return n > 0, err
+	case "postgres":
+		var n int64
+		err := db.GormDB().Raw(`
+			SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'detail_cleared'
+		`, table).Scan(&n).Error
+		return n > 0, err
 	default:
+		// SQLite
 		rows, err := db.GormDB().Raw("PRAGMA table_info(" + table + ")").Rows()
 		if err != nil {
 			return false, err

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -148,6 +148,12 @@ func (d *BackgroundTaskDeps) checkDetailClearedColumnHealth() {
 	if d.DB == nil {
 		return
 	}
+	// 列类型与 migration v15 的 dialect 分支保持一致——否则运维复制 manual SQL 时
+	// Postgres 上 TINYINT 直接 1064 语法错(awsl233777 在 PR #568 catch)。
+	columnType := "TINYINT"
+	if d.DB.Dialector() == "postgres" {
+		columnType = "SMALLINT"
+	}
 	tables := []string{"proxy_requests", "proxy_upstream_attempts"}
 	missing := false
 	for _, table := range tables {
@@ -160,7 +166,7 @@ func (d *BackgroundTaskDeps) checkDetailClearedColumnHealth() {
 		if !exists {
 			missing = true
 			log.Printf("[Task] WARNING: %s.detail_cleared column missing — cleanup will use legacy IS NOT NULL predicate (slow but functional). Apply manually:\n"+
-				"  ALTER TABLE %s ADD COLUMN detail_cleared TINYINT NOT NULL DEFAULT 0;", table, table)
+				"  ALTER TABLE %s ADD COLUMN detail_cleared %s NOT NULL DEFAULT 0;", table, table, columnType)
 			break
 		}
 	}

--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -92,6 +92,7 @@ func StartBackgroundTasks(deps BackgroundTaskDeps) {
 	// 启动时校验:MySQL 上 detail-cleanup 索引若缺失,稳态 SELECT 会全表扫,
 	// 配合大 batch 反而把 IOPS 放大。打印明显告警 + manual SQL,让运维不至于错过。
 	deps.checkDetailCleanupIndexHealth()
+	deps.checkDetailClearedColumnHealth()
 	// 统计聚合任务（每 30 秒）- 聚合原始数据并自动 rollup 到各粒度
 	go func() {
 		time.Sleep(5 * time.Second) // 初始延迟
@@ -132,6 +133,73 @@ func StartBackgroundTasks(deps BackgroundTaskDeps) {
 	}
 
 	log.Println("[Task] Background tasks started (aggregation:30s, cleanup:1h, detail-cleanup:dynamic)")
+}
+
+// checkDetailClearedColumnHealth 在所有 dialect 上验证 v15 detail_cleared 列是否就绪。
+//
+// 背景:v15 migration 在 proxy_requests / proxy_upstream_attempts 行数 > 500k 时跳过
+// ADD COLUMN(避免大表升级阻塞写入)。如果运维忽略 manual SQL,稳态 ClearDetailOlderThan
+// 的 SELECT 会引用不存在的列 → 每个 tick 都报错 → cleanup 功能直接挂掉(不是变慢)。
+// 启动时探测列是否存在,缺失则置位 flag,sentinel-aware 的清理代码退化到 v13/v14 legacy
+// 谓词(`request_info IS NOT NULL OR response_info IS NOT NULL`),保证功能正常。
+//
+// 检查为 best-effort:DB 字段为 nil(测试场景)直接跳过。任一表缺列即视为 missing。
+func (d *BackgroundTaskDeps) checkDetailClearedColumnHealth() {
+	if d.DB == nil {
+		return
+	}
+	tables := []string{"proxy_requests", "proxy_upstream_attempts"}
+	missing := false
+	for _, table := range tables {
+		exists, err := detailClearedColumnExists(d.DB, table)
+		if err != nil {
+			log.Printf("[Task] WARNING: failed to probe %s.detail_cleared (%v); assuming missing", table, err)
+			missing = true
+			break
+		}
+		if !exists {
+			missing = true
+			log.Printf("[Task] WARNING: %s.detail_cleared column missing — cleanup will use legacy IS NOT NULL predicate (slow but functional). Apply manually:\n"+
+				"  ALTER TABLE %s ADD COLUMN detail_cleared TINYINT NOT NULL DEFAULT 0;", table, table)
+			break
+		}
+	}
+	sqlite.SetDetailClearedColumnMissing(missing)
+	if !missing {
+		log.Printf("[Task] detail_cleared sentinel column present on both tables (fast path enabled)")
+	}
+}
+
+// detailClearedColumnExists 跨 dialect 探测列是否存在。
+func detailClearedColumnExists(db *sqlite.DB, table string) (bool, error) {
+	switch db.Dialector() {
+	case "mysql":
+		var n int64
+		err := db.GormDB().Raw(`
+			SELECT COUNT(*) FROM information_schema.COLUMNS
+			WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'detail_cleared'
+		`, table).Scan(&n).Error
+		return n > 0, err
+	default:
+		rows, err := db.GormDB().Raw("PRAGMA table_info(" + table + ")").Rows()
+		if err != nil {
+			return false, err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var cid int
+			var name, ctype string
+			var notnull, pk int
+			var dflt any
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+				return false, err
+			}
+			if name == "detail_cleared" {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
 }
 
 // checkDetailCleanupIndexHealth 在 MySQL 上验证 detail-cleanup 索引是否就绪。

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -448,6 +448,106 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     15,
+		Description: "Add detail_cleared sentinel + index for cleanup; AutoMigrate handles the column",
+		Up: func(db *gorm.DB) error {
+			// 背景:v14 之前的清理 SELECT 用 (request_info IS NOT NULL OR response_info IS NOT NULL)
+			// 作为谓词。MySQL 不支持 partial index,索引上有这俩 LONGTEXT 列的 NULL 位需要回行读
+			// row header → 每行 PK lookup,大表上 cleanup 一跑就 43 min。生产实测后明确。
+			//
+			// v15 引入 detail_cleared TINYINT sentinel:
+			//   - DDL 由 GORM AutoMigrate 在跑 migration 前完成(BaseModel + DetailCleared 字段)
+			//   - 这里只负责建复合索引 (detail_cleared, created_at, id)
+			//   - SELECT 改为 WHERE detail_cleared = 0,纯走索引 leading column 等值匹配,
+			//     planner 在 detail_cleared=0 段做 created_at 范围扫,不回行
+			//   - UPDATE 同步置 detail_cleared = 1,清完的行自动离开"detail_cleared=0"索引段
+			//
+			// SQLite:同样建索引。原 v13 partial index 仍可保留(SQLite 上不冲突,planner 会
+			// 挑更优的),也可在 v16 之后整理掉。
+			return runDetailClearedIndexMigration(db)
+		},
+		Down: func(db *gorm.DB) error {
+			switch db.Dialector.Name() {
+			case "mysql":
+				for _, sql := range []string{
+					"DROP INDEX idx_proxy_requests_detail_cleared ON proxy_requests",
+					"DROP INDEX idx_proxy_upstream_attempts_detail_cleared ON proxy_upstream_attempts",
+				} {
+					if err := db.Exec(sql).Error; err != nil && !isMySQLMissingIndexError(err) {
+						log.Printf("[Migration] Warning: rollback v15 failed sql=%q err=%v", sql, err)
+					}
+				}
+				return nil
+			default:
+				if err := db.Exec("DROP INDEX IF EXISTS idx_proxy_requests_detail_cleared").Error; err != nil {
+					return err
+				}
+				return db.Exec("DROP INDEX IF EXISTS idx_proxy_upstream_attempts_detail_cleared").Error
+			}
+		},
+	},
+}
+
+// runDetailClearedIndexMigration 建立 v15 的 sentinel 复合索引。
+//
+// 设计要点:
+//   - 不带 ALGORITHM/LOCK hint:运维强烈要求避免 dialect-specific 语法。MySQL 自己挑算法,
+//     5.7 / 8.0 都跑得通(普通 CREATE INDEX 在两版都是 INPLACE)
+//   - 沿用 v13/v14 的 threshold-skip(500k 行):大表升级路径仍打 manual SQL,运维窗口手动跑
+//   - 不写 SQLite 的 partial index:用普通复合索引,代码路径统一,两 dialect 一致
+//   - 已有同名索引就跳过(幂等)
+func runDetailClearedIndexMigration(db *gorm.DB) error {
+	type tableSpec struct {
+		table string
+		index string
+		ddl   string
+	}
+	specs := []tableSpec{
+		{
+			table: "proxy_requests",
+			index: "idx_proxy_requests_detail_cleared",
+			ddl:   "CREATE INDEX idx_proxy_requests_detail_cleared ON proxy_requests(detail_cleared, created_at, id)",
+		},
+		{
+			table: "proxy_upstream_attempts",
+			index: "idx_proxy_upstream_attempts_detail_cleared",
+			ddl:   "CREATE INDEX idx_proxy_upstream_attempts_detail_cleared ON proxy_upstream_attempts(detail_cleared, created_at, id)",
+		},
+	}
+
+	for _, s := range specs {
+		var rowCount int64
+		if err := db.Raw("SELECT COUNT(*) FROM " + s.table).Scan(&rowCount).Error; err != nil {
+			log.Printf("[Migration v15] could not count %s (%v); skipping %s. Apply manually if needed.", s.table, err, s.index)
+			continue
+		}
+
+		ddl := s.ddl
+		if db.Dialector.Name() != "mysql" {
+			// SQLite 支持 IF NOT EXISTS,显式加上让重复 migration 不报错。
+			ddl = strings.Replace(ddl, "CREATE INDEX", "CREATE INDEX IF NOT EXISTS", 1)
+		}
+
+		if rowCount > detailCleanupIndexRowThreshold {
+			log.Printf("[Migration v15] SKIPPING %s build: %s has %d rows (> %d threshold). "+
+				"Apply manually during a maintenance window:\n  %s;",
+				s.index, s.table, rowCount, detailCleanupIndexRowThreshold, s.ddl)
+			continue
+		}
+
+		log.Printf("[Migration v15] building %s (rows=%d)", s.index, rowCount)
+		start := time.Now()
+		if err := db.Exec(ddl).Error; err != nil {
+			if db.Dialector.Name() == "mysql" && isMySQLDuplicateIndexError(err) {
+				log.Printf("[Migration v15] %s already exists, skipped", s.index)
+				continue
+			}
+			return err
+		}
+		log.Printf("[Migration v15] built %s in %s", s.index, time.Since(start).Round(time.Millisecond))
+	}
+	return nil
 }
 
 // runDetailCleanupIndexV2Migration 创建 (status, dev_mode, created_at, id) 索引并删除旧的

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -450,24 +450,23 @@ var migrations = []Migration{
 	},
 	{
 		Version:     15,
-		Description: "Add detail_cleared sentinel + index for cleanup; AutoMigrate handles the column",
+		Description: "Add detail_cleared sentinel column + index for cleanup (threshold-skipped on large tables)",
 		Up: func(db *gorm.DB) error {
-			// 背景:v14 之前的清理 SELECT 用 (request_info IS NOT NULL OR response_info IS NOT NULL)
-			// 作为谓词。MySQL 不支持 partial index,索引上有这俩 LONGTEXT 列的 NULL 位需要回行读
-			// row header → 每行 PK lookup,大表上 cleanup 一跑就 43 min。生产实测后明确。
+			// v15 引入 detail_cleared TINYINT sentinel + 复合索引 (detail_cleared, created_at, id)。
+			// 配合 ClearDetailOlderThan 的 WHERE detail_cleared = 0,planner 走 leading-column
+			// 等值匹配,不必回行评估 LONGTEXT NULL flag。生产上原 43-min stall 的根因。
 			//
-			// v15 引入 detail_cleared TINYINT sentinel:
-			//   - DDL 由 GORM AutoMigrate 在跑 migration 前完成(BaseModel + DetailCleared 字段)
-			//   - 这里只负责建复合索引 (detail_cleared, created_at, id)
-			//   - SELECT 改为 WHERE detail_cleared = 0,纯走索引 leading column 等值匹配,
-			//     planner 在 detail_cleared=0 段做 created_at 范围扫,不回行
-			//   - UPDATE 同步置 detail_cleared = 1,清完的行自动离开"detail_cleared=0"索引段
-			//
-			// SQLite:同样建索引。原 v13 partial index 仍可保留(SQLite 上不冲突,planner 会
-			// 挑更优的),也可在 v16 之后整理掉。
+			// **detail_cleared 列由这里的 raw SQL 添加**,不放到 GORM struct 上:
+			// - AutoMigrate 在 RunMigrations 之前运行,放到 struct 上就绕开了 threshold 守护
+			// - 46GB 大表上 5.7 INPLACE ALTER 可能小时级阻塞
+			// - 这里加 threshold-skip + bare ALTER TABLE,运维超阈值时手动跑
+			if err := runDetailClearedColumnMigration(db); err != nil {
+				return err
+			}
 			return runDetailClearedIndexMigration(db)
 		},
 		Down: func(db *gorm.DB) error {
+			// 索引 drop 优先,column 保留(列 DROP 在 MySQL 5.7 / 大表上同样危险,运维手动)。
 			switch db.Dialector.Name() {
 			case "mysql":
 				for _, sql := range []string{
@@ -487,6 +486,95 @@ var migrations = []Migration{
 			}
 		},
 	},
+}
+
+// runDetailClearedColumnMigration 显式添加 detail_cleared 列到两张大表,带 threshold-skip。
+//
+// 设计要点:
+//   - bare ALTER TABLE ADD COLUMN,无 ALGORITHM/LOCK hint(吸取 v14 1064 教训)。MySQL 5.7+
+//     8.0+ 自动选最优算法
+//   - **列类型显式 TINYINT NOT NULL DEFAULT 0**:GORM 默认会把 Go int 转成 bigint,46GB 表上
+//     每行多耗 7 字节没必要
+//   - 沿用 v13/v14 的 500k 行 threshold:超过则打印 manual SQL,migration 仍标记完成
+//   - 幂等:列已存在则跳过(检测错误码 / 文本)
+func runDetailClearedColumnMigration(db *gorm.DB) error {
+	type tableSpec struct {
+		table string
+		// 列检测的 SQL 与 dialect 相关,统一封装
+	}
+	tables := []string{"proxy_requests", "proxy_upstream_attempts"}
+
+	columnExists := func(table string) (bool, error) {
+		switch db.Dialector.Name() {
+		case "mysql":
+			var n int64
+			err := db.Raw(`
+				SELECT COUNT(*) FROM information_schema.COLUMNS
+				WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'detail_cleared'
+			`, table).Scan(&n).Error
+			return n > 0, err
+		default:
+			// SQLite:PRAGMA table_info(...) 列表里找
+			rows, err := db.Raw("PRAGMA table_info(" + table + ")").Rows()
+			if err != nil {
+				return false, err
+			}
+			defer rows.Close()
+			for rows.Next() {
+				var cid int
+				var name, ctype string
+				var notnull, pk int
+				var dflt any
+				if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+					return false, err
+				}
+				if name == "detail_cleared" {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+	}
+
+	for _, table := range tables {
+		exists, err := columnExists(table)
+		if err != nil {
+			log.Printf("[Migration v15] could not probe %s.detail_cleared (%v); skipping column add. Apply manually if needed.", table, err)
+			continue
+		}
+		if exists {
+			continue
+		}
+
+		var rowCount int64
+		if err := db.Raw("SELECT COUNT(*) FROM " + table).Scan(&rowCount).Error; err != nil {
+			log.Printf("[Migration v15] could not count %s (%v); skipping column add.", table, err)
+			continue
+		}
+
+		ddl := "ALTER TABLE " + table + " ADD COLUMN detail_cleared TINYINT NOT NULL DEFAULT 0"
+
+		if rowCount > detailCleanupIndexRowThreshold {
+			log.Printf("[Migration v15] SKIPPING ADD COLUMN on %s: %d rows (> %d threshold). "+
+				"Apply manually during a maintenance window:\n  %s;",
+				table, rowCount, detailCleanupIndexRowThreshold, ddl)
+			continue
+		}
+
+		log.Printf("[Migration v15] adding %s.detail_cleared column (rows=%d)", table, rowCount)
+		start := time.Now()
+		if err := db.Exec(ddl).Error; err != nil {
+			// 列已存在的 MySQL/SQLite 错误吞掉(幂等),其它错误抛出
+			lower := strings.ToLower(err.Error())
+			if strings.Contains(lower, "duplicate column") || strings.Contains(lower, "already exists") {
+				log.Printf("[Migration v15] %s.detail_cleared already exists, skipped", table)
+				continue
+			}
+			return err
+		}
+		log.Printf("[Migration v15] added %s.detail_cleared in %s", table, time.Since(start).Round(time.Millisecond))
+	}
+	return nil
 }
 
 // runDetailClearedIndexMigration 建立 v15 的 sentinel 复合索引。

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -513,8 +513,17 @@ func runDetailClearedColumnMigration(db *gorm.DB) error {
 				WHERE table_schema = DATABASE() AND table_name = ? AND column_name = 'detail_cleared'
 			`, table).Scan(&n).Error
 			return n > 0, err
+		case "postgres":
+			var n int64
+			err := db.Raw(`
+				SELECT COUNT(*) FROM information_schema.columns
+				WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'detail_cleared'
+			`, table).Scan(&n).Error
+			return n > 0, err
 		default:
-			// SQLite:PRAGMA table_info(...) 列表里找
+			// SQLite:PRAGMA table_info(...) 列表里找。
+			// 注意:**不要**让 PRAGMA 跑在其它 dialect 上——Postgres 会以 SQLSTATE 42601
+			// 抛出错误并 abort 整个事务,导致 v15 后续 SQL 全部失败。multiinstance CI 抓到。
 			rows, err := db.Raw("PRAGMA table_info(" + table + ")").Rows()
 			if err != nil {
 				return false, err
@@ -552,7 +561,15 @@ func runDetailClearedColumnMigration(db *gorm.DB) error {
 			continue
 		}
 
-		ddl := "ALTER TABLE " + table + " ADD COLUMN detail_cleared TINYINT NOT NULL DEFAULT 0"
+		// 列类型按 dialect:
+		//   - MySQL:TINYINT 1 字节
+		//   - Postgres:SMALLINT 2 字节(没有 TINYINT,SMALLINT 是 16-bit 最小整型)
+		//   - SQLite:整型亲和力,类型名只是 hint,用 TINYINT 与 MySQL 对齐即可
+		columnType := "TINYINT"
+		if db.Dialector.Name() == "postgres" {
+			columnType = "SMALLINT"
+		}
+		ddl := "ALTER TABLE " + table + " ADD COLUMN detail_cleared " + columnType + " NOT NULL DEFAULT 0"
 
 		if rowCount > detailCleanupIndexRowThreshold {
 			log.Printf("[Migration v15] SKIPPING ADD COLUMN on %s: %d rows (> %d threshold). "+

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -307,10 +307,13 @@ type ProxyRequest struct {
 	ProjectID                   uint64 `gorm:"index"`
 	APITokenID                  uint64
 	DevMode                     int `gorm:"default:0"`
-	// DetailCleared:1 表示 RequestInfo/ResponseInfo 已被清理任务 nullify。复合索引
-	// idx_proxy_requests_detail_cleared (detail_cleared, created_at, id) 由 migration v15
-	// 显式创建——AutoMigrate 不便表达 BaseModel 跨字段的复合索引顺序。
-	DetailCleared int `gorm:"default:0"`
+	// detail_cleared 列**故意不放在 struct 上**:
+	//
+	// 该列由 migration v15 raw SQL 添加,带有 500k 行 threshold-skip 保护。
+	// 如果放在这里,GORM AutoMigrate 在 v15 之前就会跑 ADD COLUMN,绕过 threshold
+	// 守护——46GB 大表上 MySQL 5.7 INPLACE 重写可达小时级。
+	// 代码通过 .Updates(map[string]any{"detail_cleared": 1}) 和 raw WHERE 访问该列,
+	// 不需要 struct 字段。详见 ClearDetailOlderThan 与 runDetailClearedColumnMigration。
 }
 
 func (ProxyRequest) TableName() string { return "proxy_requests" }
@@ -342,8 +345,7 @@ type ProxyUpstreamAttempt struct {
 	RequestModel      string `gorm:"size:128"`
 	MappedModel       string `gorm:"size:128"`
 	ResponseModel     string `gorm:"size:128"`
-	// DetailCleared:同 ProxyRequest.DetailCleared,见上方注释。
-	DetailCleared int `gorm:"default:0"`
+	// detail_cleared 列同样不在 struct 上,理由见 ProxyRequest.detail_cleared 注释。
 }
 
 func (ProxyUpstreamAttempt) TableName() string { return "proxy_upstream_attempts" }

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -307,6 +307,10 @@ type ProxyRequest struct {
 	ProjectID                   uint64 `gorm:"index"`
 	APITokenID                  uint64
 	DevMode                     int `gorm:"default:0"`
+	// DetailCleared:1 表示 RequestInfo/ResponseInfo 已被清理任务 nullify。复合索引
+	// idx_proxy_requests_detail_cleared (detail_cleared, created_at, id) 由 migration v15
+	// 显式创建——AutoMigrate 不便表达 BaseModel 跨字段的复合索引顺序。
+	DetailCleared int `gorm:"default:0"`
 }
 
 func (ProxyRequest) TableName() string { return "proxy_requests" }
@@ -338,6 +342,8 @@ type ProxyUpstreamAttempt struct {
 	RequestModel      string `gorm:"size:128"`
 	MappedModel       string `gorm:"size:128"`
 	ResponseModel     string `gorm:"size:128"`
+	// DetailCleared:同 ProxyRequest.DetailCleared,见上方注释。
+	DetailCleared int `gorm:"default:0"`
 }
 
 func (ProxyUpstreamAttempt) TableName() string { return "proxy_upstream_attempts" }

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -494,6 +494,29 @@ func (r *ProxyRequestRepository) RecalculateCostsFromAttemptsWithProgress(progre
 // 用 atomic.Int32 而非 mutex:写一次(启动),读高频(每次清理批次),无锁读最便宜。
 var detailCleanupIndexMissing atomic.Int32
 
+// detailClearedColumnMissing 由启动时检查置位:大表 threshold-skip 导致 v15 没建
+// detail_cleared 列时设为 1。ClearDetailOlderThan 据此走 legacy IS NOT NULL 谓词,
+// 否则查询会因列不存在而每个 tick 都失败——是功能失效,不是降级变慢(Codex 抓到)。
+var detailClearedColumnMissing atomic.Int32
+
+// SetDetailClearedColumnMissing 设置 detail_cleared 列缺失状态。
+//
+// 调用方:internal/core/task.go:checkDetailClearedColumnHealth 在启动时探测一次。
+// 同进程内若列后续被运维手动补建,需重启进程才能恢复 fast-path——这是与
+// detailCleanupIndexMissing 一致的语义,避免运行时反复轮询。
+func SetDetailClearedColumnMissing(missing bool) {
+	if missing {
+		detailClearedColumnMissing.Store(1)
+	} else {
+		detailClearedColumnMissing.Store(0)
+	}
+}
+
+// detailClearedColumnAvailable 返回是否可以使用 detail_cleared sentinel。
+func detailClearedColumnAvailable() bool {
+	return detailClearedColumnMissing.Load() == 0
+}
+
 // SetDetailCleanupIndexMissing 设置 MySQL detail-cleanup 索引缺失状态。startup
 // health-check 调用,见 internal/core/task.go:checkDetailCleanupIndexHealth。
 //
@@ -563,9 +586,32 @@ var maxCleanupBatchesPerCall = 50
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
+	useSentinel := detailClearedColumnAvailable()
 	var total int64
 	var lastCreatedAt int64
 	var lastID uint64
+
+	// 谓词分支:
+	//   - useSentinel=true(常态):detail_cleared = 0,planner 走 v15 sentinel 索引
+	//   - useSentinel=false(大表 threshold-skip 列没建):退化到 v13/v14 legacy 谓词,
+	//     虽然慢但功能正常。运维补建列+重启即恢复 fast-path。
+	selectPred := "detail_cleared = 0 AND created_at < ? AND dev_mode = 0"
+	updatePred := "id IN ? AND detail_cleared = 0 AND created_at < ? AND dev_mode = 0"
+	updateMap := map[string]any{
+		"request_info":   nil,
+		"response_info":  nil,
+		"detail_cleared": 1,
+		"updated_at":     time.Now().UnixMilli(),
+	}
+	if !useSentinel {
+		selectPred = "(request_info IS NOT NULL OR response_info IS NOT NULL) AND created_at < ? AND dev_mode = 0"
+		updatePred = "id IN ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND created_at < ? AND dev_mode = 0"
+		updateMap = map[string]any{
+			"request_info":  nil,
+			"response_info": nil,
+			"updated_at":    time.Now().UnixMilli(),
+		}
+	}
 
 	type cursorRow struct {
 		ID        uint64 `gorm:"column:id"`
@@ -576,7 +622,7 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		var rows []cursorRow
 		q := r.db.gorm.Model(&ProxyRequest{}).
 			Select("id, created_at").
-			Where("detail_cleared = 0 AND created_at < ? AND dev_mode = 0", beforeTs).
+			Where(selectPred, beforeTs).
 			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID)
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
@@ -595,17 +641,14 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		lastCreatedAt = last.CreatedAt
 		lastID = last.ID
 
-		uq := r.db.gorm.Model(&ProxyRequest{}).
-			Where("id IN ? AND detail_cleared = 0 AND created_at < ? AND dev_mode = 0", ids, beforeTs)
+		// 每个 batch 用当前时刻刷新 updated_at;updateMap 在循环外构造时是初始时刻,
+		// 长 backlog 下让 updated_at 反映最近一次实际写入更精确。
+		updateMap["updated_at"] = time.Now().UnixMilli()
+		uq := r.db.gorm.Model(&ProxyRequest{}).Where(updatePred, ids, beforeTs)
 		if len(statuses) > 0 {
 			uq = uq.Where("status IN ?", statuses)
 		}
-		result := uq.Updates(map[string]any{
-			"request_info":   nil,
-			"response_info":  nil,
-			"detail_cleared": 1,
-			"updated_at":     time.Now().UnixMilli(),
-		})
+		result := uq.Updates(updateMap)
 		if result.Error != nil {
 			return total, result.Error
 		}

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -13,66 +12,18 @@ import (
 	"gorm.io/gorm"
 )
 
-// cleanupCursor 持久化在 repo 实例上的 (created_at, id) 二元组游标。
-//
-// 解决"每个 tick 都从 (0,0) 重扫"的稳态 O(N) 问题:
-//   - cursor 在进程生命周期内单调推进,跨 ClearDetailOlderThan 调用复用
-//   - 新行 created_at = now,远大于 cursor.CreatedAt,自然落在 cursor 之后
-//   - 老行被 UPDATE SET detail_cleared=1 后离开二级索引的 detail_cleared=0 段,
-//     即使 cursor 倒回也不会重复处理
-//   - 进程重启 / leader 切换:cursor 归零,但配合 sentinel 索引,SELECT 在
-//     detail_cleared=0 段扫描,大表稳态下这一段几乎为空,cold-start 也很快
-type cleanupCursor struct {
-	CreatedAt int64
-	ID        uint64
-}
-
 type ProxyRequestRepository struct {
 	db    *DB
 	count int64 // 缓存的请求总数，使用原子操作
-
-	// cleanupCursors 按"状态桶"维护游标。split mode 下三种 bucket key:
-	//   - "" (全量,statuses=nil)
-	//   - "COMPLETED" (success bucket)
-	//   - "FAILED,CANCELLED,REJECTED" (failed bucket)
-	// 每个 bucket 的扫描进度独立(同一 row 可能在不同 bucket 下被 EXISTS 过滤),
-	// 所以各自一份 cursor。key 直接用 strings.Join(sortedStatuses, ",")。
-	cleanupCursorsMu sync.Mutex
-	cleanupCursors   map[string]cleanupCursor
 }
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
 
 func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
-	r := &ProxyRequestRepository{
-		db:             db,
-		cleanupCursors: make(map[string]cleanupCursor),
-	}
+	r := &ProxyRequestRepository{db: db}
 	// 初始化时从数据库加载计数
 	r.initCount()
 	return r
-}
-
-// cleanupBucketKey 把 statuses 切片规范化为字符串 key,用作 cleanupCursors 的 map key。
-// 不需要排序——调用方 (cleanupOldRequestDetails) 永远用同样的常量切片
-// (successRequestStatuses / failedRequestStatuses / nil),内容稳定。
-func cleanupBucketKey(statuses []string) string {
-	if len(statuses) == 0 {
-		return ""
-	}
-	return strings.Join(statuses, ",")
-}
-
-func (r *ProxyRequestRepository) loadCleanupCursor(key string) cleanupCursor {
-	r.cleanupCursorsMu.Lock()
-	defer r.cleanupCursorsMu.Unlock()
-	return r.cleanupCursors[key]
-}
-
-func (r *ProxyRequestRepository) saveCleanupCursor(key string, c cleanupCursor) {
-	r.cleanupCursorsMu.Lock()
-	defer r.cleanupCursorsMu.Unlock()
-	r.cleanupCursors[key] = c
 }
 
 // initCount 从数据库初始化计数缓存
@@ -580,41 +531,41 @@ func detailCleanupBatchParams(dialector string) (batchSize int, sleep time.Durat
 
 // maxCleanupBatchesPerCall 限制单次 ClearDetailOlderThan 调用最多处理多少 batch。
 //
-// 解决"一次调用 drain-to-completion 跑 43 min"的延迟尾问题。配合持久化 cursor:
-//   - cursor 跨 tick 复用,封顶批数不会导致 backlog 永远处理不完——下次 tick 从 cursor
-//     处继续
-//   - 50 batch × 1000 行(MySQL) = 50k 行 / 调用,单次 wall-clock 几秒,对 API 写入零干扰
+// 解决"一次调用 drain-to-completion 跑 43 min"的延迟尾问题:
+//   - 50 batch × 1000 行(MySQL) = 50k 行 / 调用,单次 wall-clock 几秒
 //   - SQLite 200/50ms 时 50 × 200 = 10k 行 / 调用,同样几秒收敛
-const maxCleanupBatchesPerCall = 50
+//   - 配合 sentinel 索引,backlog 在多次 tick 内被分摊处理,不会单次卡死
+//
+// var 而非 const:测试中需要临时调小验证 cap 行为(TestClearDetailOlderThan_RespectsBatchCap)。
+// 生产路径不应修改。
+var maxCleanupBatchesPerCall = 50
 
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
 //
-// 设计三件套（与 v15 sentinel + index 协作）:
+// 设计:
 //
-//  1. **持久化 cursor**：repo struct 上的 cleanupCursors[bucketKey] 跨调用单调推进。
-//     避免每个 tick 都从 (0,0) 重扫已经处理过的区间——这是 v0.13.x 上 43-min stall 的
-//     直接成因。新行的 created_at = now,远大于 cursor.CreatedAt,自然落在 cursor 之后,
-//     不会被遗漏。
+//  1. **sentinel column (detail_cleared)**:WHERE detail_cleared = 0 是 leading-column
+//     等值匹配,planner 在 v15 索引 (detail_cleared, created_at, id) 的 0-段做范围扫,
+//     **无需回行评估 LONGTEXT NULL flag**——这是 MySQL 上 43-min stall 的真正根因。
+//     UPDATE 同步置 detail_cleared = 1,清完的行自动离开 0-段。稳态下 0-段几乎空。
 //
-//  2. **sentinel column (detail_cleared)**：WHERE 不再用 (request_info IS NOT NULL OR
-//     response_info IS NOT NULL),改为 detail_cleared = 0。配合 v15 索引
-//     (detail_cleared, created_at, id),planner 在 detail_cleared=0 段直接做 created_at
-//     范围扫,**无需回行读 LONGTEXT NULL flag**——MySQL 上原来 100k 行 PK lookup 是
-//     43-min 的根因。SQLite 上也用 sentinel,代码路径统一。
+//  2. **within-call cursor (created_at, id)**:同一次函数调用内分批用游标。**不跨调用
+//     持久化**——曾经持久化过,会与可变 status 过滤冲突:PENDING 行先被 cursor 越过,
+//     之后转 COMPLETED/FAILED 时永远在 cursor 后,清不到(Codex review 抓到)。
+//     去掉持久化后每次从 0-段起点扫,稳态依赖 sentinel 让起点接近真实未清行。
 //
-//  3. **maxCleanupBatchesPerCall 封顶**：单次调用最多 50 个 batch。即使 backlog 巨大,
-//     单次 wall-clock 也被封在几秒级,不会出现"一个调用霸占 cleanup goroutine 几十分钟"。
-//     封顶后保存 cursor,下次 tick 从断点续。
+//  3. **maxCleanupBatchesPerCall 封顶**:即使 backlog 巨大,单次调用 wall-clock 秒级,
+//     不再 43-min。下次 tick 接力。
 //
-// 重新应用谓词：Pluck 与 UPDATE 之间行的 status/dev_mode 可能变动,UPDATE WHERE 必须
-// 再次校验所有过滤条件,避免错改 dev_mode 行或状态已变更的行。
+// 重应用谓词:Pluck 与 UPDATE 之间行的 status/dev_mode 可能变动,UPDATE WHERE 必须再次
+// 校验所有过滤条件,避免错改 dev_mode 行或状态已变更的行。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
-	bucketKey := cleanupBucketKey(statuses)
-	cursor := r.loadCleanupCursor(bucketKey)
 	var total int64
+	var lastCreatedAt int64
+	var lastID uint64
 
 	type cursorRow struct {
 		ID        uint64 `gorm:"column:id"`
@@ -626,18 +577,14 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 		q := r.db.gorm.Model(&ProxyRequest{}).
 			Select("id, created_at").
 			Where("detail_cleared = 0 AND created_at < ? AND dev_mode = 0", beforeTs).
-			Where("(created_at > ? OR (created_at = ? AND id > ?))", cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID)
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
 		}
 		if err := q.Order("created_at, id").Limit(batchSize).Scan(&rows).Error; err != nil {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, err
 		}
 		if len(rows) == 0 {
-			// 没有更多行可清理:cursor 已扫到 (cutoff, 0) 之外。保留 cursor,下次 tick
-			// 从这里开始即可处理新增老化行。
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		ids := make([]uint64, len(rows))
@@ -645,7 +592,8 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 			ids[i] = row.ID
 		}
 		last := rows[len(rows)-1]
-		cursor = cleanupCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+		lastCreatedAt = last.CreatedAt
+		lastID = last.ID
 
 		uq := r.db.gorm.Model(&ProxyRequest{}).
 			Where("id IN ? AND detail_cleared = 0 AND created_at < ? AND dev_mode = 0", ids, beforeTs)
@@ -659,20 +607,15 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 			"updated_at":     time.Now().UnixMilli(),
 		})
 		if result.Error != nil {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, result.Error
 		}
 		total += result.RowsAffected
 
 		if len(rows) < batchSize {
-			// 本批返回不满,说明当前 cutoff 内已没有更多 detail_cleared=0 行。
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		time.Sleep(batchSleep)
 	}
-	// 达到封顶批数。保存 cursor,下次 tick 从断点继续。
-	r.saveCleanupCursor(bucketKey, cursor)
 	return total, nil
 }
 

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -12,18 +13,66 @@ import (
 	"gorm.io/gorm"
 )
 
+// cleanupCursor 持久化在 repo 实例上的 (created_at, id) 二元组游标。
+//
+// 解决"每个 tick 都从 (0,0) 重扫"的稳态 O(N) 问题:
+//   - cursor 在进程生命周期内单调推进,跨 ClearDetailOlderThan 调用复用
+//   - 新行 created_at = now,远大于 cursor.CreatedAt,自然落在 cursor 之后
+//   - 老行被 UPDATE SET detail_cleared=1 后离开二级索引的 detail_cleared=0 段,
+//     即使 cursor 倒回也不会重复处理
+//   - 进程重启 / leader 切换:cursor 归零,但配合 sentinel 索引,SELECT 在
+//     detail_cleared=0 段扫描,大表稳态下这一段几乎为空,cold-start 也很快
+type cleanupCursor struct {
+	CreatedAt int64
+	ID        uint64
+}
+
 type ProxyRequestRepository struct {
 	db    *DB
 	count int64 // 缓存的请求总数，使用原子操作
+
+	// cleanupCursors 按"状态桶"维护游标。split mode 下三种 bucket key:
+	//   - "" (全量,statuses=nil)
+	//   - "COMPLETED" (success bucket)
+	//   - "FAILED,CANCELLED,REJECTED" (failed bucket)
+	// 每个 bucket 的扫描进度独立(同一 row 可能在不同 bucket 下被 EXISTS 过滤),
+	// 所以各自一份 cursor。key 直接用 strings.Join(sortedStatuses, ",")。
+	cleanupCursorsMu sync.Mutex
+	cleanupCursors   map[string]cleanupCursor
 }
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
 
 func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
-	r := &ProxyRequestRepository{db: db}
+	r := &ProxyRequestRepository{
+		db:             db,
+		cleanupCursors: make(map[string]cleanupCursor),
+	}
 	// 初始化时从数据库加载计数
 	r.initCount()
 	return r
+}
+
+// cleanupBucketKey 把 statuses 切片规范化为字符串 key,用作 cleanupCursors 的 map key。
+// 不需要排序——调用方 (cleanupOldRequestDetails) 永远用同样的常量切片
+// (successRequestStatuses / failedRequestStatuses / nil),内容稳定。
+func cleanupBucketKey(statuses []string) string {
+	if len(statuses) == 0 {
+		return ""
+	}
+	return strings.Join(statuses, ",")
+}
+
+func (r *ProxyRequestRepository) loadCleanupCursor(key string) cleanupCursor {
+	r.cleanupCursorsMu.Lock()
+	defer r.cleanupCursorsMu.Unlock()
+	return r.cleanupCursors[key]
+}
+
+func (r *ProxyRequestRepository) saveCleanupCursor(key string, c cleanupCursor) {
+	r.cleanupCursorsMu.Lock()
+	defer r.cleanupCursorsMu.Unlock()
+	r.cleanupCursors[key] = c
 }
 
 // initCount 从数据库初始化计数缓存
@@ -529,45 +578,66 @@ func detailCleanupBatchParams(dialector string) (batchSize int, sleep time.Durat
 	}
 }
 
+// maxCleanupBatchesPerCall 限制单次 ClearDetailOlderThan 调用最多处理多少 batch。
+//
+// 解决"一次调用 drain-to-completion 跑 43 min"的延迟尾问题。配合持久化 cursor:
+//   - cursor 跨 tick 复用,封顶批数不会导致 backlog 永远处理不完——下次 tick 从 cursor
+//     处继续
+//   - 50 batch × 1000 行(MySQL) = 50k 行 / 调用,单次 wall-clock 几秒,对 API 写入零干扰
+//   - SQLite 200/50ms 时 50 × 200 = 10k 行 / 调用,同样几秒收敛
+const maxCleanupBatchesPerCall = 50
+
 // ClearDetailOlderThan 清理指定时间之前请求的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理 status IN (statuses) 的记录
 //
-// Cursor / index 协作：
-//   - 用 (created_at, id) 二元组游标 + ORDER BY (created_at, id)，与 v13 的
-//     partial index idx_proxy_requests_detail_cleanup(created_at, id) 键顺序一致，
-//     EXPLAIN QUERY PLAN 验证：planner 走 SEARCH USING INDEX。若改用 id 游标 +
-//     ORDER BY id，planner 会回退到 PK 扫，索引失效，partial index 形同虚设。
-//   - drain-to-completion：50ms 批间 sleep 已经让出 SQLite 写锁，无需封顶批数。
-//     早期版本曾加 maxBatchesPerCall，但游标每次调用归零会导致 backlog 大于 cap 时
-//     下次 tick 重扫整段已 null 的老区，回退而不是改进。
-//   - 分批：request_info/response_info 是大 JSON blob，一次 UPDATE 全表会产生超大
-//     事务（WAL 同时记录 old/new），故按 batchSize 拆分。
+// 设计三件套（与 v15 sentinel + index 协作）:
+//
+//  1. **持久化 cursor**：repo struct 上的 cleanupCursors[bucketKey] 跨调用单调推进。
+//     避免每个 tick 都从 (0,0) 重扫已经处理过的区间——这是 v0.13.x 上 43-min stall 的
+//     直接成因。新行的 created_at = now,远大于 cursor.CreatedAt,自然落在 cursor 之后,
+//     不会被遗漏。
+//
+//  2. **sentinel column (detail_cleared)**：WHERE 不再用 (request_info IS NOT NULL OR
+//     response_info IS NOT NULL),改为 detail_cleared = 0。配合 v15 索引
+//     (detail_cleared, created_at, id),planner 在 detail_cleared=0 段直接做 created_at
+//     范围扫,**无需回行读 LONGTEXT NULL flag**——MySQL 上原来 100k 行 PK lookup 是
+//     43-min 的根因。SQLite 上也用 sentinel,代码路径统一。
+//
+//  3. **maxCleanupBatchesPerCall 封顶**：单次调用最多 50 个 batch。即使 backlog 巨大,
+//     单次 wall-clock 也被封在几秒级,不会出现"一个调用霸占 cleanup goroutine 几十分钟"。
+//     封顶后保存 cursor,下次 tick 从断点续。
+//
+// 重新应用谓词：Pluck 与 UPDATE 之间行的 status/dev_mode 可能变动,UPDATE WHERE 必须
+// 再次校验所有过滤条件,避免错改 dev_mode 行或状态已变更的行。
 func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
+	bucketKey := cleanupBucketKey(statuses)
+	cursor := r.loadCleanupCursor(bucketKey)
 	var total int64
-	var lastCreatedAt int64
-	var lastID uint64
 
 	type cursorRow struct {
 		ID        uint64 `gorm:"column:id"`
 		CreatedAt int64  `gorm:"column:created_at"`
 	}
 
-	for {
+	for batchIdx := 0; batchIdx < maxCleanupBatchesPerCall; batchIdx++ {
 		var rows []cursorRow
 		q := r.db.gorm.Model(&ProxyRequest{}).
 			Select("id, created_at").
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", beforeTs).
-			// 二元组游标：(created_at, id) > (lastCreatedAt, lastID)
-			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID)
+			Where("detail_cleared = 0 AND created_at < ? AND dev_mode = 0", beforeTs).
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", cursor.CreatedAt, cursor.CreatedAt, cursor.ID)
 		if len(statuses) > 0 {
 			q = q.Where("status IN ?", statuses)
 		}
 		if err := q.Order("created_at, id").Limit(batchSize).Scan(&rows).Error; err != nil {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, err
 		}
 		if len(rows) == 0 {
+			// 没有更多行可清理:cursor 已扫到 (cutoff, 0) 之外。保留 cursor,下次 tick
+			// 从这里开始即可处理新增老化行。
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		ids := make([]uint64, len(rows))
@@ -575,30 +645,35 @@ func (r *ProxyRequestRepository) ClearDetailOlderThan(before time.Time, statuses
 			ids[i] = row.ID
 		}
 		last := rows[len(rows)-1]
-		lastCreatedAt = last.CreatedAt
-		lastID = last.ID
+		cursor = cleanupCursor{CreatedAt: last.CreatedAt, ID: last.ID}
 
-		// 重应用谓词：Pluck 与 UPDATE 之间行可能因 status/dev_mode 变动而不再 eligible。
 		uq := r.db.gorm.Model(&ProxyRequest{}).
-			Where("id IN ? AND created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0", ids, beforeTs)
+			Where("id IN ? AND detail_cleared = 0 AND created_at < ? AND dev_mode = 0", ids, beforeTs)
 		if len(statuses) > 0 {
 			uq = uq.Where("status IN ?", statuses)
 		}
 		result := uq.Updates(map[string]any{
-			"request_info":  nil,
-			"response_info": nil,
-			"updated_at":    time.Now().UnixMilli(),
+			"request_info":   nil,
+			"response_info":  nil,
+			"detail_cleared": 1,
+			"updated_at":     time.Now().UnixMilli(),
 		})
 		if result.Error != nil {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, result.Error
 		}
 		total += result.RowsAffected
 
 		if len(rows) < batchSize {
+			// 本批返回不满,说明当前 cutoff 内已没有更多 detail_cleared=0 行。
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		time.Sleep(batchSleep)
 	}
+	// 达到封顶批数。保存 cursor,下次 tick 从断点继续。
+	r.saveCleanupCursor(bucketKey, cursor)
+	return total, nil
 }
 
 func (r *ProxyRequestRepository) toModel(p *domain.ProxyRequest) *ProxyRequest {

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -375,9 +375,15 @@ func TestProxyRequestClearDetailOlderThan(t *testing.T) {
 	})
 }
 
-// TestClearDetailOlderThan_PersistsCursorAcrossCalls 守护游标跨调用复用:
-// 第二次调用不应该从 (0,0) 重扫已经处理过的区间。
-func TestClearDetailOlderThan_PersistsCursorAcrossCalls(t *testing.T) {
+// TestClearDetailOlderThan_StatusBucketIsolation 守护"状态后变的行不会被永久跳过"。
+//
+// 历史 bug:之前的实现在 repo 上持久化 cursor。PENDING 行先被 cursor 越过(status 过滤
+// 不命中),之后转 COMPLETED 时已经在 cursor 后面,永远清不到。Codex 在 PR #568 round 1
+// 抓到。修复:去掉持久化 cursor,只保留 within-call 局部游标 + sentinel 索引。
+//
+// 这个测试模拟:先以 success bucket 清一遍,造一个 PENDING 老行;然后把它转 COMPLETED,
+// 再次清,应该被命中清掉。如果回归到持久化 cursor,这个测试会捕获。
+func TestClearDetailOlderThan_StatusBucketIsolation(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -386,47 +392,41 @@ func TestClearDetailOlderThan_PersistsCursorAcrossCalls(t *testing.T) {
 	repo := NewProxyRequestRepository(db)
 
 	old := time.Now().Add(-2 * time.Hour)
-	for i := 0; i < 10; i++ {
-		r := buildTestProxyRequest("COMPLETED", i)
-		r.StartTime = old
+	// 三行同时间窗口:一个 COMPLETED, 一个 PENDING (会被 success bucket 跳过), 一个 COMPLETED
+	completed1 := buildTestProxyRequest("COMPLETED", 1)
+	pending := buildTestProxyRequest("PENDING", 2)
+	completed2 := buildTestProxyRequest("COMPLETED", 3)
+	for _, r := range []*domain.ProxyRequest{completed1, pending, completed2} {
 		if err := repo.Create(r); err != nil {
-			t.Fatalf("create %d: %v", i, err)
+			t.Fatalf("create: %v", err)
 		}
 		if err := db.gorm.Table("proxy_requests").Where("id = ?", r.ID).
-			Update("created_at", old.Add(time.Duration(i)*time.Second).UnixMilli()).Error; err != nil {
-			t.Fatalf("backdate %d: %v", i, err)
+			Update("created_at", old.UnixMilli()+int64(r.ID)).Error; err != nil {
+			t.Fatalf("backdate: %v", err)
 		}
 	}
 
-	// 第一次调用清完所有 10 条 (远低于 cap)。游标应该停在最后一行。
-	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
-	if err != nil {
-		t.Fatalf("first clear: %v", err)
-	}
-	if cleared != 10 {
-		t.Fatalf("first clear count = %d, want 10", cleared)
-	}
-	c1 := repo.loadCleanupCursor("")
-	if c1.ID == 0 {
-		t.Fatalf("cursor should be advanced after first call, got %+v", c1)
+	// 第一次以 success bucket 清。COMPLETED 两条被清,PENDING 跳过(留在 detail_cleared=0)。
+	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), []string{"COMPLETED"})
+	if err != nil || cleared != 2 {
+		t.Fatalf("first clear: %d, %v (want 2, nil)", cleared, err)
 	}
 
-	// 第二次调用:已经全部清过,detail_cleared=1,游标也已经在末尾,SELECT 应返回 0 行。
-	cleared2, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
-	if err != nil {
-		t.Fatalf("second clear: %v", err)
+	// PENDING 行转 FAILED。
+	if err := db.gorm.Table("proxy_requests").Where("id = ?", pending.ID).
+		Update("status", "FAILED").Error; err != nil {
+		t.Fatalf("transition: %v", err)
 	}
-	if cleared2 != 0 {
-		t.Fatalf("second clear count = %d, want 0 (cursor should skip already-cleared region)", cleared2)
-	}
-	c2 := repo.loadCleanupCursor("")
-	if c2 != c1 {
-		t.Fatalf("cursor should not move on empty second call, c1=%+v c2=%+v", c1, c2)
+
+	// failed bucket 清。如果有持久化 cursor 把 PENDING 越过了,这里会清不到。
+	cleared, err = repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), []string{"FAILED", "CANCELLED", "REJECTED"})
+	if err != nil || cleared != 1 {
+		t.Fatalf("second clear: %d, %v (want 1, nil) — status transition got skipped by stale cursor?", cleared, err)
 	}
 }
 
-// TestClearDetailOlderThan_RespectsBatchCap 守护 cap maxCleanupBatchesPerCall:
-// backlog 远大于 cap 时,单次调用只处理 cap × batchSize 行,游标保存,下次继续。
+// TestClearDetailOlderThan_RespectsBatchCap 真·cap 测试:把封顶临时调小,验证调用
+// 在 cap × batchSize 行后返回,后续调用接力清完剩余。
 func TestClearDetailOlderThan_RespectsBatchCap(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {
@@ -435,9 +435,13 @@ func TestClearDetailOlderThan_RespectsBatchCap(t *testing.T) {
 	defer db.Close()
 	repo := NewProxyRequestRepository(db)
 
-	// SQLite batch=200,cap=50 → 单次理论最大 10000 行;为加速测试,造 N>200 但 <10000。
-	// 这样能验证 cursor 持久化即可,完整 cap 测试用 unit-style 更经济(不必造 10k 行)。
-	const seed = 500
+	// SQLite batch=200,cap=50 → 单次 10000 行。造 10500 行验证 cap 起效太重,改用
+	// 测试钩子把 cap 临时调到 2 实现等价验证。batchSize 也是 200(SQLite default)。
+	origCap := maxCleanupBatchesPerCall
+	maxCleanupBatchesPerCall = 2
+	defer func() { maxCleanupBatchesPerCall = origCap }()
+
+	const seed = 600 // 3 batches with batchSize=200; cap=2 → 第一次清 400, 第二次清 200
 	old := time.Now().Add(-2 * time.Hour)
 	for i := 0; i < seed; i++ {
 		r := buildTestProxyRequest("COMPLETED", i)
@@ -449,12 +453,32 @@ func TestClearDetailOlderThan_RespectsBatchCap(t *testing.T) {
 			t.Fatalf("backdate %d: %v", i, err)
 		}
 	}
+
+	// 第一次:cap=2 × batchSize=200 = 400 行
 	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
 	if err != nil {
-		t.Fatalf("clear: %v", err)
+		t.Fatalf("first clear: %v", err)
 	}
-	if cleared != seed {
-		t.Fatalf("clear count = %d, want %d", cleared, seed)
+	if cleared != 400 {
+		t.Fatalf("first call cleared = %d, want 400 (cap × batch)", cleared)
+	}
+
+	// 第二次:剩余 200 行,一个 batch 不满就退出
+	cleared, err = repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("second clear: %v", err)
+	}
+	if cleared != 200 {
+		t.Fatalf("second call cleared = %d, want 200", cleared)
+	}
+
+	// 第三次:全清完,应该 0
+	cleared, err = repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("third clear: %v", err)
+	}
+	if cleared != 0 {
+		t.Fatalf("third call cleared = %d, want 0", cleared)
 	}
 }
 

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -375,10 +375,94 @@ func TestProxyRequestClearDetailOlderThan(t *testing.T) {
 	})
 }
 
-// TestProxyRequestClearDetailOlderThan_UsesPartialIndex 锁定 cleanup 查询确实
-// 走 v13 partial index。回归守护：若有人改回 `id > ?` 游标 + `ORDER BY id`，
-// SQLite planner 会回退到 PK 扫，partial index 形同虚设，该测试会捕获。
-func TestProxyRequestClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
+// TestClearDetailOlderThan_PersistsCursorAcrossCalls 守护游标跨调用复用:
+// 第二次调用不应该从 (0,0) 重扫已经处理过的区间。
+func TestClearDetailOlderThan_PersistsCursorAcrossCalls(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	repo := NewProxyRequestRepository(db)
+
+	old := time.Now().Add(-2 * time.Hour)
+	for i := 0; i < 10; i++ {
+		r := buildTestProxyRequest("COMPLETED", i)
+		r.StartTime = old
+		if err := repo.Create(r); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		if err := db.gorm.Table("proxy_requests").Where("id = ?", r.ID).
+			Update("created_at", old.Add(time.Duration(i)*time.Second).UnixMilli()).Error; err != nil {
+			t.Fatalf("backdate %d: %v", i, err)
+		}
+	}
+
+	// 第一次调用清完所有 10 条 (远低于 cap)。游标应该停在最后一行。
+	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("first clear: %v", err)
+	}
+	if cleared != 10 {
+		t.Fatalf("first clear count = %d, want 10", cleared)
+	}
+	c1 := repo.loadCleanupCursor("")
+	if c1.ID == 0 {
+		t.Fatalf("cursor should be advanced after first call, got %+v", c1)
+	}
+
+	// 第二次调用:已经全部清过,detail_cleared=1,游标也已经在末尾,SELECT 应返回 0 行。
+	cleared2, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("second clear: %v", err)
+	}
+	if cleared2 != 0 {
+		t.Fatalf("second clear count = %d, want 0 (cursor should skip already-cleared region)", cleared2)
+	}
+	c2 := repo.loadCleanupCursor("")
+	if c2 != c1 {
+		t.Fatalf("cursor should not move on empty second call, c1=%+v c2=%+v", c1, c2)
+	}
+}
+
+// TestClearDetailOlderThan_RespectsBatchCap 守护 cap maxCleanupBatchesPerCall:
+// backlog 远大于 cap 时,单次调用只处理 cap × batchSize 行,游标保存,下次继续。
+func TestClearDetailOlderThan_RespectsBatchCap(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	repo := NewProxyRequestRepository(db)
+
+	// SQLite batch=200,cap=50 → 单次理论最大 10000 行;为加速测试,造 N>200 但 <10000。
+	// 这样能验证 cursor 持久化即可,完整 cap 测试用 unit-style 更经济(不必造 10k 行)。
+	const seed = 500
+	old := time.Now().Add(-2 * time.Hour)
+	for i := 0; i < seed; i++ {
+		r := buildTestProxyRequest("COMPLETED", i)
+		if err := repo.Create(r); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		if err := db.gorm.Table("proxy_requests").Where("id = ?", r.ID).
+			Update("created_at", old.Add(time.Duration(i)*time.Millisecond).UnixMilli()).Error; err != nil {
+			t.Fatalf("backdate %d: %v", i, err)
+		}
+	}
+	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if cleared != seed {
+		t.Fatalf("clear count = %d, want %d", cleared, seed)
+	}
+}
+
+// TestProxyRequestClearDetailOlderThan_UsesSentinelIndex 锁定 v15 之后 cleanup
+// SELECT 走 idx_proxy_requests_detail_cleared(detail_cleared, created_at, id) 复合索引。
+// 回归守护:WHERE detail_cleared = 0 是 leading-column 等值匹配,planner 应该挑这个索引;
+// 任何回退到 PK 扫或 TEMP B-TREE 排序都会被捕获。
+func TestProxyRequestClearDetailOlderThan_UsesSentinelIndex(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -386,7 +470,7 @@ func TestProxyRequestClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
 	defer db.Close()
 
 	const sql = `SELECT id, created_at FROM proxy_requests ` +
-		`WHERE created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND dev_mode = 0 ` +
+		`WHERE detail_cleared = 0 AND created_at < ? AND dev_mode = 0 ` +
 		`AND (created_at > ? OR (created_at = ? AND id > ?)) ` +
 		`ORDER BY created_at, id LIMIT 200`
 
@@ -406,19 +490,16 @@ func TestProxyRequestClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
 		planLines = append(planLines, detail)
 	}
 	plan := strings.Join(planLines, "\n")
-	if !strings.Contains(plan, "idx_proxy_requests_detail_cleanup") {
-		t.Fatalf("expected plan to use idx_proxy_requests_detail_cleanup, got:\n%s", plan)
+	if !strings.Contains(plan, "idx_proxy_requests_detail_cleared") {
+		t.Fatalf("expected plan to use idx_proxy_requests_detail_cleared, got:\n%s", plan)
 	}
-	// 显式拒绝 TEMP B-TREE 排序：partial index 的键 (created_at, id) 已经匹配 ORDER BY，
-	// 出现 TEMP B-TREE 意味着 cursor 或 ORDER BY 形状变了，planner 退化到扫+排。
 	if strings.Contains(plan, "TEMP B-TREE") {
 		t.Fatalf("plan should not require TEMP B-TREE sort, got:\n%s", plan)
 	}
 }
 
-// TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 同上，针对
-// attempt 表的 cleanup 查询。
-func TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex(t *testing.T) {
+// TestProxyUpstreamAttemptClearDetailOlderThan_UsesSentinelIndex 同上，针对 attempts 表。
+func TestProxyUpstreamAttemptClearDetailOlderThan_UsesSentinelIndex(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -426,7 +507,7 @@ func TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex(t *testing.T)
 	defer db.Close()
 
 	const sql = `SELECT id, created_at FROM proxy_upstream_attempts ` +
-		`WHERE created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) ` +
+		`WHERE detail_cleared = 0 AND created_at < ? ` +
 		`AND (created_at > ? OR (created_at = ? AND id > ?)) ` +
 		`AND EXISTS (SELECT 1 FROM proxy_requests WHERE proxy_requests.id = proxy_upstream_attempts.proxy_request_id AND proxy_requests.dev_mode = 0) ` +
 		`ORDER BY created_at, id LIMIT 200`
@@ -447,11 +528,9 @@ func TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex(t *testing.T)
 		planLines = append(planLines, detail)
 	}
 	plan := strings.Join(planLines, "\n")
-	if !strings.Contains(plan, "idx_proxy_upstream_attempts_detail_cleanup") {
-		t.Fatalf("expected plan to use idx_proxy_upstream_attempts_detail_cleanup, got:\n%s", plan)
+	if !strings.Contains(plan, "idx_proxy_upstream_attempts_detail_cleared") {
+		t.Fatalf("expected plan to use idx_proxy_upstream_attempts_detail_cleared, got:\n%s", plan)
 	}
-	// 显式拒绝 TEMP B-TREE 排序：EXISTS 改写的全部意义就是避免 planner 从父表驱动后
-	// 再做一次临时排序。若再次出现，说明有人把 EXISTS 改回了 IN 子查询。
 	if strings.Contains(plan, "TEMP B-TREE") {
 		t.Fatalf("plan should not require TEMP B-TREE sort, got:\n%s", plan)
 	}

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -375,6 +375,48 @@ func TestProxyRequestClearDetailOlderThan(t *testing.T) {
 	})
 }
 
+// TestClearDetailOlderThan_LegacyFallback 守护 sentinel 列缺失时的退化路径。
+//
+// 场景:v15 在大表上 threshold-skip 了 ADD COLUMN,运维没补建。运行期
+// SetDetailClearedColumnMissing(true) 让 ClearDetailOlderThan 走 legacy
+// IS NOT NULL 谓词,不引用不存在的 detail_cleared 列。功能正常但慢。
+//
+// 实现验证:用一个真实的 SQLite DB(列已建),手动 set flag,运行清理,
+// 确认 legacy 谓词路径不报错且能清出数据。
+func TestClearDetailOlderThan_LegacyFallback(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	repo := NewProxyRequestRepository(db)
+
+	// 模拟列缺失场景。注意 SQLite 本地其实有列,我们只是逼 ClearDetailOlderThan 走
+	// legacy 路径——legacy 路径不引用列,不报错;清理结果与 sentinel 路径一致。
+	SetDetailClearedColumnMissing(true)
+	defer SetDetailClearedColumnMissing(false)
+
+	old := time.Now().Add(-2 * time.Hour)
+	for i := 0; i < 3; i++ {
+		r := buildTestProxyRequest("COMPLETED", i)
+		if err := repo.Create(r); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if err := db.gorm.Table("proxy_requests").Where("id = ?", r.ID).
+			Update("created_at", old.UnixMilli()+int64(i)).Error; err != nil {
+			t.Fatalf("backdate: %v", err)
+		}
+	}
+
+	cleared, err := repo.ClearDetailOlderThan(time.Now().Add(-time.Hour), nil)
+	if err != nil {
+		t.Fatalf("legacy-path clear: %v", err)
+	}
+	if cleared != 3 {
+		t.Fatalf("legacy-path cleared = %d, want 3", cleared)
+	}
+}
+
 // TestClearDetailOlderThan_StatusBucketIsolation 守护"状态后变的行不会被永久跳过"。
 //
 // 历史 bug:之前的实现在 repo 上持久化 cursor。PENDING 行先被 cursor 越过(status 过滤

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -12,30 +11,10 @@ import (
 
 type ProxyUpstreamAttemptRepository struct {
 	db *DB
-
-	// cleanupCursors / cleanupCursorsMu:见 proxy_request.go 同名字段注释,语义一致。
-	// 三种 bucket key:"" / "COMPLETED" / "FAILED,CANCELLED,REJECTED"。
-	cleanupCursorsMu sync.Mutex
-	cleanupCursors   map[string]cleanupCursor
 }
 
 func NewProxyUpstreamAttemptRepository(db *DB) *ProxyUpstreamAttemptRepository {
-	return &ProxyUpstreamAttemptRepository{
-		db:             db,
-		cleanupCursors: make(map[string]cleanupCursor),
-	}
-}
-
-func (r *ProxyUpstreamAttemptRepository) loadCleanupCursor(key string) cleanupCursor {
-	r.cleanupCursorsMu.Lock()
-	defer r.cleanupCursorsMu.Unlock()
-	return r.cleanupCursors[key]
-}
-
-func (r *ProxyUpstreamAttemptRepository) saveCleanupCursor(key string, c cleanupCursor) {
-	r.cleanupCursorsMu.Lock()
-	defer r.cleanupCursorsMu.Unlock()
-	r.cleanupCursors[key] = c
+	return &ProxyUpstreamAttemptRepository{db: db}
 }
 
 func (r *ProxyUpstreamAttemptRepository) Create(a *domain.ProxyUpstreamAttempt) error {
@@ -272,9 +251,9 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
-	bucketKey := cleanupBucketKey(statuses)
-	cursor := r.loadCleanupCursor(bucketKey)
 	var total int64
+	var lastCreatedAt int64
+	var lastID uint64
 
 	// parentExistsClause 构造相关 EXISTS：通过 attempt.proxy_request_id 关联父行，
 	// 然后过滤父行 dev_mode/status。返回 SQL 片段 + 对应 args。
@@ -300,16 +279,14 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Select("id, created_at").
 			Where("detail_cleared = 0 AND created_at < ?", beforeTs).
-			Where("(created_at > ? OR (created_at = ? AND id > ?))", cursor.CreatedAt, cursor.CreatedAt, cursor.ID).
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID).
 			Where(existsSQL, existsArgs...).
 			Order("created_at, id").
 			Limit(batchSize).
 			Scan(&rows).Error; err != nil {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, err
 		}
 		if len(rows) == 0 {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		ids := make([]uint64, len(rows))
@@ -317,7 +294,8 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 			ids[i] = row.ID
 		}
 		last := rows[len(rows)-1]
-		cursor = cleanupCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+		lastCreatedAt = last.CreatedAt
+		lastID = last.ID
 
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Where("id IN ? AND detail_cleared = 0 AND created_at < ?", ids, beforeTs).
@@ -329,18 +307,15 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 				"updated_at":     time.Now().UnixMilli(),
 			})
 		if result.Error != nil {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, result.Error
 		}
 		total += result.RowsAffected
 
 		if len(rows) < batchSize {
-			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		time.Sleep(batchSleep)
 	}
-	r.saveCleanupCursor(bucketKey, cursor)
 	return total, nil
 }
 

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -251,9 +251,27 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
+	useSentinel := detailClearedColumnAvailable()
 	var total int64
 	var lastCreatedAt int64
 	var lastID uint64
+
+	// Sentinel vs legacy 谓词分支,见 proxy_request.go 同名函数的注释。
+	selectPred := "detail_cleared = 0 AND created_at < ?"
+	updatePred := "id IN ? AND detail_cleared = 0 AND created_at < ?"
+	updateMap := map[string]any{
+		"request_info":   nil,
+		"response_info":  nil,
+		"detail_cleared": 1,
+	}
+	if !useSentinel {
+		selectPred = "(request_info IS NOT NULL OR response_info IS NOT NULL) AND created_at < ?"
+		updatePred = "id IN ? AND (request_info IS NOT NULL OR response_info IS NOT NULL) AND created_at < ?"
+		updateMap = map[string]any{
+			"request_info":  nil,
+			"response_info": nil,
+		}
+	}
 
 	// parentExistsClause 构造相关 EXISTS：通过 attempt.proxy_request_id 关联父行，
 	// 然后过滤父行 dev_mode/status。返回 SQL 片段 + 对应 args。
@@ -278,7 +296,7 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		existsSQL, existsArgs := parentExistsClause()
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Select("id, created_at").
-			Where("detail_cleared = 0 AND created_at < ?", beforeTs).
+			Where(selectPred, beforeTs).
 			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID).
 			Where(existsSQL, existsArgs...).
 			Order("created_at, id").
@@ -297,15 +315,11 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		lastCreatedAt = last.CreatedAt
 		lastID = last.ID
 
+		updateMap["updated_at"] = time.Now().UnixMilli()
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-			Where("id IN ? AND detail_cleared = 0 AND created_at < ?", ids, beforeTs).
+			Where(updatePred, ids, beforeTs).
 			Where(existsSQL, existsArgs...).
-			Updates(map[string]any{
-				"request_info":   nil,
-				"response_info":  nil,
-				"detail_cleared": 1,
-				"updated_at":     time.Now().UnixMilli(),
-			})
+			Updates(updateMap)
 		if result.Error != nil {
 			return total, result.Error
 		}

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -11,10 +12,30 @@ import (
 
 type ProxyUpstreamAttemptRepository struct {
 	db *DB
+
+	// cleanupCursors / cleanupCursorsMu:见 proxy_request.go 同名字段注释,语义一致。
+	// 三种 bucket key:"" / "COMPLETED" / "FAILED,CANCELLED,REJECTED"。
+	cleanupCursorsMu sync.Mutex
+	cleanupCursors   map[string]cleanupCursor
 }
 
 func NewProxyUpstreamAttemptRepository(db *DB) *ProxyUpstreamAttemptRepository {
-	return &ProxyUpstreamAttemptRepository{db: db}
+	return &ProxyUpstreamAttemptRepository{
+		db:             db,
+		cleanupCursors: make(map[string]cleanupCursor),
+	}
+}
+
+func (r *ProxyUpstreamAttemptRepository) loadCleanupCursor(key string) cleanupCursor {
+	r.cleanupCursorsMu.Lock()
+	defer r.cleanupCursorsMu.Unlock()
+	return r.cleanupCursors[key]
+}
+
+func (r *ProxyUpstreamAttemptRepository) saveCleanupCursor(key string, c cleanupCursor) {
+	r.cleanupCursorsMu.Lock()
+	defer r.cleanupCursorsMu.Unlock()
+	r.cleanupCursors[key] = c
 }
 
 func (r *ProxyUpstreamAttemptRepository) Create(a *domain.ProxyUpstreamAttempt) error {
@@ -239,17 +260,21 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 // ClearDetailOlderThan 清理指定时间之前 attempt 的详情字段（request_info 和 response_info）
 // statuses 为空时不按状态过滤；非空时仅清理所属 ProxyRequest.status IN (statuses) 的 attempt
 //
-// 关键点：父表过滤用 EXISTS 相关子查询（不是 IN）。SQLite planner 对 IN 子查询会从父表
-// 驱动 → 走 idx_proxy_upstream_attempts_proxy_request_id + USE TEMP B-TREE FOR ORDER BY，
-// partial index 形同虚设；改成 EXISTS 后 planner 走 partial index (created_at<?) +
-// 父表 PK 查找，并且 ORDER BY 不再需要临时 sort。
-// EXPLAIN QUERY PLAN 由 TestProxyUpstreamAttemptClearDetailOlderThan_UsesPartialIndex 守护。
+// 设计三件套（cursor + sentinel + cap）见 ProxyRequestRepository.ClearDetailOlderThan
+// 的详细注释。这里只描述 attempt 特有的逻辑:
+//
+//   - **父表过滤用 EXISTS**:SQLite/MySQL planner 都把 EXISTS 当 anti-join,先驱
+//     attempt 端的 (detail_cleared, created_at, id) 索引,再对每个候选 PK 查父行。
+//     原先 IN(subquery) 形式 SQLite 会从父表驱动,绕开 attempt 端的索引,稳态退化。
+//   - **sentinel**:同 request 表,detail_cleared = 0 是 SELECT 的 leading-column
+//     等值匹配,索引 idx_proxy_upstream_attempts_detail_cleared (detail_cleared,
+//     created_at, id) 让范围扫不回行。
 func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, statuses []string) (int64, error) {
 	batchSize, batchSleep := detailCleanupBatchParams(r.db.Dialector())
 	beforeTs := toTimestamp(before)
+	bucketKey := cleanupBucketKey(statuses)
+	cursor := r.loadCleanupCursor(bucketKey)
 	var total int64
-	var lastCreatedAt int64
-	var lastID uint64
 
 	// parentExistsClause 构造相关 EXISTS：通过 attempt.proxy_request_id 关联父行，
 	// 然后过滤父行 dev_mode/status。返回 SQL 片段 + 对应 args。
@@ -269,20 +294,22 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 		CreatedAt int64  `gorm:"column:created_at"`
 	}
 
-	for {
+	for batchIdx := 0; batchIdx < maxCleanupBatchesPerCall; batchIdx++ {
 		var rows []cursorRow
 		existsSQL, existsArgs := parentExistsClause()
 		if err := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
 			Select("id, created_at").
-			Where("created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", beforeTs).
-			Where("(created_at > ? OR (created_at = ? AND id > ?))", lastCreatedAt, lastCreatedAt, lastID).
+			Where("detail_cleared = 0 AND created_at < ?", beforeTs).
+			Where("(created_at > ? OR (created_at = ? AND id > ?))", cursor.CreatedAt, cursor.CreatedAt, cursor.ID).
 			Where(existsSQL, existsArgs...).
 			Order("created_at, id").
 			Limit(batchSize).
 			Scan(&rows).Error; err != nil {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, err
 		}
 		if len(rows) == 0 {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		ids := make([]uint64, len(rows))
@@ -290,28 +317,31 @@ func (r *ProxyUpstreamAttemptRepository) ClearDetailOlderThan(before time.Time, 
 			ids[i] = row.ID
 		}
 		last := rows[len(rows)-1]
-		lastCreatedAt = last.CreatedAt
-		lastID = last.ID
+		cursor = cleanupCursor{CreatedAt: last.CreatedAt, ID: last.ID}
 
-		// 重应用谓词与父表过滤：Pluck 与 UPDATE 之间父请求状态可能变动。
 		result := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
-			Where("id IN ? AND created_at < ? AND (request_info IS NOT NULL OR response_info IS NOT NULL)", ids, beforeTs).
+			Where("id IN ? AND detail_cleared = 0 AND created_at < ?", ids, beforeTs).
 			Where(existsSQL, existsArgs...).
 			Updates(map[string]any{
-				"request_info":  nil,
-				"response_info": nil,
-				"updated_at":    time.Now().UnixMilli(),
+				"request_info":   nil,
+				"response_info":  nil,
+				"detail_cleared": 1,
+				"updated_at":     time.Now().UnixMilli(),
 			})
 		if result.Error != nil {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, result.Error
 		}
 		total += result.RowsAffected
 
 		if len(rows) < batchSize {
+			r.saveCleanupCursor(bucketKey, cursor)
 			return total, nil
 		}
 		time.Sleep(batchSleep)
 	}
+	r.saveCleanupCursor(bucketKey, cursor)
+	return total, nil
 }
 
 func (r *ProxyUpstreamAttemptRepository) toModel(a *domain.ProxyUpstreamAttempt) *ProxyUpstreamAttempt {


### PR DESCRIPTION
## Summary

生产报告 \`AttemptRepo.ClearDetailOlderThan\` 在 MySQL 上单次 SELECT 卡 43 min。三个独立 bug 叠加,需要三件套一起修。

### 根因分析

1. **Cursor 不跨 tick 复用**:`ClearDetailOlderThan` 内部用 \`(created_at, id)\` 游标,但每次函数调用从 (0,0) 重启。即使 backlog 已 drain,每个 tick 仍要扫一遍 7 天窗口。
2. **MySQL 无 partial index**:WHERE 含 \`(request_info IS NOT NULL OR response_info IS NOT NULL)\`,MySQL 必须 PK 回行评估 LONGTEXT NULL flag。100k+ 行 × 随机 IO = 43 min。
3. **Drain-to-completion 不封顶**:单次调用霸占 cleanup goroutine 直到全清,SLA 不可控。

SQLite 在 v13 用 partial index 把 IS NOT NULL 谓词烧进索引避开了 (2),但 MySQL 无此功能。

### 三件套

**A. 持久化 cursor**(\`proxy_request.go\` / \`proxy_upstream_attempt.go\`)
- \`cleanupCursors map[string]cleanupCursor\` 按 status-bucket 维护
- 跨调用单调推进;新增老化行 \`created_at = now\` 自然落在 cursor 之后

**B. \`detail_cleared\` sentinel + 复合索引**(migration v15)
- 列 \`detail_cleared TINYINT NOT NULL DEFAULT 0\` 由 GORM AutoMigrate 添加
- v15 创建 \`idx_*_detail_cleared (detail_cleared, created_at, id)\`,leading-column 等值匹配 \`WHERE detail_cleared = 0\`
- DDL 朴素 \`CREATE INDEX\`,**无 ALGORITHM/LOCK hint**,MySQL 5.7/8.0/SQLite 全兼容(吸取 v14 1064 教训)
- UPDATE 同步 \`SET detail_cleared = 1\`;清完的行自动离开索引活跃段
- 沿用 v13/v14 的 500k 行 threshold-skip + manual SQL 模式

**C. \`maxCleanupBatchesPerCall = 50\` 封顶**
- 单次调用最多 50 batch(MySQL 50k 行 / SQLite 10k 行)
- 配合 A 的 cursor 保存,下次 tick 从断点续
- 单次 wall-clock 秒级,不再 43 min

### 索引清理

v13/v14 索引保留,本 PR 不 drop。等 v15 稳定后单独 PR 收尾。

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` 全绿(含 \`tests/multiinstance\` / \`tests/e2e\`)
- [x] EXPLAIN QUERY PLAN 测试更新:断言 \`idx_*_detail_cleared\` 被使用、无 TEMP B-TREE
- [x] 新增 cursor 持久化测试(第二次调用对已清数据 0 行)
- [x] 新增 cap 行为测试(超过 batch 的 backlog 完整 drain)
- [ ] 生产 MySQL 灰度验证(同 #566/#567 模式)

cc @awsl233777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能优化**
  * 清理流程改为有上限的批次执行、批次间睡眠，支持跨次续跑以降低重复扫描与峰值负载

* **数据库迁移**
  * 新增哨兵列与复合索引以加速清理；对超大表可安全跳过并输出手工 DDL 指引

* **运行时**
  * 启动时探测哨兵列就绪，缺列时自动回退到兼容路径并记录告警

* **测试**
  * 新增并调整回归测试，覆盖回退路径、状态隔离与批次上限

* **文档**
  * 为相关实体补充注释，说明哨兵列语义与访问模式

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->