### PR TITLE
fix(provider-proxy): record attempts + bill /provider/<id>/... direct dispatch

### DIFF
--- a/internal/executor/single_attempt.go
+++ b/internal/executor/single_attempt.go
@@ -68,7 +68,14 @@ func (e *Executor) ExecuteOnce(
 		attempt.TenantID = maxxctx.GetTenantID(c.Request.Context())
 	}
 	if err := e.attemptRepo.Create(attempt); err != nil {
+		// Fail fast: if the attempt row can't be persisted, downstream cost
+		// mirroring would write a billing row whose backing attempt doesn't
+		// exist — exactly the desync this PR is meant to prevent. The caller
+		// surfaces this as a normal failure path on the ProxyRequest, leaving
+		// proxyReq.ProxyUpstreamAttemptCount at 0 (no phantom-incremented
+		// counter).
 		log.Printf("[Executor] ExecuteOnce: failed to create attempt record: %v", err)
+		return nil, err
 	}
 
 	proxyReq.ProxyUpstreamAttemptCount++

--- a/internal/executor/single_attempt.go
+++ b/internal/executor/single_attempt.go
@@ -118,7 +118,15 @@ func (e *Executor) ExecuteOnce(
 		attempt.RequestInfo = nil
 		attempt.ResponseInfo = nil
 	}
-	_ = e.attemptRepo.Update(attempt)
+	// Persisting the final attempt is best-effort here: adapter.Execute may
+	// already have written the upstream response to the client, so converting
+	// a late DB update failure into a returned adapter error could append an
+	// error body onto an otherwise successful response. Keep the request billing
+	// mirror below as the durable billing record; stale IN_PROGRESS attempts are
+	// handled by the existing stale-attempt cleanup path.
+	if updateErr := e.attemptRepo.Update(attempt); updateErr != nil {
+		log.Printf("[Executor] ExecuteOnce: failed to update final attempt record: %v", updateErr)
+	}
 	if e.broadcaster != nil {
 		e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
 	}

--- a/internal/executor/single_attempt.go
+++ b/internal/executor/single_attempt.go
@@ -1,0 +1,126 @@
+package executor
+
+import (
+	"log"
+	"time"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/pricing"
+)
+
+// ExecuteOnce wraps a single adapter.Execute call with the per-attempt
+// bookkeeping the retry-driven dispatch middleware performs each iteration:
+// attempt-row creation, adapter-event collection, and cost finalization.
+//
+// It is intended for paths that bypass route selection / retry (currently the
+// /provider/<id>/... direct-dispatch handler) but still need a fully recorded
+// + billed attempt. Without this, the bypass path persisted a proxy request
+// with proxyUpstreamAttemptCount=0 / cost=0 / multiplier=0 and no attempt
+// rows at all — silently zero-billing every request.
+//
+// Caller contract:
+//   - c.Writer must already be configured (capture / modifier / conversion
+//     wrappers) before this is called; ExecuteOnce does not touch the writer.
+//   - The caller owns the ProxyRequest's end-of-life fields beyond what's
+//     mirrored from the attempt (Status, EndTime, Duration, ResponseInfo,
+//     StatusCode) and persists it via its repository.
+//
+// ExecuteOnce takes care of:
+//   - Inserting a ProxyUpstreamAttempt row before adapter.Execute.
+//   - Setting flow.KeyUpstreamAttempt + flow.KeyEventChan so the adapter can
+//     emit token / first-token / response-info events.
+//   - Spawning processAdapterEventsRealtime to drain those events into the
+//     attempt and broadcast progress.
+//   - Calling pricing.FinalizeAttemptCost (success or failure) and updating
+//     the attempt row.
+//   - Bumping proxyReq.ProxyUpstreamAttemptCount and, on success, setting
+//     FinalProxyUpstreamAttemptID + mirroring cost via pricing.MirrorCostToRequest
+//     and copying TTFT.
+//
+// Returns the persisted attempt and the adapter's error (nil on success).
+func (e *Executor) ExecuteOnce(
+	c *flow.Ctx,
+	proxyReq *domain.ProxyRequest,
+	route *domain.Route,
+	provider *domain.Provider,
+	adapter provideradapter.ProviderAdapter,
+	clientType domain.ClientType,
+	requestModel, mappedModel string,
+	isStream bool,
+	clearDetail bool,
+) (*domain.ProxyUpstreamAttempt, error) {
+	attempt := &domain.ProxyUpstreamAttempt{
+		TenantID:       proxyReq.TenantID,
+		ProxyRequestID: proxyReq.ID,
+		RouteID:        route.ID,
+		ProviderID:     provider.ID,
+		IsStream:       isStream,
+		Status:         "IN_PROGRESS",
+		StartTime:      time.Now(),
+		RequestModel:   requestModel,
+		MappedModel:    mappedModel,
+		RequestInfo:    proxyReq.RequestInfo,
+	}
+	if attempt.TenantID == 0 {
+		attempt.TenantID = maxxctx.GetTenantID(c.Request.Context())
+	}
+	if err := e.attemptRepo.Create(attempt); err != nil {
+		log.Printf("[Executor] ExecuteOnce: failed to create attempt record: %v", err)
+	}
+
+	proxyReq.ProxyUpstreamAttemptCount++
+	if e.broadcaster != nil {
+		e.broadcaster.BroadcastProxyRequest(proxyReq)
+		e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+	}
+
+	eventChan := domain.NewAdapterEventChan()
+	c.Set(flow.KeyUpstreamAttempt, attempt)
+	c.Set(flow.KeyEventChan, eventChan)
+	c.Set(flow.KeyBroadcaster, e.broadcaster)
+
+	eventDone := make(chan struct{})
+	go e.processAdapterEventsRealtime(eventChan, attempt, eventDone, clearDetail)
+
+	err := adapter.Execute(c, provider)
+
+	// Closing the channel signals the processor to drain remaining events
+	// and exit; waiting on eventDone guarantees all metric writes have
+	// landed on the attempt before we finalize cost.
+	eventChan.Close()
+	<-eventDone
+
+	attempt.EndTime = time.Now()
+	attempt.Duration = attempt.EndTime.Sub(attempt.StartTime)
+	switch {
+	case err == nil:
+		attempt.Status = "COMPLETED"
+	case c.Request.Context().Err() != nil:
+		attempt.Status = "CANCELLED"
+	default:
+		attempt.Status = "FAILED"
+	}
+
+	multiplier := getProviderMultiplier(provider, clientType)
+	pricing.FinalizeAttemptCost(attempt, multiplier)
+
+	if clearDetail {
+		attempt.RequestInfo = nil
+		attempt.ResponseInfo = nil
+	}
+	_ = e.attemptRepo.Update(attempt)
+	if e.broadcaster != nil {
+		e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+	}
+
+	if err == nil {
+		proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
+		pricing.MirrorCostToRequest(proxyReq, attempt)
+		proxyReq.TTFT = attempt.TTFT
+	}
+
+	return attempt, err
+}

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -212,6 +212,62 @@ func TestExecuteOnce_FailsFastOnCreateError(t *testing.T) {
 	}
 }
 
+// failingUpdateAttemptRepo records a successful Create but fails the final
+// Update, matching a late persistence failure after adapter.Execute has already
+// produced an upstream response.
+type failingUpdateAttemptRepo struct {
+	recordingAttemptRepo
+	updateErr error
+}
+
+func (r *failingUpdateAttemptRepo) Update(a *domain.ProxyUpstreamAttempt) error {
+	snap := *a
+	r.recordingAttemptRepo.updated = append(r.recordingAttemptRepo.updated, &snap)
+	return r.updateErr
+}
+
+// TestExecuteOnce_FinalUpdateFailureStillMirrorsBilling documents the direct-
+// dispatch contract for a late attempt update failure. At this point the
+// adapter may already have written a successful response, so ExecuteOnce keeps
+// the parent request billing mirror rather than converting the completed
+// client response into an adapter error. The stale attempt row is left for the
+// existing stale-attempt cleanup path.
+func TestExecuteOnce_FinalUpdateFailureStillMirrorsBilling(t *testing.T) {
+	repo := &failingUpdateAttemptRepo{updateErr: errFakeRepo}
+	e := &Executor{attemptRepo: repo}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/1/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{TenantID: 1, ID: 42}
+	route := &domain.Route{ID: 99, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+	adapter := &fakeMetricsAdapter{in: 7, out: 1290}
+
+	attempt, err := e.ExecuteOnce(
+		c, proxyReq, route, provider, adapter,
+		domain.ClientTypeOpenAI, "m", "m", false, false,
+	)
+	if err != nil {
+		t.Fatalf("ExecuteOnce returned error on final Update failure: %v", err)
+	}
+	if attempt == nil || attempt.Status != "COMPLETED" {
+		t.Fatalf("expected completed in-memory attempt, got %+v", attempt)
+	}
+	if len(repo.updated) != 1 {
+		t.Fatalf("expected exactly 1 final Update attempt, got %d", len(repo.updated))
+	}
+	if proxyReq.FinalProxyUpstreamAttemptID != attempt.ID {
+		t.Errorf("FinalProxyUpstreamAttemptID = %d, want %d",
+			proxyReq.FinalProxyUpstreamAttemptID, attempt.ID)
+	}
+	if proxyReq.InputTokenCount != 7 || proxyReq.OutputTokenCount != 1290 {
+		t.Errorf("proxyReq tokens not mirrored after final Update failure: in %d / out %d, want 7 / 1290",
+			proxyReq.InputTokenCount, proxyReq.OutputTokenCount)
+	}
+}
+
 // TestExecuteOnce_RecordsFailedAttemptWithoutMirroringCost guards the failure
 // path: when the adapter errors, the attempt row still gets persisted with
 // Status=FAILED and the multiplier is preserved (for audit), but the request's

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -1,0 +1,195 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// recordingAttemptRepo captures Create/Update calls so the test can assert on
+// the persisted attempt state. The real sqlite repo just writes to a DB; for
+// unit-testing ExecuteOnce we only need the create/update lifecycle.
+type recordingAttemptRepo struct {
+	created []*domain.ProxyUpstreamAttempt
+	updated []*domain.ProxyUpstreamAttempt
+	nextID  uint64
+}
+
+func (r *recordingAttemptRepo) Create(a *domain.ProxyUpstreamAttempt) error {
+	r.nextID++
+	a.ID = r.nextID
+	// Snapshot fields we care about so later Update mutations don't clobber
+	// our view of what was persisted at creation time.
+	snap := *a
+	r.created = append(r.created, &snap)
+	return nil
+}
+
+func (r *recordingAttemptRepo) Update(a *domain.ProxyUpstreamAttempt) error {
+	snap := *a
+	r.updated = append(r.updated, &snap)
+	return nil
+}
+
+func (r *recordingAttemptRepo) ListByProxyRequestID(uint64) ([]*domain.ProxyUpstreamAttempt, error) {
+	return nil, nil
+}
+
+func (r *recordingAttemptRepo) ListAll() ([]*domain.ProxyUpstreamAttempt, error) { return nil, nil }
+
+func (r *recordingAttemptRepo) CountAll() (int64, error) { return 0, nil }
+
+func (r *recordingAttemptRepo) StreamForCostCalc(int, func([]*domain.AttemptCostData) error) error {
+	return nil
+}
+
+func (r *recordingAttemptRepo) BatchUpdateCosts(map[uint64]domain.AttemptCostUpdate) error {
+	return nil
+}
+
+func (r *recordingAttemptRepo) MarkStaleAttemptsFailed() (int64, error) { return 0, nil }
+
+func (r *recordingAttemptRepo) FixFailedAttemptsWithoutEndTime() (int64, error) { return 0, nil }
+
+func (r *recordingAttemptRepo) ClearDetailOlderThan(time.Time, []string) (int64, error) {
+	return 0, nil
+}
+
+// fakeMetricsAdapter emits a single EventMetrics event then returns. Models a
+// provider adapter that successfully parsed usage from the upstream response.
+type fakeMetricsAdapter struct {
+	in, out uint64
+	err     error
+}
+
+func (a *fakeMetricsAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *fakeMetricsAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	if ch := flow.GetEventChan(c); ch != nil {
+		ch.SendMetrics(&domain.AdapterMetrics{InputTokens: a.in, OutputTokens: a.out})
+	}
+	return a.err
+}
+
+// TestExecuteOnce_PersistsAttemptAndMirrorsBilling pins the contract that
+// drives the /provider/<id>/... direct-dispatch fix: a single adapter
+// execution must produce a fully-billed attempt row and a ProxyRequest whose
+// billing fields mirror the attempt. Before ExecuteOnce existed, the bypass
+// path skipped attempt creation entirely — every request landed with
+// proxyUpstreamAttemptCount=0 and cost=0.
+func TestExecuteOnce_PersistsAttemptAndMirrorsBilling(t *testing.T) {
+	repo := &recordingAttemptRepo{}
+	e := &Executor{attemptRepo: repo}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/1/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{TenantID: 1, ID: 42}
+	route := &domain.Route{ID: 99, ProjectID: 0, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{
+		ID:   7,
+		Type: "custom",
+		Config: &domain.ProviderConfig{
+			Custom: &domain.ProviderConfigCustom{
+				ClientMultiplier: map[domain.ClientType]uint64{domain.ClientTypeOpenAI: 64000},
+			},
+		},
+	}
+	adapter := &fakeMetricsAdapter{in: 7, out: 1290}
+
+	attempt, err := e.ExecuteOnce(
+		c, proxyReq, route, provider, adapter,
+		domain.ClientTypeOpenAI, "gemini-2.5-flash-image", "gemini-2.5-flash-image",
+		false, false,
+	)
+	if err != nil {
+		t.Fatalf("ExecuteOnce returned error: %v", err)
+	}
+	if attempt == nil {
+		t.Fatal("ExecuteOnce returned nil attempt")
+	}
+
+	if len(repo.created) != 1 {
+		t.Fatalf("expected exactly 1 attempt created, got %d", len(repo.created))
+	}
+	if len(repo.updated) == 0 {
+		t.Fatal("expected at least one Update call to persist final state")
+	}
+
+	if got := repo.created[0].Status; got != "IN_PROGRESS" {
+		t.Errorf("created attempt status = %q, want IN_PROGRESS", got)
+	}
+
+	if attempt.Status != "COMPLETED" {
+		t.Errorf("final attempt status = %q, want COMPLETED", attempt.Status)
+	}
+	if attempt.InputTokenCount != 7 || attempt.OutputTokenCount != 1290 {
+		t.Errorf("attempt tokens = in %d / out %d, want 7 / 1290",
+			attempt.InputTokenCount, attempt.OutputTokenCount)
+	}
+	if attempt.Multiplier != 64000 {
+		t.Errorf("attempt multiplier = %d, want 64000 (6.4× from clientMultiplier)",
+			attempt.Multiplier)
+	}
+
+	if proxyReq.ProxyUpstreamAttemptCount != 1 {
+		t.Errorf("ProxyUpstreamAttemptCount = %d, want 1",
+			proxyReq.ProxyUpstreamAttemptCount)
+	}
+	if proxyReq.FinalProxyUpstreamAttemptID != attempt.ID {
+		t.Errorf("FinalProxyUpstreamAttemptID = %d, want %d",
+			proxyReq.FinalProxyUpstreamAttemptID, attempt.ID)
+	}
+	if proxyReq.InputTokenCount != 7 || proxyReq.OutputTokenCount != 1290 {
+		t.Errorf("proxyReq tokens not mirrored: in %d / out %d, want 7 / 1290",
+			proxyReq.InputTokenCount, proxyReq.OutputTokenCount)
+	}
+	if proxyReq.Multiplier != 64000 {
+		t.Errorf("proxyReq multiplier not mirrored: %d, want 64000",
+			proxyReq.Multiplier)
+	}
+}
+
+// TestExecuteOnce_RecordsFailedAttemptWithoutMirroringCost guards the failure
+// path: when the adapter errors, the attempt row still gets persisted with
+// Status=FAILED and the multiplier is preserved (for audit), but the request's
+// billing fields stay zero — we don't bill failed upstream calls.
+func TestExecuteOnce_RecordsFailedAttemptWithoutMirroringCost(t *testing.T) {
+	repo := &recordingAttemptRepo{}
+	e := &Executor{attemptRepo: repo}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/1/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{TenantID: 1, ID: 42}
+	route := &domain.Route{ID: 99, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+	adapter := &fakeMetricsAdapter{err: &domain.ProxyError{Message: "boom"}}
+
+	attempt, err := e.ExecuteOnce(
+		c, proxyReq, route, provider, adapter,
+		domain.ClientTypeOpenAI, "m", "m", false, false,
+	)
+	if err == nil {
+		t.Fatal("expected error from failing adapter")
+	}
+	if attempt == nil || attempt.Status != "FAILED" {
+		t.Fatalf("expected attempt.Status=FAILED, got %+v", attempt)
+	}
+	if proxyReq.FinalProxyUpstreamAttemptID != 0 {
+		t.Errorf("FinalProxyUpstreamAttemptID = %d on failure path; should stay zero",
+			proxyReq.FinalProxyUpstreamAttemptID)
+	}
+	if proxyReq.Cost != 0 {
+		t.Errorf("proxyReq.Cost = %d on failure path; should stay zero", proxyReq.Cost)
+	}
+}

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,8 @@ import (
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 )
+
+var errFakeRepo = errors.New("fake repo persistence error")
 
 // recordingAttemptRepo captures Create/Update calls so the test can assert on
 // the persisted attempt state. The real sqlite repo just writes to a DB; for
@@ -155,6 +158,57 @@ func TestExecuteOnce_PersistsAttemptAndMirrorsBilling(t *testing.T) {
 	if proxyReq.Multiplier != 64000 {
 		t.Errorf("proxyReq multiplier not mirrored: %d, want 64000",
 			proxyReq.Multiplier)
+	}
+}
+
+// failingCreateAttemptRepo embeds recording behaviour but returns an error
+// from Create — to verify the bypass path's fail-fast contract when the
+// attempt row can't be persisted.
+type failingCreateAttemptRepo struct {
+	recordingAttemptRepo
+	createErr error
+}
+
+func (r *failingCreateAttemptRepo) Create(a *domain.ProxyUpstreamAttempt) error {
+	r.recordingAttemptRepo.created = append(r.recordingAttemptRepo.created, &domain.ProxyUpstreamAttempt{})
+	return r.createErr
+}
+
+// TestExecuteOnce_FailsFastOnCreateError pins the safety contract added to
+// address the desync concern: if the attempt row can't be persisted, do NOT
+// continue running the adapter (which would mirror cost onto the request
+// without any backing attempt row, leaving ProxyUpstreamAttemptCount=1 and
+// FinalProxyUpstreamAttemptID=0 — exactly the corrupt state this PR fixes).
+func TestExecuteOnce_FailsFastOnCreateError(t *testing.T) {
+	repo := &failingCreateAttemptRepo{createErr: errFakeRepo}
+	e := &Executor{attemptRepo: repo}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/1/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{TenantID: 1, ID: 42}
+	route := &domain.Route{ID: 99, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+	adapter := &fakeMetricsAdapter{in: 7, out: 1290} // would emit metrics if ever called
+
+	attempt, err := e.ExecuteOnce(
+		c, proxyReq, route, provider, adapter,
+		domain.ClientTypeOpenAI, "m", "m", false, false,
+	)
+	if err != errFakeRepo {
+		t.Fatalf("expected fail-fast Create error to be returned, got %v", err)
+	}
+	if attempt != nil {
+		t.Errorf("expected nil attempt on Create failure, got %+v", attempt)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 0 {
+		t.Errorf("ProxyUpstreamAttemptCount = %d on Create failure; should stay 0 (no phantom counter)",
+			proxyReq.ProxyUpstreamAttemptCount)
+	}
+	if proxyReq.Cost != 0 || proxyReq.Multiplier != 0 {
+		t.Errorf("proxyReq billing fields touched on Create failure: cost=%d mult=%d",
+			proxyReq.Cost, proxyReq.Multiplier)
 	}
 }
 

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -148,7 +148,22 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 		responseCapture := executor.NewResponseCapture(clientWriter)
 		originalWriter := c.Writer
 		c.Writer = responseCapture
-		err = adapter.Execute(c, provider)
+		// Route through ExecuteOnce so this bypass path gets the same attempt-
+		// record + cost-finalization treatment as the retry-driven dispatch.
+		// Without this, /provider/<id>/... requests landed in the DB with 0
+		// attempts and cost=0 / multiplier=0 / modelPriceId=0 — silently
+		// zero-billing every direct-dispatch call.
+		if h.proxyHandler != nil && h.proxyHandler.executor != nil {
+			_, err = h.proxyHandler.executor.ExecuteOnce(
+				c, proxyReq, route, provider, adapter,
+				clientType, requestModel, mappedModel, isStream, clearDetail,
+			)
+		} else {
+			// Test / partially-wired setups without an executor: fall back to a
+			// bare adapter call. Billing will be unrecorded (as before) but the
+			// request still completes.
+			err = adapter.Execute(c, provider)
+		}
 		c.Writer = originalWriter
 
 		now := time.Now()

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -153,16 +153,22 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 		// Without this, /provider/<id>/... requests landed in the DB with 0
 		// attempts and cost=0 / multiplier=0 / modelPriceId=0 — silently
 		// zero-billing every direct-dispatch call.
-		if h.proxyHandler != nil && h.proxyHandler.executor != nil {
+		//
+		// Fail fast if the executor isn't wired: silently falling back to a
+		// bare adapter call would reintroduce the exact "succeeded request
+		// with no attempt/billing" condition this PR fixes whenever production
+		// is misconfigured. The /v1beta/models pre-branch above already
+		// handles the only legitimately executor-less case (model-list reads).
+		if h.proxyHandler == nil || h.proxyHandler.executor == nil {
+			err = &domain.ProxyError{
+				HTTPStatusCode: http.StatusInternalServerError,
+				Message:        "provider proxy executor not configured",
+			}
+		} else {
 			_, err = h.proxyHandler.executor.ExecuteOnce(
 				c, proxyReq, route, provider, adapter,
 				clientType, requestModel, mappedModel, isStream, clearDetail,
 			)
-		} else {
-			// Test / partially-wired setups without an executor: fall back to a
-			// bare adapter call. Billing will be unrecorded (as before) but the
-			// request still completes.
-			err = adapter.Execute(c, provider)
 		}
 		c.Writer = originalWriter
 


### PR DESCRIPTION
## Why

`ProviderProxyHandler.directDispatch` — the path that serves `/provider/<id>/...` requests by talking to one provider directly, bypassing route selection — calls `adapter.Execute` bare, without any of the attempt-recording or cost-finalization the retry-driven dispatch middleware performs per iteration.

The visible damage in production: a provider-prefixed request landed in the DB with `proxyUpstreamAttemptCount=0`, **zero attempt rows**, `cost=0 multiplier=0 modelPriceId=0` — silently zero-billing every call on this URL prefix regardless of upstream usage. Sibling `/project/<slug>/...` and root-level traffic go through the dispatch middleware and are correctly billed; only the provider-prefix path was affected.

## What

Add `executor.ExecuteOnce`, a small exported helper that wraps a single `adapter.Execute` call with the per-attempt lifecycle: insert `ProxyUpstreamAttempt` row, wire `flow.KeyUpstreamAttempt` + `flow.KeyEventChan` so the adapter can emit usage events, spawn `processAdapterEventsRealtime` to drain them, run `pricing.FinalizeAttemptCost` on completion (success or failure), and on success mirror cost + `FinalProxyUpstreamAttemptID` + TTFT up to the `ProxyRequest` via `pricing.MirrorCostToRequest`.

`directDispatch` routes its `adapter.Execute` through `ExecuteOnce`, keeping its existing modifier / capture writer chain intact. If `executor` is nil (test-only wiring) it falls back to a bare adapter call rather than panicking — billing stays unrecorded in that path, matching prior behaviour.

## Tests

`internal/executor/single_attempt_test.go`:
- `TestExecuteOnce_PersistsAttemptAndMirrorsBilling` — fake adapter emits `EventMetrics(in=7, out=1290)`; asserts attempt row created with `Status=IN_PROGRESS` then updated to `COMPLETED`, multiplier `64000` (from `clientMultiplier.openai`), `proxyReq.ProxyUpstreamAttemptCount=1`, mirrored tokens / multiplier / `FinalProxyUpstreamAttemptID`.
- `TestExecuteOnce_RecordsFailedAttemptWithoutMirroringCost` — failed adapter still records `Status=FAILED` attempt, but `proxyReq.Cost` / `FinalProxyUpstreamAttemptID` stay zero (we don't bill failed upstream calls).

Full `go test ./internal/...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为直连请求引入了单次尝试的记录与管理，覆盖尝试生命周期、状态与计费镜像
  * 在无执行器配置时改为返回服务器错误，避免绕过尝试记录的直接执行路径

* **修复/改进**
  * 统一了成功/失败路径的费用结算与镜像行为，确保计费一致性

* **测试**
  * 新增覆盖成功、创建失败、最终更新失败与适配器失败等场景的单元测试，验证持久化与计费逻辑

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->