### PR TITLE
refactor(pricing): unify Calculator and preserve historical multiplier in backfill

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -563,6 +563,7 @@ type AttemptCostData struct {
 	Cache1hWriteCount uint64
 	Cost              uint64
 	Multiplier        uint64 // 历史倍率(10000=1×, 0 视作 10000)
+	ModelPriceID      uint64 // 历史 model_price_id;backfill 时跟新匹配 ID 对比来判断是否需要刷新
 }
 
 // AttemptCostUpdate 是 backfill 时批量更新 attempt 成本字段的载荷:

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -546,7 +546,9 @@ type ProxyUpstreamAttempt struct {
 	Cost uint64 `json:"cost"`
 }
 
-// AttemptCostData contains minimal data needed for cost recalculation
+// AttemptCostData contains minimal data needed for cost recalculation.
+// 重算 cost 时需要带上历史 Multiplier:重算用当前价表得出新 cost,
+// 但合约层面的倍率(由 Provider×ClientType 决定)是历史值,不能在 backfill 时悄悄丢掉。
 type AttemptCostData struct {
 	ID                uint64
 	ProxyRequestID    uint64
@@ -560,6 +562,14 @@ type AttemptCostData struct {
 	Cache5mWriteCount uint64
 	Cache1hWriteCount uint64
 	Cost              uint64
+	Multiplier        uint64 // 历史倍率(10000=1×, 0 视作 10000)
+}
+
+// AttemptCostUpdate 是 backfill 时批量更新 attempt 成本字段的载荷:
+// cost 是按当前价表 + 历史倍率算出的新值,model_price_id 同步更新到当前匹配的价格记录。
+type AttemptCostUpdate struct {
+	Cost         uint64
+	ModelPriceID uint64
 }
 
 // 重试配置

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -212,7 +212,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 						pricingModel = attemptRecord.MappedModel
 					}
 					multiplier := getProviderMultiplier(matchedRoute.Provider, clientType)
-					result := pricing.GlobalCalculator().CalculateWithResult(pricingModel, metrics, multiplier)
+					result := pricing.GlobalCalculator().Calculate(pricingModel, metrics, multiplier)
 					attemptRecord.Cost = result.Cost
 					attemptRecord.ModelPriceID = result.ModelPriceID
 					attemptRecord.Multiplier = result.Multiplier
@@ -295,7 +295,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 					pricingModel = attemptRecord.MappedModel
 				}
 				multiplier := getProviderMultiplier(matchedRoute.Provider, clientType)
-				result := pricing.GlobalCalculator().CalculateWithResult(pricingModel, metrics, multiplier)
+				result := pricing.GlobalCalculator().Calculate(pricingModel, metrics, multiplier)
 				attemptRecord.Cost = result.Cost
 				attemptRecord.ModelPriceID = result.ModelPriceID
 				attemptRecord.Multiplier = result.Multiplier

--- a/internal/pricing/calculator.go
+++ b/internal/pricing/calculator.go
@@ -2,390 +2,227 @@ package pricing
 
 import (
 	"log"
+	"strings"
 	"sync"
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/usage"
 )
 
+// DefaultMultiplier 表示 1× 倍率。倍率单位为万分之一。
+const DefaultMultiplier uint64 = 10000
+
 // CostResult 成本计算结果
 type CostResult struct {
 	Cost         uint64 // 成本（纳美元）
-	ModelPriceID uint64 // 使用的价格记录ID（0 表示使用内置价格表）
-	Multiplier   uint64 // 倍率（10000=1倍）
+	ModelPriceID uint64 // 使用的价格记录ID（0 表示使用内置默认价表）
+	Multiplier   uint64 // 实际应用的倍率（10000=1倍）
 }
 
-// Calculator 成本计算器
+// Calculator 维护 modelID → ModelPrice 映射。
+// 启动时载入内置默认价表(ID=0),LoadFromDatabase 会用 DB 记录覆盖同名条目。
+// 这样运行期只有一份价格源,不再有“内置 vs DB”分支。
 type Calculator struct {
-	priceTable *PriceTable
-
-	// 数据库价格缓存
-	modelPriceCache map[string]*domain.ModelPrice // key: modelID
-	modelPriceByID  map[uint64]*domain.ModelPrice // key: price ID
-	useDBPrices     bool                          // 是否使用数据库价格
-
-	mu sync.RWMutex
+	mu          sync.RWMutex
+	pricesByKey map[string]*domain.ModelPrice
+	pricesByID  map[uint64]*domain.ModelPrice
 }
 
-// 全局计算器实例
 var (
 	globalCalculator *Calculator
 	calculatorOnce   sync.Once
 )
 
-// GlobalCalculator 返回全局计算器实例
+// GlobalCalculator 返回全局计算器单例。
 func GlobalCalculator() *Calculator {
 	calculatorOnce.Do(func() {
-		globalCalculator = NewCalculator(DefaultPriceTable())
+		globalCalculator = NewCalculator()
 	})
 	return globalCalculator
 }
 
-// NewCalculator 创建新的计算器
-func NewCalculator(pt *PriceTable) *Calculator {
-	return &Calculator{
-		priceTable:      pt,
-		modelPriceCache: make(map[string]*domain.ModelPrice),
-		modelPriceByID:  make(map[uint64]*domain.ModelPrice),
-		useDBPrices:     false,
+// NewCalculator 构造仅含内置默认价的计算器。
+func NewCalculator() *Calculator {
+	c := &Calculator{
+		pricesByKey: make(map[string]*domain.ModelPrice),
+		pricesByID:  make(map[uint64]*domain.ModelPrice),
+	}
+	c.loadBuiltinsLocked()
+	return c
+}
+
+// loadBuiltinsLocked 用内置默认价表填充 pricesByKey。调用方需独占 c 或在构造期间。
+func (c *Calculator) loadBuiltinsLocked() {
+	for _, mp := range ConvertToDBPrices(DefaultPriceTable()) {
+		// 内置价表的 ID 恒为 0,只按 ModelID 索引。
+		c.pricesByKey[mp.ModelID] = mp
 	}
 }
 
-// LoadFromDatabase 从数据库加载当前价格
+// LoadFromDatabase 用 DB 价格覆盖内置默认价。
+// 同一 ModelID 的 DB 记录会取代内置默认;未在 DB 出现的内置默认仍然可用。
 func (c *Calculator) LoadFromDatabase(prices []*domain.ModelPrice) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.modelPriceCache = make(map[string]*domain.ModelPrice, len(prices))
-	c.modelPriceByID = make(map[uint64]*domain.ModelPrice, len(prices))
-
+	c.pricesByKey = make(map[string]*domain.ModelPrice)
+	c.pricesByID = make(map[uint64]*domain.ModelPrice)
+	c.loadBuiltinsLocked()
 	for _, p := range prices {
-		c.modelPriceCache[p.ModelID] = p
-		c.modelPriceByID[p.ID] = p
+		c.pricesByKey[p.ModelID] = p
+		c.pricesByID[p.ID] = p
 	}
-	c.useDBPrices = len(prices) > 0
 	log.Printf("[Pricing] Loaded %d model prices from database", len(prices))
 }
 
-// GetModelPrice 获取模型价格（支持前缀匹配），返回价格记录
+// GetModelPrice 按模型名取价格,支持前缀匹配。未命中返回 nil。
 func (c *Calculator) GetModelPrice(model string) *domain.ModelPrice {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-
-	if !c.useDBPrices {
-		return nil
-	}
-
-	// 精确匹配
-	if p, ok := c.modelPriceCache[model]; ok {
-		return p
-	}
-
-	// 前缀匹配：找最长匹配
-	var bestMatch *domain.ModelPrice
-	var bestLen int
-
-	for key, price := range c.modelPriceCache {
-		if len(key) > 0 && len(model) >= len(key) && model[:len(key)] == key {
-			if len(key) > bestLen {
-				bestMatch = price
-				bestLen = len(key)
-			}
-		}
-	}
-
-	return bestMatch
+	return c.lookupLocked(model)
 }
 
-// GetModelPriceByID 根据ID获取价格记录
+// GetModelPriceByID 按 DB 记录 ID 取价格。
 func (c *Calculator) GetModelPriceByID(id uint64) *domain.ModelPrice {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.modelPriceByID[id]
+	return c.pricesByID[id]
 }
 
-// Calculate 计算成本，返回纳美元 (1 USD = 1,000,000,000 nanoUSD)
-// model: 模型名称
-// metrics: token使用指标
-// 如果模型未找到，返回0并记录警告日志
-func (c *Calculator) Calculate(model string, metrics *usage.Metrics) uint64 {
+// lookupLocked 在 pricesByKey 中查找,先精确再最长前缀。需持有 RLock 或 Lock。
+func (c *Calculator) lookupLocked(model string) *domain.ModelPrice {
+	if p, ok := c.pricesByKey[model]; ok {
+		return p
+	}
+	var best *domain.ModelPrice
+	var bestLen int
+	for key, p := range c.pricesByKey {
+		if len(key) > bestLen && strings.HasPrefix(model, key) {
+			best = p
+			bestLen = len(key)
+		}
+	}
+	return best
+}
+
+// Calculate 计算成本。multiplier 单位为万分之一,0 视作 DefaultMultiplier(1×)。
+// 模型未命中价表时返回零成本(Multiplier 仍带回入参,便于审计)。
+func (c *Calculator) Calculate(model string, metrics *usage.Metrics, multiplier uint64) CostResult {
+	if multiplier == 0 {
+		multiplier = DefaultMultiplier
+	}
 	if metrics == nil {
-		return 0
+		return CostResult{Multiplier: multiplier}
 	}
 
 	c.mu.RLock()
-	pricing := c.priceTable.Get(model)
+	price := c.lookupLocked(model)
 	c.mu.RUnlock()
 
-	if pricing == nil {
+	if price == nil {
 		log.Printf("[Pricing] Unknown model: %s, cost will be 0", model)
-		return 0
+		return CostResult{Multiplier: multiplier}
 	}
 
-	return c.CalculateWithPricing(pricing, metrics)
-}
-
-// CalculateWithPricing 使用指定价格计算成本（纯整数运算）
-// 返回: 纳美元成本 (nanoUSD)
-func (c *Calculator) CalculateWithPricing(pricing *ModelPricing, metrics *usage.Metrics) uint64 {
-	if pricing == nil || metrics == nil {
-		return 0
-	}
-
-	var totalCost uint64
-
-	// 1. 输入成本
-	if metrics.InputTokens > 0 {
-		if pricing.Has1MContext {
-			inputNum, inputDenom := pricing.GetInputPremiumFraction()
-			totalCost += CalculateTieredCost(
-				metrics.InputTokens,
-				pricing.InputPriceMicro,
-				inputNum, inputDenom,
-				pricing.GetContext1MThreshold(),
-			)
-		} else {
-			totalCost += CalculateLinearCost(metrics.InputTokens, pricing.InputPriceMicro)
-		}
-	}
-
-	// 2. 输出成本
-	if metrics.OutputTokens > 0 {
-		if pricing.Has1MContext {
-			outputNum, outputDenom := pricing.GetOutputPremiumFraction()
-			totalCost += CalculateTieredCost(
-				metrics.OutputTokens,
-				pricing.OutputPriceMicro,
-				outputNum, outputDenom,
-				pricing.GetContext1MThreshold(),
-			)
-		} else {
-			totalCost += CalculateLinearCost(metrics.OutputTokens, pricing.OutputPriceMicro)
-		}
-	}
-
-	// 3. 缓存读取成本（使用 input 价格的 10%）
-	if metrics.CacheReadCount > 0 {
-		totalCost += CalculateLinearCost(
-			metrics.CacheReadCount,
-			pricing.GetEffectiveCacheReadPriceMicro(),
-		)
-	}
-
-	// 4. 5分钟缓存写入成本（使用 input 价格的 125%）
-	if metrics.Cache5mCreationCount > 0 {
-		totalCost += CalculateLinearCost(
-			metrics.Cache5mCreationCount,
-			pricing.GetEffectiveCache5mWritePriceMicro(),
-		)
-	}
-
-	// 5. 1小时缓存写入成本（使用 input 价格的 200%）
-	if metrics.Cache1hCreationCount > 0 {
-		totalCost += CalculateLinearCost(
-			metrics.Cache1hCreationCount,
-			pricing.GetEffectiveCache1hWritePriceMicro(),
-		)
-	}
-
-	// 6. Fallback: 如果没有 5m/1h 细分但有总缓存写入数
-	if metrics.Cache5mCreationCount == 0 && metrics.Cache1hCreationCount == 0 && metrics.CacheCreationCount > 0 {
-		totalCost += CalculateLinearCost(
-			metrics.CacheCreationCount,
-			pricing.GetEffectiveCache5mWritePriceMicro(), // 使用 5m 价格作为默认
-		)
-	}
-
-	return totalCost
-}
-
-// CalculateWithResult 计算成本，返回完整结果（包含 model_price_id 和 multiplier）
-// model: 模型名称
-// metrics: token使用指标
-// multiplier: 倍率（10000=1倍），0 表示使用默认值 10000
-func (c *Calculator) CalculateWithResult(model string, metrics *usage.Metrics, multiplier uint64) CostResult {
-	if metrics == nil {
-		return CostResult{Cost: 0, ModelPriceID: 0, Multiplier: 10000}
-	}
-
-	if multiplier == 0 {
-		multiplier = 10000
-	}
-
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	// 优先使用数据库价格
-	if c.useDBPrices {
-		mp := c.getModelPriceLocked(model)
-		if mp != nil {
-			cost := c.calculateWithModelPrice(mp, metrics)
-			// 应用倍率: cost * multiplier / 10000
-			if multiplier != 10000 {
-				cost = cost * multiplier / 10000
-			}
-			return CostResult{
-				Cost:         cost,
-				ModelPriceID: mp.ID,
-				Multiplier:   multiplier,
-			}
-		}
-	}
-
-	// 回退到内置价格表
-	pricing := c.priceTable.Get(model)
-	if pricing == nil {
-		log.Printf("[Pricing] Unknown model: %s, cost will be 0", model)
-		return CostResult{Cost: 0, ModelPriceID: 0, Multiplier: multiplier}
-	}
-
-	cost := c.CalculateWithPricing(pricing, metrics)
-	// 应用倍率
-	if multiplier != 10000 {
-		cost = cost * multiplier / 10000
+	cost := computeCost(price, metrics)
+	if multiplier != DefaultMultiplier {
+		cost = cost * multiplier / DefaultMultiplier
 	}
 	return CostResult{
 		Cost:         cost,
-		ModelPriceID: 0, // 使用内置价格表
+		ModelPriceID: price.ID,
 		Multiplier:   multiplier,
 	}
 }
 
-// getModelPriceLocked 获取模型价格（需要持有读锁）
-func (c *Calculator) getModelPriceLocked(model string) *domain.ModelPrice {
-	// 精确匹配
-	if p, ok := c.modelPriceCache[model]; ok {
-		return p
-	}
-
-	// 前缀匹配：找最长匹配
-	var bestMatch *domain.ModelPrice
-	var bestLen int
-
-	for key, price := range c.modelPriceCache {
-		if len(key) > 0 && len(model) >= len(key) && model[:len(key)] == key {
-			if len(key) > bestLen {
-				bestMatch = price
-				bestLen = len(key)
-			}
-		}
-	}
-
-	return bestMatch
+// effectivePrice 把 domain.ModelPrice 上“0 表示用默认”的字段解析为实际值,
+// 便于 computeCost 不必到处写 fallback 逻辑。
+type effectivePrice struct {
+	InputMicro         uint64
+	OutputMicro        uint64
+	CacheReadMicro     uint64
+	Cache5mWriteMicro  uint64
+	Cache1hWriteMicro  uint64
+	Has1MContext       bool
+	Context1MThreshold uint64
+	InputPremNum       uint64
+	InputPremDenom     uint64
+	OutputPremNum      uint64
+	OutputPremDenom    uint64
 }
 
-// calculateWithModelPrice 使用数据库价格计算成本
-func (c *Calculator) calculateWithModelPrice(mp *domain.ModelPrice, metrics *usage.Metrics) uint64 {
-	if mp == nil || metrics == nil {
-		return 0
+func resolveEffective(p *domain.ModelPrice) effectivePrice {
+	e := effectivePrice{
+		InputMicro:         p.InputPriceMicro,
+		OutputMicro:        p.OutputPriceMicro,
+		CacheReadMicro:     p.CacheReadPriceMicro,
+		Cache5mWriteMicro:  p.Cache5mWritePriceMicro,
+		Cache1hWriteMicro:  p.Cache1hWritePriceMicro,
+		Has1MContext:       p.Has1MContext,
+		Context1MThreshold: p.Context1MThreshold,
+		InputPremNum:       p.InputPremiumNum,
+		InputPremDenom:     p.InputPremiumDenom,
+		OutputPremNum:      p.OutputPremiumNum,
+		OutputPremDenom:    p.OutputPremiumDenom,
 	}
+	if e.CacheReadMicro == 0 {
+		e.CacheReadMicro = e.InputMicro / 10
+	}
+	if e.Cache5mWriteMicro == 0 {
+		e.Cache5mWriteMicro = e.InputMicro * 5 / 4
+	}
+	if e.Cache1hWriteMicro == 0 {
+		e.Cache1hWriteMicro = e.InputMicro * 2
+	}
+	if e.Context1MThreshold == 0 {
+		e.Context1MThreshold = 200_000
+	}
+	if e.InputPremNum == 0 {
+		e.InputPremNum = 2
+	}
+	if e.InputPremDenom == 0 {
+		e.InputPremDenom = 1
+	}
+	if e.OutputPremNum == 0 {
+		e.OutputPremNum = 3
+	}
+	if e.OutputPremDenom == 0 {
+		e.OutputPremDenom = 2
+	}
+	return e
+}
 
-	var totalCost uint64
+func computeCost(p *domain.ModelPrice, m *usage.Metrics) uint64 {
+	e := resolveEffective(p)
+	var total uint64
 
-	// 获取有效的缓存价格
-	cacheReadPrice := mp.CacheReadPriceMicro
-	if cacheReadPrice == 0 {
-		cacheReadPrice = mp.InputPriceMicro / 10
-	}
-	cache5mWritePrice := mp.Cache5mWritePriceMicro
-	if cache5mWritePrice == 0 {
-		cache5mWritePrice = mp.InputPriceMicro * 5 / 4
-	}
-	cache1hWritePrice := mp.Cache1hWritePriceMicro
-	if cache1hWritePrice == 0 {
-		cache1hWritePrice = mp.InputPriceMicro * 2
-	}
-
-	// 获取 1M context 参数
-	threshold := mp.Context1MThreshold
-	if threshold == 0 {
-		threshold = 200000
-	}
-	inputNum := mp.InputPremiumNum
-	if inputNum == 0 {
-		inputNum = 2
-	}
-	inputDenom := mp.InputPremiumDenom
-	if inputDenom == 0 {
-		inputDenom = 1
-	}
-	outputNum := mp.OutputPremiumNum
-	if outputNum == 0 {
-		outputNum = 3
-	}
-	outputDenom := mp.OutputPremiumDenom
-	if outputDenom == 0 {
-		outputDenom = 2
-	}
-
-	// 1. 输入成本
-	if metrics.InputTokens > 0 {
-		if mp.Has1MContext {
-			totalCost += CalculateTieredCost(
-				metrics.InputTokens,
-				mp.InputPriceMicro,
-				inputNum, inputDenom,
-				threshold,
-			)
+	if m.InputTokens > 0 {
+		if e.Has1MContext {
+			total += CalculateTieredCost(m.InputTokens, e.InputMicro, e.InputPremNum, e.InputPremDenom, e.Context1MThreshold)
 		} else {
-			totalCost += CalculateLinearCost(metrics.InputTokens, mp.InputPriceMicro)
+			total += CalculateLinearCost(m.InputTokens, e.InputMicro)
 		}
 	}
-
-	// 2. 输出成本
-	if metrics.OutputTokens > 0 {
-		if mp.Has1MContext {
-			totalCost += CalculateTieredCost(
-				metrics.OutputTokens,
-				mp.OutputPriceMicro,
-				outputNum, outputDenom,
-				threshold,
-			)
+	if m.OutputTokens > 0 {
+		if e.Has1MContext {
+			total += CalculateTieredCost(m.OutputTokens, e.OutputMicro, e.OutputPremNum, e.OutputPremDenom, e.Context1MThreshold)
 		} else {
-			totalCost += CalculateLinearCost(metrics.OutputTokens, mp.OutputPriceMicro)
+			total += CalculateLinearCost(m.OutputTokens, e.OutputMicro)
 		}
 	}
-
-	// 3. 缓存读取成本
-	if metrics.CacheReadCount > 0 {
-		totalCost += CalculateLinearCost(metrics.CacheReadCount, cacheReadPrice)
+	if m.CacheReadCount > 0 {
+		total += CalculateLinearCost(m.CacheReadCount, e.CacheReadMicro)
+	}
+	if m.Cache5mCreationCount > 0 {
+		total += CalculateLinearCost(m.Cache5mCreationCount, e.Cache5mWriteMicro)
+	}
+	if m.Cache1hCreationCount > 0 {
+		total += CalculateLinearCost(m.Cache1hCreationCount, e.Cache1hWriteMicro)
+	}
+	// 旧响应只给 cache_creation_input_tokens、没有拆 5m/1h:按 5m 价格计。
+	if m.Cache5mCreationCount == 0 && m.Cache1hCreationCount == 0 && m.CacheCreationCount > 0 {
+		total += CalculateLinearCost(m.CacheCreationCount, e.Cache5mWriteMicro)
 	}
 
-	// 4. 5分钟缓存写入成本
-	if metrics.Cache5mCreationCount > 0 {
-		totalCost += CalculateLinearCost(metrics.Cache5mCreationCount, cache5mWritePrice)
-	}
-
-	// 5. 1小时缓存写入成本
-	if metrics.Cache1hCreationCount > 0 {
-		totalCost += CalculateLinearCost(metrics.Cache1hCreationCount, cache1hWritePrice)
-	}
-
-	// 6. Fallback: 如果没有 5m/1h 细分但有总缓存写入数
-	if metrics.Cache5mCreationCount == 0 && metrics.Cache1hCreationCount == 0 && metrics.CacheCreationCount > 0 {
-		totalCost += CalculateLinearCost(metrics.CacheCreationCount, cache5mWritePrice)
-	}
-
-	return totalCost
-}
-
-// SetPriceTable 更新价格表
-func (c *Calculator) SetPriceTable(pt *PriceTable) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.priceTable = pt
-}
-
-// GetPricing 获取模型价格
-func (c *Calculator) GetPricing(model string) *ModelPricing {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.priceTable.Get(model)
-}
-
-// IsUsingDBPrices 返回是否使用数据库价格
-func (c *Calculator) IsUsingDBPrices() bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.useDBPrices
+	return total
 }

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/awsl-project/maxx/internal/usage"
 )
 
-func TestCalculateTieredCostMicro(t *testing.T) {
-	// 测试: $3/M tokens, 阈值 200K, 超阈值倍率 2/1
-	basePriceMicro := uint64(3_000_000) // $3/M
+func TestCalculateTieredCost(t *testing.T) {
+	// $3/M tokens, 阈值 200K, 超阈值倍率 2/1。期望值为纳美元。
+	basePriceMicro := uint64(3_000_000)
 
 	tests := []struct {
 		name     string
@@ -18,31 +18,31 @@ func TestCalculateTieredCostMicro(t *testing.T) {
 		{
 			name:     "below threshold 100K",
 			tokens:   100_000,
-			expected: 300_000, // 100K × $3/M = $0.30 = 300,000 microUSD
+			expected: 300_000_000, // 100K × $3/M = $0.30 = 300,000,000 nanoUSD
 		},
 		{
 			name:     "at threshold 200K",
 			tokens:   200_000,
-			expected: 600_000, // 200K × $3/M = $0.60 = 600,000 microUSD
+			expected: 600_000_000, // 200K × $3/M = $0.60
 		},
 		{
 			name:     "above threshold 300K",
 			tokens:   300_000,
-			expected: 1_200_000, // 200K × $3/M + 100K × $3/M × 2 = $0.60 + $0.60 = 1,200,000 microUSD
+			expected: 1_200_000_000, // 200K × $3 + 100K × $3 × 2 = $0.60 + $0.60
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateTieredCostMicro(tt.tokens, basePriceMicro, 2, 1, 200_000)
+			got := CalculateTieredCost(tt.tokens, basePriceMicro, 2, 1, 200_000)
 			if got != tt.expected {
-				t.Errorf("CalculateTieredCostMicro() = %d, want %d", got, tt.expected)
+				t.Errorf("CalculateTieredCost() = %d, want %d", got, tt.expected)
 			}
 		})
 	}
 }
 
-func TestCalculateLinearCostMicro(t *testing.T) {
+func TestCalculateLinearCost(t *testing.T) {
 	tests := []struct {
 		name       string
 		tokens     uint64
@@ -53,34 +53,34 @@ func TestCalculateLinearCostMicro(t *testing.T) {
 			name:       "1M tokens at $3/M",
 			tokens:     1_000_000,
 			priceMicro: 3_000_000,
-			expected:   3_000_000, // $3
+			expected:   3_000_000_000, // $3 = 3,000,000,000 nanoUSD
 		},
 		{
 			name:       "100K tokens at $15/M",
 			tokens:     100_000,
 			priceMicro: 15_000_000,
-			expected:   1_500_000, // $1.50
+			expected:   1_500_000_000, // $1.50
 		},
 		{
 			name:       "50K tokens at $0.30/M (cache read)",
 			tokens:     50_000,
-			priceMicro: 300_000, // $0.30/M
-			expected:   15_000,  // $0.015
+			priceMicro: 300_000,
+			expected:   15_000_000, // $0.015
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalculateLinearCostMicro(tt.tokens, tt.priceMicro)
+			got := CalculateLinearCost(tt.tokens, tt.priceMicro)
 			if got != tt.expected {
-				t.Errorf("CalculateLinearCostMicro() = %d, want %d", got, tt.expected)
+				t.Errorf("CalculateLinearCost() = %d, want %d", got, tt.expected)
 			}
 		})
 	}
 }
 
 func TestCalculator_Calculate(t *testing.T) {
-	calc := GlobalCalculator()
+	calc := NewCalculator()
 
 	tests := []struct {
 		name     string
@@ -95,7 +95,6 @@ func TestCalculator_Calculate(t *testing.T) {
 				InputTokens:  100_000,
 				OutputTokens: 10_000,
 			},
-			wantZero: false,
 		},
 		{
 			name:  "gpt-5.1 basic",
@@ -104,25 +103,6 @@ func TestCalculator_Calculate(t *testing.T) {
 				InputTokens:  50_000,
 				OutputTokens: 5_000,
 			},
-			wantZero: false,
-		},
-		{
-			name:  "gpt-5.3 basic",
-			model: "gpt-5.3",
-			metrics: &usage.Metrics{
-				InputTokens:  50_000,
-				OutputTokens: 5_000,
-			},
-			wantZero: false,
-		},
-		{
-			name:  "gpt-5.4 basic",
-			model: "gpt-5.4",
-			metrics: &usage.Metrics{
-				InputTokens:  50_000,
-				OutputTokens: 5_000,
-			},
-			wantZero: false,
 		},
 		{
 			name:  "gpt-5.4-mini basic",
@@ -131,25 +111,6 @@ func TestCalculator_Calculate(t *testing.T) {
 				InputTokens:  50_000,
 				OutputTokens: 5_000,
 			},
-			wantZero: false,
-		},
-		{
-			name:  "gpt-5.5 basic",
-			model: "gpt-5.5",
-			metrics: &usage.Metrics{
-				InputTokens:  50_000,
-				OutputTokens: 5_000,
-			},
-			wantZero: false,
-		},
-		{
-			name:  "gpt-5.5-pro basic",
-			model: "gpt-5.5-pro",
-			metrics: &usage.Metrics{
-				InputTokens:  50_000,
-				OutputTokens: 5_000,
-			},
-			wantZero: false,
 		},
 		{
 			name:  "gemini-2.5-pro basic",
@@ -158,7 +119,6 @@ func TestCalculator_Calculate(t *testing.T) {
 				InputTokens:  50_000,
 				OutputTokens: 5_000,
 			},
-			wantZero: false,
 		},
 		{
 			name:  "unknown model",
@@ -179,57 +139,73 @@ func TestCalculator_Calculate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calc.Calculate(tt.model, tt.metrics)
-			if tt.wantZero && got != 0 {
-				t.Errorf("Calculate() = %d, want 0", got)
+			got := calc.Calculate(tt.model, tt.metrics, 0)
+			if tt.wantZero && got.Cost != 0 {
+				t.Errorf("Calculate() Cost = %d, want 0", got.Cost)
 			}
-			if !tt.wantZero && got == 0 {
-				t.Errorf("Calculate() = 0, want non-zero")
+			if !tt.wantZero && got.Cost == 0 {
+				t.Errorf("Calculate() Cost = 0, want non-zero")
+			}
+			if got.Multiplier != DefaultMultiplier {
+				t.Errorf("Calculate() Multiplier = %d, want %d", got.Multiplier, DefaultMultiplier)
 			}
 		})
 	}
 }
 
 func TestCalculator_Calculate_WithCache(t *testing.T) {
-	calc := GlobalCalculator()
+	calc := NewCalculator()
 
 	// Claude Sonnet 4.5: input=$3/M, output=$15/M
-	// Cache read: $0.30/M (显式配置)
-	// Cache 5m/1h write: $3.75/M (显式配置)
+	// Cache read: $0.30/M(显式), 5m/1h write: $3.75/M(显式)
 	metrics := &usage.Metrics{
-		InputTokens:          100_000, // 100K × $3/M = $0.30 = 300,000,000 nanoUSD
-		OutputTokens:         10_000,  // 10K × $15/M = $0.15 = 150,000,000 nanoUSD
-		CacheReadCount:       50_000,  // 50K × $0.30/M = $0.015 = 15,000,000 nanoUSD
-		Cache5mCreationCount: 20_000,  // 20K × $3.75/M = $0.075 = 75,000,000 nanoUSD
-		Cache1hCreationCount: 10_000,  // 10K × $3.75/M = $0.0375 = 37,500,000 nanoUSD
+		InputTokens:          100_000, // 100K × $3/M = 300,000,000 nanoUSD
+		OutputTokens:         10_000,  // 10K × $15/M = 150,000,000 nanoUSD
+		CacheReadCount:       50_000,  // 50K × $0.30/M = 15,000,000 nanoUSD
+		Cache5mCreationCount: 20_000,  // 20K × $3.75/M = 75,000,000 nanoUSD
+		Cache1hCreationCount: 10_000,  // 10K × $3.75/M = 37,500,000 nanoUSD
 	}
 
-	cost := calc.Calculate("claude-sonnet-4-5", metrics)
-	if cost == 0 {
-		t.Fatal("Calculate() = 0, want non-zero")
+	got := calc.Calculate("claude-sonnet-4-5", metrics, 0)
+	if got.Cost == 0 {
+		t.Fatal("Calculate() Cost = 0, want non-zero")
 	}
 
-	// Expected: 300,000,000 + 150,000,000 + 15,000,000 + 75,000,000 + 37,500,000 = 577,500,000 nanoUSD
-	expectedNanoUSD := uint64(577_500_000)
-	if cost != expectedNanoUSD {
-		t.Errorf("Calculate() = %d nanoUSD, want %d nanoUSD", cost, expectedNanoUSD)
+	expected := uint64(577_500_000)
+	if got.Cost != expected {
+		t.Errorf("Calculate() Cost = %d nanoUSD, want %d nanoUSD", got.Cost, expected)
 	}
 }
 
 func TestCalculator_Calculate_1MContext(t *testing.T) {
-	calc := GlobalCalculator()
+	calc := NewCalculator()
 
-	// Claude Sonnet 4.5 with 1M context: 超过 200K 时 input×2, output×1.5
+	// Claude Sonnet 4.5 1M context: 超 200K 时 input×2, output×1.5
 	// input: $3/M, output: $15/M
 	metrics := &usage.Metrics{
-		InputTokens:  300_000, // 200K×$3 + 100K×$3×2 = $0.6 + $0.6 = $1.2 = 1,200,000,000 nanoUSD
-		OutputTokens: 50_000,  // 全部低于 200K: 50K×$15/M = $0.75 = 750,000,000 nanoUSD
+		InputTokens:  300_000, // 200K×$3 + 100K×$3×2 = $0.6 + $0.6 = $1.2
+		OutputTokens: 50_000,  // <200K: 50K×$15/M = $0.75
 	}
 
-	cost := calc.Calculate("claude-sonnet-4-5", metrics)
-	expectedNanoUSD := uint64(1_200_000_000 + 750_000_000)
-	if cost != expectedNanoUSD {
-		t.Errorf("Calculate() = %d nanoUSD, want %d nanoUSD", cost, expectedNanoUSD)
+	got := calc.Calculate("claude-sonnet-4-5", metrics, 0)
+	expected := uint64(1_200_000_000 + 750_000_000)
+	if got.Cost != expected {
+		t.Errorf("Calculate() Cost = %d nanoUSD, want %d nanoUSD", got.Cost, expected)
+	}
+}
+
+func TestCalculator_Calculate_AppliesMultiplier(t *testing.T) {
+	calc := NewCalculator()
+
+	metrics := &usage.Metrics{InputTokens: 1_000_000} // $3 = 3,000,000,000 nanoUSD
+	base := calc.Calculate("claude-sonnet-4-5", metrics, DefaultMultiplier)
+	scaled := calc.Calculate("claude-sonnet-4-5", metrics, 12_000) // 1.2×
+
+	if scaled.Cost != base.Cost*12000/10000 {
+		t.Errorf("multiplier not applied: base=%d scaled=%d", base.Cost, scaled.Cost)
+	}
+	if scaled.Multiplier != 12_000 {
+		t.Errorf("returned Multiplier = %d, want 12000", scaled.Multiplier)
 	}
 }
 
@@ -241,23 +217,20 @@ func TestPriceTable_Get_PrefixMatch(t *testing.T) {
 		wantFound bool
 	}{
 		{"claude-sonnet-4-5", true},
-		{"claude-sonnet-4-5-20250514", true}, // prefix match
+		{"claude-sonnet-4-5-20250514", true},
 		{"claude-opus-4-5", true},
-		{"claude-opus-4-5-20251001", true}, // prefix match
+		{"claude-opus-4-5-20251001", true},
 		{"claude-opus-4-6", true},
-		{"claude-opus-4-6-20260205", true}, // prefix match
+		{"claude-opus-4-6-20260205", true},
 		{"claude-haiku-4-5", true},
-		{"claude-haiku-4-5-20251001", true}, // prefix match
+		{"claude-haiku-4-5-20251001", true},
 		{"gpt-5.1", true},
 		{"gpt-5.1-codex", true},
-		{"gpt-5.2", true},
-		{"gpt-5.3", true},
 		{"gpt-5.4", true},
 		{"gpt-5.4-mini", true},
 		{"gpt-5.5", true},
 		{"gpt-5.5-pro", true},
 		{"gemini-2.5-pro", true},
-		{"gemini-2.5-flash", true},
 		{"gemini-3-pro-preview", true},
 		{"unknown-model", false},
 	}
@@ -278,46 +251,34 @@ func TestPriceTable_Get_PrefixMatch(t *testing.T) {
 func TestExplicitCachePrices(t *testing.T) {
 	pt := DefaultPriceTable()
 
-	// 验证 Claude Sonnet 4.5 的显式缓存价格
 	pricing := pt.Get("claude-sonnet-4-5")
 	if pricing == nil {
 		t.Fatal("claude-sonnet-4-5 not found")
 	}
 
-	// cache read: $0.30/M = 300,000 microUSD/M
 	if got := pricing.GetEffectiveCacheReadPriceMicro(); got != 300_000 {
 		t.Errorf("GetEffectiveCacheReadPriceMicro() = %d, want 300000", got)
 	}
-
-	// cache 5m write: $3.75/M = 3,750,000 microUSD/M
 	if got := pricing.GetEffectiveCache5mWritePriceMicro(); got != 3_750_000 {
 		t.Errorf("GetEffectiveCache5mWritePriceMicro() = %d, want 3750000", got)
 	}
-
-	// cache 1h write: $3.75/M = 3,750,000 microUSD/M
 	if got := pricing.GetEffectiveCache1hWritePriceMicro(); got != 3_750_000 {
 		t.Errorf("GetEffectiveCache1hWritePriceMicro() = %d, want 3750000", got)
 	}
 }
 
 func TestDefaultCachePrices(t *testing.T) {
-	// 验证没有显式配置缓存价格时的默认计算
 	pricing := &ModelPricing{
-		InputPriceMicro:  1_000_000, // $1/M
-		OutputPriceMicro: 5_000_000, // $5/M
+		InputPriceMicro:  1_000_000,
+		OutputPriceMicro: 5_000_000,
 	}
 
-	// cache read: input / 10 = $0.10/M = 100,000 microUSD/M
 	if got := pricing.GetEffectiveCacheReadPriceMicro(); got != 100_000 {
 		t.Errorf("GetEffectiveCacheReadPriceMicro() = %d, want 100000", got)
 	}
-
-	// cache 5m write: input * 5/4 = $1.25/M = 1,250,000 microUSD/M
 	if got := pricing.GetEffectiveCache5mWritePriceMicro(); got != 1_250_000 {
 		t.Errorf("GetEffectiveCache5mWritePriceMicro() = %d, want 1250000", got)
 	}
-
-	// cache 1h write: input * 2 = $2/M = 2,000,000 microUSD/M
 	if got := pricing.GetEffectiveCache1hWritePriceMicro(); got != 2_000_000 {
 		t.Errorf("GetEffectiveCache1hWritePriceMicro() = %d, want 2000000", got)
 	}

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -3,6 +3,7 @@ package pricing
 import (
 	"testing"
 
+	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/usage"
 )
 
@@ -191,6 +192,109 @@ func TestCalculator_Calculate_1MContext(t *testing.T) {
 	expected := uint64(1_200_000_000 + 750_000_000)
 	if got.Cost != expected {
 		t.Errorf("Calculate() Cost = %d nanoUSD, want %d nanoUSD", got.Cost, expected)
+	}
+}
+
+func TestCalculator_Calculate_BuiltinHasZeroPriceID(t *testing.T) {
+	// 内置默认价表的条目都没有 DB ID,Calculate 返回的 ModelPriceID 应为 0。
+	// 这保证 attempt 表里"用内置价表算出"的记录可以和"用 DB 价算出"的区分开。
+	calc := NewCalculator()
+	got := calc.Calculate("claude-sonnet-4-5", &usage.Metrics{InputTokens: 1_000_000}, 0)
+	if got.ModelPriceID != 0 {
+		t.Errorf("builtin price ModelPriceID = %d, want 0", got.ModelPriceID)
+	}
+	if got.Cost == 0 {
+		t.Fatal("expected non-zero cost from builtin price")
+	}
+}
+
+func TestCalculator_LoadFromDatabase_OverlaysBuiltin(t *testing.T) {
+	// DB 中 claude-sonnet-4-5 的 input 改为 $6/M(默认是 $3/M)。
+	// LoadFromDatabase 后,Calculate 应当走 DB 价(cost 翻倍),并把 DB 记录 ID 写回结果。
+	// 用 100K tokens 避开 1M-context 阈值,让两条路径都走线性公式,比较精确。
+	calc := NewCalculator()
+	metrics := &usage.Metrics{InputTokens: 100_000}
+	baseline := calc.Calculate("claude-sonnet-4-5", metrics, 0)
+
+	calc.LoadFromDatabase([]*domain.ModelPrice{
+		{
+			ID:              42,
+			ModelID:         "claude-sonnet-4-5",
+			InputPriceMicro: 6_000_000,
+		},
+	})
+
+	got := calc.Calculate("claude-sonnet-4-5", metrics, 0)
+	if got.ModelPriceID != 42 {
+		t.Errorf("after LoadFromDatabase, ModelPriceID = %d, want 42", got.ModelPriceID)
+	}
+	if got.Cost != baseline.Cost*2 {
+		t.Errorf("DB price not applied: db=%d builtin=%d (want db = 2× builtin)", got.Cost, baseline.Cost)
+	}
+}
+
+func TestCalculator_LoadFromDatabase_KeepsBuiltinForUnoverridden(t *testing.T) {
+	// LoadFromDatabase 只覆盖 DB 中存在的 ModelID;未覆盖的模型仍应能用内置价计算。
+	// 这是为了让用户只配置自己关心的模型,其余继续走内置。
+	calc := NewCalculator()
+	calc.LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 7, ModelID: "claude-sonnet-4-5", InputPriceMicro: 6_000_000},
+	})
+
+	got := calc.Calculate("gpt-4o", &usage.Metrics{InputTokens: 1_000_000}, 0)
+	if got.Cost == 0 {
+		t.Fatal("gpt-4o cost should still be computed from builtin defaults")
+	}
+	if got.ModelPriceID != 0 {
+		t.Errorf("gpt-4o ModelPriceID = %d, want 0 (builtin)", got.ModelPriceID)
+	}
+}
+
+func TestCalculator_GetModelPriceByID(t *testing.T) {
+	calc := NewCalculator()
+	calc.LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 99, ModelID: "claude-sonnet-4-5", InputPriceMicro: 1_000_000},
+	})
+
+	got := calc.GetModelPriceByID(99)
+	if got == nil || got.ModelID != "claude-sonnet-4-5" {
+		t.Errorf("GetModelPriceByID(99) = %+v, want claude-sonnet-4-5", got)
+	}
+	if calc.GetModelPriceByID(0) != nil {
+		t.Error("GetModelPriceByID(0) should be nil; builtins are not indexed by ID")
+	}
+	if calc.GetModelPriceByID(123) != nil {
+		t.Error("GetModelPriceByID for unknown ID should be nil")
+	}
+}
+
+func TestCalculator_Calculate_ZeroMultiplierDefaultsToOne(t *testing.T) {
+	// 倍率传 0 时,实际应用 DefaultMultiplier(10000),且结果里也回填 10000。
+	// 这是 backfill 旧数据(没有 multiplier 列)的兜底语义。
+	calc := NewCalculator()
+	metrics := &usage.Metrics{InputTokens: 1_000_000}
+	base := calc.Calculate("claude-sonnet-4-5", metrics, DefaultMultiplier)
+	zero := calc.Calculate("claude-sonnet-4-5", metrics, 0)
+	if zero.Cost != base.Cost {
+		t.Errorf("Cost(mul=0) = %d, want = Cost(mul=10000) = %d", zero.Cost, base.Cost)
+	}
+	if zero.Multiplier != DefaultMultiplier {
+		t.Errorf("Multiplier(mul=0) = %d, want %d", zero.Multiplier, DefaultMultiplier)
+	}
+}
+
+func TestCalculator_Calculate_UnknownModelKeepsMultiplier(t *testing.T) {
+	// 模型未命中价表时返回零成本,但 Multiplier 仍按入参回填(便于审计与日志)。
+	calc := NewCalculator()
+	got := calc.Calculate("nope-not-in-table", &usage.Metrics{InputTokens: 1000}, 15000)
+	if got.Cost != 0 {
+		t.Errorf("unknown model Cost = %d, want 0", got.Cost)
+	}
+	if got.ModelPriceID != 0 {
+		t.Errorf("unknown model ModelPriceID = %d, want 0", got.ModelPriceID)
+	}
+	if got.Multiplier != 15000 {
+		t.Errorf("unknown model Multiplier = %d, want 15000 (echo back input)", got.Multiplier)
 	}
 }
 

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -119,20 +119,7 @@ func (p *ModelPricing) GetContext1MThreshold() uint64 {
 	return 200000
 }
 
-// GetInputPremiumFraction 获取超阈值input倍率（分数）
-// 默认 2/1 = 2.0
-func (p *ModelPricing) GetInputPremiumFraction() (num, denom uint64) {
-	num, denom = p.InputPremiumNum, p.InputPremiumDenom
-	if num == 0 {
-		num = 2
-	}
-	if denom == 0 {
-		denom = 1
-	}
-	return
-}
-
-// GetInputPremiumNum 获取超阈值input倍率分子（默认2）
+// GetInputPremiumNum 获取超阈值 input 倍率分子(默认 2)
 func (p *ModelPricing) GetInputPremiumNum() uint64 {
 	if p.InputPremiumNum > 0 {
 		return p.InputPremiumNum
@@ -140,7 +127,7 @@ func (p *ModelPricing) GetInputPremiumNum() uint64 {
 	return 2
 }
 
-// GetInputPremiumDenom 获取超阈值input倍率分母（默认1）
+// GetInputPremiumDenom 获取超阈值 input 倍率分母(默认 1)
 func (p *ModelPricing) GetInputPremiumDenom() uint64 {
 	if p.InputPremiumDenom > 0 {
 		return p.InputPremiumDenom
@@ -148,20 +135,7 @@ func (p *ModelPricing) GetInputPremiumDenom() uint64 {
 	return 1
 }
 
-// GetOutputPremiumFraction 获取超阈值output倍率（分数）
-// 默认 3/2 = 1.5
-func (p *ModelPricing) GetOutputPremiumFraction() (num, denom uint64) {
-	num, denom = p.OutputPremiumNum, p.OutputPremiumDenom
-	if num == 0 {
-		num = 3
-	}
-	if denom == 0 {
-		denom = 2
-	}
-	return
-}
-
-// GetOutputPremiumNum 获取超阈值output倍率分子（默认3）
+// GetOutputPremiumNum 获取超阈值 output 倍率分子(默认 3)
 func (p *ModelPricing) GetOutputPremiumNum() uint64 {
 	if p.OutputPremiumNum > 0 {
 		return p.OutputPremiumNum
@@ -169,7 +143,7 @@ func (p *ModelPricing) GetOutputPremiumNum() uint64 {
 	return 3
 }
 
-// GetOutputPremiumDenom 获取超阈值output倍率分母（默认2）
+// GetOutputPremiumDenom 获取超阈值 output 倍率分母(默认 2)
 func (p *ModelPricing) GetOutputPremiumDenom() uint64 {
 	if p.OutputPremiumDenom > 0 {
 		return p.OutputPremiumDenom

--- a/internal/pricing/tiered.go
+++ b/internal/pricing/tiered.go
@@ -3,14 +3,13 @@ package pricing
 import "math/big"
 
 // 价格单位常量
+//
+//	storage:  microUSD/M tokens   (1 USD = 1,000,000 microUSD)
+//	output:   nanoUSD            (1 USD = 1,000,000,000 nanoUSD)
 const (
-	// MicroUSDPerUSD 1美元 = 1,000,000 微美元 (用于价格表存储)
-	MicroUSDPerUSD = 1_000_000
-	// NanoUSDPerUSD 1美元 = 1,000,000,000 纳美元 (用于成本存储，提供更高精度)
-	NanoUSDPerUSD = 1_000_000_000
-	// TokensPerMillion 百万tokens
+	// TokensPerMillion 价格单位分母:百万 tokens。
 	TokensPerMillion = 1_000_000
-	// MicroToNano 微美元转纳美元的倍数
+	// MicroToNano 微美元到纳美元的倍数(成本输出乘以这个值)。
 	MicroToNano = 1000
 )
 
@@ -70,22 +69,3 @@ func calculateLinearCostBig(tokens, priceMicro uint64) uint64 {
 	return t.Uint64()
 }
 
-// Deprecated: 使用 CalculateTieredCost 代替
-func CalculateTieredCostMicro(tokens uint64, basePriceMicro uint64, premiumNum, premiumDenom, threshold uint64) uint64 {
-	return CalculateTieredCost(tokens, basePriceMicro, premiumNum, premiumDenom, threshold) / MicroToNano
-}
-
-// Deprecated: 使用 CalculateLinearCost 代替
-func CalculateLinearCostMicro(tokens, priceMicro uint64) uint64 {
-	return CalculateLinearCost(tokens, priceMicro) / MicroToNano
-}
-
-// NanoToUSD 将纳美元转换为美元（用于显示）
-func NanoToUSD(nanoUSD uint64) float64 {
-	return float64(nanoUSD) / NanoUSDPerUSD
-}
-
-// MicroToUSD 将微美元转换为美元（用于显示）
-func MicroToUSD(microUSD uint64) float64 {
-	return float64(microUSD) / MicroUSDPerUSD
-}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -156,6 +156,10 @@ type ProxyRequestRepository interface {
 	HasRecentRequests(since time.Time) (bool, error)
 	// UpdateCost updates only the cost field of a request
 	UpdateCost(id uint64, cost uint64) error
+	// UpdateCostAtomically updates the request cost AND a batch of attempt cost updates
+	// in a single transaction. Used by RecalculateRequestCost to keep
+	// proxy_requests.cost == SUM(proxy_upstream_attempts.cost) atomic.
+	UpdateCostAtomically(requestID, requestCost uint64, attemptUpdates map[uint64]domain.AttemptCostUpdate) error
 	// RecalculateCostsFromAttempts recalculates all request costs by summing their attempt costs
 	RecalculateCostsFromAttempts() (int64, error)
 	// RecalculateCostsFromAttemptsWithProgress recalculates all request costs with progress reporting via channel

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -156,10 +156,6 @@ type ProxyRequestRepository interface {
 	HasRecentRequests(since time.Time) (bool, error)
 	// UpdateCost updates only the cost field of a request
 	UpdateCost(id uint64, cost uint64) error
-	// AddCost adds a delta to the cost field of a request (can be negative)
-	AddCost(id uint64, delta int64) error
-	// BatchUpdateCosts updates costs for multiple requests in a single transaction
-	BatchUpdateCosts(updates map[uint64]uint64) error
 	// RecalculateCostsFromAttempts recalculates all request costs by summing their attempt costs
 	RecalculateCostsFromAttempts() (int64, error)
 	// RecalculateCostsFromAttemptsWithProgress recalculates all request costs with progress reporting via channel
@@ -180,10 +176,9 @@ type ProxyUpstreamAttemptRepository interface {
 	// StreamForCostCalc iterates through all attempts for cost calculation
 	// Calls the callback with batches of minimal data, returns early if callback returns error
 	StreamForCostCalc(batchSize int, callback func(batch []*domain.AttemptCostData) error) error
-	// UpdateCost updates only the cost field of an attempt
-	UpdateCost(id uint64, cost uint64) error
-	// BatchUpdateCosts updates costs for multiple attempts in a single transaction
-	BatchUpdateCosts(updates map[uint64]uint64) error
+	// BatchUpdateCosts 批量更新 attempt 的 cost 和 model_price_id。
+	// model_price_id 跟随 cost 一起更新到当前匹配的价格记录,保证审计字段与金额一致。
+	BatchUpdateCosts(updates map[uint64]domain.AttemptCostUpdate) error
 	// MarkStaleAttemptsFailed marks stale attempts as failed with proper end_time and duration
 	MarkStaleAttemptsFailed() (int64, error)
 	// FixFailedAttemptsWithoutEndTime fixes FAILED attempts that have no end_time set

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -345,6 +345,18 @@ func (r *ProxyRequestRepository) UpdateCost(id uint64, cost uint64) error {
 	return r.db.gorm.Model(&ProxyRequest{}).Where("id = ?", id).Update("cost", cost).Error
 }
 
+// UpdateCostAtomically 一个事务里同时更新 proxy_requests.cost 和一批 attempt 的 cost+model_price_id。
+// 保证 proxy_requests.cost == SUM(proxy_upstream_attempts.cost) 这条不变量在中途不会被打破:
+// 如果只用两步独立写,attempt 写完 / request 写失败 会留下父子不一致的窗口,审计后续很难发现。
+func (r *ProxyRequestRepository) UpdateCostAtomically(requestID, requestCost uint64, attemptUpdates map[uint64]domain.AttemptCostUpdate) error {
+	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		if err := batchUpdateAttemptCostsInTx(tx, attemptUpdates); err != nil {
+			return err
+		}
+		return tx.Model(&ProxyRequest{}).Where("id = ?", requestID).Update("cost", requestCost).Error
+	})
+}
+
 // RecalculateCostsFromAttempts recalculates all request costs by summing their attempt costs
 func (r *ProxyRequestRepository) RecalculateCostsFromAttempts() (int64, error) {
 	return r.RecalculateCostsFromAttemptsWithProgress(nil)

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -345,64 +345,6 @@ func (r *ProxyRequestRepository) UpdateCost(id uint64, cost uint64) error {
 	return r.db.gorm.Model(&ProxyRequest{}).Where("id = ?", id).Update("cost", cost).Error
 }
 
-// AddCost adds a delta to the cost field of a request (can be negative)
-func (r *ProxyRequestRepository) AddCost(id uint64, delta int64) error {
-	return r.db.gorm.Model(&ProxyRequest{}).Where("id = ?", id).
-		Update("cost", gorm.Expr("cost + ?", delta)).Error
-}
-
-// BatchUpdateCosts updates costs for multiple requests in a single transaction
-func (r *ProxyRequestRepository) BatchUpdateCosts(updates map[uint64]uint64) error {
-	if len(updates) == 0 {
-		return nil
-	}
-
-	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
-		// Use CASE WHEN for batch update
-		const batchSize = 500
-		ids := make([]uint64, 0, len(updates))
-		for id := range updates {
-			ids = append(ids, id)
-		}
-
-		for i := 0; i < len(ids); i += batchSize {
-			end := i + batchSize
-			if end > len(ids) {
-				end = len(ids)
-			}
-			batchIDs := ids[i:end]
-
-			// Build CASE WHEN statement
-			var cases strings.Builder
-			cases.WriteString("CASE id ")
-			args := make([]interface{}, 0, len(batchIDs)*3+1)
-
-			// First: CASE WHEN pairs (id, cost)
-			for _, id := range batchIDs {
-				cases.WriteString("WHEN ? THEN ? ")
-				args = append(args, id, updates[id])
-			}
-			cases.WriteString("END")
-
-			// Second: timestamp for updated_at
-			args = append(args, time.Now().UnixMilli())
-
-			// Third: WHERE IN ids
-			for _, id := range batchIDs {
-				args = append(args, id)
-			}
-
-			sql := fmt.Sprintf("UPDATE proxy_requests SET cost = %s, updated_at = ? WHERE id IN (?%s)",
-				cases.String(), strings.Repeat(",?", len(batchIDs)-1))
-
-			if err := tx.Exec(sql, args...).Error; err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-}
-
 // RecalculateCostsFromAttempts recalculates all request costs by summing their attempt costs
 func (r *ProxyRequestRepository) RecalculateCostsFromAttempts() (int64, error) {
 	return r.RecalculateCostsFromAttemptsWithProgress(nil)

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -186,61 +186,73 @@ func (r *ProxyUpstreamAttemptRepository) FixFailedAttemptsWithoutEndTime() (int6
 
 // BatchUpdateCosts 批量更新 attempt 的 cost 和 model_price_id。
 // model_price_id 在重算时会跟着 cost 一起更新到当前匹配的价格记录,二者保持一致。
+//
+// 内部走 r.db.gorm.Transaction;若调用方已经持有 tx,改用 batchUpdateAttemptCostsInTx 直接拼进去。
 func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]domain.AttemptCostUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}
 
 	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
-		const batchSize = 500
-		ids := make([]uint64, 0, len(updates))
-		for id := range updates {
-			ids = append(ids, id)
-		}
-
-		for i := 0; i < len(ids); i += batchSize {
-			end := i + batchSize
-			if end > len(ids) {
-				end = len(ids)
-			}
-			batchIDs := ids[i:end]
-
-			var costCases, priceIDCases strings.Builder
-			costCases.WriteString("CASE id ")
-			priceIDCases.WriteString("CASE id ")
-			args := make([]interface{}, 0, len(batchIDs)*4)
-
-			for _, id := range batchIDs {
-				costCases.WriteString("WHEN ? THEN ? ")
-				args = append(args, id, updates[id].Cost)
-			}
-			costCases.WriteString("END")
-
-			for _, id := range batchIDs {
-				priceIDCases.WriteString("WHEN ? THEN ? ")
-				args = append(args, id, updates[id].ModelPriceID)
-			}
-			priceIDCases.WriteString("END")
-
-			// Second: timestamp for updated_at
-			args = append(args, time.Now().UnixMilli())
-
-			// Third: WHERE IN ids
-			for _, id := range batchIDs {
-				args = append(args, id)
-			}
-
-			sql := fmt.Sprintf(
-				"UPDATE proxy_upstream_attempts SET cost = %s, model_price_id = %s, updated_at = ? WHERE id IN (?%s)",
-				costCases.String(), priceIDCases.String(), strings.Repeat(",?", len(batchIDs)-1),
-			)
-
-			if err := tx.Exec(sql, args...).Error; err != nil {
-				return err
-			}
-		}
-		return nil
+		return batchUpdateAttemptCostsInTx(tx, updates)
 	})
+}
+
+// batchUpdateAttemptCostsInTx 用调用方提供的 tx 执行批量 cost+model_price_id 更新。
+// 抽出来供需要跨表事务的路径(例如 ProxyRequestRepository.UpdateCostAtomically)调用,
+// 让父请求 cost 和 attempt cost 在一个事务里写,避免 partial-state window。
+func batchUpdateAttemptCostsInTx(tx *gorm.DB, updates map[uint64]domain.AttemptCostUpdate) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	const batchSize = 500
+	ids := make([]uint64, 0, len(updates))
+	for id := range updates {
+		ids = append(ids, id)
+	}
+
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batchIDs := ids[i:end]
+
+		var costCases, priceIDCases strings.Builder
+		costCases.WriteString("CASE id ")
+		priceIDCases.WriteString("CASE id ")
+		args := make([]interface{}, 0, len(batchIDs)*4)
+
+		for _, id := range batchIDs {
+			costCases.WriteString("WHEN ? THEN ? ")
+			args = append(args, id, updates[id].Cost)
+		}
+		costCases.WriteString("END")
+
+		for _, id := range batchIDs {
+			priceIDCases.WriteString("WHEN ? THEN ? ")
+			args = append(args, id, updates[id].ModelPriceID)
+		}
+		priceIDCases.WriteString("END")
+
+		// timestamp for updated_at
+		args = append(args, time.Now().UnixMilli())
+
+		// WHERE IN ids
+		for _, id := range batchIDs {
+			args = append(args, id)
+		}
+
+		sql := fmt.Sprintf(
+			"UPDATE proxy_upstream_attempts SET cost = %s, model_price_id = %s, updated_at = ? WHERE id IN (?%s)",
+			costCases.String(), priceIDCases.String(), strings.Repeat(",?", len(batchIDs)-1),
+		)
+
+		if err := tx.Exec(sql, args...).Error; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ClearDetailOlderThan 清理指定时间之前 attempt 的详情字段（request_info 和 response_info）

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -80,10 +80,11 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 			Cache1hWriteCount uint64 `gorm:"column:cache_1h_write_count"`
 			Cost              uint64 `gorm:"column:cost"`
 			Multiplier        uint64 `gorm:"column:multiplier"`
+			ModelPriceID      uint64 `gorm:"column:model_price_id"`
 		}
 
 		err := r.db.gorm.Table("proxy_upstream_attempts").
-			Select("id, proxy_request_id, response_model, mapped_model, request_model, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, multiplier").
+			Select("id, proxy_request_id, response_model, mapped_model, request_model, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, multiplier, model_price_id").
 			Where("id > ?", lastID).
 			Order("id").
 			Limit(batchSize).
@@ -114,6 +115,7 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 				Cache1hWriteCount: r.Cache1hWriteCount,
 				Cost:              r.Cost,
 				Multiplier:        r.Multiplier,
+				ModelPriceID:      r.ModelPriceID,
 			}
 		}
 

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -79,10 +79,11 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 			Cache5mWriteCount uint64 `gorm:"column:cache_5m_write_count"`
 			Cache1hWriteCount uint64 `gorm:"column:cache_1h_write_count"`
 			Cost              uint64 `gorm:"column:cost"`
+			Multiplier        uint64 `gorm:"column:multiplier"`
 		}
 
 		err := r.db.gorm.Table("proxy_upstream_attempts").
-			Select("id, proxy_request_id, response_model, mapped_model, request_model, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost").
+			Select("id, proxy_request_id, response_model, mapped_model, request_model, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, multiplier").
 			Where("id > ?", lastID).
 			Order("id").
 			Limit(batchSize).
@@ -112,6 +113,7 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 				Cache5mWriteCount: r.Cache5mWriteCount,
 				Cache1hWriteCount: r.Cache1hWriteCount,
 				Cost:              r.Cost,
+				Multiplier:        r.Multiplier,
 			}
 		}
 
@@ -127,10 +129,6 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 	}
 
 	return nil
-}
-
-func (r *ProxyUpstreamAttemptRepository) UpdateCost(id uint64, cost uint64) error {
-	return r.db.gorm.Model(&ProxyUpstreamAttempt{}).Where("id = ?", id).Update("cost", cost).Error
 }
 
 // MarkStaleAttemptsFailed marks all IN_PROGRESS/PENDING attempts belonging to stale requests as FAILED
@@ -184,14 +182,14 @@ func (r *ProxyUpstreamAttemptRepository) FixFailedAttemptsWithoutEndTime() (int6
 	return result.RowsAffected, nil
 }
 
-// BatchUpdateCosts updates costs for multiple attempts in a single transaction
-func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uint64) error {
+// BatchUpdateCosts 批量更新 attempt 的 cost 和 model_price_id。
+// model_price_id 在重算时会跟着 cost 一起更新到当前匹配的价格记录,二者保持一致。
+func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]domain.AttemptCostUpdate) error {
 	if len(updates) == 0 {
 		return nil
 	}
 
 	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
-		// Use CASE WHEN for batch update
 		const batchSize = 500
 		ids := make([]uint64, 0, len(updates))
 		for id := range updates {
@@ -205,17 +203,22 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 			}
 			batchIDs := ids[i:end]
 
-			// Build CASE WHEN statement
-			var cases strings.Builder
-			cases.WriteString("CASE id ")
-			args := make([]interface{}, 0, len(batchIDs)*3+1)
+			var costCases, priceIDCases strings.Builder
+			costCases.WriteString("CASE id ")
+			priceIDCases.WriteString("CASE id ")
+			args := make([]interface{}, 0, len(batchIDs)*4)
 
-			// First: CASE WHEN pairs (id, cost)
 			for _, id := range batchIDs {
-				cases.WriteString("WHEN ? THEN ? ")
-				args = append(args, id, updates[id])
+				costCases.WriteString("WHEN ? THEN ? ")
+				args = append(args, id, updates[id].Cost)
 			}
-			cases.WriteString("END")
+			costCases.WriteString("END")
+
+			for _, id := range batchIDs {
+				priceIDCases.WriteString("WHEN ? THEN ? ")
+				args = append(args, id, updates[id].ModelPriceID)
+			}
+			priceIDCases.WriteString("END")
 
 			// Second: timestamp for updated_at
 			args = append(args, time.Now().UnixMilli())
@@ -225,8 +228,10 @@ func (r *ProxyUpstreamAttemptRepository) BatchUpdateCosts(updates map[uint64]uin
 				args = append(args, id)
 			}
 
-			sql := fmt.Sprintf("UPDATE proxy_upstream_attempts SET cost = %s, updated_at = ? WHERE id IN (?%s)",
-				cases.String(), strings.Repeat(",?", len(batchIDs)-1))
+			sql := fmt.Sprintf(
+				"UPDATE proxy_upstream_attempts SET cost = %s, model_price_id = %s, updated_at = ? WHERE id IN (?%s)",
+				costCases.String(), priceIDCases.String(), strings.Repeat(",?", len(batchIDs)-1),
+			)
 
 			if err := tx.Exec(sql, args...).Error; err != nil {
 				return err

--- a/internal/repository/sqlite/proxy_upstream_attempt_test.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt_test.go
@@ -7,6 +7,122 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
+// TestStreamForCostCalc_IncludesMultiplier 确保 backfill 流式读取路径会把
+// 历史 Multiplier 带出来。这是 PR1 修复 backfill 倍率丢失 bug 的关键前提:
+// 如果 SELECT 不查 multiplier,calculator 在重算时拿不到历史值,只能默认 1.0×。
+func TestStreamForCostCalc_IncludesMultiplier(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	attRepo := NewProxyUpstreamAttemptRepository(db)
+
+	att := &domain.ProxyUpstreamAttempt{
+		TenantID:        1,
+		Status:          "COMPLETED",
+		ProxyRequestID:  100,
+		RequestModel:    "claude-sonnet-4-5",
+		ResponseModel:   "claude-sonnet-4-5",
+		InputTokenCount: 1000,
+		Multiplier:      12_500, // 1.25×
+		ModelPriceID:    7,
+		Cost:            1234,
+	}
+	if err := attRepo.Create(att); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+
+	var got *domain.AttemptCostData
+	if err := attRepo.StreamForCostCalc(10, func(batch []*domain.AttemptCostData) error {
+		if len(batch) != 1 {
+			t.Fatalf("batch size = %d, want 1", len(batch))
+		}
+		got = batch[0]
+		return nil
+	}); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+
+	if got.Multiplier != 12_500 {
+		t.Errorf("Multiplier = %d, want 12500", got.Multiplier)
+	}
+	if got.Cost != 1234 {
+		t.Errorf("Cost = %d, want 1234", got.Cost)
+	}
+	if got.ResponseModel != "claude-sonnet-4-5" {
+		t.Errorf("ResponseModel = %q, want claude-sonnet-4-5", got.ResponseModel)
+	}
+}
+
+// TestBatchUpdateCosts_UpdatesCostAndModelPriceID 验证 cost 和 model_price_id
+// 在同一条 UPDATE 中写入。这是 PR1 修复"重算后 cost 变了但 model_price_id
+// 停留在旧值"的不一致问题的根本检查。
+func TestBatchUpdateCosts_UpdatesCostAndModelPriceID(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	attRepo := NewProxyUpstreamAttemptRepository(db)
+
+	a1 := &domain.ProxyUpstreamAttempt{
+		TenantID: 1, Status: "COMPLETED", ProxyRequestID: 1,
+		Cost: 100, ModelPriceID: 1,
+	}
+	a2 := &domain.ProxyUpstreamAttempt{
+		TenantID: 1, Status: "COMPLETED", ProxyRequestID: 1,
+		Cost: 200, ModelPriceID: 2,
+	}
+	if err := attRepo.Create(a1); err != nil {
+		t.Fatalf("create a1: %v", err)
+	}
+	if err := attRepo.Create(a2); err != nil {
+		t.Fatalf("create a2: %v", err)
+	}
+
+	updates := map[uint64]domain.AttemptCostUpdate{
+		a1.ID: {Cost: 999, ModelPriceID: 42},
+		a2.ID: {Cost: 888, ModelPriceID: 43},
+	}
+	if err := attRepo.BatchUpdateCosts(updates); err != nil {
+		t.Fatalf("BatchUpdateCosts: %v", err)
+	}
+
+	// 直接从 DB 重新读出来,确认 cost 与 model_price_id 都被更新到新值且互相对应。
+	var rows []ProxyUpstreamAttempt
+	if err := db.gorm.Find(&rows).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	got := map[uint64]ProxyUpstreamAttempt{}
+	for _, r := range rows {
+		got[r.ID] = r
+	}
+	if got[a1.ID].Cost != 999 || got[a1.ID].ModelPriceID != 42 {
+		t.Errorf("a1 = (cost=%d, priceID=%d), want (999, 42)", got[a1.ID].Cost, got[a1.ID].ModelPriceID)
+	}
+	if got[a2.ID].Cost != 888 || got[a2.ID].ModelPriceID != 43 {
+		t.Errorf("a2 = (cost=%d, priceID=%d), want (888, 43)", got[a2.ID].Cost, got[a2.ID].ModelPriceID)
+	}
+}
+
+// TestBatchUpdateCosts_Empty 验证空入参是 no-op,不抛错(被 RecalculateCosts 在没有
+// 需要更新的 batch 上调用)。
+func TestBatchUpdateCosts_Empty(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	attRepo := NewProxyUpstreamAttemptRepository(db)
+	if err := attRepo.BatchUpdateCosts(nil); err != nil {
+		t.Errorf("empty BatchUpdateCosts returned error: %v", err)
+	}
+	if err := attRepo.BatchUpdateCosts(map[uint64]domain.AttemptCostUpdate{}); err != nil {
+		t.Errorf("empty map BatchUpdateCosts returned error: %v", err)
+	}
+}
+
 // seedAttemptForRequest 为指定 ProxyRequest 创建一个带详情的 attempt，并把 created_at 回拨
 func seedAttemptForRequest(t *testing.T, repo *ProxyUpstreamAttemptRepository, db *DB, parentID uint64, createdAt time.Time) *domain.ProxyUpstreamAttempt {
 	t.Helper()

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -935,6 +935,52 @@ func (s *AdminService) RecalculateUsageStats() error {
 	return err
 }
 
+// pickPricingModel 返回用于计价的模型名。
+// 价格表按上游真实返回的 ResponseModel 匹配最准;Mapped/Request 仅作回退。
+func pickPricingModel(responseModel, mappedModel, requestModel string) string {
+	if responseModel != "" {
+		return responseModel
+	}
+	if mappedModel != "" {
+		return mappedModel
+	}
+	return requestModel
+}
+
+// pricingModelForAttempt picks pricing model for streamed AttemptCostData (backfill path).
+func pricingModelForAttempt(a *domain.AttemptCostData) string {
+	return pickPricingModel(a.ResponseModel, a.MappedModel, a.RequestModel)
+}
+
+// pricingModelForFullAttempt picks pricing model for a full ProxyUpstreamAttempt.
+func pricingModelForFullAttempt(a *domain.ProxyUpstreamAttempt) string {
+	return pickPricingModel(a.ResponseModel, a.MappedModel, a.RequestModel)
+}
+
+// metricsFromAttemptCostData 把 backfill 用的最小 attempt 字段装进 usage.Metrics。
+func metricsFromAttemptCostData(a *domain.AttemptCostData) *usage.Metrics {
+	return &usage.Metrics{
+		InputTokens:          a.InputTokenCount,
+		OutputTokens:         a.OutputTokenCount,
+		CacheReadCount:       a.CacheReadCount,
+		CacheCreationCount:   a.CacheWriteCount,
+		Cache5mCreationCount: a.Cache5mWriteCount,
+		Cache1hCreationCount: a.Cache1hWriteCount,
+	}
+}
+
+// metricsFromFullAttempt 把完整的 attempt 字段装进 usage.Metrics(单请求重算路径)。
+func metricsFromFullAttempt(a *domain.ProxyUpstreamAttempt) *usage.Metrics {
+	return &usage.Metrics{
+		InputTokens:          a.InputTokenCount,
+		OutputTokens:         a.OutputTokenCount,
+		CacheReadCount:       a.CacheReadCount,
+		CacheCreationCount:   a.CacheWriteCount,
+		Cache5mCreationCount: a.Cache5mWriteCount,
+		Cache1hCreationCount: a.Cache1hWriteCount,
+	}
+}
+
 // RecalculateCostsResult holds the result of cost recalculation
 type RecalculateCostsResult struct {
 	TotalAttempts   int    `json:"totalAttempts"`
@@ -994,47 +1040,29 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 	calculator := pricing.GlobalCalculator()
 	processedCount := 0
 	const batchSize = 100
-	affectedRequestIDs := make(map[uint64]struct{})
 
 	// 2. Stream through attempts, process and update each batch immediately
 	err = s.attemptRepo.StreamForCostCalc(batchSize, func(batch []*domain.AttemptCostData) error {
-		attemptUpdates := make(map[uint64]uint64, len(batch))
+		attemptUpdates := make(map[uint64]domain.AttemptCostUpdate, len(batch))
 
 		for _, attempt := range batch {
-			// Use responseModel if available, otherwise use mappedModel or requestModel
-			model := attempt.ResponseModel
-			if model == "" {
-				model = attempt.MappedModel
-			}
-			if model == "" {
-				model = attempt.RequestModel
-			}
+			model := pricingModelForAttempt(attempt)
+			metrics := metricsFromAttemptCostData(attempt)
 
-			// Build metrics from attempt data
-			metrics := &usage.Metrics{
-				InputTokens:          attempt.InputTokenCount,
-				OutputTokens:         attempt.OutputTokenCount,
-				CacheReadCount:       attempt.CacheReadCount,
-				CacheCreationCount:   attempt.CacheWriteCount,
-				Cache5mCreationCount: attempt.Cache5mWriteCount,
-				Cache1hCreationCount: attempt.Cache1hWriteCount,
-			}
+			// 保留历史 Multiplier:重算用当前价表算出新 cost,
+			// 但合约层面的倍率(由 Provider×ClientType 决定)是历史值,不能在 backfill 时悄悄改。
+			res := calculator.Calculate(model, metrics, attempt.Multiplier)
 
-			// Calculate new cost
-			newCost := calculator.Calculate(model, metrics)
-
-			// Track affected request IDs
-			affectedRequestIDs[attempt.ProxyRequestID] = struct{}{}
-
-			// Track if attempt needs update
-			if newCost != attempt.Cost {
-				attemptUpdates[attempt.ID] = newCost
+			if res.Cost != attempt.Cost {
+				attemptUpdates[attempt.ID] = domain.AttemptCostUpdate{
+					Cost:         res.Cost,
+					ModelPriceID: res.ModelPriceID,
+				}
 			}
 
 			processedCount++
 		}
 
-		// Batch update attempt costs immediately
 		if len(attemptUpdates) > 0 {
 			if err := s.attemptRepo.BatchUpdateCosts(attemptUpdates); err != nil {
 				log.Printf("[RecalculateCosts] Failed to batch update attempts: %v", err)
@@ -1043,11 +1071,10 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 			}
 		}
 
-		// Broadcast progress
 		broadcastProgress("calculating", processedCount, int(totalCount),
 			fmt.Sprintf("Processed %d/%d attempts", processedCount, totalCount))
 
-		// Small delay to allow UI to update (WebSocket messages need time to be processed)
+		// 给 UI 一点时间消费 WebSocket 消息;否则进度条会一段段跳。
 		time.Sleep(50 * time.Millisecond)
 
 		return nil
@@ -1114,39 +1141,29 @@ func (s *AdminService) RecalculateRequestCost(tenantID uint64, requestID uint64)
 
 	calculator := pricing.GlobalCalculator()
 	var totalCost uint64
+	updates := make(map[uint64]domain.AttemptCostUpdate, len(attempts))
 
 	// 3. Recalculate cost for each attempt
 	for _, attempt := range attempts {
-		// Use responseModel if available, otherwise use mappedModel or requestModel
-		model := attempt.ResponseModel
-		if model == "" {
-			model = attempt.MappedModel
-		}
-		if model == "" {
-			model = attempt.RequestModel
-		}
+		model := pricingModelForFullAttempt(attempt)
+		metrics := metricsFromFullAttempt(attempt)
 
-		// Build metrics from attempt data
-		metrics := &usage.Metrics{
-			InputTokens:          attempt.InputTokenCount,
-			OutputTokens:         attempt.OutputTokenCount,
-			CacheReadCount:       attempt.CacheReadCount,
-			CacheCreationCount:   attempt.CacheWriteCount,
-			Cache5mCreationCount: attempt.Cache5mWriteCount,
-			Cache1hCreationCount: attempt.Cache1hWriteCount,
-		}
+		res := calculator.Calculate(model, metrics, attempt.Multiplier)
+		totalCost += res.Cost
 
-		// Calculate new cost
-		newCost := calculator.Calculate(model, metrics)
-		totalCost += newCost
-
-		// Update attempt cost if changed
-		if newCost != attempt.Cost {
-			if err := s.attemptRepo.UpdateCost(attempt.ID, newCost); err != nil {
-				log.Printf("[RecalculateRequestCost] Failed to update attempt %d cost: %v", attempt.ID, err)
-				continue
+		if res.Cost != attempt.Cost {
+			updates[attempt.ID] = domain.AttemptCostUpdate{
+				Cost:         res.Cost,
+				ModelPriceID: res.ModelPriceID,
 			}
-			result.UpdatedAttempts++
+		}
+	}
+
+	if len(updates) > 0 {
+		if err := s.attemptRepo.BatchUpdateCosts(updates); err != nil {
+			log.Printf("[RecalculateRequestCost] Failed to update attempts: %v", err)
+		} else {
+			result.UpdatedAttempts = len(updates)
 		}
 	}
 

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
@@ -1091,21 +1092,32 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 		return nil, fmt.Errorf("failed to stream attempts: %w", err)
 	}
 
-	// 3. Recalculate request costs from attempts (with progress via channel)
+	// 3. Recalculate request costs from attempts (with progress via channel).
+	// 记一下最后一次见到的 progress,失败时用 request 单位重放(避免 step-2 attempt 单位串台)。
 	progressChan := make(chan domain.Progress, 10)
+	var lastReqProgress domain.Progress
+	var progressMu sync.Mutex
+	progressDone := make(chan struct{})
 	go func() {
+		defer close(progressDone)
 		for progress := range progressChan {
+			progressMu.Lock()
+			lastReqProgress = progress
+			progressMu.Unlock()
 			broadcastProgress(progress.Phase, progress.Current, progress.Total, progress.Message)
 		}
 	}()
 
 	updatedRequests, err := s.proxyRequestRepo.RecalculateCostsFromAttemptsWithProgress(progressChan)
 	close(progressChan)
+	<-progressDone // 确保 goroutine drain 完成,后面读 lastReqProgress 不竞争
 
 	if err != nil {
 		// Step 3 失败时不能继续 broadcast "completed":attempts 行已改、父 request 部分
 		// 未同步,UI 报成功会掩盖审计偏差。统一传播错误 + 发 failed phase 让运维知道。
-		broadcastProgress("failed", result.UpdatedAttempts, int(totalCount),
+		// counter 单位用 step-3 自己看到的最后一次进度(request 单位),不是 step-2 的 attempt 单位 —
+		// 后者会让进度条在失败时跳回到一个无意义的位置。
+		broadcastProgress("failed", lastReqProgress.Current, lastReqProgress.Total,
 			fmt.Sprintf("failed to recalculate request costs: %v", err))
 		return nil, fmt.Errorf("failed to recalculate request costs: %w", err)
 	}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1084,6 +1084,10 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 	})
 
 	if err != nil {
+		// Step 2 failed (attempt-cost rewrite). 把 phase 改成 failed 让 UI 不会卡在
+		// 最后一次 "calculating N/M";否则进度条会永远停在那里直到超时。
+		broadcastProgress("failed", processedCount, int(totalCount),
+			fmt.Sprintf("failed to stream attempts: %v", err))
 		return nil, fmt.Errorf("failed to stream attempts: %w", err)
 	}
 
@@ -1099,10 +1103,13 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 	close(progressChan)
 
 	if err != nil {
-		log.Printf("[RecalculateCosts] Failed to recalculate request costs: %v", err)
-	} else {
-		result.UpdatedRequests = int(updatedRequests)
+		// Step 3 失败时不能继续 broadcast "completed":attempts 行已改、父 request 部分
+		// 未同步,UI 报成功会掩盖审计偏差。统一传播错误 + 发 failed phase 让运维知道。
+		broadcastProgress("failed", result.UpdatedAttempts, int(totalCount),
+			fmt.Sprintf("failed to recalculate request costs: %v", err))
+		return nil, fmt.Errorf("failed to recalculate request costs: %w", err)
 	}
+	result.UpdatedRequests = int(updatedRequests)
 
 	broadcastProgress("updating_requests", result.UpdatedRequests, result.UpdatedRequests,
 		fmt.Sprintf("Updated %d requests", result.UpdatedRequests))
@@ -1164,20 +1171,13 @@ func (s *AdminService) RecalculateRequestCost(tenantID uint64, requestID uint64)
 		}
 	}
 
-	if len(updates) > 0 {
-		// 不能 swallow:否则 attempts 行没刷,父 request.Cost 却基于内存计算值更新,
-		// 导致 proxy_requests.cost != SUM(proxy_upstream_attempts.cost)。
-		if err := s.attemptRepo.BatchUpdateCosts(updates); err != nil {
-			return nil, fmt.Errorf("batch update attempts: %w", err)
-		}
-		result.UpdatedAttempts = len(updates)
-	}
-
-	// 4. Update request cost
+	// 4. Atomic write:attempt updates + request cost 在一个事务里写,
+	// 避免 BatchUpdate 成功后 UpdateCost 失败留下"子刷父没刷"的反向 partial-state window。
 	result.NewCost = totalCost
-	if err := s.proxyRequestRepo.UpdateCost(requestID, totalCost); err != nil {
-		return nil, fmt.Errorf("failed to update request cost: %w", err)
+	if err := s.proxyRequestRepo.UpdateCostAtomically(requestID, totalCost, updates); err != nil {
+		return nil, fmt.Errorf("failed to update request and attempt costs atomically: %w", err)
 	}
+	result.UpdatedAttempts = len(updates)
 
 	result.Message = fmt.Sprintf("Recalculated request %d: %d -> %d (updated %d attempts)",
 		requestID, result.OldCost, result.NewCost, result.UpdatedAttempts)

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1053,7 +1053,9 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 			// 但合约层面的倍率(由 Provider×ClientType 决定)是历史值,不能在 backfill 时悄悄改。
 			res := calculator.Calculate(model, metrics, attempt.Multiplier)
 
-			if res.Cost != attempt.Cost {
+			// 同步刷 model_price_id 以保留审计:即使 cost 没变,
+			// 若价格记录被替换成等额新版本,旧 ID 也必须更新到当前匹配的行。
+			if res.Cost != attempt.Cost || res.ModelPriceID != attempt.ModelPriceID {
 				attemptUpdates[attempt.ID] = domain.AttemptCostUpdate{
 					Cost:         res.Cost,
 					ModelPriceID: res.ModelPriceID,
@@ -1064,11 +1066,12 @@ func (s *AdminService) RecalculateCosts() (*RecalculateCostsResult, error) {
 		}
 
 		if len(attemptUpdates) > 0 {
+			// 把写入失败传播出去:吞掉的话父请求 cost 会基于内存重算值更新,
+			// 跟数据库里实际 attempt 行不一致,后续审计很难发现。
 			if err := s.attemptRepo.BatchUpdateCosts(attemptUpdates); err != nil {
-				log.Printf("[RecalculateCosts] Failed to batch update attempts: %v", err)
-			} else {
-				result.UpdatedAttempts += len(attemptUpdates)
+				return fmt.Errorf("batch update attempts: %w", err)
 			}
+			result.UpdatedAttempts += len(attemptUpdates)
 		}
 
 		broadcastProgress("calculating", processedCount, int(totalCount),
@@ -1151,7 +1154,9 @@ func (s *AdminService) RecalculateRequestCost(tenantID uint64, requestID uint64)
 		res := calculator.Calculate(model, metrics, attempt.Multiplier)
 		totalCost += res.Cost
 
-		if res.Cost != attempt.Cost {
+		// 同步刷 model_price_id 以保留审计:即使 cost 不变,
+		// 若价格记录被替换成等额新版本,旧 ID 也必须更新到当前匹配的行。
+		if res.Cost != attempt.Cost || res.ModelPriceID != attempt.ModelPriceID {
 			updates[attempt.ID] = domain.AttemptCostUpdate{
 				Cost:         res.Cost,
 				ModelPriceID: res.ModelPriceID,
@@ -1160,11 +1165,12 @@ func (s *AdminService) RecalculateRequestCost(tenantID uint64, requestID uint64)
 	}
 
 	if len(updates) > 0 {
+		// 不能 swallow:否则 attempts 行没刷,父 request.Cost 却基于内存计算值更新,
+		// 导致 proxy_requests.cost != SUM(proxy_upstream_attempts.cost)。
 		if err := s.attemptRepo.BatchUpdateCosts(updates); err != nil {
-			log.Printf("[RecalculateRequestCost] Failed to update attempts: %v", err)
-		} else {
-			result.UpdatedAttempts = len(updates)
+			return nil, fmt.Errorf("batch update attempts: %w", err)
 		}
+		result.UpdatedAttempts = len(updates)
 	}
 
 	// 4. Update request cost

--- a/internal/service/recalculate_costs_test.go
+++ b/internal/service/recalculate_costs_test.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/pricing"
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
+)
+
+// TestRecalculateCosts_PreservesHistoricalMultiplier 是 PR1 修复的核心 bug 的端到端覆盖:
+//
+// 重算之前的实现把 multiplier 完全忽略,导致用户合约里 "Claude 客户端在 X provider
+// 上算 1.2×" 这种历史成本被悄悄抹平成 1.0×。修复后,重算应:
+//  1. 用当前价表算出新的基础 cost
+//  2. 应用 attempt 上历史保存的 Multiplier
+//  3. 把 model_price_id 同步更新到当前匹配的价格记录 ID
+//
+// 这个测试同时锁住这三条不变量;任一回退都会失败。
+func TestRecalculateCosts_PreservesHistoricalMultiplier(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	attRepo := sqlite.NewProxyUpstreamAttemptRepository(db)
+	reqRepo := sqlite.NewProxyRequestRepository(db)
+
+	// 注入一个完全受控的价格记录:test-model, input=$3/M, 无 1M context, 无 cache 字段。
+	// 这样 1M input tokens 的基础成本就是 3,000,000,000 nanoUSD,容易心算验证。
+	pricing.GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{
+		{
+			ID:              123,
+			ModelID:         "test-model",
+			InputPriceMicro: 3_000_000, // $3/M
+		},
+	})
+	// 测试完后还原,避免污染后续测试中的 GlobalCalculator 单例。
+	t.Cleanup(func() {
+		pricing.GlobalCalculator().LoadFromDatabase(nil)
+	})
+
+	// 父请求(RecalculateCostsFromAttemptsWithProgress 需要 proxy_requests 行存在)。
+	req := &domain.ProxyRequest{
+		TenantID:  1,
+		Status:    "COMPLETED",
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}
+	if err := reqRepo.Create(req); err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	// Attempt:历史 Multiplier=12000(1.2×),旧 Cost=999(故意写错以验证会被改正),
+	// 旧 ModelPriceID=88(故意指向不存在的 ID,以验证会被更新)。
+	att := &domain.ProxyUpstreamAttempt{
+		TenantID:        1,
+		Status:          "COMPLETED",
+		ProxyRequestID:  req.ID,
+		ResponseModel:   "test-model",
+		InputTokenCount: 1_000_000,
+		Multiplier:      12_000, // 1.2×
+		ModelPriceID:    88,     // 历史旧记录
+		Cost:            999,    // 故意写错
+	}
+	if err := attRepo.Create(att); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+
+	svc := &AdminService{
+		attemptRepo:      attRepo,
+		proxyRequestRepo: reqRepo,
+	}
+
+	result, err := svc.RecalculateCosts()
+	if err != nil {
+		t.Fatalf("RecalculateCosts: %v", err)
+	}
+	if result.UpdatedAttempts != 1 {
+		t.Errorf("UpdatedAttempts = %d, want 1", result.UpdatedAttempts)
+	}
+
+	// Expected:1M tokens × $3/M = $3 = 3_000_000_000 nano,再乘 1.2 → 3_600_000_000。
+	const expected = uint64(3_600_000_000)
+
+	var attempts []sqlite.ProxyUpstreamAttempt
+	if err := db.GormDB().Find(&attempts).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("got %d attempts, want 1", len(attempts))
+	}
+	got := attempts[0]
+	if got.Cost != expected {
+		t.Errorf("Cost = %d, want %d (multiplier应应用)", got.Cost, expected)
+	}
+	if got.ModelPriceID != 123 {
+		t.Errorf("ModelPriceID = %d, want 123 (应同步到当前匹配 ID)", got.ModelPriceID)
+	}
+
+	// 父请求的 cost 应被刷新为 attempt cost 之和。
+	updatedReq, err := reqRepo.GetByID(1, req.ID)
+	if err != nil {
+		t.Fatalf("reload request: %v", err)
+	}
+	if updatedReq.Cost != expected {
+		t.Errorf("request.Cost = %d, want %d", updatedReq.Cost, expected)
+	}
+}

--- a/internal/service/recalculate_costs_test.go
+++ b/internal/service/recalculate_costs_test.go
@@ -109,3 +109,74 @@ func TestRecalculateCosts_PreservesHistoricalMultiplier(t *testing.T) {
 		t.Errorf("request.Cost = %d, want %d", updatedReq.Cost, expected)
 	}
 }
+
+// TestRecalculateCosts_ModelPriceIDOnlyChange 验证 review 提的 audit-trail 风险:
+// 当价格被替换成等额的新版本(cost 不变,但 model_price ID 换了)时,
+// 重算必须把 model_price_id 也刷新到新行;否则审计上会看到指向已删除/旧版价格的孤儿引用。
+//
+// 修复前的 gate 只检查 res.Cost != attempt.Cost,会漏掉这种"金额等同但价格版本换了"的场景。
+func TestRecalculateCosts_ModelPriceIDOnlyChange(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	attRepo := sqlite.NewProxyUpstreamAttemptRepository(db)
+	reqRepo := sqlite.NewProxyRequestRepository(db)
+
+	// 当前价表:test-model 指向 ID=200(假设旧 ID=100 已被替换成等额新版本)。
+	pricing.GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 200, ModelID: "test-model", InputPriceMicro: 3_000_000},
+	})
+	t.Cleanup(func() {
+		pricing.GlobalCalculator().LoadFromDatabase(nil)
+	})
+
+	req := &domain.ProxyRequest{
+		TenantID:  1,
+		Status:    "COMPLETED",
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}
+	if err := reqRepo.Create(req); err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	// Attempt:Cost 已经正确(3e9),但 ModelPriceID 还指向旧的 100。
+	// 旧的 gate (`cost != cost`) 会判定无需更新,model_price_id 永远停在 100。
+	const correctCost = uint64(3_000_000_000)
+	att := &domain.ProxyUpstreamAttempt{
+		TenantID:        1,
+		Status:          "COMPLETED",
+		ProxyRequestID:  req.ID,
+		ResponseModel:   "test-model",
+		InputTokenCount: 1_000_000,
+		Multiplier:      10_000, // 1.0×
+		ModelPriceID:    100,    // 旧版本 ID
+		Cost:            correctCost,
+	}
+	if err := attRepo.Create(att); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+
+	svc := &AdminService{attemptRepo: attRepo, proxyRequestRepo: reqRepo}
+	result, err := svc.RecalculateCosts()
+	if err != nil {
+		t.Fatalf("RecalculateCosts: %v", err)
+	}
+	if result.UpdatedAttempts != 1 {
+		t.Errorf("UpdatedAttempts = %d, want 1 (model_price_id 不一致也应触发 update)", result.UpdatedAttempts)
+	}
+
+	var attempts []sqlite.ProxyUpstreamAttempt
+	if err := db.GormDB().Find(&attempts).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if attempts[0].Cost != correctCost {
+		t.Errorf("Cost = %d, want %d (本应不变)", attempts[0].Cost, correctCost)
+	}
+	if attempts[0].ModelPriceID != 200 {
+		t.Errorf("ModelPriceID = %d, want 200 (必须刷新到当前匹配 ID,即使 cost 不变)", attempts[0].ModelPriceID)
+	}
+}

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -957,7 +957,7 @@ export interface RecalculateCostsResult {
 
 /** RecalculateCostsProgress - 成本重算进度更新 */
 export interface RecalculateCostsProgress {
-  phase: 'calculating' | 'updating_attempts' | 'updating_requests' | 'completed';
+  phase: 'calculating' | 'updating_attempts' | 'updating_requests' | 'completed' | 'failed';
   current: number;
   total: number;
   percentage: number;

--- a/web/src/pages/stats/index.tsx
+++ b/web/src/pages/stats/index.tsx
@@ -42,16 +42,7 @@ import type {
   RecalculateStatsProgress,
 } from '@/lib/transport';
 import { getTransport } from '@/lib/transport';
-import {
-  ComposedChart,
-  Bar,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Legend,
-} from 'recharts';
+import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 
 type TimeRange =
   | '1h'
@@ -431,8 +422,10 @@ export function StatsPage() {
       'recalculate_costs_progress',
       (data) => {
         setCostsProgress(data);
-        // Clear progress after completion (with a delay to show final message)
-        if (data.phase === 'completed') {
+        // Clear progress on terminal phases (completed or failed) after a brief
+        // delay so the user can read the final message. Without the 'failed'
+        // branch the button stays disabled and the progress bar hangs.
+        if (data.phase === 'completed' || data.phase === 'failed') {
           setTimeout(() => setCostsProgress(null), 3000);
         }
       },
@@ -888,7 +881,10 @@ export function StatsPage() {
             ) : chartData.length === 0 ? (
               <div className="text-center text-muted-foreground py-8">{t('common.noData')}</div>
             ) : (
-              <Card data-testid="stats-chart-card" className="border-border/50 bg-card/50 backdrop-blur-sm">
+              <Card
+                data-testid="stats-chart-card"
+                className="border-border/50 bg-card/50 backdrop-blur-sm"
+              >
                 <CardHeader className="flex flex-row items-center justify-between pb-2">
                   <CardTitle className="text-base font-semibold flex items-center gap-2">
                     <BarChart3 className="h-4 w-4 text-emerald-500" />


### PR DESCRIPTION
## Summary

第一步重构,把分散的计费逻辑收归到 `internal/pricing.Calculator` 单一入口,并修一个 backfill bug。

- **统一 Calculator**:用单一 `Calculate(model, metrics, multiplier) CostResult` 替代旧的双重价表(`priceTable + modelPriceCache`),内部以 `pricesByKey` + `pricesByID` 两张表索引,built-in 也转成 `*domain.ModelPrice` (ID=0) 在初始化时灌入。返回 `CostResult{Cost, ModelPriceID, Multiplier}` 让调用方一次拿到全部写回字段
- **修 backfill 倍率/model_price_id 丢失 bug**:`RecalculateCosts` / `RecalculateRequestCost` 旧代码调 `Calculate(model, metrics)` 不带 multiplier,会把历史 1.2× 等折扣率悄悄回退到 1.0×,且不更新 `model_price_id`。修复方案:`StreamForCostCalc` SELECT 带回 `multiplier`,`BatchUpdateCosts` 签名改成 `map[uint64]domain.AttemptCostUpdate{Cost, ModelPriceID}` 用两个 `CASE id WHEN ... END` 块在一条 UPDATE 里同步写回 cost + model_price_id
- 删 `internal/pricing/tiered.go` 里的死代码 (`CalculateTieredCostMicro`、`CalculateLinearCostMicro`、`NanoToUSD` 等单位转换常量) 和 repository 接口里的死方法 (`UpdateCost`、`AddCost`、旧版 `BatchUpdateCosts`)
- 补端到端测试 `TestRecalculateCosts_PreservesHistoricalMultiplier`:in-memory sqlite,seed attempt with `Multiplier=12000`,assert cost = 1M × \$3 × 1.2 = 3.6e9 nano 且 `ModelPriceID` 同步

包含两个 commit:
- \`91e0b18\` 重构主体
- \`5d749fb\` 补 PR1 多维测试(7 个 calculator 测试 + 3 个 sqlite 测试 + 1 个 service 端到端)

## Test plan

- [ ] \`go test ./internal/pricing/...\` ✅(本地已绿)
- [ ] \`go test ./internal/repository/sqlite/...\` ✅
- [ ] \`go test ./internal/service/... -run Recalculate\` ✅
- [ ] \`go vet ./internal/...\` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **New Features**
  * 支持按历史倍率回填并保留/同步定价记录标识，重算时同时更新尝试与请求成本与价格版本。

* **Bug Fixes**
  * 修复倍率丢失与价格版本不同步导致的成本不一致，确保汇总与回填正确。

* **Refactor**
  * 重构定价引擎与批量落库/原子更新流程，改进价格加载、前缀匹配与缓存策略。

* **Tests**
  * 新增多项端到端与仓库层测试，覆盖倍率保留、价格版本变更、批量更新与失败场景。

* **Style**
  * 进度回传支持失败状态，前端统计页在失败/完成时正确清理进度显示。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->