### PR TITLE
fix(web): prevent provider details dialog overflow with long names/URLs

### DIFF
--- a/web/src/components/provider-details-dialog.tsx
+++ b/web/src/components/provider-details-dialog.tsx
@@ -246,7 +246,7 @@ export function ProviderDetailsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false} className="overflow-hidden p-0 w-full max-w-lg bg-card">
+      <DialogContent showCloseButton={false} className="overflow-hidden p-0 w-full max-w-lg bg-card grid-cols-[minmax(0,1fr)]">
         {/* Header */}
         <div className="flex items-center gap-3 p-4 border-b border-border">
           <div className={cn(
@@ -260,14 +260,14 @@ export function ProviderDetailsDialog({
             )}
           </div>
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <h2 className="text-base font-bold truncate">{provider.name}</h2>
+            <div className="flex items-center gap-2 min-w-0">
+              <h2 className="text-base font-bold truncate min-w-0">{provider.name}</h2>
               {isNative ? (
-                <span className="px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-emerald-500/10 text-emerald-500 border border-emerald-500/20">NATIVE</span>
+                <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-emerald-500/10 text-emerald-500 border border-emerald-500/20">NATIVE</span>
               ) : (
-                <span className="px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-500/10 text-amber-500 border border-amber-500/20">CONV</span>
+                <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-500/10 text-amber-500 border border-amber-500/20">CONV</span>
               )}
-              <span className="text-[10px] text-muted-foreground">{provider.type}</span>
+              <span className="shrink-0 text-[10px] text-muted-foreground">{provider.type}</span>
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
@@ -280,12 +280,14 @@ export function ProviderDetailsDialog({
 
         {/* Provider Info */}
         <div className="px-4 py-3 text-xs text-muted-foreground flex items-center gap-4 border-b border-border/50">
-          <span className="flex items-center gap-1.5">
-            <Info size={11} />
-            {provider.config?.custom?.baseURL || provider.config?.custom?.clientBaseURL?.[clientType] || '\u2014'}
+          <span className="flex items-center gap-1.5 min-w-0">
+            <Info size={11} className="shrink-0" />
+            <span className="truncate">
+              {provider.config?.custom?.baseURL || provider.config?.custom?.clientBaseURL?.[clientType] || '\u2014'}
+            </span>
           </span>
-          <span>{clientType}</span>
-          <span>Priority #{route?.position || '\u2014'}</span>
+          <span className="shrink-0">{clientType}</span>
+          <span className="shrink-0">Priority #{route?.position || '\u2014'}</span>
         </div>
 
         {/* Cooldowns Section */}
@@ -302,7 +304,7 @@ export function ProviderDetailsDialog({
                 <div key={i} className={cn('flex items-center gap-3 p-3 rounded-xl border', reasonInfo.bgColor)}>
                   <Icon size={16} className={cn('shrink-0', reasonInfo.color)} />
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-semibold">
+                    <div className="text-sm font-semibold truncate">
                       {cd.model || (isFrozen ? 'Provider' : cd.clientType || 'All')}
                     </div>
                     <div className="text-[11px] text-muted-foreground">{reasonInfo.label}</div>

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -49,6 +49,10 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Popup
         data-slot="dialog-content"
+        // NOTE: this `grid` has no explicit columns, so the implicit track is minmax(auto,1fr).
+        // Unbreakable long content (e.g. a long URL/name) can expand the track past max-width and
+        // push children off-screen. Callers needing truncation must pass `grid-cols-[minmax(0,1fr)]`.
+        // Globalizing that here requires auditing all dialogs that rely on auto track sizing first.
         className={cn(
           'bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-6 rounded-xl p-6 text-sm ring-1 duration-100 sm:max-w-md fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none',
           className,


### PR DESCRIPTION
## Summary
- 名称/URL 超长的 provider 在 routes 与 providers 页面点击打开详情弹窗时，内容溢出屏幕、展示不全。
- 根因：`DialogContent` 用 `grid` 布局，隐式列继承 `min-width:auto`，不可断行的长字符串会把列从 ~448px 撑到 ~1124px，把内容推出弹窗。
- 修复：在该弹窗的 `DialogContent` 上加 `grid-cols-[minmax(0,1fr)]` 锁死列宽，并为 header 名称、provider info 行、cooldown 模型名补齐 `min-w-0` / `truncate` / `shrink-0`。
- 在 `DialogContent` 基类处留注释标注该 grid 隐患，作为后续全局审计的线索（本 PR 不改基类，避免风险半径过大）。

## Changes
- `web/src/components/provider-details-dialog.tsx`：grid 列约束 + header/info 行截断 + cooldown 行 `cd.model` 补 `truncate`
- `web/src/components/ui/dialog.tsx`：基类 grid 隐患注释

## Test plan
- [x] 类型检查通过（`tsc -b`）
- [x] 浏览器实测：超长名称/URL 弹窗 grid 列宽 1124px → 448px，header 名称与 baseURL 截断省略、所有内容居中不溢出
- [x] 浏览器实测：cooldown 行超长模型名 `truncate` 生效（scrollWidth > clientWidth，右边界 1012 ≤ 弹窗 1184），倒计时与 unfreeze 按钮完整可见

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 改进了提供商详情对话框在窄屏或小窗口下的布局稳定性，优化了提供商名称、类型标签、URL 等信息的文本截断显示效果
* 增强了对话框内容在空间受限环境中的呈现效果，确保关键信息不会溢出或错位

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->