### PR TITLE
fix(pricing): recalc uses historical price snapshot via attempt.ModelPriceID

### DIFF
--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -542,6 +542,9 @@ func initializeModelPrices(repo repository.ModelPriceRepository) error {
 	}
 
 	pricing.GlobalCalculator().LoadFromDatabase(prices)
+	// 注入历史价反查:重算路径在 attempt.ModelPriceID 指向已软删行时,
+	// 走这条回 DB 取当时的价格快照。
+	pricing.GlobalCalculator().SetHistoricalLookup(repo.GetByIDIncludingDeleted)
 	return nil
 }
 

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -503,6 +503,10 @@ func (r *selfServiceModelPriceRepo) GetByID(id uint64) (*domain.ModelPrice, erro
 	return nil, domain.ErrNotFound
 }
 
+func (r *selfServiceModelPriceRepo) GetByIDIncludingDeleted(id uint64) (*domain.ModelPrice, error) {
+	return r.GetByID(id)
+}
+
 func (r *selfServiceModelPriceRepo) GetCurrentByModelID(modelID string) (*domain.ModelPrice, error) {
 	for _, price := range r.prices {
 		if price.ModelID == modelID {

--- a/internal/pricing/attempt.go
+++ b/internal/pricing/attempt.go
@@ -31,15 +31,32 @@ func attemptMetrics(in, out, cacheRead, cacheWrite, c5m, c1h uint64) *usage.Metr
 	}
 }
 
-// RecalcAttemptUpdate 用当前价表+attempt 历史倍率重算 cost。
+// RecalcAttemptUpdate 用"当时价" × 最新 token × 历史 multiplier 重算 cost。
 // 第三个返回值 changed=true 当且仅当 Cost 或 ModelPriceID 跟当前值不一致;
 // 这样即便金额没变,只要价格记录被换成等额新版本,也会刷新 model_price_id 保留审计链。
 // 第一个返回值是新算出的 cost,即使无变化也填充(给上层做 totalCost 累加用)。
 //
+// 定价决策顺序:
+//  1. attempt 已记录 ModelPriceID(>0)→ 按 ID 反查当时的价格快照(版本化
+//     机制保证这一行物理保留)。这是正常路径,典型用途:流式结尾 token 数
+//     后补、缺失指标 backfill,需要"按当时价 × 最新 token 数"重算,而不
+//     是按今天的当前价。
+//  2. 反查不到 / ModelPriceID==0(极老数据)→ fallback 按模型名走 Calculate
+//     取当前价兜底。
+//
 // 注意:multiplier 用 attempt 自己的历史值,而不是 Provider 当下的合约值。
 // 否则 backfill 会把历史折扣率悄悄改写,违反"重算价格不改合约"的原则。
 func RecalcAttemptUpdate(model string, metrics *usage.Metrics, multiplier, currentCost, currentModelPriceID uint64) (uint64, domain.AttemptCostUpdate, bool) {
-	res := GlobalCalculator().Calculate(model, metrics, multiplier)
+	var res CostResult
+	if currentModelPriceID != 0 {
+		if r, ok := GlobalCalculator().CalculateByPriceID(currentModelPriceID, metrics, multiplier); ok {
+			res = r
+		} else {
+			res = GlobalCalculator().Calculate(model, metrics, multiplier)
+		}
+	} else {
+		res = GlobalCalculator().Calculate(model, metrics, multiplier)
+	}
 	if res.Cost == currentCost && res.ModelPriceID == currentModelPriceID {
 		return res.Cost, domain.AttemptCostUpdate{}, false
 	}

--- a/internal/pricing/attempt.go
+++ b/internal/pricing/attempt.go
@@ -1,6 +1,8 @@
 package pricing
 
 import (
+	"log"
+
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/usage"
 )
@@ -49,9 +51,18 @@ func attemptMetrics(in, out, cacheRead, cacheWrite, c5m, c1h uint64) *usage.Metr
 func RecalcAttemptUpdate(model string, metrics *usage.Metrics, multiplier, currentCost, currentModelPriceID uint64) (uint64, domain.AttemptCostUpdate, bool) {
 	var res CostResult
 	if currentModelPriceID != 0 {
-		if r, ok := GlobalCalculator().CalculateByPriceID(currentModelPriceID, metrics, multiplier); ok {
+		r, ok, err := GlobalCalculator().CalculateByPriceID(currentModelPriceID, metrics, multiplier)
+		if err != nil {
+			// historicalLookup 返回了错误(DB 故障、网络抖动等)。
+			// 不得回退到当前价——那会用今天的价格悄悄覆盖历史 attempt 成本,
+			// 违反本次改动的核心契约。直接放弃本次重算,保留原值。
+			log.Printf("[Pricing] RecalcAttemptUpdate: historical lookup failed for ModelPriceID=%d model=%s: %v; skipping recalc", currentModelPriceID, model, err)
+			return currentCost, domain.AttemptCostUpdate{}, false
+		}
+		if ok {
 			res = r
 		} else {
+			// p==nil: 历史记录确认不存在(极老数据或被硬删),安全回退到当前价。
 			res = GlobalCalculator().Calculate(model, metrics, multiplier)
 		}
 	} else {

--- a/internal/pricing/attempt_test.go
+++ b/internal/pricing/attempt_test.go
@@ -237,3 +237,93 @@ func TestRecalcFromCostData_ZeroMultiplierDefaultsToOne(t *testing.T) {
 		t.Errorf("multiplier=0: newCost = %d, want 3e9 (zero must default to 1.0×)", newCost)
 	}
 }
+
+// TestRecalcFromAttempt_UsesHistoricalSnapshotByID 锁住"当时价"重算契约:
+// 当 attempt.ModelPriceID 指向已被新价覆盖的历史快照(版本化机制保留),
+// 重算应该用旧快照价 × 最新 token,而不是按今天的当前价(模型名查表)。
+//
+// 这是这次改动的核心:之前 RecalcAttemptUpdate 用模型名走 Calculate,
+// 等于把"重算"语义变成"按今天的价回填",违背了 token 后补/缺失指标
+// backfill 的真正意图(按当时合约价 × 已知 token 数补足成本)。
+func TestRecalcFromAttempt_UsesHistoricalSnapshotByID(t *testing.T) {
+	resetGlobalCalculator(t)
+	old := &domain.ModelPrice{ID: 10, ModelID: "claude-3-opus", InputPriceMicro: 3_000_000}
+	current := &domain.ModelPrice{ID: 20, ModelID: "claude-3-opus", InputPriceMicro: 9_000_000}
+	GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{current})
+	GlobalCalculator().SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+		if id == 10 {
+			return old, nil
+		}
+		return nil, nil
+	})
+
+	// attempt 当时按 $3 价记入 ModelPriceID=10。流式结尾 token 后补,
+	// Cost 字段是 0(或老值),触发重算。
+	attempt := &domain.ProxyUpstreamAttempt{
+		ResponseModel:   "claude-3-opus",
+		InputTokenCount: 1_000_000,
+		Multiplier:      DefaultMultiplier,
+		Cost:            0,
+		ModelPriceID:    10, // 历史 ID
+	}
+
+	newCost, update, changed := RecalcFromAttempt(attempt)
+	if !changed {
+		t.Fatal("changed = false, want true (cost 从 0 改到 3e9)")
+	}
+	// 当时价 $3 → 1M × $3 = 3e9 nanoUSD,不是按今天 $9 的 9e9
+	if newCost != 3_000_000_000 {
+		t.Errorf("newCost = %d, want 3e9 (当时价 $3, 不是 today's $9)", newCost)
+	}
+	if update.ModelPriceID != 10 {
+		t.Errorf("update.ModelPriceID = %d, want 10 (维持历史 ID,不被刷成 20)", update.ModelPriceID)
+	}
+}
+
+// TestRecalcFromAttempt_FallsBackToByModelWhenIDMissing 验证 ModelPriceID=0
+// (极老数据,从未记录过 ID)走按模型名查当前价的兜底路径。
+func TestRecalcFromAttempt_FallsBackToByModelWhenIDMissing(t *testing.T) {
+	resetGlobalCalculator(t)
+	GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 20, ModelID: "claude-3-opus", InputPriceMicro: 9_000_000},
+	})
+	// 未设置 historicalLookup;ModelPriceID=0 也根本不该触发它。
+
+	attempt := &domain.ProxyUpstreamAttempt{
+		ResponseModel:   "claude-3-opus",
+		InputTokenCount: 1_000_000,
+		Multiplier:      DefaultMultiplier,
+		ModelPriceID:    0, // 没记录历史 ID
+	}
+	newCost, update, _ := RecalcFromAttempt(attempt)
+	if newCost != 9_000_000_000 {
+		t.Errorf("newCost = %d, want 9e9 (fallback 按模型名取当前价)", newCost)
+	}
+	if update.ModelPriceID != 20 {
+		t.Errorf("update.ModelPriceID = %d, want 20 (写入当前 ID,补齐历史空缺)", update.ModelPriceID)
+	}
+}
+
+// TestRecalcFromAttempt_FallsBackWhenHistoricalLookupReturnsNil 验证:
+// ModelPriceID 非 0,但反查不到(例如硬删了历史表 / 测试环境未注入 lookup),
+// 不应该崩,而是降级走模型名取当前价。
+func TestRecalcFromAttempt_FallsBackWhenHistoricalLookupReturnsNil(t *testing.T) {
+	resetGlobalCalculator(t)
+	GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 20, ModelID: "claude-3-opus", InputPriceMicro: 9_000_000},
+	})
+	GlobalCalculator().SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+		return nil, nil // 反查不到
+	})
+
+	attempt := &domain.ProxyUpstreamAttempt{
+		ResponseModel:   "claude-3-opus",
+		InputTokenCount: 1_000_000,
+		Multiplier:      DefaultMultiplier,
+		ModelPriceID:    99, // 不存在的 ID
+	}
+	newCost, _, _ := RecalcFromAttempt(attempt)
+	if newCost != 9_000_000_000 {
+		t.Errorf("newCost = %d, want 9e9 (fallback 必须工作)", newCost)
+	}
+}

--- a/internal/pricing/attempt_test.go
+++ b/internal/pricing/attempt_test.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -301,6 +302,44 @@ func TestRecalcFromAttempt_FallsBackToByModelWhenIDMissing(t *testing.T) {
 	}
 	if update.ModelPriceID != 20 {
 		t.Errorf("update.ModelPriceID = %d, want 20 (写入当前 ID,补齐历史空缺)", update.ModelPriceID)
+	}
+}
+
+// TestRecalcFromAttempt_DoesNotFallBackOnLookupError 锁住核心安全契约:
+// historicalLookup 返回非 nil 错误时,不得回退到按模型名走当前价——那会用
+// 今天的价格悄悄覆盖历史 attempt 的成本,违反"重算当时价"的语义保证。
+// 正确行为:放弃本次重算,保留原 cost 和 model_price_id,并返回 changed=false。
+func TestRecalcFromAttempt_DoesNotFallBackOnLookupError(t *testing.T) {
+	resetGlobalCalculator(t)
+	GlobalCalculator().LoadFromDatabase([]*domain.ModelPrice{
+		{ID: 20, ModelID: "claude-3-opus", InputPriceMicro: 9_000_000},
+	})
+	GlobalCalculator().SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+		return nil, fmt.Errorf("db timeout") // 瞬态错误
+	})
+
+	const originalCost = uint64(3_000_000_000)
+	attempt := &domain.ProxyUpstreamAttempt{
+		ResponseModel:   "claude-3-opus",
+		InputTokenCount: 1_000_000,
+		Multiplier:      DefaultMultiplier,
+		Cost:            originalCost, // 当时价 $3 算出的历史值
+		ModelPriceID:    10,           // 历史 ID,反查会失败
+	}
+
+	newCost, update, changed := RecalcFromAttempt(attempt)
+
+	// 必须 changed=false:不得因为 lookup 错误就写入一个当前价算出的新值
+	if changed {
+		t.Error("changed = true on lookup error; must be false to protect historical cost")
+	}
+	// 返回的 newCost 必须是原值,不是按今天的当前价($9)算出的 9e9
+	if newCost != originalCost {
+		t.Errorf("newCost = %d on lookup error, want %d (original cost must be preserved)", newCost, originalCost)
+	}
+	// update 必须是零值,不得更新 model_price_id
+	if update != (domain.AttemptCostUpdate{}) {
+		t.Errorf("update = %+v on lookup error; want zero value (no DB write should happen)", update)
 	}
 }
 

--- a/internal/pricing/calculator.go
+++ b/internal/pricing/calculator.go
@@ -107,35 +107,41 @@ func (c *Calculator) SetHistoricalLookup(fn HistoricalLookup) {
 }
 
 // resolvePriceByID 优先查内存缓存;未命中且配置了 historicalLookup 时
-// 回 DB 取并缓存。返回 nil 表示该 ID 在 DB 中也不存在(或未配置反查)。
-func (c *Calculator) resolvePriceByID(id uint64) *domain.ModelPrice {
+// 回 DB 取并缓存。
+//   - 返回 (p, nil)     表示命中(p != nil)或确认不存在(p == nil)
+//   - 返回 (nil, err)   表示 DB 查询出错,调用方不得以此为由回退到当前价——
+//     否则会用今天的价格悄悄覆盖历史 attempt 的成本
+func (c *Calculator) resolvePriceByID(id uint64) (*domain.ModelPrice, error) {
 	if id == 0 {
-		return nil
+		return nil, nil
 	}
 	c.mu.RLock()
 	if p, ok := c.pricesByID[id]; ok {
 		c.mu.RUnlock()
-		return p
+		return p, nil
 	}
 	lookup := c.historicalLookup
 	c.mu.RUnlock()
 
 	if lookup == nil {
-		return nil
+		return nil, nil
 	}
 	p, err := lookup(id)
-	if err != nil || p == nil {
-		return nil
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, nil
 	}
 	c.mu.Lock()
 	// 双检:并发情况下别人可能已经填好。
 	if existing, ok := c.pricesByID[id]; ok {
 		c.mu.Unlock()
-		return existing
+		return existing, nil
 	}
 	c.pricesByID[id] = p
 	c.mu.Unlock()
-	return p
+	return p, nil
 }
 
 // lookupLocked 在 pricesByKey 中查找,先精确再最长前缀。需持有 RLock 或 Lock。
@@ -180,20 +186,27 @@ func (c *Calculator) Calculate(model string, metrics *usage.Metrics, multiplier 
 // 用这条:attempt 保存了它写入时的 ModelPriceID,据此还原"当时价" × token
 // × multiplier,而不是按今天的当前价回填。
 //
-// 未命中(ID=0 或反查不到该 ID)返回 (CostResult{Multiplier},false)。调
-// 用方据此决定是否回退到按模型名走 Calculate。
-func (c *Calculator) CalculateByPriceID(priceID uint64, metrics *usage.Metrics, multiplier uint64) (CostResult, bool) {
+// 返回值语义:
+//   - (result, true,  nil): 找到价格快照并完成计算
+//   - (empty,  false, nil): ID=0 或 DB 中确认不存在(p==nil),调用方可安全
+//     回退到按模型名走 Calculate
+//   - (empty,  false, err): historicalLookup 返回错误,调用方必须终止本次
+//     重算并上报错误,不得回退到当前价——否则会用今天的价格覆盖历史成本
+func (c *Calculator) CalculateByPriceID(priceID uint64, metrics *usage.Metrics, multiplier uint64) (CostResult, bool, error) {
 	if multiplier == 0 {
 		multiplier = DefaultMultiplier
 	}
 	if metrics == nil {
-		return CostResult{Multiplier: multiplier}, false
+		return CostResult{Multiplier: multiplier}, false, nil
 	}
-	price := c.resolvePriceByID(priceID)
+	price, err := c.resolvePriceByID(priceID)
+	if err != nil {
+		return CostResult{Multiplier: multiplier}, false, err
+	}
 	if price == nil {
-		return CostResult{Multiplier: multiplier}, false
+		return CostResult{Multiplier: multiplier}, false, nil
 	}
-	return applyPrice(price, metrics, multiplier), true
+	return applyPrice(price, metrics, multiplier), true, nil
 }
 
 // applyPrice 把 token 用量按指定价格 + 倍率算成 cost,统一两条计算入口。

--- a/internal/pricing/calculator.go
+++ b/internal/pricing/calculator.go
@@ -19,13 +19,22 @@ type CostResult struct {
 	Multiplier   uint64 // 实际应用的倍率（10000=1倍）
 }
 
+// HistoricalLookup 通过 DB 反查任意 ModelPriceID(包括已软删的历史快照)。
+// 由仓储层注入,用于按 attempt.ModelPriceID 还原当时的价格做"当时价"重算。
+type HistoricalLookup func(id uint64) (*domain.ModelPrice, error)
+
 // Calculator 维护 modelID → ModelPrice 映射。
 // 启动时载入内置默认价表(ID=0),LoadFromDatabase 会用 DB 记录覆盖同名条目。
 // 这样运行期只有一份价格源,不再有“内置 vs DB”分支。
+//
+// pricesByID 缓存"当前价"行(ID > 0)。需要查历史快照(已软删行)时,
+// CalculateByPriceID 通过 historicalLookup 懒加载到 pricesByID,避免重算
+// 大批 attempt 时打爆 DB。
 type Calculator struct {
-	mu          sync.RWMutex
-	pricesByKey map[string]*domain.ModelPrice
-	pricesByID  map[uint64]*domain.ModelPrice
+	mu               sync.RWMutex
+	pricesByKey      map[string]*domain.ModelPrice
+	pricesByID       map[uint64]*domain.ModelPrice
+	historicalLookup HistoricalLookup
 }
 
 var (
@@ -82,11 +91,51 @@ func (c *Calculator) GetModelPrice(model string) *domain.ModelPrice {
 	return c.lookupLocked(model)
 }
 
-// GetModelPriceByID 按 DB 记录 ID 取价格。
+// GetModelPriceByID 按 DB 记录 ID 取价格(仅看内存缓存,不触发懒加载)。
 func (c *Calculator) GetModelPriceByID(id uint64) *domain.ModelPrice {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.pricesByID[id]
+}
+
+// SetHistoricalLookup 注入历史价反查函数。由仓储装配阶段调用一次,
+// 之后 CalculateByPriceID 在缓存未命中时会经此回填历史快照行。
+func (c *Calculator) SetHistoricalLookup(fn HistoricalLookup) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.historicalLookup = fn
+}
+
+// resolvePriceByID 优先查内存缓存;未命中且配置了 historicalLookup 时
+// 回 DB 取并缓存。返回 nil 表示该 ID 在 DB 中也不存在(或未配置反查)。
+func (c *Calculator) resolvePriceByID(id uint64) *domain.ModelPrice {
+	if id == 0 {
+		return nil
+	}
+	c.mu.RLock()
+	if p, ok := c.pricesByID[id]; ok {
+		c.mu.RUnlock()
+		return p
+	}
+	lookup := c.historicalLookup
+	c.mu.RUnlock()
+
+	if lookup == nil {
+		return nil
+	}
+	p, err := lookup(id)
+	if err != nil || p == nil {
+		return nil
+	}
+	c.mu.Lock()
+	// 双检:并发情况下别人可能已经填好。
+	if existing, ok := c.pricesByID[id]; ok {
+		c.mu.Unlock()
+		return existing
+	}
+	c.pricesByID[id] = p
+	c.mu.Unlock()
+	return p
 }
 
 // lookupLocked 在 pricesByKey 中查找,先精确再最长前缀。需持有 RLock 或 Lock。
@@ -124,6 +173,31 @@ func (c *Calculator) Calculate(model string, metrics *usage.Metrics, multiplier 
 		return CostResult{Multiplier: multiplier}
 	}
 
+	return applyPrice(price, metrics, multiplier)
+}
+
+// CalculateByPriceID 按指定的 ModelPriceID 取价格快照计算成本——重算路径
+// 用这条:attempt 保存了它写入时的 ModelPriceID,据此还原"当时价" × token
+// × multiplier,而不是按今天的当前价回填。
+//
+// 未命中(ID=0 或反查不到该 ID)返回 (CostResult{Multiplier},false)。调
+// 用方据此决定是否回退到按模型名走 Calculate。
+func (c *Calculator) CalculateByPriceID(priceID uint64, metrics *usage.Metrics, multiplier uint64) (CostResult, bool) {
+	if multiplier == 0 {
+		multiplier = DefaultMultiplier
+	}
+	if metrics == nil {
+		return CostResult{Multiplier: multiplier}, false
+	}
+	price := c.resolvePriceByID(priceID)
+	if price == nil {
+		return CostResult{Multiplier: multiplier}, false
+	}
+	return applyPrice(price, metrics, multiplier), true
+}
+
+// applyPrice 把 token 用量按指定价格 + 倍率算成 cost,统一两条计算入口。
+func applyPrice(price *domain.ModelPrice, metrics *usage.Metrics, multiplier uint64) CostResult {
 	cost := computeCost(price, metrics)
 	if multiplier != DefaultMultiplier {
 		cost = cost * multiplier / DefaultMultiplier

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -1,6 +1,7 @@
 package pricing
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -406,7 +407,10 @@ func TestCalculator_CalculateByPriceID_UsesCachedSnapshot(t *testing.T) {
 	})
 
 	metrics := &usage.Metrics{InputTokens: 1_000_000}
-	res, ok := calc.CalculateByPriceID(10, metrics, DefaultMultiplier)
+	res, ok, err := calc.CalculateByPriceID(10, metrics, DefaultMultiplier)
+	if err != nil {
+		t.Fatalf("CalculateByPriceID(10) unexpected error: %v", err)
+	}
 	if !ok {
 		t.Fatal("CalculateByPriceID(10) should succeed via historical lookup")
 	}
@@ -435,7 +439,7 @@ func TestCalculator_CalculateByPriceID_LazyLoadCaches(t *testing.T) {
 
 	metrics := &usage.Metrics{InputTokens: 1_000_000}
 	for i := 0; i < 5; i++ {
-		_, _ = calc.CalculateByPriceID(42, metrics, DefaultMultiplier)
+		_, _, _ = calc.CalculateByPriceID(42, metrics, DefaultMultiplier)
 	}
 	if calls != 1 {
 		t.Errorf("historicalLookup called %d times, want 1 (后续应命中缓存)", calls)
@@ -443,20 +447,29 @@ func TestCalculator_CalculateByPriceID_LazyLoadCaches(t *testing.T) {
 }
 
 // TestCalculator_CalculateByPriceID_NoLookupOrUnknownID 验证 ok=false 路径:
-// 没注入 lookup、或 lookup 返回 nil,都应返回 false 让上层走 fallback。
+// 没注入 lookup、lookup 返回 nil 或返回 error,都应返回 false。
+// 其中 error 情形还要求调用方拿到非 nil 的 err,不得盲目 fallback。
 func TestCalculator_CalculateByPriceID_NoLookupOrUnknownID(t *testing.T) {
 	metrics := &usage.Metrics{InputTokens: 1_000_000}
 
 	t.Run("ID==0 unconditionally false", func(t *testing.T) {
 		calc := NewCalculator()
-		if _, ok := calc.CalculateByPriceID(0, metrics, DefaultMultiplier); ok {
+		_, ok, err := calc.CalculateByPriceID(0, metrics, DefaultMultiplier)
+		if err != nil {
+			t.Fatalf("CalculateByPriceID(0) unexpected error: %v", err)
+		}
+		if ok {
 			t.Error("CalculateByPriceID(0) should return ok=false")
 		}
 	})
 
 	t.Run("no lookup configured", func(t *testing.T) {
 		calc := NewCalculator()
-		if _, ok := calc.CalculateByPriceID(99, metrics, DefaultMultiplier); ok {
+		_, ok, err := calc.CalculateByPriceID(99, metrics, DefaultMultiplier)
+		if err != nil {
+			t.Fatalf("CalculateByPriceID without lookup unexpected error: %v", err)
+		}
+		if ok {
 			t.Error("CalculateByPriceID without lookup should return ok=false")
 		}
 	})
@@ -466,8 +479,27 @@ func TestCalculator_CalculateByPriceID_NoLookupOrUnknownID(t *testing.T) {
 		calc.SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
 			return nil, nil
 		})
-		if _, ok := calc.CalculateByPriceID(99, metrics, DefaultMultiplier); ok {
+		_, ok, err := calc.CalculateByPriceID(99, metrics, DefaultMultiplier)
+		if err != nil {
+			t.Fatalf("CalculateByPriceID with nil-returning lookup unexpected error: %v", err)
+		}
+		if ok {
 			t.Error("CalculateByPriceID with nil-returning lookup should return ok=false")
+		}
+	})
+
+	t.Run("lookup returns error", func(t *testing.T) {
+		calc := NewCalculator()
+		lookupErr := fmt.Errorf("db connection timeout")
+		calc.SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+			return nil, lookupErr
+		})
+		_, ok, err := calc.CalculateByPriceID(99, metrics, DefaultMultiplier)
+		if ok {
+			t.Error("CalculateByPriceID with erroring lookup should return ok=false")
+		}
+		if err == nil {
+			t.Error("CalculateByPriceID with erroring lookup should return non-nil error")
 		}
 	})
 }

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -387,3 +387,87 @@ func TestDefaultCachePrices(t *testing.T) {
 		t.Errorf("GetEffectiveCache1hWritePriceMicro() = %d, want 2000000", got)
 	}
 }
+
+// TestCalculator_CalculateByPriceID_UsesCachedSnapshot 验证按 ID 计算时,
+// 即使同名模型在 pricesByKey 已被新价覆盖,仍然从 pricesByID 取当时的快照。
+// 这就是"当时价"重算的核心契约。
+func TestCalculator_CalculateByPriceID_UsesCachedSnapshot(t *testing.T) {
+	calc := NewCalculator()
+	old := &domain.ModelPrice{ID: 10, ModelID: "claude-sonnet-4-5", InputPriceMicro: 3_000_000}
+	current := &domain.ModelPrice{ID: 20, ModelID: "claude-sonnet-4-5", InputPriceMicro: 6_000_000}
+
+	calc.LoadFromDatabase([]*domain.ModelPrice{current})
+	// 注入历史反查:让 ID=10 能被解析出来。
+	calc.SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+		if id == 10 {
+			return old, nil
+		}
+		return nil, nil
+	})
+
+	metrics := &usage.Metrics{InputTokens: 1_000_000}
+	res, ok := calc.CalculateByPriceID(10, metrics, DefaultMultiplier)
+	if !ok {
+		t.Fatal("CalculateByPriceID(10) should succeed via historical lookup")
+	}
+	if res.ModelPriceID != 10 {
+		t.Errorf("res.ModelPriceID = %d, want 10 (历史快照,不被新价 ID 覆盖)", res.ModelPriceID)
+	}
+	// 按模型名走当前价
+	byName := calc.Calculate("claude-sonnet-4-5", metrics, DefaultMultiplier)
+	if res.Cost == byName.Cost {
+		t.Errorf("by-ID cost (snapshot $3) == by-name cost (current $6) = %d; 二者应分歧", res.Cost)
+	}
+	if res.Cost*2 != byName.Cost {
+		t.Errorf("by-ID cost should be half of by-name (snapshot=$3, current=$6); got %d vs %d", res.Cost, byName.Cost)
+	}
+}
+
+// TestCalculator_CalculateByPriceID_LazyLoadCaches 验证未命中缓存时通过
+// historicalLookup 加载,且只回 DB 一次(后续命中走内存缓存)。
+func TestCalculator_CalculateByPriceID_LazyLoadCaches(t *testing.T) {
+	calc := NewCalculator()
+	calls := 0
+	calc.SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+		calls++
+		return &domain.ModelPrice{ID: id, ModelID: "claude-sonnet-4-5", InputPriceMicro: 3_000_000}, nil
+	})
+
+	metrics := &usage.Metrics{InputTokens: 1_000_000}
+	for i := 0; i < 5; i++ {
+		_, _ = calc.CalculateByPriceID(42, metrics, DefaultMultiplier)
+	}
+	if calls != 1 {
+		t.Errorf("historicalLookup called %d times, want 1 (后续应命中缓存)", calls)
+	}
+}
+
+// TestCalculator_CalculateByPriceID_NoLookupOrUnknownID 验证 ok=false 路径:
+// 没注入 lookup、或 lookup 返回 nil,都应返回 false 让上层走 fallback。
+func TestCalculator_CalculateByPriceID_NoLookupOrUnknownID(t *testing.T) {
+	metrics := &usage.Metrics{InputTokens: 1_000_000}
+
+	t.Run("ID==0 unconditionally false", func(t *testing.T) {
+		calc := NewCalculator()
+		if _, ok := calc.CalculateByPriceID(0, metrics, DefaultMultiplier); ok {
+			t.Error("CalculateByPriceID(0) should return ok=false")
+		}
+	})
+
+	t.Run("no lookup configured", func(t *testing.T) {
+		calc := NewCalculator()
+		if _, ok := calc.CalculateByPriceID(99, metrics, DefaultMultiplier); ok {
+			t.Error("CalculateByPriceID without lookup should return ok=false")
+		}
+	})
+
+	t.Run("lookup returns nil", func(t *testing.T) {
+		calc := NewCalculator()
+		calc.SetHistoricalLookup(func(id uint64) (*domain.ModelPrice, error) {
+			return nil, nil
+		})
+		if _, ok := calc.CalculateByPriceID(99, metrics, DefaultMultiplier); ok {
+			t.Error("CalculateByPriceID with nil-returning lookup should return ok=false")
+		}
+	})
+}

--- a/internal/pricing/calculator_test.go
+++ b/internal/pricing/calculator_test.go
@@ -439,7 +439,13 @@ func TestCalculator_CalculateByPriceID_LazyLoadCaches(t *testing.T) {
 
 	metrics := &usage.Metrics{InputTokens: 1_000_000}
 	for i := 0; i < 5; i++ {
-		_, _, _ = calc.CalculateByPriceID(42, metrics, DefaultMultiplier)
+		_, ok, err := calc.CalculateByPriceID(42, metrics, DefaultMultiplier)
+		if err != nil {
+			t.Fatalf("CalculateByPriceID(42) unexpected error on iter=%d: %v", i, err)
+		}
+		if !ok {
+			t.Fatalf("CalculateByPriceID(42) should return ok=true on iter=%d", i)
+		}
 	}
 	if calls != 1 {
 		t.Errorf("historicalLookup called %d times, want 1 (后续应命中缓存)", calls)

--- a/internal/pricing/writeback_test.go
+++ b/internal/pricing/writeback_test.go
@@ -7,12 +7,14 @@ import (
 )
 
 // resetGlobalCalculator 在测试间还原 GlobalCalculator,避免上一个测试写入的 DB 价格
-// 污染后续测试中的查表结果。
+// 或注入的 historicalLookup 污染后续测试中的查表结果。
 func resetGlobalCalculator(t *testing.T) {
 	t.Helper()
 	GlobalCalculator().LoadFromDatabase(nil)
+	GlobalCalculator().SetHistoricalLookup(nil)
 	t.Cleanup(func() {
 		GlobalCalculator().LoadFromDatabase(nil)
+		GlobalCalculator().SetHistoricalLookup(nil)
 	})
 }
 

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -303,8 +303,10 @@ type ModelPriceRepository interface {
 	Create(price *domain.ModelPrice) error
 	// BatchCreate 批量创建价格记录
 	BatchCreate(prices []*domain.ModelPrice) error
-	// GetByID 获取指定ID的价格记录
+	// GetByID 获取指定ID的价格记录（仅未软删，用于 admin 读路径）
 	GetByID(id uint64) (*domain.ModelPrice, error)
+	// GetByIDIncludingDeleted 按 ID 取价格记录，包括已软删的历史版本（用于 attempt 历史快照反查）
+	GetByIDIncludingDeleted(id uint64) (*domain.ModelPrice, error)
 	// GetCurrentByModelID 获取模型的当前价格（最新记录），支持前缀匹配
 	GetCurrentByModelID(modelID string) (*domain.ModelPrice, error)
 	// ListCurrentPrices 获取所有模型的当前价格（用于初始化 Calculator）

--- a/internal/repository/sqlite/model_price.go
+++ b/internal/repository/sqlite/model_price.go
@@ -64,13 +64,26 @@ func (r *ModelPriceRepository) BatchCreate(prices []*domain.ModelPrice) error {
 // GetByID 获取指定ID的价格记录(仅未软删的)。
 //
 // admin 单条编辑/查看路径,语义是"当前行";Delete 后再 GET 必须 404
-// (e2e: TestDeleteModelPrice)。"按历史 ModelPriceID 反查价格快照"目前
-// 没有实际调用方——RecalcFromAttempt 是用模型名走 GlobalCalculator 查
-// 当前价,不经此路径。如果未来需要历史反查,加一个独立方法,而不是
-// 削弱这里。
+// (e2e: TestDeleteModelPrice)。如果调用方需要拿到已被软删的历史快照行
+// (例如按 attempt.ModelPriceID 反查当时的价格),用 GetByIDIncludingDeleted。
 func (r *ModelPriceRepository) GetByID(id uint64) (*domain.ModelPrice, error) {
 	var m ModelPrice
 	if err := r.db.gorm.Where("deleted_at = 0").First(&m, id).Error; err != nil {
+		return nil, err
+	}
+	return r.toDomain(&m), nil
+}
+
+// GetByIDIncludingDeleted 按 ID 取价格记录,包括已软删的历史版本。
+//
+// 专门给"按 attempt.ModelPriceID 反查当时价"用——版本化机制保证每次价
+// 格变更都会软删旧行 + INSERT 新行,旧行物理保留作为审计快照。Calculator
+// 通过 SetHistoricalLookup 注入此方法,实现按 ID 懒加载历史价格。
+//
+// 不暴露在 admin/API 读路径,避免被删的价格意外回流到 UI。
+func (r *ModelPriceRepository) GetByIDIncludingDeleted(id uint64) (*domain.ModelPrice, error) {
+	var m ModelPrice
+	if err := r.db.gorm.First(&m, id).Error; err != nil {
 		return nil, err
 	}
 	return r.toDomain(&m), nil

--- a/internal/repository/sqlite/model_price_test.go
+++ b/internal/repository/sqlite/model_price_test.go
@@ -178,3 +178,54 @@ func TestUpdate_NoOpWhenUnchanged(t *testing.T) {
 		t.Errorf("after real-change Update, current row count = %d, want 1 (旧行已软删,不计入)", count)
 	}
 }
+
+// TestGetByIDIncludingDeleted_ReturnsSoftDeletedRow 锁住"历史快照按 ID 反查"
+// 的契约:Delete(软删) → GetByID 404,但 GetByIDIncludingDeleted 仍能取出
+// 该行(且 deleted_at != 0)。RecalcAttemptUpdate / Calculator 的历史价反查
+// 路径依赖这条性质;若有人无意中把 GetByIDIncludingDeleted 改成也过滤
+// deleted_at,本测试会立刻报警。
+func TestGetByIDIncludingDeleted_ReturnsSoftDeletedRow(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	repo := NewModelPriceRepository(db)
+
+	p := &domain.ModelPrice{
+		ModelID:          "soft-delete-target",
+		InputPriceMicro:  3_000_000,
+		OutputPriceMicro: 15_000_000,
+	}
+	if err := repo.Create(p); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := p.ID
+	if id == 0 {
+		t.Fatal("created ID should be set")
+	}
+
+	if err := repo.Delete(id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// GetByID 必须 404(admin 读路径不该看到软删行)
+	if got, err := repo.GetByID(id); err == nil {
+		t.Errorf("GetByID(id=%d) after Delete should fail; got %+v", id, got)
+	}
+
+	// GetByIDIncludingDeleted 必须返回完整行(历史快照仍可达)
+	got, err := repo.GetByIDIncludingDeleted(id)
+	if err != nil {
+		t.Fatalf("GetByIDIncludingDeleted(id=%d) failed: %v", id, err)
+	}
+	if got == nil {
+		t.Fatalf("GetByIDIncludingDeleted returned nil")
+	}
+	if got.ID != id {
+		t.Errorf("returned ID = %d, want %d", got.ID, id)
+	}
+	if got.InputPriceMicro != 3_000_000 {
+		t.Errorf("returned InputPriceMicro = %d, want 3_000_000 (历史价不应被改写)", got.InputPriceMicro)
+	}
+}


### PR DESCRIPTION
## Summary

之前 \`RecalcAttemptUpdate\` 用模型名调 \`Calculator.Calculate\`,实际上取的是\`pricesByKey\` 里的**当前价**,等于把"重算"语义偷换成"按今天的价回填历史 attempt"。这违背了重算的真实意图——\`token\` 后补 / 流式结尾丢 metrics / 手工 backfill 等场景需要的是"按**当时价** × 最新 token × 历史 multiplier"重算。

随着 #574 让价格表版本化(\`Update\` 软删旧行 + INSERT 新行,旧行物理保留),\`attempt.ModelPriceID\` 已经是一个稳定的"当时价"句柄,可以接进重算路径。

## Changes

1. **\`ModelPriceRepository.GetByIDIncludingDeleted(id)\`** — 绕过 \`deleted_at = 0\` 过滤,专给 attempt 历史快照反查用。与 #574 review 中和 maintainer 达成的约定一致(独立方法,不削弱 \`GetByID\` 的 admin \"Delete → 404\" 语义)。

2. **\`pricing.Calculator\`**:
    - 新字段 \`historicalLookup HistoricalLookup\` + \`SetHistoricalLookup(fn)\` 注入点
    - 新方法 \`CalculateByPriceID(id, metrics, multiplier) (CostResult, bool)\` — 先查内存 \`pricesByID\` 缓存,未命中走 \`historicalLookup\` 懒加载并双检入缓存(避免重算大批 attempt 打爆 DB);返回 \`ok=false\` 时上层回退
    - 抽出 \`applyPrice\` 共享 cost × multiplier 公式

3. **\`RecalcAttemptUpdate\` 定价决策**:
    \`\`\`
    attempt.ModelPriceID > 0 → CalculateByPriceID(id, ...)            ← 当时价
    miss / ID == 0           → fallback Calculate(model, ...)         ← 当前价兜底
    \`\`\`

4. **\`core/database.go\` 启动 wiring**:\`Calculator.SetHistoricalLookup(repo.GetByIDIncludingDeleted)\`。

## 升级影响

- **无 schema 变化、无 migration**
- 现有 \`attempt.ModelPriceID\` 字段早就有,此前虽然写入但不被读;现在读它走当时价
- v0.13.82(本次基线)所有现存 attempt 的 \`ModelPriceID\` 都是 seed 时分配的当前 ID,价格从未版本化分裂过,所以本次部署不会改变任何已有数值
- 第一次 admin 改价之后,**那时**起新写入的 attempt 拿到新版本 ID;之后任何重算都会自动用当时的价格快照,**不会因为新的价格而把历史 cost 改写**
- 反向用例(故意按新价回填):本 PR 不动这条路径,如果未来需要可以另开独立 admin 操作显式触发

## Test plan

- [x] \`go test ./internal/pricing/\` — 新增 7 个子测试通过(by-ID 取快照不被同名当前价覆盖、lazy-load 缓存只回 DB 一次、ID=0 / 无 lookup / lookup 返回 nil 三种 fallback 路径、Recalc 端到端验证)
- [x] \`go test ./internal/service/ ./internal/repository/sqlite/ ./tests/e2e/\` 全包无回归
- [x] \`go build ./internal/... ./cmd/...\` 干净
- [ ] 部署后:在 admin UI 改一次 sonnet 价格,生成新 attempt,然后改回原价,触发"重算成本"——确认 cost 保持当时价不漂移

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持按历史价格快照重算已有尝试的成本，并能按 ID 读取包含已软删除的历史价格记录。

* **Bug Fixes**
  * 当历史快照可用时优先使用其单价；历史查表失败时保留原始成本并避免不安全回退。
  * 在历史快照缺失或未命中时，自动降级为按模型当前价格重算。

* **Tests**
  * 增加覆盖历史查表与重算契约的自动化测试并改进全局重置，防止测试间污染。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->