### PR TITLE
fix(proxy): whitelist /v1/images/ in project & provider proxy paths

### DIFF
--- a/internal/handler/project_proxy.go
+++ b/internal/handler/project_proxy.go
@@ -103,6 +103,12 @@ func isValidAPIPath(path string) bool {
 	if strings.HasPrefix(path, "/v1/chat/completions") {
 		return true
 	}
+	// OpenAI Images API (gpt-image-* generation + edits). Without this branch,
+	// /project/<slug>/v1/images/generations is rejected with 404 even though
+	// proxy_routes.go registers /v1/images/* at the root mux.
+	if strings.HasPrefix(path, "/v1/images/") {
+		return true
+	}
 	// Codex API
 	if strings.HasPrefix(path, "/responses") {
 		return true

--- a/internal/handler/project_proxy.go
+++ b/internal/handler/project_proxy.go
@@ -103,10 +103,11 @@ func isValidAPIPath(path string) bool {
 	if strings.HasPrefix(path, "/v1/chat/completions") {
 		return true
 	}
-	// OpenAI Images API (gpt-image-* generation + edits). Without this branch,
-	// /project/<slug>/v1/images/generations is rejected with 404 even though
-	// proxy_routes.go registers /v1/images/* at the root mux.
-	if strings.HasPrefix(path, "/v1/images/") {
+	// OpenAI Images API (gpt-image-* generation + edits). Match the exact
+	// endpoints proxy_routes.go registers at the root mux; widening this to
+	// HasPrefix("/v1/images/") would make project-prefixed routes more
+	// permissive than the root contract.
+	if path == "/v1/images/generations" || path == "/v1/images/edits" {
 		return true
 	}
 	// Codex API

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -326,6 +326,12 @@ func isValidProviderAPIPath(path string) bool {
 	if path == "/v1/chat/completions" || strings.HasPrefix(path, "/v1/chat/completions/") {
 		return true
 	}
+	// OpenAI Images API (gpt-image-* generation + edits). Same sync gap as
+	// isValidAPIPath: without this branch, /provider/<id>/v1/images/generations
+	// 404s even though proxy_routes.go registers /v1/images/* at the root mux.
+	if strings.HasPrefix(path, "/v1/images/") {
+		return true
+	}
 	if path == "/responses" || strings.HasPrefix(path, "/responses/") {
 		return true
 	}

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -326,10 +326,11 @@ func isValidProviderAPIPath(path string) bool {
 	if path == "/v1/chat/completions" || strings.HasPrefix(path, "/v1/chat/completions/") {
 		return true
 	}
-	// OpenAI Images API (gpt-image-* generation + edits). Same sync gap as
-	// isValidAPIPath: without this branch, /provider/<id>/v1/images/generations
-	// 404s even though proxy_routes.go registers /v1/images/* at the root mux.
-	if strings.HasPrefix(path, "/v1/images/") {
+	// OpenAI Images API (gpt-image-* generation + edits). Mirror isValidAPIPath
+	// and proxy_routes.go: allow exactly the two registered endpoints rather
+	// than HasPrefix("/v1/images/"), so the provider-prefixed contract doesn't
+	// drift wider than the root.
+	if path == "/v1/images/generations" || path == "/v1/images/edits" {
 		return true
 	}
 	if path == "/responses" || strings.HasPrefix(path, "/responses/") {

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -174,6 +174,18 @@ func TestProjectAPIPathAllowsImagesEndpoints(t *testing.T) {
 	}
 }
 
+// TestProviderAPIPathAllowsImagesEndpoints pins the same contract for the
+// sibling /provider/<id>/ prefix. Both whitelists must stay in sync with
+// proxy_routes.go; otherwise provider-scoped image requests 404 with
+// "invalid provider proxy path".
+func TestProviderAPIPathAllowsImagesEndpoints(t *testing.T) {
+	for _, path := range []string{"/v1/images/generations", "/v1/images/edits"} {
+		if !isValidProviderAPIPath(path) {
+			t.Fatalf("expected %q to be valid for provider proxy URLs", path)
+		}
+	}
+}
+
 func TestProjectProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
 	handler := NewProjectProxyHandler(nil, modelsHandler, &fakeProjectRepo{

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -161,6 +161,19 @@ func TestProjectAPIPathAllowsExactGeminiModelList(t *testing.T) {
 	}
 }
 
+// TestProjectAPIPathAllowsImagesEndpoints pins the contract that
+// /v1/images/generations and /v1/images/edits work under the /project/<slug>/
+// prefix. proxy_routes.go registers them at the root mux; this whitelist must
+// stay in sync, otherwise project-scoped image requests 404 with
+// "invalid project proxy path".
+func TestProjectAPIPathAllowsImagesEndpoints(t *testing.T) {
+	for _, path := range []string{"/v1/images/generations", "/v1/images/edits"} {
+		if !isValidAPIPath(path) {
+			t.Fatalf("expected %q to be valid for project proxy URLs", path)
+		}
+	}
+}
+
 func TestProjectProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
 	handler := NewProjectProxyHandler(nil, modelsHandler, &fakeProjectRepo{

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -163,25 +163,47 @@ func TestProjectAPIPathAllowsExactGeminiModelList(t *testing.T) {
 
 // TestProjectAPIPathAllowsImagesEndpoints pins the contract that
 // /v1/images/generations and /v1/images/edits work under the /project/<slug>/
-// prefix. proxy_routes.go registers them at the root mux; this whitelist must
-// stay in sync, otherwise project-scoped image requests 404 with
-// "invalid project proxy path".
+// prefix and nothing else under /v1/images/ leaks through. proxy_routes.go
+// only registers those two endpoints at the root mux; this whitelist must
+// stay equally tight, otherwise project-scoped routes become more permissive
+// than the root contract.
 func TestProjectAPIPathAllowsImagesEndpoints(t *testing.T) {
 	for _, path := range []string{"/v1/images/generations", "/v1/images/edits"} {
 		if !isValidAPIPath(path) {
 			t.Fatalf("expected %q to be valid for project proxy URLs", path)
 		}
 	}
+	for _, path := range []string{
+		"/v1/images",
+		"/v1/images/",
+		"/v1/images/variations",
+		"/v1/images/generations/extra",
+		"/v1/images/random",
+	} {
+		if isValidAPIPath(path) {
+			t.Fatalf("did not expect %q to pass the project proxy whitelist", path)
+		}
+	}
 }
 
 // TestProviderAPIPathAllowsImagesEndpoints pins the same contract for the
-// sibling /provider/<id>/ prefix. Both whitelists must stay in sync with
-// proxy_routes.go; otherwise provider-scoped image requests 404 with
-// "invalid provider proxy path".
+// sibling /provider/<id>/ prefix: only the two registered endpoints, no
+// broader prefix match.
 func TestProviderAPIPathAllowsImagesEndpoints(t *testing.T) {
 	for _, path := range []string{"/v1/images/generations", "/v1/images/edits"} {
 		if !isValidProviderAPIPath(path) {
 			t.Fatalf("expected %q to be valid for provider proxy URLs", path)
+		}
+	}
+	for _, path := range []string{
+		"/v1/images",
+		"/v1/images/",
+		"/v1/images/variations",
+		"/v1/images/generations/extra",
+		"/v1/images/random",
+	} {
+		if isValidProviderAPIPath(path) {
+			t.Fatalf("did not expect %q to pass the provider proxy whitelist", path)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

#579 wired `/v1/images/generations` and `/v1/images/edits` into the root mux via `internal/core/proxy_routes.go`, but missed **two parallel whitelists** that gate the project- and provider-prefixed proxy paths:

- `internal/handler/project_proxy.go:isValidAPIPath` → `/project/<slug>/v1/images/*` → **404 "invalid project proxy path"**
- `internal/handler/provider_proxy.go:isValidProviderAPIPath` → `/provider/<id>/v1/images/*` → **404 "invalid provider proxy path"**

Both reproduced on live v0.13.84 (root-path `/v1/images/generations` works fine; the project/provider-prefixed variants 404 with the messages above).

## Fix

Add `strings.HasPrefix(path, "/v1/images/")` to both whitelists next to `/v1/chat/completions`. Two tiny, mirrored changes.

## Tests

Two regression tests, one per whitelist, mirroring the existing `TestProjectAPIPathAllowsExactGeminiModelList`:

- `TestProjectAPIPathAllowsImagesEndpoints`
- `TestProviderAPIPathAllowsImagesEndpoints`

Both cover `/v1/images/generations` and `/v1/images/edits`. `go test ./internal/handler/...` green.

## Note (not fixed, intentionally)

`internal/testutil/mockserver/protocol.go:DetectProtocol` has no explicit `/v1/images/` case, but its default branch returns `ProtocolOpenAI` which is the correct protocol for images — functionally fine; left implicit to keep this PR scoped to the production bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **问题修复**
  * 在以项目或供应商为前缀的代理路径下，允许图像生成与图像编辑请求（精确为 /v1/images/generations 与 /v1/images/edits），避免被误判为无效路径或返回 404。
* **测试**
  * 新增针对项目与供应商代理路径的测试，验证上述图像端点在相应作用域下被视为合法 API 路径。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->