### PR TITLE
fix(usage): correctly extract OpenAI chat-completions + banana image tokens

### DIFF
--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -129,8 +129,18 @@ func extractFromSSE(body string) *Metrics {
 // extractUsageFromMap extracts usage metrics from a parsed JSON map.
 // Handles multiple API formats.
 func extractUsageFromMap(data map[string]interface{}) *Metrics {
-	// Try Claude/Anthropic format: { "usage": { ... } }
+	// Try top-level { "usage": { ... } }. The same key serves both OpenAI chat
+	// completions (prompt_tokens / completion_tokens) and Claude / OpenAI Images
+	// (input_tokens / output_tokens), so we dispatch by inspecting the usage
+	// map itself. OpenAI-compatible relays (linkapi, oneapi, etc.) sometimes
+	// emit *both* schemas in the same payload — typically real numbers in
+	// prompt_tokens/completion_tokens and zero-padded input_tokens/output_tokens
+	// for Claude-client compatibility. Detecting OpenAI first prevents those
+	// zero-pads from silently zeroing chat-completions billing.
 	if usage, ok := data["usage"].(map[string]interface{}); ok {
+		if isOpenAIUsage(usage) {
+			return extractOpenAIUsage(usage)
+		}
 		return extractClaudeUsage(usage)
 	}
 
@@ -159,15 +169,21 @@ func extractUsageFromMap(data map[string]interface{}) *Metrics {
 		}
 	}
 
-	// Try OpenAI choices format for some responses
-	if choices, ok := data["choices"].([]interface{}); ok && len(choices) > 0 {
-		// Usage might be at root level alongside choices
-		if usage, ok := data["usage"].(map[string]interface{}); ok {
-			return extractOpenAIUsage(usage)
-		}
-	}
-
 	return nil
+}
+
+// isOpenAIUsage reports whether a usage map uses OpenAI chat-completions naming
+// (prompt_tokens / completion_tokens). These keys are absent from Claude and
+// from the OpenAI Images API (which both use input_tokens / output_tokens), so
+// their presence is a reliable discriminator.
+func isOpenAIUsage(usage map[string]interface{}) bool {
+	if _, ok := usage["prompt_tokens"]; ok {
+		return true
+	}
+	if _, ok := usage["completion_tokens"]; ok {
+		return true
+	}
+	return false
 }
 
 // extractClaudeUsage extracts metrics from Claude/Anthropic usage format.
@@ -213,10 +229,18 @@ func extractClaudeUsage(usage map[string]interface{}) *Metrics {
 	return metrics
 }
 
-// applyImageTokenDetails pulls the image-token breakdown out of an OpenAI Images
-// API usage object: input_tokens_details.image_tokens and
-// output_tokens_details.image_tokens. Subsets of input/output tokens, billed at
-// the image rate. No-op for text models (the *_details.image_tokens are absent).
+// applyImageTokenDetails pulls the image-token breakdown out of a usage object.
+// Two parallel namings exist across OpenAI-compatible APIs:
+//
+//   - Images API (gpt-image-*): input_tokens_details.image_tokens,
+//     output_tokens_details.image_tokens.
+//   - Chat completions (e.g. gemini-2.5-flash-image / "nano-banana" relayed via
+//     OpenAI-compatible aggregators): prompt_tokens_details.image_tokens,
+//     completion_tokens_details.image_tokens.
+//
+// Both produce subsets of InputTokens/OutputTokens that pricing charges at the
+// image rate. We accept either naming and let later writes win (in practice
+// only one of each pair carries nonzero image_tokens for a given response).
 func applyImageTokenDetails(usage map[string]interface{}, m *Metrics) {
 	if d, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
 		if v, ok := d["image_tokens"].(float64); ok {
@@ -224,6 +248,16 @@ func applyImageTokenDetails(usage map[string]interface{}, m *Metrics) {
 		}
 	}
 	if d, ok := usage["output_tokens_details"].(map[string]interface{}); ok {
+		if v, ok := d["image_tokens"].(float64); ok {
+			m.OutputImageTokens = uint64(v)
+		}
+	}
+	if d, ok := usage["prompt_tokens_details"].(map[string]interface{}); ok {
+		if v, ok := d["image_tokens"].(float64); ok {
+			m.InputImageTokens = uint64(v)
+		}
+	}
+	if d, ok := usage["completion_tokens_details"].(map[string]interface{}); ok {
 		if v, ok := d["image_tokens"].(float64); ok {
 			m.OutputImageTokens = uint64(v)
 		}
@@ -237,23 +271,21 @@ func applyImageTokenDetails(usage map[string]interface{}, m *Metrics) {
 func extractOpenAIUsage(usage map[string]interface{}) *Metrics {
 	metrics := &Metrics{}
 
-	// Standard OpenAI format: prompt_tokens → Input tokens
+	// Token counts: prefer chat-completions naming (prompt_tokens /
+	// completion_tokens) over Response-API naming (input_tokens / output_tokens)
+	// when both are present. OpenAI-compatible relays often dual-emit both —
+	// typically with real numbers in prompt_tokens/completion_tokens and zero
+	// padding in input_tokens/output_tokens for Claude-client compatibility —
+	// so a naive last-wins overwrite would zero out billing.
 	if v, ok := usage["prompt_tokens"].(float64); ok {
 		metrics.InputTokens = uint64(v)
-	}
-
-	// Response API / Codex format: input_tokens (may include cached tokens)
-	if v, ok := usage["input_tokens"].(float64); ok {
+	} else if v, ok := usage["input_tokens"].(float64); ok {
 		metrics.InputTokens = uint64(v)
 	}
 
-	// Standard OpenAI format: completion_tokens → Output tokens
 	if v, ok := usage["completion_tokens"].(float64); ok {
 		metrics.OutputTokens = uint64(v)
-	}
-
-	// Response API / Codex format: output_tokens
-	if v, ok := usage["output_tokens"].(float64); ok {
+	} else if v, ok := usage["output_tokens"].(float64); ok {
 		metrics.OutputTokens = uint64(v)
 	}
 

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -299,6 +299,93 @@ func TestExtractFromResponse_GptImageEditsTokenSplit(t *testing.T) {
 	}
 }
 
+// TestExtractFromResponse_OpenAIChatCompletions pins the dispatcher contract
+// for plain OpenAI chat-completions responses. Before the fix, the top-level
+// {"usage": ...} branch unconditionally ran the Claude extractor, which only
+// looks for input_tokens / output_tokens — so prompt_tokens / completion_tokens
+// were silently dropped and the request billed at zero.
+func TestExtractFromResponse_OpenAIChatCompletions(t *testing.T) {
+	body := `{
+		"id": "chatcmpl-xyz",
+		"object": "chat.completion",
+		"model": "gpt-4o-mini",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+		"usage": {
+			"prompt_tokens": 17,
+			"completion_tokens": 5,
+			"total_tokens": 22
+		}
+	}`
+
+	m := ExtractFromResponse(body)
+	if m == nil {
+		t.Fatal("expected metrics for chat-completions response, got nil")
+	}
+	if m.InputTokens != 17 || m.OutputTokens != 5 {
+		t.Errorf("tokens = in %d / out %d, want 17 / 5", m.InputTokens, m.OutputTokens)
+	}
+}
+
+// TestExtractFromResponse_OpenAIChatCompletionsZeroPadded covers the real-world
+// shape returned by OpenAI-compatible aggregators (linkapi, oneapi, etc.) that
+// dual-emit Claude-style zero-padded input_tokens / output_tokens alongside the
+// real OpenAI numbers. The dispatcher must pick OpenAI by detecting
+// prompt_tokens / completion_tokens, not silently zero out billing.
+func TestExtractFromResponse_OpenAIChatCompletionsZeroPadded(t *testing.T) {
+	body := `{
+		"object": "chat.completion",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+		"usage": {
+			"prompt_tokens": 12,
+			"completion_tokens": 34,
+			"total_tokens": 46,
+			"input_tokens": 0,
+			"output_tokens": 0,
+			"input_tokens_details": null
+		}
+	}`
+
+	m := ExtractFromResponse(body)
+	if m == nil {
+		t.Fatal("expected metrics, got nil")
+	}
+	if m.InputTokens != 12 || m.OutputTokens != 34 {
+		t.Errorf("zero-padded relay should not zero billing: tokens = in %d / out %d, want 12 / 34", m.InputTokens, m.OutputTokens)
+	}
+}
+
+// TestExtractFromResponse_GeminiFlashImageViaChatCompletions covers the
+// "nano-banana" (gemini-2.5-flash-image) shape relayed through OpenAI chat
+// completions: image tokens land under completion_tokens_details.image_tokens,
+// not output_tokens_details.image_tokens like the OpenAI Images API. Without
+// this branch the image-rate price wouldn't be applied (image_tokens stays 0).
+func TestExtractFromResponse_GeminiFlashImageViaChatCompletions(t *testing.T) {
+	body := `{
+		"id": "chatcmpl-banana",
+		"object": "chat.completion",
+		"model": "gemini-2.5-flash-image",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "![image](data:...)"}, "finish_reason": "stop"}],
+		"usage": {
+			"prompt_tokens": 7,
+			"completion_tokens": 1290,
+			"total_tokens": 1297,
+			"prompt_tokens_details": {"text_tokens": 7, "image_tokens": 0},
+			"completion_tokens_details": {"text_tokens": 0, "image_tokens": 1290}
+		}
+	}`
+
+	m := ExtractFromResponse(body)
+	if m == nil {
+		t.Fatal("expected metrics for banana response, got nil")
+	}
+	if m.InputTokens != 7 || m.OutputTokens != 1290 {
+		t.Errorf("tokens = in %d / out %d, want 7 / 1290", m.InputTokens, m.OutputTokens)
+	}
+	if m.OutputImageTokens != 1290 {
+		t.Errorf("OutputImageTokens = %d, want 1290 (banana image output should bill at image rate)", m.OutputImageTokens)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Benchmarks: Old (full-buffer) vs New (incremental)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

While verifying billing for `gemini-2.5-flash-image` ("nano-banana") through maxx I traced a request that returned HTTP 200 with a real image and upstream `usage.prompt_tokens=7, usage.completion_tokens=1290, usage.completion_tokens_details.image_tokens=1290`, but landed in the DB with `inputTokenCount=0 outputTokenCount=0 cost=0 modelPriceId=0`. The token extractor was silently zeroing it.

Two stacked bugs in `internal/usage/extractor.go`:

1. **Dispatch ordering** — `extractUsageFromMap` unconditionally ran `extractClaudeUsage` for any top-level `{"usage": …}`. Claude's extractor only reads `input_tokens` / `output_tokens`, so OpenAI chat-completions (`prompt_tokens` / `completion_tokens`) were dropped. The OpenAI branch further down was dead code, unreachable while `data["usage"]` is set. Affects all openai-clientType chat-completions traffic — Codex (Response API, `response.usage`) is unaffected because it goes through a different branch.

2. **Within `extractOpenAIUsage`** — naive last-wins overwrite of `prompt_tokens` by `input_tokens`. OpenAI-compatible aggregators (linkapi, oneapi, …) dual-emit Claude-style zero-padded `input_tokens:0` / `output_tokens:0` alongside the real OpenAI numbers for Claude-client compatibility. Even with #1 fixed, the zero pads would still clobber the real values.

Plus a third gap blocking image-rate billing: `applyImageTokenDetails` only knew the Images API naming (`input_tokens_details.image_tokens`, `output_tokens_details.image_tokens`). Banana goes through chat completions and uses `prompt_tokens_details.image_tokens` / `completion_tokens_details.image_tokens` instead.

## What

- `extractUsageFromMap` detects format from the usage map itself via a small `isOpenAIUsage` helper (presence of `prompt_tokens` or `completion_tokens`) and dispatches before the Claude fallback. Removes the now-redundant `choices`+`usage` block at the bottom (that path was always unreachable).
- `extractOpenAIUsage` switches `input_tokens` / `output_tokens` to an `else if` fallback so chat-completions naming wins when both are present.
- `applyImageTokenDetails` accepts both naming conventions.

## Tests

Three new tests in `extractor_test.go`:
- `TestExtractFromResponse_OpenAIChatCompletions` — plain chat completions
- `TestExtractFromResponse_OpenAIChatCompletionsZeroPadded` — linkapi-style dual emit (the actual production trigger)
- `TestExtractFromResponse_GeminiFlashImageViaChatCompletions` — banana with `completion_tokens_details.image_tokens=1290` correctly populates `OutputImageTokens`

All existing extractor tests (gpt-image-2 generations + edits, Claude / Codex / Gemini variants) untouched and still pass; full `go test ./internal/...` is green.

## Verification (live)

Traced via a maxx admin attempt for a banana request through linkapi:
- Before: `tokens=0/0 cost=0 modelPriceId=0`
- After (locally with this fix + a `gemini-2.5-flash-image` `model_prices` entry priced at Google list rates): tokens read `7/1290` with `OutputImageTokens=1290`, so the calculator bills the 1290 output tokens at the image rate ($30/M) rather than the text rate ($2.50/M) — ~12× difference per banana image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **错误修复**
  * 修复了OpenAI兼容API转发时token计数被零覆盖导致计费异常的问题
  * 改进了图片token的提取逻辑

* **测试**
  * 新增单元测试用于验证OpenAI聊天完成API的token计数准确性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->