### PR TITLE
Fix Bedrock adaptive thinking retry

### DIFF
--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -240,13 +240,16 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// Build upstream URL
 	upstreamURL := buildBedrockURL(region, bedrockModelID, clientWantsStream)
 
-	// Up to three attempts: two independent retry paths each fire at
+	// Up to four attempts: three independent retry paths each fire at
 	// most once. (1) a Bedrock 400 that rejects a thinking-block
 	// envelope (signature on `thinking`, opaque `data` on
 	// `redacted_thinking`) is recoverable by stripping those blocks
 	// and replaying once. (2) a 400 rejecting temperature/top_p/top_k
 	// (extended-thinking mode) is recoverable by stripping those
-	// fields and replaying once. Cross-deployment replays produced by
+	// fields and replaying once. (3) a 400 rejecting
+	// thinking.type="enabled" for an adaptive-only model is recoverable
+	// by rewriting to thinking.type="adaptive" and moving the budget
+	// signal into output_config.effort. Cross-deployment replays produced by
 	// clients that captured a transcript against Anthropic and now
 	// hit Bedrock are the common cause; retry preserves the rest of
 	// the conversation rather than failing the whole request.
@@ -259,6 +262,7 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	var resp *http.Response
 	thinkingRetried := false
 	samplingRetried := false
+	adaptiveRetried := false
 	for {
 		var attemptErr error
 		resp, attemptErr = a.sendBedrockRequest(ctx, c, upstreamURL, requestBody, region, clientWantsStream)
@@ -299,6 +303,18 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			if !bytes.Equal(stripped, requestBody) {
 				requestBody = stripped
 				samplingRetried = true
+				continue
+			}
+		}
+
+		// Discovery/model tables can lag Bedrock capability changes. If AWS
+		// says this exact model no longer accepts the classic thinking shape,
+		// trust the runtime validation and replay with adaptive thinking.
+		if !adaptiveRetried && resp.StatusCode == 400 && IsClassicThinkingRejectedError(body) {
+			rewritten := RewriteClassicThinkingToAdaptive(requestBody)
+			if !bytes.Equal(rewritten, requestBody) {
+				requestBody = rewritten
+				adaptiveRetried = true
 				continue
 			}
 		}
@@ -764,4 +780,3 @@ func newHTTPClient() *http.Client {
 		Timeout:   600 * time.Second,
 	}
 }
-

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -1,6 +1,8 @@
 package bedrock
 
 import (
+	"regexp"
+
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -67,25 +69,25 @@ func AdaptThinkingForModel(body []byte, shortName string) []byte {
 	// always-on adaptive — so we re-strip here, with model context.
 	body = StripSamplingParams(body)
 
+	return RewriteClassicThinkingToAdaptive(body)
+}
+
+// RewriteClassicThinkingToAdaptive converts Claude's classic extended-thinking
+// shape into the adaptive shape used by newer Bedrock Claude SKUs. It does not
+// require model context, so the error-driven retry path can use it when AWS
+// tells us at runtime that a model is adaptive-only.
+func RewriteClassicThinkingToAdaptive(body []byte) []byte {
 	thinkingType := gjson.GetBytes(body, "thinking.type").String()
 	if thinkingType == "" || thinkingType == "adaptive" || thinkingType == "disabled" {
 		return body
 	}
 
-	budget := gjson.GetBytes(body, "thinking.budget_tokens").Int()
-	effort := "low"
-	switch {
-	case budget >= 32000:
-		effort = "high"
-	case budget >= 8000:
-		effort = "medium"
-	}
+	effort := effortForThinkingBudget(gjson.GetBytes(body, "thinking.budget_tokens").Int())
 
-	// Replace the thinking block with just {type: adaptive}. budget_tokens
-	// is not valid under adaptive and would be rejected; the effort
-	// signal moves to output_config.effort.
-	body, _ = sjson.SetBytes(body, "thinking.type", "adaptive")
-	body, _ = sjson.DeleteBytes(body, "thinking.budget_tokens")
+	// Replace the thinking block with exactly {type: adaptive}. budget_tokens
+	// and any other classic-only thinking fields are not valid under adaptive
+	// and would be rejected; the effort signal moves to output_config.effort.
+	body, _ = sjson.SetRawBytes(body, "thinking", []byte(`{"type":"adaptive"}`))
 
 	// Preserve any effort the client already set on output_config; only
 	// fill it in when absent, so a caller who knows what they want wins.
@@ -93,4 +95,28 @@ func AdaptThinkingForModel(body []byte, shortName string) []byte {
 		body, _ = sjson.SetBytes(body, "output_config.effort", effort)
 	}
 	return body
+}
+
+func effortForThinkingBudget(budget int64) string {
+	switch {
+	case budget >= 32000:
+		return "high"
+	case budget >= 8000:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+var classicThinkingRejectedPattern = regexp.MustCompile(
+	`(?i)(?:"?thinking\.type\.enabled"?|thinking\.type\s*=\s*"?enabled"?)` +
+		`[^\n]{0,200}\b(?:not\s+supported|unsupported|is\s+not\s+allowed|requires?\s+adaptive)\b` +
+		`|` +
+		`\buse\b[^\n]{0,120}"?thinking\.type\.adaptive"?[^\n]{0,120}\boutput_config\.effort\b`,
+)
+
+// IsClassicThinkingRejectedError reports whether Bedrock rejected the classic
+// thinking.type="enabled" shape and asked for adaptive thinking instead.
+func IsClassicThinkingRejectedError(body []byte) bool {
+	return classicThinkingRejectedPattern.Match(body)
 }

--- a/internal/adapter/provider/bedrock/thinking_policy_test.go
+++ b/internal/adapter/provider/bedrock/thinking_policy_test.go
@@ -150,3 +150,87 @@ func TestAdaptThinkingForModelStripsSamplingParams(t *testing.T) {
 		})
 	}
 }
+
+func TestRewriteClassicThinkingToAdaptive(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantEffort string
+	}{
+		{
+			name:       "maps medium budget",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000}}`,
+			wantEffort: "medium",
+		},
+		{
+			name:       "preserves explicit effort",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000},"output_config":{"effort":"high"}}`,
+			wantEffort: "high",
+		},
+		{
+			name:       "maps missing budget to low",
+			input:      `{"thinking":{"type":"enabled"}}`,
+			wantEffort: "low",
+		},
+		{
+			name:       "drops extra thinking fields",
+			input:      `{"thinking":{"type":"enabled","budget_tokens":16000,"foo":"bar","nested":{"x":1}}}`,
+			wantEffort: "medium",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteClassicThinkingToAdaptive([]byte(c.input))
+			if gt := gjson.GetBytes(got, "thinking.type").String(); gt != "adaptive" {
+				t.Fatalf("thinking.type = %q; want adaptive (body=%s)", gt, string(got))
+			}
+			if gjson.GetBytes(got, "thinking.budget_tokens").Exists() {
+				t.Fatalf("thinking.budget_tokens should be removed (body=%s)", string(got))
+			}
+			if ge := gjson.GetBytes(got, "output_config.effort").String(); ge != c.wantEffort {
+				t.Fatalf("output_config.effort = %q; want %q (body=%s)", ge, c.wantEffort, string(got))
+			}
+			if thinkingKeys := len(gjson.GetBytes(got, "thinking").Map()); thinkingKeys != 1 {
+				t.Fatalf("thinking should contain only type, got %d keys (body=%s)", thinkingKeys, string(got))
+			}
+		})
+	}
+}
+
+func TestIsClassicThinkingRejectedError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "reported bedrock validation",
+			body: `{"message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}`,
+			want: true,
+		},
+		{
+			name: "generic not supported wording",
+			body: `{"message":"thinking.type=enabled is not supported; use adaptive thinking"}`,
+			want: true,
+		},
+		{
+			name: "unrelated thinking budget error",
+			body: `{"message":"thinking.budget_tokens must be less than max_tokens"}`,
+			want: false,
+		},
+		{
+			name: "sampling rejection",
+			body: `{"message":"temperature may only be set to 1 when thinking is enabled"}`,
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsClassicThinkingRejectedError([]byte(c.body)); got != c.want {
+				t.Fatalf("IsClassicThinkingRejectedError = %v; want %v", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- detect Bedrock 400s that reject classic thinking.type=enabled
- rewrite classic thinking requests to adaptive shape with output_config.effort
- add focused tests for the adaptive rewrite and error matcher

## Tests
- go test ./internal/adapter/provider/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新增功能**
  * 请求重试机制扩展到最多四次，提升请求成功率。
* **修复与改进**
  * 遇到上游拒绝经典思维形式时，自动将思维参数改写为自适应形态并单次重放以恢复请求，避免重复触发重试。
  * 增强对相关错误的识别与处理，改善鲁棒性与故障恢复。
* **测试**
  * 新增改写与错误识别相关单元测试，覆盖多种场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->