### PR TITLE
feat(routing): weighted load balancing with session-affinity sticky

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ AWS_REGION=us-east-1
 # Bedrock-compatible proxy (e.g. code0, bedrock-access-gateway)
 BEDROCK_PROXY_BASE_URL=
 BEDROCK_PROXY_API_KEY=
+
+# Routing — optional shared salt for the weighted_random strategy.
+# Set the same value on every instance for consistent first-pick
+# behavior in multi-instance deployments. When unset, each process
+# generates a per-process random salt; anti-grinding and Redis sticky
+# still work, but the pre-sticky first pick for a given (token, session)
+# may differ across instances until the sticky binding is written.
+MAXX_ROUTING_SEED_SALT=

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ codex
 | `MAXX_ADMIN_PASSWORD` | Enable admin authentication with JWT. Default username: `admin`, password: the value of this variable |
 | `MAXX_DSN` | Database connection string |
 | `MAXX_DATA_DIR` | Custom data directory path |
+| `MAXX_ROUTING_SEED_SALT` | Optional shared secret for the `weighted_random` routing strategy. If unset, each process generates its own random salt — anti-grinding still holds and Redis sticky bindings still converge after the first successful request, but the pre-sticky first-pick order for the same `(token, session)` can differ across instances. Set the **same value on every instance** when you need consistent first-pick behavior in multi-instance deployments. |
 
 ### System Settings
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -268,6 +268,7 @@ codex
 | `MAXX_ADMIN_PASSWORD` | 启用管理员 JWT 认证。默认用户名：`admin`，密码为该变量的值 |
 | `MAXX_DSN` | 数据库连接字符串 |
 | `MAXX_DATA_DIR` | 自定义数据目录路径 |
+| `MAXX_ROUTING_SEED_SALT` | 可选共享密钥，用于 `weighted_random` 路由策略。未设置时每个进程会生成自己的随机盐——防 SessionID 枚举仍然成立，Redis sticky 绑定也会在首次成功后跨实例收敛；但相同 `(token, session)` 在 sticky 写入前的首选顺序在各实例间可能不一致。**多实例部署且需要一致首选顺序**时，请在所有实例上设置相同的值 |
 
 ### 系统设置
 

--- a/docs/multi-instance-rfc.md
+++ b/docs/multi-instance-rfc.md
@@ -73,10 +73,31 @@ boot, you keep getting Redis errors until Redis recovers."
 | `MAXX_PROXY_REQUEST_SWEEP_INTERVAL`         | `45s`         | stale-request sweep period                        |
 | `MAXX_COOLDOWN_GEN_SYNC_INTERVAL`           | `2s`          | per-provider generation re-check throttle         |
 | `MAXX_COORDINATOR_RECONNECT_INTERVAL`       | `5s`          | degraded-mode reconnect cadence                   |
+| `MAXX_ROUTING_SEED_SALT`                    | `""`          | shared HMAC salt for weighted_random first-pick   |
 
 Legacy `MAXX_REDIS_URL` is retained as an alias for
 `MAXX_COORDINATOR_REDIS_URL` for backward compatibility with the original
 draft of this work.
+
+`MAXX_ROUTING_SEED_SALT` is **optional but recommended** in multi-instance
+deployments using the `weighted_random` routing strategy. Each instance
+falls back to a per-process random 32-byte salt when the variable is
+unset. Anti-grinding (a client cannot brute-force `X-Session-Id` to
+steer themselves onto a specific upstream) still holds in either mode,
+because the salt is never exposed. Redis sticky bindings remain
+consistent across instances as soon as the first dispatch succeeds —
+sticky reads the provider ID directly from Redis without re-shuffling.
+The visible difference between "shared salt" and "per-process salt" is
+only the **pre-sticky first pick** for the same `(token, session)`:
+without a shared salt, instance A and instance B may pick a different
+provider on the first request; whichever instance's pick succeeds first
+writes the sticky binding, and both instances converge for the rest of
+the session's lifetime.
+
+Set the same `MAXX_ROUTING_SEED_SALT` value on every instance if you
+want first-pick consistency before sticky writes land — useful for
+debugging hot-spot reports or making cold-start behavior reproducible
+across the fleet.
 
 ## Stale request reclamation
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/awsl-project/maxx
 go 1.26.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/andybalholm/brotli v1.2.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -30,7 +31,6 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
-	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/internal/core/coordinator_setup.go
+++ b/internal/core/coordinator_setup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/coordinator"
 	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/sticky"
 )
 
 // CoordinatorComponents 是 SetupCoordinator 的输出。
@@ -50,6 +51,7 @@ func SetupCoordinator(parentCtx context.Context, instanceID string, forceStandal
 	coordinator.StartHeartbeat(coordCtx, coord, cfg.InstanceTTL)
 
 	cooldown.Default().SetCoordinator(coordCtx, coord)
+	sticky.Default().SetCoordinator(coordCtx, coord)
 
 	cleanup := func() {
 		// 顺序很重要:先 Unregister 让其他实例感知到本实例下线,

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -625,7 +625,23 @@ var (
 type RoutingStrategyConfig struct {
 	// 加权随机策略的权重配置等
 	// 根据具体策略扩展
+
+	// Sticky / session-affinity 配置（用于 weighted_random 策略；priority 下忽略）
+	// 启用后：同一 (api token[+session]) 命中过的 provider 会在 TTL 内被记住，
+	// 后续请求优先尝试它（最大化上游 prompt cache 命中率）。
+	StickyEnabled    bool                 `json:"stickyEnabled,omitempty"`
+	StickyScope      RoutingStickyScope   `json:"stickyScope,omitempty"`      // "token" | "conversation"，默认 "token"
+	StickyTTLSeconds int                  `json:"stickyTTLSeconds,omitempty"` // 默认 1800（30 分钟），<=0 取默认
 }
+
+type RoutingStickyScope string
+
+const (
+	// 按 API token 粘性：同 token 的所有 session 都打同一 provider（命中率高，亲和粒度粗）
+	RoutingStickyScopeToken RoutingStickyScope = "token"
+	// 按 conversation 粘性：(token, sessionID) 粘性（亲和粒度细，sticky 项更多）
+	RoutingStickyScopeConversation RoutingStickyScope = "conversation"
+)
 
 // 路由策略
 type RoutingStrategy struct {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -629,9 +629,9 @@ type RoutingStrategyConfig struct {
 	// Sticky / session-affinity 配置（用于 weighted_random 策略；priority 下忽略）
 	// 启用后：同一 (api token[+session]) 命中过的 provider 会在 TTL 内被记住，
 	// 后续请求优先尝试它（最大化上游 prompt cache 命中率）。
-	StickyEnabled    bool                 `json:"stickyEnabled,omitempty"`
-	StickyScope      RoutingStickyScope   `json:"stickyScope,omitempty"`      // "token" | "conversation"，默认 "token"
-	StickyTTLSeconds int                  `json:"stickyTTLSeconds,omitempty"` // 默认 1800（30 分钟），<=0 取默认
+	StickyEnabled    bool               `json:"stickyEnabled,omitempty"`
+	StickyScope      RoutingStickyScope `json:"stickyScope,omitempty"`      // "token" | "conversation"，默认 "token"
+	StickyTTLSeconds int64              `json:"stickyTTLSeconds,omitempty"` // 默认 1800（30 分钟），<=0 取默认
 }
 
 type RoutingStickyScope string

--- a/internal/executor/flow_state.go
+++ b/internal/executor/flow_state.go
@@ -13,6 +13,7 @@ type execState struct {
 	ctx            context.Context
 	proxyReq       *domain.ProxyRequest
 	routes         []*router.MatchedRoute
+	stickyWrite    *router.StickyWrite
 	currentAttempt *domain.ProxyUpstreamAttempt
 	lastErr        error
 

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -225,9 +225,12 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				// time we get here the request ctx may already be Done (for
 				// streaming responses the client has disconnected just before
 				// this hook fires), which would turn every Set into a silent
-				// failure under load.
+				// failure under load. 500ms is a deliberate budget — the
+				// write is on the response tail-latency path, so a slow
+				// Redis must not stall the request; affinity is best-effort
+				// and the next request will re-roll if the write timed out.
 				if state.stickyWrite != nil {
-					stickyCtx, stickyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+					stickyCtx, stickyCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 					if err := sticky.Default().Set(stickyCtx, state.stickyWrite.Key, matchedRoute.Provider.ID, state.stickyWrite.TTL); err != nil {
 						log.Printf("[Executor] sticky set failed (non-fatal): %v", err)
 					}

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -220,10 +220,18 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				// we failed over from A → B, sticky now points at B for the
 				// next request). Errors are non-fatal — affinity is best-effort,
 				// the next call would just re-roll via weighted_random.
+				//
+				// Use a fresh background context with a tight timeout: by the
+				// time we get here the request ctx may already be Done (for
+				// streaming responses the client has disconnected just before
+				// this hook fires), which would turn every Set into a silent
+				// failure under load.
 				if state.stickyWrite != nil {
-					if err := sticky.Default().Set(ctx, state.stickyWrite.Key, matchedRoute.Provider.ID, state.stickyWrite.TTL); err != nil {
+					stickyCtx, stickyCancel := context.WithTimeout(context.Background(), 2*time.Second)
+					if err := sticky.Default().Set(stickyCtx, state.stickyWrite.Key, matchedRoute.Provider.ID, state.stickyWrite.TTL); err != nil {
 						log.Printf("[Executor] sticky set failed (non-fatal): %v", err)
 					}
+					stickyCancel()
 				}
 
 				proxyReq.Status = "COMPLETED"

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/pricing"
+	"github.com/awsl-project/maxx/internal/sticky"
 )
 
 func (e *Executor) dispatch(c *flow.Ctx) {
@@ -213,6 +214,17 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				state.currentAttempt = nil
 
 				cooldown.Default().RecordSuccess(matchedRoute.Provider.ID, string(currentClientType), mappedModel)
+
+				// Sticky write-back: bind this session to the provider that
+				// just succeeded. Overwrites any previous binding (e.g. when
+				// we failed over from A → B, sticky now points at B for the
+				// next request). Errors are non-fatal — affinity is best-effort,
+				// the next call would just re-roll via weighted_random.
+				if state.stickyWrite != nil {
+					if err := sticky.Default().Set(ctx, state.stickyWrite.Key, matchedRoute.Provider.ID, state.stickyWrite.TTL); err != nil {
+						log.Printf("[Executor] sticky set failed (non-fatal): %v", err)
+					}
+				}
 
 				proxyReq.Status = "COMPLETED"
 				proxyReq.EndTime = time.Now()

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -21,12 +21,13 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	}
 
 	proxyReq := state.proxyReq
-	routes, err := e.router.Match(&router.MatchContext{
+	result, err := e.router.Match(&router.MatchContext{
 		TenantID:     state.tenantID,
 		ClientType:   state.clientType,
 		ProjectID:    state.projectID,
 		RequestModel: state.requestModel,
 		APITokenID:   state.apiTokenID,
+		SessionID:    state.sessionID,
 	})
 	if err != nil {
 		proxyReq.Status = "FAILED"
@@ -47,7 +48,7 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		return
 	}
 
-	if len(routes) == 0 {
+	if len(result.Routes) == 0 {
 		proxyReq.Status = "FAILED"
 		proxyReq.Error = "no routes configured"
 		proxyReq.EndTime = time.Now()
@@ -73,7 +74,8 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	if e.broadcaster != nil {
 		e.broadcaster.BroadcastProxyRequest(proxyReq)
 	}
-	state.routes = routes
+	state.routes = result.Routes
+	state.stickyWrite = result.Sticky
 
 	c.Next()
 }

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -22,6 +22,7 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 
 	proxyReq := state.proxyReq
 	result, err := e.router.Match(&router.MatchContext{
+		Ctx:          state.ctx,
 		TenantID:     state.tenantID,
 		ClientType:   state.clientType,
 		ProjectID:    state.projectID,

--- a/internal/repository/cached/routing_strategy.go
+++ b/internal/repository/cached/routing_strategy.go
@@ -93,6 +93,18 @@ func (r *RoutingStrategyRepository) Delete(tenantID uint64, id uint64) error {
 	return nil
 }
 
+func (r *RoutingStrategyRepository) GetByID(tenantID uint64, id uint64) (*domain.RoutingStrategy, error) {
+	r.mu.RLock()
+	for key, s := range r.cache {
+		if s.ID == id && (tenantID == domain.TenantIDAll || key.TenantID == tenantID) {
+			r.mu.RUnlock()
+			return s, nil
+		}
+	}
+	r.mu.RUnlock()
+	return r.repo.GetByID(tenantID, id)
+}
+
 func (r *RoutingStrategyRepository) GetByProjectID(tenantID uint64, projectID uint64) (*domain.RoutingStrategy, error) {
 	r.mu.RLock()
 	if tenantID == domain.TenantIDAll {

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -71,6 +71,7 @@ type RoutingStrategyRepository interface {
 	Create(strategy *domain.RoutingStrategy) error
 	Update(strategy *domain.RoutingStrategy) error
 	Delete(tenantID uint64, id uint64) error
+	GetByID(tenantID uint64, id uint64) (*domain.RoutingStrategy, error)
 	GetByProjectID(tenantID uint64, projectID uint64) (*domain.RoutingStrategy, error)
 	List(tenantID uint64) ([]*domain.RoutingStrategy, error)
 }

--- a/internal/repository/sqlite/routing_strategy.go
+++ b/internal/repository/sqlite/routing_strategy.go
@@ -56,6 +56,17 @@ func (r *RoutingStrategyRepository) GetByProjectID(tenantID uint64, projectID ui
 	return r.toDomain(&model), nil
 }
 
+func (r *RoutingStrategyRepository) GetByID(tenantID uint64, id uint64) (*domain.RoutingStrategy, error) {
+	var model RoutingStrategy
+	if err := tenantScope(r.db.gorm, tenantID).Where("id = ? AND deleted_at = 0", id).First(&model).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	return r.toDomain(&model), nil
+}
+
 func (r *RoutingStrategyRepository) List(tenantID uint64) ([]*domain.RoutingStrategy, error) {
 	var models []RoutingStrategy
 	if err := tenantScope(r.db.gorm, tenantID).Where("deleted_at = 0").Order("id").Find(&models).Error; err != nil {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -45,8 +45,13 @@ type StickyWrite struct {
 	TTL time.Duration
 }
 
-// MatchContext contains all context needed for route matching
+// MatchContext contains all context needed for route matching.
+// Ctx is the originating request's context — Match honors its cancellation
+// when doing best-effort IO (currently just the sticky lookup). If Ctx is
+// nil we fall back to context.Background; nil is allowed so existing
+// non-proxy call sites don't have to plumb a context in.
 type MatchContext struct {
+	Ctx          context.Context
 	TenantID     uint64
 	ClientType   domain.ClientType
 	ProjectID    uint64
@@ -312,10 +317,16 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		stickyWrite = &StickyWrite{Key: key, TTL: ttl}
 
 		// Bound the sticky Get: a slow/unavailable Redis must not stall the
-		// match path. On timeout/error sticky.Get returns (0,false) and we
-		// fall through to the normal weighted_random order — affinity is
-		// best-effort by design.
-		stickyCtx, stickyCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		// match path. We derive from the caller's request context so a
+		// client cancel propagates here too; if no context was supplied,
+		// Background is the safe fallback. On timeout/error sticky.Get
+		// returns (0,false) and we fall through to the normal
+		// weighted_random order — affinity is best-effort by design.
+		parentCtx := ctx.Ctx
+		if parentCtx == nil {
+			parentCtx = context.Background()
+		}
+		stickyCtx, stickyCancel := context.WithTimeout(parentCtx, 100*time.Millisecond)
 		if pinned, ok := sticky.Default().Get(stickyCtx, key); ok {
 			matched = promoteByProvider(matched, pinned)
 		}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,10 +2,12 @@ package router
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"math/rand"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -217,12 +219,14 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	// Get routing strategy
 	strategy := r.getRoutingStrategy(tenantID, projectID)
 
-	// Sort routes by strategy. For weighted_random we seed the RNG with the
-	// caller's (api token + session) so the same session sees a stable
-	// fallback order while different sessions diverge — this gives implicit
-	// per-session affinity without any shared state, and naturally spreads
-	// load across providers across the active session population.
-	seed := makeSessionSeed(ctx.APITokenID, ctx.SessionID)
+	// Sort routes by strategy. For weighted_random we seed the RNG via an
+	// HMAC of the caller identity + routing context so the same session
+	// sees a stable fallback order while different sessions diverge —
+	// implicit per-session affinity without shared state, and natural
+	// load spread across the active session population. The HMAC salt
+	// prevents an authenticated client from grinding session ids to
+	// steer their traffic onto a specific provider.
+	seed := makeSessionSeed(ctx)
 	r.sortRoutes(filtered, strategy, seed)
 
 	// Get default retry config
@@ -303,9 +307,15 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		ttl := sticky.TTLFromConfig(strategy.Config.StickyTTLSeconds)
 		stickyWrite = &StickyWrite{Key: key, TTL: ttl}
 
-		if pinned, ok := sticky.Default().Get(context.Background(), key); ok {
+		// Bound the sticky Get: a slow/unavailable Redis must not stall the
+		// match path. On timeout/error sticky.Get returns (0,false) and we
+		// fall through to the normal weighted_random order — affinity is
+		// best-effort by design.
+		stickyCtx, stickyCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		if pinned, ok := sticky.Default().Get(stickyCtx, key); ok {
 			matched = promoteByProvider(matched, pinned)
 		}
+		stickyCancel()
 	}
 
 	return &MatchResult{Routes: matched, Sticky: stickyWrite}, nil
@@ -387,9 +397,11 @@ func policyFingerprint(routes []*domain.Route) string {
 		h.Write([]byte{flag})
 	}
 	sum := h.Sum(nil)
-	// 12 hex chars (48 bits) is plenty for distinguishing config snapshots
-	// and keeps Redis keys compact.
-	return hex.EncodeToString(sum[:6])
+	// 32 hex chars (128 bits): birthday collisions only matter past ~1.8e19
+	// distinct configs, which we will never approach. Earlier 48-bit hashes
+	// would have hit ~1.6e7 — Codex reviewer flagged this as a long-tail
+	// adversarial concern even though normal tenants never get close.
+	return hex.EncodeToString(sum[:16])
 }
 
 // promoteByProvider moves the matched route for providerID (if any) to the
@@ -410,21 +422,48 @@ func promoteByProvider(matched []*MatchedRoute, providerID uint64) []*MatchedRou
 	return matched
 }
 
-// makeSessionSeed derives a stable seed from the caller identity so the
-// weighted shuffle becomes deterministic per (api token, session). Same
-// session → same order (implicit affinity, also same fallback chain). When
-// no session info is available we fall back to time-based randomness so
-// behavior is no worse than the previous global rand.
-func makeSessionSeed(apiTokenID uint64, sessionID string) int64 {
-	if apiTokenID == 0 && sessionID == "" {
-		return time.Now().UnixNano()
+// routingSeedSalt is a process-wide secret mixed into makeSessionSeed.
+// Without it, an attacker holding any valid API token could grind through
+// X-Session-Id values offline until the seeded shuffle lands traffic on
+// whichever upstream they want to target (e.g. always the cheapest, or
+// always the one with the largest prompt cache they want to poison).
+//
+// Operators can set MAXX_ROUTING_SEED_SALT to a stable secret that's the
+// same on every instance (required for multi-instance to keep affinity
+// across nodes). When unset we fall back to a hardcoded constant: the
+// salt still prevents trivial offline grinding by anyone without the
+// binary, but a determined attacker with source access can reproduce it.
+// Setting the env var is recommended for any multi-tenant deployment.
+var routingSeedSalt = func() []byte {
+	if v := os.Getenv("MAXX_ROUTING_SEED_SALT"); v != "" {
+		return []byte(v)
 	}
-	h := sha256.New()
-	var idBuf [8]byte
-	binary.LittleEndian.PutUint64(idBuf[:], apiTokenID)
-	h.Write(idBuf[:])
-	h.Write([]byte(sessionID))
-	sum := h.Sum(nil)
+	return []byte("maxx/v1/routing-seed-salt/default")
+}()
+
+// makeSessionSeed derives a stable seed from the caller identity + the
+// MatchContext so the weighted shuffle becomes deterministic per session
+// (implicit affinity) but unpredictable to clients who don't know the salt.
+//
+// When no session anchor is available (no api token, no session id) we
+// still want determinism per tenant/client/project so distribution doesn't
+// degrade to global rand — incorporate the routing context as the anchor.
+func makeSessionSeed(ctx *MatchContext) int64 {
+	mac := hmac.New(sha256.New, routingSeedSalt)
+	var u64 [8]byte
+	binary.LittleEndian.PutUint64(u64[:], ctx.TenantID)
+	mac.Write(u64[:])
+	mac.Write([]byte{0})
+	binary.LittleEndian.PutUint64(u64[:], uint64(len(ctx.ClientType)))
+	mac.Write(u64[:])
+	mac.Write([]byte(ctx.ClientType))
+	binary.LittleEndian.PutUint64(u64[:], ctx.ProjectID)
+	mac.Write(u64[:])
+	binary.LittleEndian.PutUint64(u64[:], ctx.APITokenID)
+	mac.Write(u64[:])
+	mac.Write([]byte{0})
+	mac.Write([]byte(ctx.SessionID))
+	sum := mac.Sum(nil)
 	return int64(binary.LittleEndian.Uint64(sum[:8]))
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,9 +3,11 @@ package router
 import (
 	"context"
 	"crypto/hmac"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"log"
 	"math/rand"
 	"os"
 	"sort"
@@ -232,10 +234,11 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	// Get default retry config
 	defaultRetry, _ := r.retryConfigRepo.GetDefault(tenantID)
 
-	// Build matched routes
+	// Build matched routes under r.mu so adapter map snapshots are stable.
+	// Release the lock as soon as the slice is built — the sticky lookup
+	// below can take up to 100ms on a degraded Redis and we don't want
+	// that blocking adapter refresh/removal on the write side.
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	var matched []*MatchedRoute
 	providers := r.providerRepo.GetAll()
 
@@ -279,6 +282,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 			RetryConfig:     retryConfig,
 		})
 	}
+	r.mu.RUnlock()
 
 	if len(matched) == 0 {
 		return nil, domain.ErrNoRoutes
@@ -428,18 +432,43 @@ func promoteByProvider(matched []*MatchedRoute, providerID uint64) []*MatchedRou
 // whichever upstream they want to target (e.g. always the cheapest, or
 // always the one with the largest prompt cache they want to poison).
 //
-// Operators can set MAXX_ROUTING_SEED_SALT to a stable secret that's the
-// same on every instance (required for multi-instance to keep affinity
-// across nodes). When unset we fall back to a hardcoded constant: the
-// salt still prevents trivial offline grinding by anyone without the
-// binary, but a determined attacker with source access can reproduce it.
-// Setting the env var is recommended for any multi-tenant deployment.
-var routingSeedSalt = func() []byte {
-	if v := os.Getenv("MAXX_ROUTING_SEED_SALT"); v != "" {
-		return []byte(v)
-	}
-	return []byte("maxx/v1/routing-seed-salt/default")
-}()
+// Resolution order, lazy on first use:
+//  1. MAXX_ROUTING_SEED_SALT env var (operator-controlled; required for
+//     full sticky-binding consistency across multi-instance deployments).
+//  2. 32 bytes from crypto/rand. Per-process random — different instances
+//     will compute different first-pick orders for the same session, but
+//     each instance still picks deterministically per session and Redis
+//     sticky writes (keyed by routes/policy, not salt) converge across
+//     instances after the first success. Single-instance and dev
+//     deployments are fully covered.
+//
+// Lazy resolution lets tests override via t.Setenv before the first
+// Match() call. Reset via routingSeedSaltForTest only.
+var (
+	routingSeedSalt     []byte
+	routingSeedSaltOnce sync.Once
+)
+
+func getRoutingSeedSalt() []byte {
+	routingSeedSaltOnce.Do(func() {
+		if v := os.Getenv("MAXX_ROUTING_SEED_SALT"); v != "" {
+			routingSeedSalt = []byte(v)
+			return
+		}
+		buf := make([]byte, 32)
+		if _, err := crand.Read(buf); err != nil {
+			// crypto/rand failures are nearly impossible; fall back to a
+			// time-derived seed so we never panic at request time. This
+			// path produces an unstable per-process salt, same security
+			// properties as the normal crypto/rand path.
+			binary.LittleEndian.PutUint64(buf[:8], uint64(time.Now().UnixNano()))
+		}
+		routingSeedSalt = buf
+		log.Printf("[Router] MAXX_ROUTING_SEED_SALT not set — generated a per-process random salt. " +
+			"For consistent first-pick behavior across multi-instance deployments, set MAXX_ROUTING_SEED_SALT to a shared secret.")
+	})
+	return routingSeedSalt
+}
 
 // makeSessionSeed derives a stable seed from the caller identity + the
 // MatchContext so the weighted shuffle becomes deterministic per session
@@ -448,21 +477,26 @@ var routingSeedSalt = func() []byte {
 // When no session anchor is available (no api token, no session id) we
 // still want determinism per tenant/client/project so distribution doesn't
 // degrade to global rand — incorporate the routing context as the anchor.
+//
+// Encoding is unambiguous by construction: every variable-length field is
+// length-prefixed (uint64 LE), every fixed-length integer is uint64 LE.
+// No clever separators, no field can collide with another's payload.
 func makeSessionSeed(ctx *MatchContext) int64 {
-	mac := hmac.New(sha256.New, routingSeedSalt)
+	mac := hmac.New(sha256.New, getRoutingSeedSalt())
 	var u64 [8]byte
-	binary.LittleEndian.PutUint64(u64[:], ctx.TenantID)
-	mac.Write(u64[:])
-	mac.Write([]byte{0})
-	binary.LittleEndian.PutUint64(u64[:], uint64(len(ctx.ClientType)))
-	mac.Write(u64[:])
-	mac.Write([]byte(ctx.ClientType))
-	binary.LittleEndian.PutUint64(u64[:], ctx.ProjectID)
-	mac.Write(u64[:])
-	binary.LittleEndian.PutUint64(u64[:], ctx.APITokenID)
-	mac.Write(u64[:])
-	mac.Write([]byte{0})
-	mac.Write([]byte(ctx.SessionID))
+	writeU64 := func(v uint64) {
+		binary.LittleEndian.PutUint64(u64[:], v)
+		mac.Write(u64[:])
+	}
+	writeBytes := func(b []byte) {
+		writeU64(uint64(len(b)))
+		mac.Write(b)
+	}
+	writeU64(ctx.TenantID)
+	writeBytes([]byte(ctx.ClientType))
+	writeU64(ctx.ProjectID)
+	writeU64(ctx.APITokenID)
+	writeBytes([]byte(ctx.SessionID))
 	sum := mac.Sum(nil)
 	return int64(binary.LittleEndian.Uint64(sum[:8]))
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,14 +1,20 @@
 package router
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"math/rand"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/sticky"
 )
 
 // MatchedRoute contains all data needed to execute a proxy request
@@ -19,6 +25,22 @@ type MatchedRoute struct {
 	RetryConfig     *domain.RetryConfig
 }
 
+// MatchResult is the output of Match. Routes are the ordered candidates the
+// dispatcher should try (first = preferred). Sticky, when non-nil, carries
+// the key the dispatcher must SETEX after a successful upstream call so the
+// affinity layer learns the binding.
+type MatchResult struct {
+	Routes []*MatchedRoute
+	Sticky *StickyWrite
+}
+
+// StickyWrite is the write-back context handed to the dispatcher. It is only
+// populated when the routing strategy has sticky enabled.
+type StickyWrite struct {
+	Key sticky.Key
+	TTL time.Duration
+}
+
 // MatchContext contains all context needed for route matching
 type MatchContext struct {
 	TenantID     uint64
@@ -26,6 +48,7 @@ type MatchContext struct {
 	ProjectID    uint64
 	RequestModel string
 	APITokenID   uint64
+	SessionID    string
 }
 
 // Router handles route matching and selection
@@ -118,8 +141,9 @@ func (r *Router) GetAdapter(providerID uint64) (provider.ProviderAdapter, bool) 
 	return a, ok
 }
 
-// Match returns matched routes for a client type and project
-func (r *Router) Match(ctx *MatchContext) ([]*MatchedRoute, error) {
+// Match returns matched routes for a client type and project, plus optional
+// sticky write-back context.
+func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	tenantID := ctx.TenantID
 	clientType := ctx.ClientType
 	projectID := ctx.ProjectID
@@ -193,8 +217,13 @@ func (r *Router) Match(ctx *MatchContext) ([]*MatchedRoute, error) {
 	// Get routing strategy
 	strategy := r.getRoutingStrategy(tenantID, projectID)
 
-	// Sort routes by strategy
-	r.sortRoutes(filtered, strategy)
+	// Sort routes by strategy. For weighted_random we seed the RNG with the
+	// caller's (api token + session) so the same session sees a stable
+	// fallback order while different sessions diverge — this gives implicit
+	// per-session affinity without any shared state, and naturally spreads
+	// load across providers across the active session population.
+	seed := makeSessionSeed(ctx.APITokenID, ctx.SessionID)
+	r.sortRoutes(filtered, strategy, seed)
 
 	// Get default retry config
 	defaultRetry, _ := r.retryConfigRepo.GetDefault(tenantID)
@@ -251,7 +280,35 @@ func (r *Router) Match(ctx *MatchContext) ([]*MatchedRoute, error) {
 		return nil, domain.ErrNoRoutes
 	}
 
-	return matched, nil
+	// Sticky / session-affinity layer. Only meaningful when:
+	//   - strategy is weighted_random (priority is already deterministic; sticky
+	//     would be a no-op in steady state)
+	//   - sticky is explicitly enabled in the strategy config
+	//   - we have a stable principal (api token id) to anchor the binding to
+	//
+	// On hit (and the pointed-to provider is still in the matched set, i.e. not
+	// in cooldown and still supports the model), we prepend it; otherwise the
+	// existing seeded-weighted order stands and the dispatcher's first success
+	// will write a fresh sticky.
+	var stickyWrite *StickyWrite
+	if strategy != nil && strategy.Type == domain.RoutingStrategyWeightedRandom &&
+		strategy.Config != nil && strategy.Config.StickyEnabled && ctx.APITokenID != 0 {
+		key := sticky.Key{
+			TenantID:   tenantID,
+			ClientType: string(clientType),
+			ProjectID:  projectID,
+			PolicyVer:  policyFingerprint(filtered),
+			BaseKey:    sticky.BaseKey(strategy.Config.StickyScope, ctx.APITokenID, ctx.SessionID),
+		}
+		ttl := sticky.TTLFromConfig(strategy.Config.StickyTTLSeconds)
+		stickyWrite = &StickyWrite{Key: key, TTL: ttl}
+
+		if pinned, ok := sticky.Default().Get(context.Background(), key); ok {
+			matched = promoteByProvider(matched, pinned)
+		}
+	}
+
+	return &MatchResult{Routes: matched, Sticky: stickyWrite}, nil
 }
 
 // isModelSupported checks if a model matches any pattern in the support list
@@ -279,11 +336,11 @@ func (r *Router) getRoutingStrategy(tenantID uint64, projectID uint64) *domain.R
 	return &domain.RoutingStrategy{Type: domain.RoutingStrategyPriority}
 }
 
-func (r *Router) sortRoutes(routes []*domain.Route, strategy *domain.RoutingStrategy) {
+func (r *Router) sortRoutes(routes []*domain.Route, strategy *domain.RoutingStrategy, seed int64) {
 	switch strategy.Type {
 	case domain.RoutingStrategyWeightedRandom:
 		// 按权重做概率排序：权重越大，排在前面的概率越高
-		weightedShuffle(routes)
+		weightedShuffle(routes, rand.New(rand.NewSource(seed)))
 	default: // priority
 		sort.Slice(routes, func(i, j int) bool {
 			return routes[i].Position < routes[j].Position
@@ -291,9 +348,89 @@ func (r *Router) sortRoutes(routes []*domain.Route, strategy *domain.RoutingStra
 	}
 }
 
+// policyFingerprint returns a short, stable hash of the routes that are in
+// scope for this Match call. Sticky entries embed it so any user-driven
+// config change (route added/removed, weight/position edited, provider
+// re-pointed) naturally invalidates all bindings — no explicit cache flush.
+//
+// Cooldown state is *not* included: cooldown is transient and already
+// handled by the matched-set filter at request time. Mixing it in would
+// invalidate sticky every time a provider blips.
+func policyFingerprint(routes []*domain.Route) string {
+	// Sort by ID for a stable hash regardless of input order. We hash IDs
+	// directly (instead of sorting routes) to avoid mutating the caller's
+	// slice ordering.
+	ids := make([]uint64, len(routes))
+	byID := make(map[uint64]*domain.Route, len(routes))
+	for i, r := range routes {
+		ids[i] = r.ID
+		byID[r.ID] = r
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	h := sha256.New()
+	var buf [8]byte
+	for _, id := range ids {
+		r := byID[id]
+		binary.LittleEndian.PutUint64(buf[:], r.ID)
+		h.Write(buf[:])
+		binary.LittleEndian.PutUint64(buf[:], r.ProviderID)
+		h.Write(buf[:])
+		binary.LittleEndian.PutUint64(buf[:], uint64(r.Position))
+		h.Write(buf[:])
+		binary.LittleEndian.PutUint64(buf[:], uint64(r.Weight))
+		h.Write(buf[:])
+		var flag byte
+		if r.IsEnabled {
+			flag = 1
+		}
+		h.Write([]byte{flag})
+	}
+	sum := h.Sum(nil)
+	// 12 hex chars (48 bits) is plenty for distinguishing config snapshots
+	// and keeps Redis keys compact.
+	return hex.EncodeToString(sum[:6])
+}
+
+// promoteByProvider moves the matched route for providerID (if any) to the
+// front, preserving the relative order of the rest. No-op if not present.
+func promoteByProvider(matched []*MatchedRoute, providerID uint64) []*MatchedRoute {
+	for i, mr := range matched {
+		if mr.Provider.ID == providerID {
+			if i == 0 {
+				return matched
+			}
+			out := make([]*MatchedRoute, 0, len(matched))
+			out = append(out, mr)
+			out = append(out, matched[:i]...)
+			out = append(out, matched[i+1:]...)
+			return out
+		}
+	}
+	return matched
+}
+
+// makeSessionSeed derives a stable seed from the caller identity so the
+// weighted shuffle becomes deterministic per (api token, session). Same
+// session → same order (implicit affinity, also same fallback chain). When
+// no session info is available we fall back to time-based randomness so
+// behavior is no worse than the previous global rand.
+func makeSessionSeed(apiTokenID uint64, sessionID string) int64 {
+	if apiTokenID == 0 && sessionID == "" {
+		return time.Now().UnixNano()
+	}
+	h := sha256.New()
+	var idBuf [8]byte
+	binary.LittleEndian.PutUint64(idBuf[:], apiTokenID)
+	h.Write(idBuf[:])
+	h.Write([]byte(sessionID))
+	sum := h.Sum(nil)
+	return int64(binary.LittleEndian.Uint64(sum[:8]))
+}
+
 // weightedShuffle 按权重做加权随机排序
 // 使用加权采样算法：每次从剩余路由中按权重概率选一个放到当前位置
-func weightedShuffle(routes []*domain.Route) {
+func weightedShuffle(routes []*domain.Route, rng *rand.Rand) {
 	n := len(routes)
 	for i := 0; i < n-1; i++ {
 		// 计算剩余路由的权重总和
@@ -307,7 +444,7 @@ func weightedShuffle(routes []*domain.Route) {
 		}
 
 		// 按权重随机选择一个
-		r := rand.Intn(totalWeight)
+		pick := rng.Intn(totalWeight)
 		cumulative := 0
 		for j := i; j < n; j++ {
 			w := routes[j].Weight
@@ -315,7 +452,7 @@ func weightedShuffle(routes []*domain.Route) {
 				w = 1
 			}
 			cumulative += w
-			if r < cumulative {
+			if pick < cumulative {
 				routes[i], routes[j] = routes[j], routes[i]
 				break
 			}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -443,7 +443,7 @@ func promoteByProvider(matched []*MatchedRoute, providerID uint64) []*MatchedRou
 //     deployments are fully covered.
 //
 // Lazy resolution lets tests override via t.Setenv before the first
-// Match() call. Reset via routingSeedSaltForTest only.
+// Match() call.
 var (
 	routingSeedSalt     []byte
 	routingSeedSaltOnce sync.Once
@@ -457,11 +457,15 @@ func getRoutingSeedSalt() []byte {
 		}
 		buf := make([]byte, 32)
 		if _, err := crand.Read(buf); err != nil {
-			// crypto/rand failures are nearly impossible; fall back to a
-			// time-derived seed so we never panic at request time. This
-			// path produces an unstable per-process salt, same security
-			// properties as the normal crypto/rand path.
-			binary.LittleEndian.PutUint64(buf[:8], uint64(time.Now().UnixNano()))
+			// crypto/rand failures are nearly impossible (an unprivileged
+			// process is denied /dev/urandom and getrandom etc.). Build
+			// a time-derived fallback that still fills all 32 bytes so
+			// HMAC entropy doesn't collapse to 64 bits.
+			now := uint64(time.Now().UnixNano())
+			for i := 0; i < len(buf); i += 8 {
+				binary.LittleEndian.PutUint64(buf[i:i+8], now)
+				now = now*6364136223846793005 + 1442695040888963407 // splitmix-style step
+			}
 		}
 		routingSeedSalt = buf
 		log.Printf("[Router] MAXX_ROUTING_SEED_SALT not set — generated a per-process random salt. " +

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -383,7 +383,7 @@ func (s *AdminService) GetRoutingStrategies(tenantID uint64) ([]*domain.RoutingS
 }
 
 func (s *AdminService) GetRoutingStrategy(tenantID uint64, id uint64) (*domain.RoutingStrategy, error) {
-	return s.routingStrategyRepo.GetByProjectID(tenantID, id)
+	return s.routingStrategyRepo.GetByID(tenantID, id)
 }
 
 func (s *AdminService) CreateRoutingStrategy(tenantID uint64, strategy *domain.RoutingStrategy) error {

--- a/internal/sticky/manager.go
+++ b/internal/sticky/manager.go
@@ -44,7 +44,20 @@ var defaultManager = NewManager()
 func Default() *Manager { return defaultManager }
 
 // SetCoordinator picks an appropriate Store based on the coordinator's
-// underlying implementation (Redis vs in-memory). Safe to call multiple times.
+// underlying implementation (Redis vs in-memory).
+//
+// Lifecycle expectation: this is meant to be called once at process start,
+// before any traffic is served. The atomic.Pointer swap is safe under
+// concurrent reads, but any in-flight Get/Set against the previous Store
+// continues against the *old* backend — if the old store owns connection
+// resources that need closing, the caller is responsible for ordering the
+// new store's installation before tearing the old one down. Today both the
+// memory and Redis stores share the coordinator's pool, so there is no
+// teardown to coordinate.
+//
+// The ctx is currently unused but kept in the signature for symmetry with
+// cooldown.Manager.SetCoordinator and in case a future Store needs to do
+// async initialization here.
 func (m *Manager) SetCoordinator(_ context.Context, c coordinator.Coordinator) {
 	store := StoreFor(c)
 	m.store.Store(&store)
@@ -119,7 +132,7 @@ func BaseKey(scope domain.RoutingStickyScope, apiTokenID uint64, sessionID strin
 }
 
 // TTLFromConfig returns the configured TTL or DefaultTTL when unset.
-func TTLFromConfig(seconds int) time.Duration {
+func TTLFromConfig(seconds int64) time.Duration {
 	if seconds <= 0 {
 		return DefaultTTL
 	}

--- a/internal/sticky/manager.go
+++ b/internal/sticky/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"log"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -23,7 +24,8 @@ const DefaultTTL = 30 * time.Minute
 // caller can always fall back to a fresh routing decision. On the write path
 // errors are reported so callers can choose to log them.
 type Manager struct {
-	store atomic.Pointer[Store]
+	store          atomic.Pointer[Store]
+	lastGetErrorAt atomic.Int64 // unix nano of last logged Get error
 }
 
 // NewManager creates a Manager backed by the in-process memory store. Use
@@ -78,17 +80,40 @@ func (m *Manager) currentStore() Store {
 
 // Get returns the sticky provider for the key, or (0,false) if none.
 // Any error is treated as a miss; callers fall through to fresh selection.
+// Persistent errors (e.g. a chronically unreachable Redis) are surfaced as
+// rate-limited warnings so the operator notices the affinity layer is down
+// rather than silently observing degraded prompt-cache hit rates.
 func (m *Manager) Get(ctx context.Context, key Key) (uint64, bool) {
 	s := m.currentStore()
 	if s == nil {
 		return 0, false
 	}
 	id, ok, err := s.Get(ctx, key)
-	if err != nil || !ok {
+	if err != nil {
+		m.maybeLogGetError(err)
+		return 0, false
+	}
+	if !ok {
 		return 0, false
 	}
 	return id, true
 }
+
+// maybeLogGetError prints at most one Get-error log per
+// stickyErrorLogInterval — enough to make operational outages visible
+// without spamming the log when Redis is down for hours.
+func (m *Manager) maybeLogGetError(err error) {
+	now := time.Now().UnixNano()
+	last := m.lastGetErrorAt.Load()
+	if last != 0 && time.Duration(now-last) < stickyErrorLogInterval {
+		return
+	}
+	if m.lastGetErrorAt.CompareAndSwap(last, now) {
+		log.Printf("[Sticky] Get failed (best-effort, falling through to weighted_random): %v", err)
+	}
+}
+
+const stickyErrorLogInterval = time.Minute
 
 // Set records the sticky decision with the given TTL (clamped to DefaultTTL
 // when non-positive).

--- a/internal/sticky/manager.go
+++ b/internal/sticky/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"log"
 	"strconv"
 	"sync/atomic"
@@ -83,6 +84,11 @@ func (m *Manager) currentStore() Store {
 // Persistent errors (e.g. a chronically unreachable Redis) are surfaced as
 // rate-limited warnings so the operator notices the affinity layer is down
 // rather than silently observing degraded prompt-cache hit rates.
+//
+// Context errors (Canceled / DeadlineExceeded) are *not* logged: the
+// router wraps every Get in a 100ms timeout derived from the request ctx,
+// so a client disconnect or our own short cap shows up here as a context
+// error and would otherwise drown the genuine-Redis-down signal.
 func (m *Manager) Get(ctx context.Context, key Key) (uint64, bool) {
 	s := m.currentStore()
 	if s == nil {
@@ -90,7 +96,9 @@ func (m *Manager) Get(ctx context.Context, key Key) (uint64, bool) {
 	}
 	id, ok, err := s.Get(ctx, key)
 	if err != nil {
-		m.maybeLogGetError(err)
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			m.maybeLogGetError(err)
+		}
 		return 0, false
 	}
 	if !ok {

--- a/internal/sticky/manager.go
+++ b/internal/sticky/manager.go
@@ -1,0 +1,135 @@
+package sticky
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/coordinator"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// DefaultTTL is the fallback TTL when none is configured. 30 minutes balances
+// affinity stickiness with bounded staleness in case a provider silently
+// degrades — the next request after expiry re-rolls via weighted_random.
+const DefaultTTL = 30 * time.Minute
+
+// Manager wraps a Store with type-safe helpers used by the router/dispatcher.
+//
+// Errors are intentionally swallowed (return ok=false) on the read path: the
+// caller can always fall back to a fresh routing decision. On the write path
+// errors are reported so callers can choose to log them.
+type Manager struct {
+	store atomic.Pointer[Store]
+}
+
+// NewManager creates a Manager backed by the in-process memory store. Use
+// SetStore to swap to a Redis-backed implementation after the coordinator is
+// available.
+func NewManager() *Manager {
+	m := &Manager{}
+	s := NewMemoryStore()
+	m.store.Store(&s)
+	return m
+}
+
+// Default global manager.
+var defaultManager = NewManager()
+
+// Default returns the default global sticky manager. Wire SetStore via
+// SetCoordinator at startup.
+func Default() *Manager { return defaultManager }
+
+// SetCoordinator picks an appropriate Store based on the coordinator's
+// underlying implementation (Redis vs in-memory). Safe to call multiple times.
+func (m *Manager) SetCoordinator(_ context.Context, c coordinator.Coordinator) {
+	store := StoreFor(c)
+	m.store.Store(&store)
+}
+
+// SetStore lets tests or alternative wiring inject an explicit Store.
+func (m *Manager) SetStore(s Store) {
+	m.store.Store(&s)
+}
+
+func (m *Manager) currentStore() Store {
+	p := m.store.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// Get returns the sticky provider for the key, or (0,false) if none.
+// Any error is treated as a miss; callers fall through to fresh selection.
+func (m *Manager) Get(ctx context.Context, key Key) (uint64, bool) {
+	s := m.currentStore()
+	if s == nil {
+		return 0, false
+	}
+	id, ok, err := s.Get(ctx, key)
+	if err != nil || !ok {
+		return 0, false
+	}
+	return id, true
+}
+
+// Set records the sticky decision with the given TTL (clamped to DefaultTTL
+// when non-positive).
+func (m *Manager) Set(ctx context.Context, key Key, providerID uint64, ttl time.Duration) error {
+	s := m.currentStore()
+	if s == nil {
+		return nil
+	}
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	return s.Set(ctx, key, providerID, ttl)
+}
+
+// Delete drops the entry. Errors are non-fatal — the entry will expire on its
+// own and the next selection cannot rely on stale data anyway.
+func (m *Manager) Delete(ctx context.Context, key Key) error {
+	s := m.currentStore()
+	if s == nil {
+		return nil
+	}
+	return s.Delete(ctx, key)
+}
+
+// BaseKey builds the per-session anchor. With scope=token the same api token
+// always lands on the same provider (best prompt-cache locality at the cost
+// of coarser affinity). With scope=conversation each session id forks.
+//
+// The api token is an internal uint64, not the user-visible API key string,
+// so no obfuscation is required for it. Session IDs (which may carry
+// user-supplied data via the X-Session-Id header) are short-hashed before
+// joining to keep Redis keys bounded and to avoid embedding raw user input
+// in the schema.
+func BaseKey(scope domain.RoutingStickyScope, apiTokenID uint64, sessionID string) string {
+	switch scope {
+	case domain.RoutingStickyScopeConversation:
+		return "c/" + strconv.FormatUint(apiTokenID, 10) + "/" + shortHash(sessionID)
+	default: // token or unset
+		return "t/" + strconv.FormatUint(apiTokenID, 10)
+	}
+}
+
+// TTLFromConfig returns the configured TTL or DefaultTTL when unset.
+func TTLFromConfig(seconds int) time.Duration {
+	if seconds <= 0 {
+		return DefaultTTL
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func shortHash(s string) string {
+	if s == "" {
+		return "0"
+	}
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:8])
+}

--- a/internal/sticky/store.go
+++ b/internal/sticky/store.go
@@ -1,0 +1,35 @@
+// Package sticky stores per-session "remember which upstream provider this
+// session is currently routed to" decisions. It is consumed by the router as
+// an affinity layer on top of weighted_random: when enabled, a session's
+// first successful provider becomes its preferred pick for a TTL window.
+//
+// Architecture mirrors internal/cooldown:
+//   - Store interface with memory + Redis implementations
+//   - sticky.Default() process-wide singleton, coordinator-aware
+//   - Multi-instance correctness via shared Redis; standalone falls back to
+//     in-process map (still functionally correct for a single instance)
+package sticky
+
+import (
+	"context"
+	"time"
+)
+
+// Key identifies a single sticky entry. The fingerprint of the routing policy
+// (routes + weights + provider IDs) is embedded so any config change naturally
+// invalidates all entries without explicit cleanup.
+type Key struct {
+	TenantID   uint64
+	ClientType string
+	ProjectID  uint64
+	PolicyVer  string
+	BaseKey    string
+}
+
+// Store is the persistence interface. Implementations must be safe for
+// concurrent use.
+type Store interface {
+	Get(ctx context.Context, key Key) (providerID uint64, found bool, err error)
+	Set(ctx context.Context, key Key, providerID uint64, ttl time.Duration) error
+	Delete(ctx context.Context, key Key) error
+}

--- a/internal/sticky/store_factory.go
+++ b/internal/sticky/store_factory.go
@@ -1,0 +1,13 @@
+package sticky
+
+import "github.com/awsl-project/maxx/internal/coordinator"
+
+// StoreFor selects a Store based on the coordinator's actual implementation:
+//   - redis  → redisStore (distributed truth)
+//   - memory → memoryStore (single-process)
+func StoreFor(c coordinator.Coordinator) Store {
+	if rdb := coordinator.RedisClient(c); rdb != nil {
+		return NewRedisStore(rdb)
+	}
+	return NewMemoryStore()
+}

--- a/internal/sticky/store_memory.go
+++ b/internal/sticky/store_memory.go
@@ -1,0 +1,51 @@
+package sticky
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// memoryStore is an in-process Store for standalone deployments. Different
+// instances cannot share state but each request is still served correctly.
+type memoryStore struct {
+	mu      sync.RWMutex
+	entries map[Key]memoryEntry
+}
+
+type memoryEntry struct {
+	providerID uint64
+	expiresAt  time.Time
+}
+
+// NewMemoryStore returns a fresh in-process sticky store.
+func NewMemoryStore() Store {
+	return &memoryStore{entries: make(map[Key]memoryEntry)}
+}
+
+func (s *memoryStore) Get(_ context.Context, key Key) (uint64, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[key]
+	if !ok || time.Now().After(e.expiresAt) {
+		return 0, false, nil
+	}
+	return e.providerID, true, nil
+}
+
+func (s *memoryStore) Set(_ context.Context, key Key, providerID uint64, ttl time.Duration) error {
+	if ttl <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = memoryEntry{providerID: providerID, expiresAt: time.Now().Add(ttl)}
+	return nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, key Key) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+	return nil
+}

--- a/internal/sticky/store_memory.go
+++ b/internal/sticky/store_memory.go
@@ -25,9 +25,21 @@ func NewMemoryStore() Store {
 
 func (s *memoryStore) Get(_ context.Context, key Key) (uint64, bool, error) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
 	e, ok := s.entries[key]
-	if !ok || time.Now().After(e.expiresAt) {
+	s.mu.RUnlock()
+	if !ok {
+		return 0, false, nil
+	}
+	if time.Now().After(e.expiresAt) {
+		// Lazy delete: the Redis backend gets TTL eviction for free; the
+		// memory backend would otherwise accumulate expired entries
+		// indefinitely as sessions churn. Re-check under the write lock
+		// in case a fresher Set raced in between the read above and now.
+		s.mu.Lock()
+		if cur, ok := s.entries[key]; ok && !time.Now().Before(cur.expiresAt) {
+			delete(s.entries, key)
+		}
+		s.mu.Unlock()
 		return 0, false, nil
 	}
 	return e.providerID, true, nil

--- a/internal/sticky/store_memory.go
+++ b/internal/sticky/store_memory.go
@@ -30,19 +30,26 @@ func (s *memoryStore) Get(_ context.Context, key Key) (uint64, bool, error) {
 	if !ok {
 		return 0, false, nil
 	}
-	if time.Now().After(e.expiresAt) {
-		// Lazy delete: the Redis backend gets TTL eviction for free; the
-		// memory backend would otherwise accumulate expired entries
-		// indefinitely as sessions churn. Re-check under the write lock
-		// in case a fresher Set raced in between the read above and now.
-		s.mu.Lock()
-		if cur, ok := s.entries[key]; ok && !time.Now().Before(cur.expiresAt) {
-			delete(s.entries, key)
-		}
-		s.mu.Unlock()
+	if time.Now().Before(e.expiresAt) {
+		return e.providerID, true, nil
+	}
+	// Looked expired. Take the write lock and re-check: a fresher Set may
+	// have raced in between our RUnlock and Lock. If it did, return the
+	// fresh value so the caller doesn't see a phantom miss right after a
+	// successful write. Otherwise delete the expired entry — Redis gets
+	// TTL eviction for free; the memory backend would otherwise
+	// accumulate forever as sessions churn.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur, ok := s.entries[key]
+	if !ok {
 		return 0, false, nil
 	}
-	return e.providerID, true, nil
+	if time.Now().Before(cur.expiresAt) {
+		return cur.providerID, true, nil
+	}
+	delete(s.entries, key)
+	return 0, false, nil
 }
 
 func (s *memoryStore) Set(_ context.Context, key Key, providerID uint64, ttl time.Duration) error {

--- a/internal/sticky/store_redis.go
+++ b/internal/sticky/store_redis.go
@@ -1,0 +1,72 @@
+package sticky
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis key schema:
+//
+//	maxx:v1:sticky:t<tenantID>:c<clientType>:p<projectID>:v<policyVer>:k<baseKey>
+//
+// clientType / baseKey are URL-escaped to keep ":" inside model names or
+// session IDs from breaking the schema. Value is the provider ID as ASCII
+// decimal. TTL is set on SET so Redis auto-expires entries.
+const (
+	redisStickyPrefix = "maxx:v1:sticky"
+	redisStickyKeyFmt = redisStickyPrefix + ":t%d:c%s:p%d:v%s:k%s"
+)
+
+type redisStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisStore wraps a go-redis client into a sticky Store. The client's
+// lifecycle is owned by the caller (typically shared with the coordinator's
+// connection pool).
+func NewRedisStore(rdb *redis.Client) Store {
+	return &redisStore{rdb: rdb}
+}
+
+func keyName(k Key) string {
+	return fmt.Sprintf(
+		redisStickyKeyFmt,
+		k.TenantID,
+		url.QueryEscape(k.ClientType),
+		k.ProjectID,
+		url.QueryEscape(k.PolicyVer),
+		url.QueryEscape(k.BaseKey),
+	)
+}
+
+func (s *redisStore) Get(ctx context.Context, key Key) (uint64, bool, error) {
+	v, err := s.rdb.Get(ctx, keyName(key)).Result()
+	if errors.Is(err, redis.Nil) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, err
+	}
+	id, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("invalid sticky value %q: %w", v, err)
+	}
+	return id, true, nil
+}
+
+func (s *redisStore) Set(ctx context.Context, key Key, providerID uint64, ttl time.Duration) error {
+	if ttl <= 0 {
+		return nil
+	}
+	return s.rdb.Set(ctx, keyName(key), strconv.FormatUint(providerID, 10), ttl).Err()
+}
+
+func (s *redisStore) Delete(ctx context.Context, key Key) error {
+	return s.rdb.Del(ctx, keyName(key)).Err()
+}

--- a/internal/sticky/store_redis_test.go
+++ b/internal/sticky/store_redis_test.go
@@ -56,7 +56,10 @@ func TestRedisStoreCrossInstance(t *testing.T) {
 	if err := storeB.Set(ctx, key, 11, 10*time.Second); err != nil {
 		t.Fatalf("storeB.Set: %v", err)
 	}
-	got, found, _ = storeA.Get(ctx, key)
+	got, found, err = storeA.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("storeA.Get after overwrite: %v", err)
+	}
 	if !found || got != 11 {
 		t.Errorf("overwrite from B then read from A: got=%d found=%v, want 11/true", got, found)
 	}
@@ -68,7 +71,9 @@ func TestRedisStoreCrossInstance(t *testing.T) {
 		t.Fatalf("set short ttl: %v", err)
 	}
 	mr.FastForward(500 * time.Millisecond)
-	if _, found, _ := storeB.Get(ctx, shortKey); found {
+	if _, found, err := storeB.Get(ctx, shortKey); err != nil {
+		t.Fatalf("storeB.Get after TTL: %v", err)
+	} else if found {
 		t.Errorf("TTL: expected expiry on B, still found")
 	}
 	t.Logf("verify> Probe C — TTL expiry (set on A, observe on B after fast-forward) → expired ✓")
@@ -83,7 +88,10 @@ func TestRedisStoreCrossInstance(t *testing.T) {
 	if err := storeA.Set(ctx, weirdKey, 13, time.Minute); err != nil {
 		t.Fatalf("set weird key: %v", err)
 	}
-	got, found, _ = storeB.Get(ctx, weirdKey)
+	got, found, err = storeB.Get(ctx, weirdKey)
+	if err != nil {
+		t.Fatalf("storeB.Get weirdKey: %v", err)
+	}
 	if !found || got != 13 {
 		t.Errorf("escape: got=%d found=%v, want 13/true", got, found)
 	}
@@ -116,7 +124,9 @@ func TestRedisStoreCrossInstance(t *testing.T) {
 	if err := storeA.Delete(ctx, key); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if _, found, _ := storeB.Get(ctx, key); found {
+	if _, found, err := storeB.Get(ctx, key); err != nil {
+		t.Fatalf("storeB.Get after Delete: %v", err)
+	} else if found {
 		t.Errorf("delete: expected miss after A.Delete, B.Get still found")
 	}
 	t.Logf("verify> Probe C — Delete on A, Get on B → miss ✓")

--- a/internal/sticky/store_redis_test.go
+++ b/internal/sticky/store_redis_test.go
@@ -1,0 +1,132 @@
+package sticky
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// TestRedisStoreCrossInstance simulates a multi-instance deployment by
+// creating two separate Store instances backed by the same Redis. This is the
+// real distributed correctness contract: when instance A writes a sticky
+// binding, instance B (which never ran the dispatcher) must be able to read
+// it on the next request. miniredis is used so we don't need a real Redis
+// running in CI.
+func TestRedisStoreCrossInstance(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	newRdb := func() *redis.Client {
+		return redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	}
+	storeA := NewRedisStore(newRdb())
+	storeB := NewRedisStore(newRdb())
+
+	ctx := context.Background()
+	key := Key{
+		TenantID:   1,
+		ClientType: "openai",
+		ProjectID:  0,
+		PolicyVer:  "abc123",
+		BaseKey:    "t/42",
+	}
+
+	// Cross-instance read after write
+	if err := storeA.Set(ctx, key, 7, 10*time.Second); err != nil {
+		t.Fatalf("storeA.Set: %v", err)
+	}
+	got, found, err := storeB.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("storeB.Get: %v", err)
+	}
+	if !found || got != 7 {
+		t.Errorf("cross-instance Get: got=%d found=%v, want providerID=7 found=true", got, found)
+	}
+	t.Logf("verify> Probe C — write on store A, read on store B → providerID=%d found=%v ✓", got, found)
+
+	// Overwrite from B; A must see it
+	if err := storeB.Set(ctx, key, 11, 10*time.Second); err != nil {
+		t.Fatalf("storeB.Set: %v", err)
+	}
+	got, found, _ = storeA.Get(ctx, key)
+	if !found || got != 11 {
+		t.Errorf("overwrite from B then read from A: got=%d found=%v, want 11/true", got, found)
+	}
+	t.Logf("verify> Probe C — overwrite on B, read on A → providerID=%d found=%v ✓", got, found)
+
+	// TTL expiry across instances
+	shortKey := Key{TenantID: 1, ClientType: "openai", PolicyVer: "abc123", BaseKey: "t/expiry"}
+	if err := storeA.Set(ctx, shortKey, 9, 100*time.Millisecond); err != nil {
+		t.Fatalf("set short ttl: %v", err)
+	}
+	mr.FastForward(500 * time.Millisecond)
+	if _, found, _ := storeB.Get(ctx, shortKey); found {
+		t.Errorf("TTL: expected expiry on B, still found")
+	}
+	t.Logf("verify> Probe C — TTL expiry (set on A, observe on B after fast-forward) → expired ✓")
+
+	// Special characters in BaseKey and PolicyVer should not break the schema
+	weirdKey := Key{
+		TenantID:   2,
+		ClientType: "claude:turbo",
+		PolicyVer:  "ver/with:colon",
+		BaseKey:    "c/42/abc:def/with spaces",
+	}
+	if err := storeA.Set(ctx, weirdKey, 13, time.Minute); err != nil {
+		t.Fatalf("set weird key: %v", err)
+	}
+	got, found, _ = storeB.Get(ctx, weirdKey)
+	if !found || got != 13 {
+		t.Errorf("escape: got=%d found=%v, want 13/true", got, found)
+	}
+	t.Logf("verify> Probe C — key escaping (colons + spaces) → providerID=%d found=%v ✓", got, found)
+
+	// Concurrent writers: the last write must win and Get must not return
+	// garbage or error out. Run under -race to catch any racy bookkeeping.
+	concKey := Key{TenantID: 3, ClientType: "openai", PolicyVer: "abc", BaseKey: "t/conc"}
+	const writers = 50
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := 0; i < writers; i++ {
+		go func(n int) {
+			defer wg.Done()
+			_ = storeA.Set(ctx, concKey, uint64(n+1), time.Minute)
+		}(i)
+	}
+	wg.Wait()
+	got, found, err = storeB.Get(ctx, concKey)
+	if err != nil {
+		t.Fatalf("concurrent Get: %v", err)
+	}
+	if !found || got == 0 || got > writers {
+		t.Errorf("concurrent: got=%d found=%v, want one of 1..%d", got, found, writers)
+	}
+	t.Logf("verify> Probe C — %d concurrent writers, surviving value providerID=%d (must be 1..%d) ✓",
+		writers, got, writers)
+
+	// Delete on one instance, miss on the other
+	if err := storeA.Delete(ctx, key); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, found, _ := storeB.Get(ctx, key); found {
+		t.Errorf("delete: expected miss after A.Delete, B.Get still found")
+	}
+	t.Logf("verify> Probe C — Delete on A, Get on B → miss ✓")
+
+	// Quick sanity: serialized form remains a decimal uint64 in the bucket
+	raw, err := newRdb().Get(ctx, keyName(concKey)).Result()
+	if err != nil {
+		t.Fatalf("raw read: %v", err)
+	}
+	if _, err := strconv.ParseUint(raw, 10, 64); err != nil {
+		t.Errorf("raw value not uint64: %q", raw)
+	}
+}

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -278,19 +278,32 @@ func TestVerifyRoutingPhase2(t *testing.T) {
 		sendOne(fmt.Sprintf("probe-%d", i))
 	}
 	snapP := hitsSnap()
-	t.Logf("verify> Probe — cooldown still on p1, %d distinct sessions: p1=%d p2=%d p3=%d (expect ~2:1 between p2 and p3)",
-		spreadN, snapP[0], snapP[1], snapP[2])
-	if snapP[0] != 0 {
-		t.Errorf("probe: cooled-down p1 received %d hits", snapP[0])
+	t.Logf("verify> Probe — cooldown on p%d (weight %d), %d distinct sessions: p1=%d p2=%d p3=%d",
+		primedProvider+1, weights[primedProvider], spreadN, snapP[0], snapP[1], snapP[2])
+	if snapP[primedProvider] != 0 {
+		t.Errorf("probe: cooled-down p%d received %d hits", primedProvider+1, snapP[primedProvider])
 	}
-	// Tighten: with p1 down, traffic over p2 (weight 2) vs p3 (weight 1)
-	// should land near 2:1. N=200 → expected ~133/67. Binomial σ ≈ 6.7;
-	// allow ±20 (≈3σ) per bucket so flakes don't fire on legitimate sampling.
-	if snapP[1] < 113 || snapP[1] > 153 {
-		t.Errorf("probe: p2 (weight 2) got %d hits, want 133±20 with p1 cooled", snapP[1])
+	// With the primed provider cooled, traffic distributes between the
+	// surviving two by their weight ratio. Per-process random salt means
+	// primedProvider varies across runs, so compute expected counts
+	// dynamically. Use ±20 (~3σ for N=200, p≈0.2..0.9) per bucket to
+	// allow legitimate sampling variance.
+	survivingWeight := 0
+	for i, w := range weights {
+		if i != primedProvider {
+			survivingWeight += w
+		}
 	}
-	if snapP[2] < 47 || snapP[2] > 87 {
-		t.Errorf("probe: p3 (weight 1) got %d hits, want 67±20 with p1 cooled", snapP[2])
+	for i, w := range weights {
+		if i == primedProvider {
+			continue
+		}
+		expected := float64(spreadN) * float64(w) / float64(survivingWeight)
+		got := float64(snapP[i])
+		if got < expected-20 || got > expected+20 {
+			t.Errorf("probe: p%d (weight %d) got %d hits, want %.0f±20 with p%d cooled",
+				i+1, w, snapP[i], expected, primedProvider+1)
+		}
 	}
 
 	// Clean up cooldown state so other tests aren't affected

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -284,25 +285,31 @@ func TestVerifyRoutingPhase2(t *testing.T) {
 		t.Errorf("probe: cooled-down p%d received %d hits", primedProvider+1, snapP[primedProvider])
 	}
 	// With the primed provider cooled, traffic distributes between the
-	// surviving two by their weight ratio. Per-process random salt means
-	// primedProvider varies across runs, so compute expected counts
-	// dynamically. Use ±20 (~3σ for N=200, p≈0.2..0.9) per bucket to
-	// allow legitimate sampling variance.
+	// surviving providers by their weight ratio. Per-process random salt
+	// means primedProvider varies across runs, so compute expected
+	// counts dynamically and use a per-bucket 4σ tolerance (binomial
+	// std dev sqrt(N·p·(1-p))). 4σ gives a Pr(flake) ≈ 6.3e-5 per
+	// bucket per run — comfortably above the empirical noise floor
+	// regardless of which weight bucket gets cooled.
 	survivingWeight := 0
 	for i, w := range weights {
 		if i != primedProvider {
 			survivingWeight += w
 		}
 	}
+	const k = 4.0 // sigmas of tolerance
 	for i, w := range weights {
 		if i == primedProvider {
 			continue
 		}
-		expected := float64(spreadN) * float64(w) / float64(survivingWeight)
+		p := float64(w) / float64(survivingWeight)
+		expected := float64(spreadN) * p
+		sigma := math.Sqrt(float64(spreadN) * p * (1 - p))
+		tol := k * sigma
 		got := float64(snapP[i])
-		if got < expected-20 || got > expected+20 {
-			t.Errorf("probe: p%d (weight %d) got %d hits, want %.0f±20 with p%d cooled",
-				i+1, w, snapP[i], expected, primedProvider+1)
+		if got < expected-tol || got > expected+tol {
+			t.Errorf("probe: p%d (weight %d) got %d hits, want %.1f±%.1f (4σ) with p%d cooled",
+				i+1, w, snapP[i], expected, tol, primedProvider+1)
 		}
 	}
 

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -1,0 +1,484 @@
+package e2e_test
+
+// Ad-hoc verification driver for the load-balancing + sticky change.
+// Not part of the regression suite — meant to be invoked manually:
+//   go test ./tests/e2e -run VerifyRoutingPhase2 -v
+// The captured "verify> ..." log lines are the evidence.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/cooldown"
+)
+
+type hitMock struct {
+	server *httptest.Server
+	hits   atomic.Int64
+}
+
+func newHitMock(_ *testing.T, model string) *hitMock {
+	hm := &hitMock{}
+	hm.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hm.hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-mock",
+			"object":  "chat.completion",
+			"model":   model,
+			"created": 1700000000,
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "hi"},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{
+				"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2,
+			},
+		})
+	}))
+	return hm
+}
+
+func TestVerifyRoutingPhase2(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	// 3 mock upstreams with hit counters
+	mocks := []*hitMock{
+		newHitMock(t, "gpt-4o"),
+		newHitMock(t, "gpt-4o"),
+		newHitMock(t, "gpt-4o"),
+	}
+	defer func() {
+		for _, m := range mocks {
+			m.server.Close()
+		}
+	}()
+
+	// 3 providers + routes; weights 7 / 2 / 1
+	weights := []int{7, 2, 1}
+	providerIDs := make([]uint64, 3)
+	for i, m := range mocks {
+		providerIDs[i] = createProvider(t, env, fmt.Sprintf("p%d", i+1), m.server.URL, []string{"openai"})
+		resp := env.AdminPost("/api/admin/routes", map[string]any{
+			"isEnabled":  true,
+			"clientType": "openai",
+			"providerID": providerIDs[i],
+			"position":   i + 1,
+			"weight":     weights[i],
+		})
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("create route %d: status=%d body=%s", i, resp.StatusCode, body)
+		}
+		resp.Body.Close()
+	}
+
+	// weighted_random strategy (no sticky yet)
+	resp := env.AdminPost("/api/admin/routing-strategies", map[string]any{
+		"projectID": 0,
+		"type":      "weighted_random",
+		"config":    nil,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create strategy: status=%d body=%s", resp.StatusCode, body)
+	}
+	var stratResp map[string]any
+	DecodeJSON(t, resp, &stratResp)
+	stratID := uint64(stratResp["id"].(float64))
+
+	// Enable API token auth + create a token (sticky needs a non-zero APITokenID)
+	resp = env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	resp = env.AdminPost("/api/admin/api-tokens", map[string]any{
+		"name": "verify-token", "description": "verify",
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var tokCreated map[string]any
+	DecodeJSON(t, resp, &tokCreated)
+	tokenStr := tokCreated["token"].(string)
+
+	sendOne := func(sessionID string) int {
+		resp := env.ProxyPost("/v1/chat/completions",
+			openaiRequest("gpt-4o"),
+			map[string]string{
+				"Authorization": "Bearer " + tokenStr,
+				"X-Session-Id":  sessionID,
+			},
+		)
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("proxy POST failed: %d", resp.StatusCode)
+		}
+		// Determine which mock got hit by sampling hit counts (won't tell us
+		// which one if multiple changed; we check delta per-mock).
+		return resp.StatusCode
+	}
+
+	hitsSnap := func() []int64 {
+		out := make([]int64, len(mocks))
+		for i, m := range mocks {
+			out[i] = m.hits.Load()
+		}
+		return out
+	}
+	resetHits := func() {
+		for _, m := range mocks {
+			m.hits.Store(0)
+		}
+	}
+
+	// =====================================================================
+	// Phase A: distribution across many distinct sessions
+	// Expected 70/20/10; with N=2000 each bucket's 99% CI is ~±3% (binomial
+	// std dev ≈ sqrt(N*p*(1-p)) → roughly ±1% per σ; we allow ±3% ≈ 3σ).
+	// =====================================================================
+	resetHits()
+	const N = 2000
+	for i := 0; i < N; i++ {
+		sendOne(fmt.Sprintf("phaseA-%d", i))
+	}
+	snapA := hitsSnap()
+	total := snapA[0] + snapA[1] + snapA[2]
+	pct := func(n int64) float64 { return float64(n) * 100 / float64(total) }
+	t.Logf("verify> Phase A — distribution over %d distinct sessions: p1=%d (%.1f%%) p2=%d (%.1f%%) p3=%d (%.1f%%)",
+		N, snapA[0], pct(snapA[0]), snapA[1], pct(snapA[1]), snapA[2], pct(snapA[2]))
+	if total != int64(N) {
+		t.Fatalf("phase A: expected %d total hits, got %d", N, total)
+	}
+	check := func(label string, got int64, wantPct float64, tolPct float64) {
+		gotPct := pct(got)
+		if gotPct < wantPct-tolPct || gotPct > wantPct+tolPct {
+			t.Errorf("phase A %s: got %.1f%%, want ~%.1f%% (±%.1f%%)", label, gotPct, wantPct, tolPct)
+		}
+	}
+	check("p1 (weight 7)", snapA[0], 70, 3)
+	check("p2 (weight 2)", snapA[1], 20, 3)
+	check("p3 (weight 1)", snapA[2], 10, 3)
+
+	// =====================================================================
+	// Phase B: seeded determinism — same session always lands on same provider
+	// (even with sticky disabled, the seeded shuffle is deterministic).
+	// =====================================================================
+	resetHits()
+	const repeats = 10
+	for i := 0; i < repeats; i++ {
+		sendOne("phaseB-stable")
+	}
+	snapB := hitsSnap()
+	picked := -1
+	picks := 0
+	for i, h := range snapB {
+		if h > 0 {
+			if picked != -1 {
+				picks = 2 // more than one provider got hit
+			}
+			picked = i
+			picks++
+		}
+	}
+	t.Logf("verify> Phase B — same session repeated %dx (sticky OFF): p1=%d p2=%d p3=%d → %s",
+		repeats, snapB[0], snapB[1], snapB[2],
+		map[bool]string{true: "DETERMINISTIC ✓", false: "SPLIT ✗"}[picks == 1])
+	if picks != 1 || snapB[picked] != int64(repeats) {
+		t.Errorf("phase B: expected all %d hits on one provider, got %v", repeats, snapB)
+	}
+
+	// =====================================================================
+	// Phase C: turn sticky ON, send fresh session, verify sticky.Default()
+	// records the binding AND subsequent calls keep hitting the same provider.
+	// =====================================================================
+	resp = env.AdminPut(fmt.Sprintf("/api/admin/routing-strategies/%d", stratID), map[string]any{
+		"projectID": 0,
+		"type":      "weighted_random",
+		"config": map[string]any{
+			"stickyEnabled":    true,
+			"stickyScope":      "conversation",
+			"stickyTTLSeconds": 600,
+		},
+	})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	// Let cached repo settle (route/strategy cache reload is sync, but be safe).
+	time.Sleep(50 * time.Millisecond)
+
+	resetHits()
+	// Single warm-up hit creates the binding
+	sendOne("phaseC-alpha")
+	warmHits := hitsSnap()
+	primedProvider := -1
+	for i, h := range warmHits {
+		if h > 0 {
+			primedProvider = i
+			break
+		}
+	}
+	if primedProvider == -1 {
+		t.Fatalf("phase C warm-up: no provider got hit")
+	}
+	t.Logf("verify> Phase C warm-up — session phaseC-alpha → provider p%d", primedProvider+1)
+
+	const stickyRepeats = 30
+	for i := 0; i < stickyRepeats; i++ {
+		sendOne("phaseC-alpha")
+	}
+	snapC := hitsSnap()
+	expectedPrimed := int64(1 + stickyRepeats) // warm-up + repeats
+	totalC := snapC[0] + snapC[1] + snapC[2]
+	t.Logf("verify> Phase C — sticky ON, session phaseC-alpha repeated %dx after warm-up: p1=%d p2=%d p3=%d (expect all %d on p%d)",
+		stickyRepeats, snapC[0], snapC[1], snapC[2], expectedPrimed, primedProvider+1)
+	if totalC != expectedPrimed {
+		t.Errorf("phase C: hit total mismatch: got %d, want %d", totalC, expectedPrimed)
+	}
+	if snapC[primedProvider] != expectedPrimed {
+		t.Errorf("phase C: sticky leak: provider p%d expected %d hits, got %d (others: %v)",
+			primedProvider+1, expectedPrimed, snapC[primedProvider], snapC)
+	}
+
+	// =====================================================================
+	// Phase D: cooldown the sticky-pinned provider; same session should fail
+	// over to the others. The pinned provider must receive 0 new hits.
+	// =====================================================================
+	cooldown.Default().UpdateCooldown(providerIDs[primedProvider], "openai", "gpt-4o", time.Now().Add(30*time.Second))
+	cooldown.Default().UpdateCooldown(providerIDs[primedProvider], "openai", "", time.Now().Add(30*time.Second))
+	cooldown.Default().UpdateCooldown(providerIDs[primedProvider], "", "", time.Now().Add(30*time.Second))
+
+	resetHits()
+	const failoverRepeats = 20
+	for i := 0; i < failoverRepeats; i++ {
+		sendOne("phaseC-alpha") // same session — sticky still says primed, but cooldown filters it
+	}
+	snapD := hitsSnap()
+	t.Logf("verify> Phase D — cooldown applied to p%d, same session phaseC-alpha repeated %dx: p1=%d p2=%d p3=%d",
+		primedProvider+1, failoverRepeats, snapD[0], snapD[1], snapD[2])
+	if snapD[primedProvider] != 0 {
+		t.Errorf("phase D: cooled-down provider p%d still received %d hits", primedProvider+1, snapD[primedProvider])
+	}
+	totalD := snapD[0] + snapD[1] + snapD[2]
+	if totalD != int64(failoverRepeats) {
+		t.Errorf("phase D: total hits %d, want %d", totalD, failoverRepeats)
+	}
+
+	// Probe: under cooldown of p1, distinct sessions should still spread across
+	// the remaining {p2, p3} by their weight ratio 2:1. (Phase D with one
+	// session showed all 20 going to a single fallback — that's seeded
+	// determinism for the same session, by design.)
+	resetHits()
+	const spreadN = 200
+	for i := 0; i < spreadN; i++ {
+		sendOne(fmt.Sprintf("probe-%d", i))
+	}
+	snapP := hitsSnap()
+	t.Logf("verify> Probe — cooldown still on p1, %d distinct sessions: p1=%d p2=%d p3=%d (expect ~2:1 between p2 and p3)",
+		spreadN, snapP[0], snapP[1], snapP[2])
+	if snapP[0] != 0 {
+		t.Errorf("probe: cooled-down p1 received %d hits", snapP[0])
+	}
+
+	// Clean up cooldown state so other tests aren't affected
+	cooldown.Default().ClearCooldown(providerIDs[primedProvider], "", "")
+}
+
+// togglableMock returns a mock upstream whose response status can be flipped
+// at runtime via the returned setter. Used by TestVerifyRoutingErrorClass to
+// drive 5xx/429 failure modes without restarting the server.
+func togglableMock() (*httptest.Server, *hitMock, func(int)) {
+	hm := &hitMock{}
+	var status atomic.Int32
+	status.Store(200)
+	hm.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hm.hits.Add(1)
+		code := int(status.Load())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		if code >= 400 {
+			_, _ = w.Write([]byte(`{"error":{"type":"server_error","message":"forced"}}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-mock",
+			"object":  "chat.completion",
+			"model":   "gpt-4o",
+			"created": 1700000000,
+			"choices": []map[string]any{{
+				"index":         0,
+				"message":       map[string]any{"role": "assistant", "content": "hi"},
+				"finish_reason": "stop",
+			}},
+			"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+		})
+	}))
+	return hm.server, hm, func(code int) { status.Store(int32(code)) }
+}
+
+// TestVerifyRoutingErrorClass exercises the failure / sticky-update story:
+//
+//   - When the sticky-pinned provider returns 5xx, dispatch fails over to the
+//     next route. On success there, sticky overwrites to the new provider.
+//   - Returning the previously-pinned provider to health does NOT cause
+//     subsequent requests to drift back (sticky now points elsewhere).
+//   - 429 follows the same path as 5xx — the implementation doesn't branch on
+//     error class today; this just makes that explicit.
+func TestVerifyRoutingErrorClass(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	srvA, hmA, setA := togglableMock()
+	defer srvA.Close()
+	srvB, hmB, _ := togglableMock()
+	defer srvB.Close()
+
+	pA := createProvider(t, env, "pA", srvA.URL, []string{"openai"})
+	pB := createProvider(t, env, "pB", srvB.URL, []string{"openai"})
+
+	for _, pid := range []uint64{pA, pB} {
+		resp := env.AdminPost("/api/admin/routes", map[string]any{
+			"isEnabled":  true,
+			"clientType": "openai",
+			"providerID": pid,
+			"position":   1,
+			"weight":     1,
+		})
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("create route: %d %s", resp.StatusCode, body)
+		}
+		resp.Body.Close()
+	}
+
+	resp := env.AdminPost("/api/admin/routing-strategies", map[string]any{
+		"projectID": 0,
+		"type":      "weighted_random",
+		"config": map[string]any{
+			"stickyEnabled":    true,
+			"stickyScope":      "conversation",
+			"stickyTTLSeconds": 600,
+		},
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	resp = env.AdminPost("/api/admin/api-tokens", map[string]any{"name": "err-tok"})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	token := created["token"].(string)
+
+	hit := func(session string) int {
+		r := env.ProxyPost("/v1/chat/completions",
+			openaiRequest("gpt-4o"),
+			map[string]string{"Authorization": "Bearer " + token, "X-Session-Id": session})
+		defer r.Body.Close()
+		_, _ = io.Copy(io.Discard, r.Body)
+		return r.StatusCode
+	}
+
+	// 1) Warm-up: both healthy, observe which one sticky picks.
+	hmA.hits.Store(0)
+	hmB.hits.Store(0)
+	if code := hit("alpha"); code != 200 {
+		t.Fatalf("warm-up status=%d", code)
+	}
+	primed := "A"
+	if hmB.hits.Load() == 1 && hmA.hits.Load() == 0 {
+		primed = "B"
+	}
+	t.Logf("verify> ErrorClass warm-up — sticky pinned to p%s (A=%d B=%d)",
+		primed, hmA.hits.Load(), hmB.hits.Load())
+
+	// 2) Flip A to 500. If sticky points to A, the next call should fail at A
+	// once then fall through to B successfully; if it points to B, we
+	// instead want a way to force the failure path. Flip B to 500 if needed.
+	if primed == "B" {
+		// Reverse roles so the failing one is the sticky-pinned one.
+		// (Sticky must be invalidated implicitly via cooldown — but we want to
+		// test pure error fallback, so we simply make B fail. After 1
+		// successful failover, sticky now points to A.)
+		// We use setA for both to keep the test self-contained: switch B.
+		hmA.hits.Store(0)
+		hmB.hits.Store(0)
+		// no way to control B with the captured setter; fail-over by failing
+		// B inline using a temp swap. We instead drive a known failure flow:
+		// kill B by closing the server; dispatch should fall back to A.
+		srvB.CloseClientConnections()
+		// In this configuration we expect the dispatch to fail-over to A on
+		// the next request. Just record the observation.
+		code := hit("alpha")
+		t.Logf("verify> ErrorClass primed=B path — closed pB conns; next request: status=%d A=%d B=%d",
+			code, hmA.hits.Load(), hmB.hits.Load())
+		// The key claim is: sticky should now point to A (after success
+		// there). We verify by sending more and observing A wins.
+		hmA.hits.Store(0)
+		hmB.hits.Store(0)
+		const reps = 10
+		for i := 0; i < reps; i++ {
+			hit("alpha")
+		}
+		t.Logf("verify> ErrorClass after recovery — %d requests for alpha: A=%d B=%d (expect all A)",
+			reps, hmA.hits.Load(), hmB.hits.Load())
+		if hmA.hits.Load() != int64(reps) {
+			t.Errorf("ErrorClass: expected sticky to re-pin to A after B failed, got A=%d B=%d",
+				hmA.hits.Load(), hmB.hits.Load())
+		}
+		return
+	}
+
+	// Primed=A path: flip A to 500
+	setA(500)
+	hmA.hits.Store(0)
+	hmB.hits.Store(0)
+	const reps = 10
+	codes := make([]int, reps)
+	for i := 0; i < reps; i++ {
+		codes[i] = hit("alpha")
+	}
+	finalAHits := hmA.hits.Load()
+	finalBHits := hmB.hits.Load()
+	t.Logf("verify> ErrorClass primed=A then A→500 — %d requests for alpha: A=%d B=%d (codes=%v)",
+		reps, finalAHits, finalBHits, codes)
+
+	if finalBHits == 0 {
+		t.Errorf("ErrorClass: B never received traffic during A's 500s; failover broken")
+	}
+
+	// All client requests should still return 200 because B is healthy.
+	for i, c := range codes {
+		if c != 200 {
+			t.Errorf("ErrorClass: request %d returned %d, want 200 (failover should succeed)", i, c)
+			break
+		}
+	}
+
+	// 3) Heal A. Subsequent requests should STILL hit B (sticky now points
+	// to B after each success there). We expect no drift back to A.
+	setA(200)
+	hmA.hits.Store(0)
+	hmB.hits.Store(0)
+	for i := 0; i < reps; i++ {
+		hit("alpha")
+	}
+	t.Logf("verify> ErrorClass A healed — %d requests for alpha: A=%d B=%d (expect all B, sticky points to B now)",
+		reps, hmA.hits.Load(), hmB.hits.Load())
+	if hmA.hits.Load() != 0 {
+		t.Errorf("ErrorClass: sticky drifted back to recovered A; A=%d B=%d", hmA.hits.Load(), hmB.hits.Load())
+	}
+	if hmB.hits.Load() != int64(reps) {
+		t.Errorf("ErrorClass: expected %d hits on B, got %d", reps, hmB.hits.Load())
+	}
+
+	// Cleanup: clear any cooldowns that the dispatch loop may have applied
+	// during the failure phase so other tests aren't affected.
+	cooldown.Default().ClearCooldown(pA, "", "")
+	cooldown.Default().ClearCooldown(pB, "", "")
+}

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -283,6 +283,15 @@ func TestVerifyRoutingPhase2(t *testing.T) {
 	if snapP[0] != 0 {
 		t.Errorf("probe: cooled-down p1 received %d hits", snapP[0])
 	}
+	// Tighten: with p1 down, traffic over p2 (weight 2) vs p3 (weight 1)
+	// should land near 2:1. N=200 → expected ~133/67. Binomial σ ≈ 6.7;
+	// allow ±20 (≈3σ) per bucket so flakes don't fire on legitimate sampling.
+	if snapP[1] < 113 || snapP[1] > 153 {
+		t.Errorf("probe: p2 (weight 2) got %d hits, want 133±20 with p1 cooled", snapP[1])
+	}
+	if snapP[2] < 47 || snapP[2] > 87 {
+		t.Errorf("probe: p3 (weight 1) got %d hits, want 67±20 with p1 cooled", snapP[2])
+	}
 
 	// Clean up cooldown state so other tests aren't affected
 	cooldown.Default().ClearCooldown(providerIDs[primedProvider], "", "")
@@ -333,7 +342,7 @@ func TestVerifyRoutingErrorClass(t *testing.T) {
 
 	srvA, hmA, setA := togglableMock()
 	defer srvA.Close()
-	srvB, hmB, _ := togglableMock()
+	srvB, hmB, setB := togglableMock()
 	defer srvB.Close()
 
 	pA := createProvider(t, env, "pA", srvA.URL, []string{"openai"})
@@ -384,58 +393,43 @@ func TestVerifyRoutingErrorClass(t *testing.T) {
 		return r.StatusCode
 	}
 
-	// 1) Warm-up: both healthy, observe which one sticky picks.
+	// Identify primed/spare by their roles so the test can drive either
+	// initial sticky binding symmetrically. After warm-up sticky points
+	// at one provider; we always fail *that* one and expect the dispatcher
+	// to fall through to the other.
+	type sideRefs struct {
+		name string
+		hits *hitMock
+		set  func(int)
+		id   uint64
+	}
+	a := sideRefs{name: "A", hits: hmA, set: setA, id: pA}
+	b := sideRefs{name: "B", hits: hmB, set: setB, id: pB}
+
+	// 1) Warm-up: both healthy, observe which one sticky pinned to.
 	hmA.hits.Store(0)
 	hmB.hits.Store(0)
 	if code := hit("alpha"); code != 200 {
 		t.Fatalf("warm-up status=%d", code)
 	}
-	primed := "A"
-	if hmB.hits.Load() == 1 && hmA.hits.Load() == 0 {
-		primed = "B"
+	var primed, spare sideRefs
+	switch {
+	case hmA.hits.Load() == 1 && hmB.hits.Load() == 0:
+		primed, spare = a, b
+	case hmB.hits.Load() == 1 && hmA.hits.Load() == 0:
+		primed, spare = b, a
+	default:
+		t.Fatalf("warm-up: unexpected hits A=%d B=%d", hmA.hits.Load(), hmB.hits.Load())
 	}
 	t.Logf("verify> ErrorClass warm-up — sticky pinned to p%s (A=%d B=%d)",
-		primed, hmA.hits.Load(), hmB.hits.Load())
+		primed.name, hmA.hits.Load(), hmB.hits.Load())
 
-	// 2) Flip A to 500. If sticky points to A, the next call should fail at A
-	// once then fall through to B successfully; if it points to B, we
-	// instead want a way to force the failure path. Flip B to 500 if needed.
-	if primed == "B" {
-		// Reverse roles so the failing one is the sticky-pinned one.
-		// (Sticky must be invalidated implicitly via cooldown — but we want to
-		// test pure error fallback, so we simply make B fail. After 1
-		// successful failover, sticky now points to A.)
-		// We use setA for both to keep the test self-contained: switch B.
-		hmA.hits.Store(0)
-		hmB.hits.Store(0)
-		// no way to control B with the captured setter; fail-over by failing
-		// B inline using a temp swap. We instead drive a known failure flow:
-		// kill B by closing the server; dispatch should fall back to A.
-		srvB.CloseClientConnections()
-		// In this configuration we expect the dispatch to fail-over to A on
-		// the next request. Just record the observation.
-		code := hit("alpha")
-		t.Logf("verify> ErrorClass primed=B path — closed pB conns; next request: status=%d A=%d B=%d",
-			code, hmA.hits.Load(), hmB.hits.Load())
-		// The key claim is: sticky should now point to A (after success
-		// there). We verify by sending more and observing A wins.
-		hmA.hits.Store(0)
-		hmB.hits.Store(0)
-		const reps = 10
-		for i := 0; i < reps; i++ {
-			hit("alpha")
-		}
-		t.Logf("verify> ErrorClass after recovery — %d requests for alpha: A=%d B=%d (expect all A)",
-			reps, hmA.hits.Load(), hmB.hits.Load())
-		if hmA.hits.Load() != int64(reps) {
-			t.Errorf("ErrorClass: expected sticky to re-pin to A after B failed, got A=%d B=%d",
-				hmA.hits.Load(), hmB.hits.Load())
-		}
-		return
-	}
-
-	// Primed=A path: flip A to 500
-	setA(500)
+	// 2) Flip the primed side to 500. Each subsequent request should attempt
+	// the primed provider once (since sticky still says "go there"), get a
+	// 500, fail over to the spare, succeed there, and write sticky=spare.
+	// From the second request onward, sticky points at the spare and the
+	// failing primed provider is bypassed entirely.
+	primed.set(500)
 	hmA.hits.Store(0)
 	hmB.hits.Store(0)
 	const reps = 10
@@ -443,16 +437,15 @@ func TestVerifyRoutingErrorClass(t *testing.T) {
 	for i := 0; i < reps; i++ {
 		codes[i] = hit("alpha")
 	}
-	finalAHits := hmA.hits.Load()
-	finalBHits := hmB.hits.Load()
-	t.Logf("verify> ErrorClass primed=A then A→500 — %d requests for alpha: A=%d B=%d (codes=%v)",
-		reps, finalAHits, finalBHits, codes)
+	primedHits := primed.hits.hits.Load()
+	spareHits := spare.hits.hits.Load()
+	t.Logf("verify> ErrorClass primed=%s then %s→500 — %d requests for alpha: %s=%d %s=%d (codes=%v)",
+		primed.name, primed.name, reps, primed.name, primedHits, spare.name, spareHits, codes)
 
-	if finalBHits == 0 {
-		t.Errorf("ErrorClass: B never received traffic during A's 500s; failover broken")
+	if spareHits == 0 {
+		t.Errorf("ErrorClass: spare p%s never received traffic during p%s 500s; failover broken",
+			spare.name, primed.name)
 	}
-
-	// All client requests should still return 200 because B is healthy.
 	for i, c := range codes {
 		if c != 200 {
 			t.Errorf("ErrorClass: request %d returned %d, want 200 (failover should succeed)", i, c)
@@ -460,25 +453,51 @@ func TestVerifyRoutingErrorClass(t *testing.T) {
 		}
 	}
 
-	// 3) Heal A. Subsequent requests should STILL hit B (sticky now points
-	// to B after each success there). We expect no drift back to A.
-	setA(200)
+	// 3) Heal the primed side. Subsequent requests should STILL hit the
+	// spare (sticky was rebound to it after each success); no drift back.
+	primed.set(200)
 	hmA.hits.Store(0)
 	hmB.hits.Store(0)
 	for i := 0; i < reps; i++ {
 		hit("alpha")
 	}
-	t.Logf("verify> ErrorClass A healed — %d requests for alpha: A=%d B=%d (expect all B, sticky points to B now)",
-		reps, hmA.hits.Load(), hmB.hits.Load())
-	if hmA.hits.Load() != 0 {
-		t.Errorf("ErrorClass: sticky drifted back to recovered A; A=%d B=%d", hmA.hits.Load(), hmB.hits.Load())
+	t.Logf("verify> ErrorClass p%s healed — %d requests for alpha: A=%d B=%d (expect all p%s, sticky points there now)",
+		primed.name, reps, hmA.hits.Load(), hmB.hits.Load(), spare.name)
+	if primed.hits.hits.Load() != 0 {
+		t.Errorf("ErrorClass: sticky drifted back to recovered p%s; A=%d B=%d",
+			primed.name, hmA.hits.Load(), hmB.hits.Load())
 	}
-	if hmB.hits.Load() != int64(reps) {
-		t.Errorf("ErrorClass: expected %d hits on B, got %d", reps, hmB.hits.Load())
+	if spare.hits.hits.Load() != int64(reps) {
+		t.Errorf("ErrorClass: expected %d hits on p%s, got %d", reps, spare.name, spare.hits.hits.Load())
 	}
 
-	// Cleanup: clear any cooldowns that the dispatch loop may have applied
+	// 4) Explicit 429 case. The dispatcher doesn't branch by error class
+	// today — 4xx/429/5xx all fail over the same way — but Codex review
+	// asked to make the 429 path observable so future rate-limit-specific
+	// logic doesn't silently break the contract. Sticky now points at the
+	// spare; flip it to 429 and verify the healed primed becomes the
+	// failover target.
+	cooldown.Default().ClearCooldown(primed.id, "", "")
+	cooldown.Default().ClearCooldown(spare.id, "", "")
+	spare.set(429)
+	primed.set(200)
+	hmA.hits.Store(0)
+	hmB.hits.Store(0)
+	for i := 0; i < reps; i++ {
+		hit("alpha")
+	}
+	t.Logf("verify> ErrorClass 429 probe — p%s→429, %d requests for alpha: A=%d B=%d (expect majority p%s)",
+		spare.name, reps, hmA.hits.Load(), hmB.hits.Load(), primed.name)
+	if primed.hits.hits.Load() < int64(reps-1) {
+		// One initial hit on the spare (the sticky-preferred) is expected;
+		// everything after the failover should land on the primed.
+		t.Errorf("ErrorClass 429: expected ≥%d hits on p%s after p%s→429, got A=%d B=%d",
+			reps-1, primed.name, spare.name, hmA.hits.Load(), hmB.hits.Load())
+	}
+
+	// Cleanup: clear any cooldowns the dispatch loop may have applied
 	// during the failure phase so other tests aren't affected.
+	spare.set(200)
 	cooldown.Default().ClearCooldown(pA, "", "")
 	cooldown.Default().ClearCooldown(pB, "", "")
 }

--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -272,7 +272,7 @@ function ClientTypeRoutesContentInner({
     return map;
   }, [items]);
 
-  const activeItem = activeId ? itemsById.get(activeId) ?? null : null;
+  const activeItem = activeId ? (itemsById.get(activeId) ?? null) : null;
 
   const handleToggle = (item: ProviderConfigItem) => {
     if (item.route) {
@@ -285,6 +285,7 @@ function ClientTypeRoutesContentInner({
         clientType,
         providerID: item.provider.id,
         position: items.length + 1,
+        weight: 1,
         retryConfigID: 0,
       });
     }
@@ -298,6 +299,7 @@ function ClientTypeRoutesContentInner({
       clientType,
       providerID: provider.id,
       position: items.length + 1,
+      weight: 1,
       retryConfigID: 0,
     });
   };
@@ -379,10 +381,7 @@ function ClientTypeRoutesContentInner({
               onDragStart={handleDragStart}
               onDragEnd={handleDragEnd}
             >
-              <SortableContext
-                items={itemIds}
-                strategy={verticalListSortingStrategy}
-              >
+              <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
                 <div className="space-y-2">
                   {items.map((item, index) => (
                     <SortableProviderRow

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -25,6 +25,7 @@ export type {
   RoutingStrategy,
   RoutingStrategyType,
   RoutingStrategyConfig,
+  RoutingStickyScope,
   CreateRoutingStrategyData,
   ProxyRequest,
   ProxyRequestStatus,

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -195,6 +195,7 @@ export interface Route {
   clientType: ClientType;
   providerID: number;
   position: number;
+  weight: number;
   retryConfigID: number;
   modelMapping?: Record<string, string>;
 }
@@ -226,8 +227,13 @@ export type CreateRetryConfigData = Omit<RetryConfig, 'id' | 'createdAt' | 'upda
 
 export type RoutingStrategyType = 'priority' | 'weighted_random';
 
+export type RoutingStickyScope = 'token' | 'conversation';
+
 export interface RoutingStrategyConfig {
-  // 扩展字段
+  // Sticky / session-affinity (only meaningful for weighted_random; ignored for priority)
+  stickyEnabled?: boolean;
+  stickyScope?: RoutingStickyScope;
+  stickyTTLSeconds?: number;
 }
 
 export interface RoutingStrategy {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -591,6 +591,8 @@
       "provider": "Provider",
       "project": "Project",
       "position": "Position (lower = higher priority)",
+      "weight": "Weight (load balancing)",
+      "weightHelp": "Used by the weighted-random routing strategy. Higher = more likely to be picked. Default 1.",
       "modelMapping": "Model Mapping (Override)",
       "enabled": "Enabled",
       "selectProvider": "Select provider...",
@@ -852,7 +854,17 @@
     "newTitle": "New Routing Strategy",
     "priorityByPosition": "Priority (by position)",
     "id": "ID",
-    "noStrategies": "No strategies"
+    "noStrategies": "No strategies",
+    "description": "Choose how upstream providers are picked when more than one matches.",
+    "stickyEnabled": "Session affinity (sticky)",
+    "stickyHelp": "After a successful pick, remember the binding for a TTL window so the same session keeps hitting the same upstream (maximizes prompt cache hits). Bindings auto-invalidate when route config changes or the target enters cooldown.",
+    "stickyScope": "Affinity scope",
+    "stickyScopeToken": "By API token (coarser, better cache hits)",
+    "stickyScopeConversation": "By conversation (finer, more entries)",
+    "stickyScopeTokenHelp": "All sessions sharing one API token land on the same provider.",
+    "stickyScopeConversationHelp": "Each (token, session id) gets its own binding.",
+    "stickyTTL": "TTL (seconds)",
+    "stickyTTLHelp": "Default 1800 (30 min). Shorter = adapts faster to weight changes; longer = stickier affinity."
   },
   "documentation": {
     "title": "Documentation",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -590,6 +590,8 @@
       "provider": "提供商",
       "project": "项目",
       "position": "位置 (数值越小优先级越高)",
+      "weight": "权重 (负载均衡)",
+      "weightHelp": "用于加权随机路由策略。值越大被选中概率越高，默认 1。",
       "modelMapping": "模型映射 (覆盖)",
       "enabled": "启用",
       "selectProvider": "选择提供商...",
@@ -851,7 +853,17 @@
     "newTitle": "新建路由策略",
     "priorityByPosition": "按位置优先级",
     "id": "ID",
-    "noStrategies": "暂无策略"
+    "noStrategies": "暂无策略",
+    "description": "在多条路由命中时选择如何分发上游 provider。",
+    "stickyEnabled": "Session 亲和（粘性）",
+    "stickyHelp": "成功命中后在 TTL 内记住绑定，让同一 session 持续打到同一 provider（最大化上游 prompt cache 命中）。路由配置变更或目标进入冷却时绑定自动失效。",
+    "stickyScope": "亲和粒度",
+    "stickyScopeToken": "按 API token（粗，命中率高）",
+    "stickyScopeConversation": "按 conversation（细，条目多）",
+    "stickyScopeTokenHelp": "同一 API token 下的所有 session 都落到同一 provider。",
+    "stickyScopeConversationHelp": "每个 (token, session id) 各自绑定。",
+    "stickyTTL": "TTL（秒）",
+    "stickyTTLHelp": "默认 1800（30 分钟）。短 = 更快响应权重变化；长 = 亲和更稳。"
   },
   "documentation": {
     "title": "文档",

--- a/web/src/pages/routes/form.tsx
+++ b/web/src/pages/routes/form.tsx
@@ -35,6 +35,7 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
   const [providerID, setProviderID] = useState('');
   const [projectID, setProjectID] = useState(projectId !== undefined ? String(projectId) : '0');
   const [position, setPosition] = useState('1');
+  const [weight, setWeight] = useState('1');
   const [isEnabled, setIsEnabled] = useState(true);
   const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
 
@@ -70,6 +71,7 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
       setProviderID(String(route.providerID));
       setProjectID(String(route.projectID));
       setPosition(String(route.position));
+      setWeight(String(route.weight ?? 1));
       setIsEnabled(route.isEnabled);
       setModelMapping(route.modelMapping || {});
     }
@@ -87,11 +89,13 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
+    const parsedWeight = Number(weight);
     const data = {
       clientType,
       providerID: Number(providerID),
       projectID: Number(projectID),
       position: Number(position),
+      weight: Number.isFinite(parsedWeight) && parsedWeight > 0 ? parsedWeight : 1,
       isEnabled,
       isNative: route?.isNative ?? false, // 手动创建的 Route 默认为转换路由
       retryConfigID: route?.retryConfigID ?? 0,
@@ -177,6 +181,18 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
             min="1"
             required
           />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">{t('routes.form.weight')}</label>
+          <Input
+            type="number"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            min="1"
+            step="1"
+            required
+          />
+          <p className="mt-1 text-xs text-text-secondary">{t('routes.form.weightHelp')}</p>
         </div>
       </div>
 

--- a/web/src/pages/routing-strategies/index.tsx
+++ b/web/src/pages/routing-strategies/index.tsx
@@ -23,7 +23,8 @@ import {
 import { PageHeader } from '@/components/layout/page-header';
 import { Plus, Trash2, Pencil, Workflow } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { RoutingStrategy, RoutingStrategyType } from '@/lib/transport';
+import type { RoutingStrategy, RoutingStrategyType, RoutingStickyScope } from '@/lib/transport';
+import { Input } from '@/components/ui';
 import { useDialog } from '@/contexts/dialog-context';
 
 export function RoutingStrategiesPage() {
@@ -39,16 +40,25 @@ export function RoutingStrategiesPage() {
 
   const [projectID, setProjectID] = useState('0');
   const [type, setType] = useState<RoutingStrategyType>('priority');
+  const [stickyEnabled, setStickyEnabled] = useState(false);
+  const [stickyScope, setStickyScope] = useState<RoutingStickyScope>('token');
+  const [stickyTTL, setStickyTTL] = useState('1800');
 
   const resetForm = () => {
     setProjectID('0');
     setType('priority');
+    setStickyEnabled(false);
+    setStickyScope('token');
+    setStickyTTL('1800');
   };
 
   const handleEdit = (strategy: RoutingStrategy) => {
     setEditingStrategy(strategy);
     setProjectID(String(strategy.projectID));
     setType(strategy.type);
+    setStickyEnabled(strategy.config?.stickyEnabled ?? false);
+    setStickyScope(strategy.config?.stickyScope ?? 'token');
+    setStickyTTL(String(strategy.config?.stickyTTLSeconds ?? 1800));
     setShowForm(true);
   };
 
@@ -60,10 +70,21 @@ export function RoutingStrategiesPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // Sticky config is only meaningful for weighted_random; collapse it to
+    // null for priority so the JSON stays clean.
+    const ttlNum = Number(stickyTTL);
+    const config =
+      type === 'weighted_random' && stickyEnabled
+        ? {
+            stickyEnabled: true,
+            stickyScope,
+            stickyTTLSeconds: Number.isFinite(ttlNum) && ttlNum > 0 ? ttlNum : 1800,
+          }
+        : null;
     const data = {
       projectID: Number(projectID),
       type,
-      config: null,
+      config,
     };
 
     if (editingStrategy) {
@@ -154,6 +175,68 @@ export function RoutingStrategiesPage() {
                       </select>
                     </div>
                   </div>
+
+                  {type === 'weighted_random' && (
+                    <div className="rounded-md border border-input bg-muted/30 p-4 space-y-4">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          id="stickyEnabled"
+                          checked={stickyEnabled}
+                          onChange={(e) => setStickyEnabled(e.target.checked)}
+                          className="h-4 w-4 rounded border-gray-300"
+                        />
+                        <label htmlFor="stickyEnabled" className="text-sm font-medium">
+                          {t('routingStrategies.stickyEnabled')}
+                        </label>
+                      </div>
+                      <p className="text-xs text-text-secondary">
+                        {t('routingStrategies.stickyHelp')}
+                      </p>
+                      {stickyEnabled && (
+                        <div className="grid gap-4 md:grid-cols-2">
+                          <div>
+                            <label className="mb-1 block text-sm font-medium">
+                              {t('routingStrategies.stickyScope')}
+                            </label>
+                            <select
+                              value={stickyScope}
+                              onChange={(e) => setStickyScope(e.target.value as RoutingStickyScope)}
+                              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs focus:border-ring focus:ring-2 focus:ring-ring/50 outline-none"
+                            >
+                              <option value="token">
+                                {t('routingStrategies.stickyScopeToken')}
+                              </option>
+                              <option value="conversation">
+                                {t('routingStrategies.stickyScopeConversation')}
+                              </option>
+                            </select>
+                            <p className="mt-1 text-xs text-text-secondary">
+                              {stickyScope === 'token'
+                                ? t('routingStrategies.stickyScopeTokenHelp')
+                                : t('routingStrategies.stickyScopeConversationHelp')}
+                            </p>
+                          </div>
+                          <div>
+                            <label className="mb-1 block text-sm font-medium">
+                              {t('routingStrategies.stickyTTL')}
+                            </label>
+                            <Input
+                              type="number"
+                              value={stickyTTL}
+                              onChange={(e) => setStickyTTL(e.target.value)}
+                              min="60"
+                              step="60"
+                            />
+                            <p className="mt-1 text-xs text-text-secondary">
+                              {t('routingStrategies.stickyTTLHelp')}
+                            </p>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
                   <div className="flex justify-end gap-2">
                     <Button type="button" variant="outline" onClick={handleCloseForm}>
                       {t('common.cancel')}


### PR DESCRIPTION
## Summary

Adds real weighted load balancing for routes plus a Redis-backed session-affinity layer on top. Previously routing was either strict priority (sequential fallback) or a per-request reshuffle whose `Route.Weight` was never exposed in the UI.

- **Weighted distribution**: `Route.Weight` is editable from the routes form and used by the existing `weighted_random` strategy. The shuffle is now seeded from `(APITokenID, SessionID)` so the same session sees a stable fallback order while different sessions diverge — implicit affinity, even before sticky is enabled.
- **Session-affinity sticky** (`internal/sticky/`): a new package storing `(session → provider)` bindings in Redis (memory fallback for standalone) with a `policyFingerprint` embedded in the key so any route config change auto-invalidates every binding. TTL configurable (default 30 min). Scope toggles between `token` (one binding per API token, coarser, best prompt-cache locality) and `conversation` (per session id).
- **Architecture** mirrors `internal/cooldown`: `Store` interface, Redis + memory impls, `sticky.Default()` singleton wired in `core/coordinator_setup.go`, zero new shared-state dependencies.
- **Router.Match** now returns `MatchResult{Routes, Sticky}`; the dispatcher SETEXes the binding only after a confirmed-good upstream response. Failure paths intentionally don't branch by error class — failover + overwrite-on-success handles 4xx/429/5xx uniformly; the next request's `Match` re-filters via cooldown, which is already distributed.
- **Pre-existing fix bundled**: `AdminService.GetRoutingStrategy` was calling `repo.GetByProjectID` with the strategy ID, causing PUT `/admin/routing-strategies/{id}` to 404 for any global strategy. Adds a real `GetByID` to the repository interface + sqlite + cached layer.

UI exposes the sticky config block in the routing-strategies page only when `weighted_random` is selected (priority writes `config: null`).

## Test plan

End-to-end verification was run against the full HTTP proxy stack with three mock upstreams; all probes are committed as tests.

- [x] **Phase A — large-sample weight distribution.** 2000 distinct sessions with weights 7/2/1 → 70.2% / 19.3% / 10.4% (each bucket within ±3% of expected). `TestVerifyRoutingPhase2`
- [x] **Phase B — seeded determinism.** Same session repeated 10× with sticky OFF lands on a single provider every time. `TestVerifyRoutingPhase2`
- [x] **Phase C — sticky write+read.** Warm-up + 30 follow-ups for one session all hit the primed provider; SETEX-on-success + GET-on-Match exercised through the real dispatcher. `TestVerifyRoutingPhase2`
- [x] **Phase D — cooldown failover.** Cooldown the primed provider; 20 same-session requests transparently land elsewhere with the pinned provider receiving 0 hits. `TestVerifyRoutingPhase2`
- [x] **Failover spread probe.** 200 distinct sessions under cooldown spread across surviving providers per their 2:1 weight ratio. `TestVerifyRoutingPhase2`
- [x] **Error-class behavior.** Flipping a mock to return 500: dispatcher fails over to the healthy provider, sticky overwrites to it, and after the original recovers there is no drift back. Client sees 200 throughout. `TestVerifyRoutingErrorClass`
- [x] **Multi-instance Redis consistency.** Two `redisStore` instances backed by the same miniredis: cross-instance read after write, overwrite, TTL expiry (FastForward), key escaping with colons/spaces, 50 concurrent writers under `-race`, cross-instance delete, raw uint64 schema. `TestRedisStoreCrossInstance`
- [x] **Full regression sweep.** `go test ./internal/... ./tests/...` green.

## Notes

- Single-session fallback is deterministic (Phase D one session always picked p3, not 2:1) — that's the seeded-shuffle property by design; aggregate failover across many sessions still spreads by weight (see probe). Documented in the test log.
- Codex was consulted twice during design; final architecture (weighted_random + lazy sticky with policy fingerprint, instead of consistent hashing) and the production-PASS bar (large sample, error class, 2-node Redis) both came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 为加权随机路由添加会话粘性（sticky），支持按 API Token 或会话绑定提供者并可配置 TTL；路由支持权重配置。
* **修复/改进**
  * 路由匹配在同一会话中更确定稳定，粘性信息可跨实例持久化并在请求成功后回写，写失败不影响主请求流；管理端可按策略 ID 查询。
* **测试**
  * 新增端到端与存储一致性测试覆盖粘性、故障切换与冷却场景。
* **文档**
  * 增加 UI 文案与环境变量说明（可选共享种子）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/awsl-project/maxx/pull/584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->