### PR TITLE
feat: surface Ollama provider setup

### DIFF
--- a/web/src/components/provider-details-dialog.tsx
+++ b/web/src/components/provider-details-dialog.tsx
@@ -24,6 +24,7 @@ import type { ProviderConfigItem } from '@/pages/client-routes/types';
 import { useCooldownsContext } from '@/contexts/cooldowns-context';
 import { Button, Switch } from '@/components/ui';
 import { getProviderColor, type ProviderType } from '@/lib/theme';
+import { getProviderDisplayType } from '@/pages/providers/types';
 import { cn } from '@/lib/utils';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { CooldownTimer } from '@/components/cooldown-timer';
@@ -240,6 +241,7 @@ export function ProviderDetailsDialog({
 
   const { provider, enabled, route, isNative } = item;
   const color = getProviderColor(provider.type as ProviderType);
+  const providerTypeLabel = getProviderDisplayType(provider);
 
   const activeCooldowns = cooldowns; // already filtered by hook
   const isInCooldown = activeCooldowns.length > 0;
@@ -267,7 +269,7 @@ export function ProviderDetailsDialog({
               ) : (
                 <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-amber-500/10 text-amber-500 border border-amber-500/20">CONV</span>
               )}
-              <span className="shrink-0 text-[10px] text-muted-foreground">{provider.type}</span>
+              <span className="shrink-0 text-[10px] text-muted-foreground">{providerTypeLabel}</span>
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1272,6 +1272,7 @@
     "unfreeze": "Unfreeze",
     "configure": "Configure Provider",
     "configureDescription": "Set up your custom provider connection",
+    "configureOllamaDescription": "Configure a local Ollama connection through maxx's Claude-compatible endpoint",
     "create": "Create Provider",
     "edit": "Edit Provider",
     "editDescription": "Update your custom provider settings",
@@ -1468,6 +1469,10 @@
     "custom": {
       "name": "Custom Provider",
       "description": "Configure your own API endpoint"
+    },
+    "ollama": {
+      "name": "Ollama",
+      "description": "Local Ollama /api/chat through the Claude-compatible endpoint"
     },
     "templates": {
       "88code": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1271,6 +1271,7 @@
     "unfreeze": "解冻",
     "configure": "配置提供商",
     "configureDescription": "设置您的自定义提供商连接",
+    "configureOllamaDescription": "配置本地 Ollama 连接，并通过 maxx 的 Claude-compatible 入口使用",
     "create": "创建提供商",
     "edit": "编辑提供商",
     "editDescription": "更新您的自定义提供商设置",
@@ -1466,6 +1467,10 @@
     "custom": {
       "name": "自定义提供商",
       "description": "配置您自己的 API 端点"
+    },
+    "ollama": {
+      "name": "Ollama",
+      "description": "本地 Ollama /api/chat，通过 Claude-compatible 入口访问"
     },
     "templates": {
       "88code": {

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -112,7 +112,11 @@ export function CustomConfigStep() {
       <PageHeader
         icon={<ChevronLeft className="cursor-pointer" onClick={goToSelectType} />}
         title={t('provider.configure')}
-        description={t('provider.configureDescription')}
+        description={
+          formData.backend === 'ollama'
+            ? t('provider.configureOllamaDescription')
+            : t('provider.configureDescription')
+        }
       >
         <Button onClick={goToProviders} variant={'secondary'}>
           {t('common.cancel')}

--- a/web/src/pages/providers/components/provider-card.tsx
+++ b/web/src/pages/providers/components/provider-card.tsx
@@ -4,7 +4,7 @@ import { ClientIcon } from '@/components/icons/client-icons';
 import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import type { Provider } from '@/lib/transport';
-import { ANTIGRAVITY_COLOR } from '../types';
+import { ANTIGRAVITY_COLOR, isOllamaCustomProvider } from '../types';
 import { useCooldowns } from '@/hooks/use-cooldowns';
 
 interface ProviderCardProps {
@@ -142,6 +142,7 @@ export function CustomProviderCard({ provider, onClick, streamingCount }: Provid
   const modelCooldowns = providerCooldowns.filter((cd) => cd.model);
   const worstCooldown = providerCooldowns[0];
   const isFrozenOrLimited = healthLevel === 'frozen' || healthLevel === 'limited';
+  const isOllama = isOllamaCustomProvider(provider);
 
   const getDisplayUrl = () => {
     if (provider.config?.custom?.baseURL) return provider.config.custom.baseURL;
@@ -227,7 +228,14 @@ export function CustomProviderCard({ provider, onClick, streamingCount }: Provid
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between mb-1">
-            <h4 className="text-sm font-medium text-foreground truncate">{provider.name}</h4>
+            <div className="flex items-center gap-2 min-w-0">
+              <h4 className="text-sm font-medium text-foreground truncate">{provider.name}</h4>
+              {isOllama && (
+                <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-primary/10 text-primary border border-primary/20">
+                  Ollama
+                </span>
+              )}
+            </div>
             <ChevronRight
               size={16}
               className="text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -13,7 +13,7 @@ import type {
   KiroQuotaData,
   CodexQuotaData,
 } from '@/lib/transport';
-import { getProviderTypeConfig } from '../types';
+import { getProviderTypeConfig, isOllamaCustomProvider } from '../types';
 import { cn } from '@/lib/utils';
 import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-context';
 import { useCodexQuotaFromContext } from '@/contexts/codex-quotas-context';
@@ -208,6 +208,7 @@ export function ProviderRow({ provider, stats, streamingCount, onClick, title }:
   const typeConfig = getProviderTypeConfig(provider.type);
   const color = typeConfig.color;
   const displayInfo = typeConfig.getDisplayInfo(provider);
+  const isOllama = isOllamaCustomProvider(provider);
 
   const isAntigravity = provider.type === 'antigravity';
   const isKiro = provider.type === 'kiro';
@@ -321,6 +322,11 @@ export function ProviderRow({ provider, stats, streamingCount, onClick, title }:
       <div className="relative z-10 flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
           <h3 className="text-[15px] font-bold text-foreground truncate">{provider.name}</h3>
+          {isOllama && (
+            <span className="shrink-0 px-1.5 py-0.5 rounded-full text-[10px] font-bold bg-provider-custom/10 text-provider-custom border border-provider-custom/20">
+              Ollama
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-3">
           {/* 对于 Antigravity，显示 Claude 和 Imagen Quota */}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -11,7 +11,7 @@ import {
   Sparkles,
   ChevronLeft,
 } from 'lucide-react';
-import { quickTemplates, PROVIDER_TYPE_CONFIGS } from '../types';
+import { defaultClients, quickTemplates, PROVIDER_TYPE_CONFIGS } from '../types';
 import { Button } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +27,21 @@ export function SelectTypeStep() {
   const { t } = useTranslation();
 
   const handleSelectType = (type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude') => {
-    updateFormData({ type, ...(type === 'custom' ? { backend: 'http' as const } : {}) });
+    updateFormData({
+      type,
+      ...(type === 'custom'
+        ? {
+            selectedTemplate: null,
+            name: '',
+            baseURL: '',
+            backend: 'http' as const,
+            apiKey: '',
+            clients: [...defaultClients],
+            modelMappings: undefined,
+            logo: undefined,
+          }
+        : {}),
+    });
     if (type === 'antigravity') {
       goToAntigravity();
     } else if (type === 'bedrock') {
@@ -72,7 +86,9 @@ export function SelectTypeStep() {
       updateFormData({
         selectedTemplate: templateId,
         name: template.name,
+        baseURL: '',
         backend: 'http',
+        apiKey: '',
         clients: updatedClients,
         modelMappings: template.modelMappings,
         logo: template.logoUrl,

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -1,4 +1,5 @@
 import {
+  Bot,
   Server,
   Wand2,
   Layers,
@@ -21,10 +22,12 @@ export function SelectTypeStep() {
   const { formData, updateFormData } = useProviderForm();
   const { goToCustomConfig, goToAntigravity, goToKiro, goToCodex, goToClaude, goToBedrock, goToProviders } =
     useProviderNavigation();
+  const isPlainCustomSelected =
+    formData.type === 'custom' && formData.backend !== 'ollama' && !!formData.name.trim();
   const { t } = useTranslation();
 
   const handleSelectType = (type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude') => {
-    updateFormData({ type });
+    updateFormData({ type, ...(type === 'custom' ? { backend: 'http' as const } : {}) });
     if (type === 'antigravity') {
       goToAntigravity();
     } else if (type === 'bedrock') {
@@ -36,6 +39,25 @@ export function SelectTypeStep() {
     } else if (type === 'claude') {
       goToClaude();
     }
+  };
+
+  const handleSelectOllama = () => {
+    updateFormData({
+      type: 'custom',
+      selectedTemplate: null,
+      name: 'Ollama',
+      baseURL: 'http://127.0.0.1:11434',
+      backend: 'ollama',
+      apiKey: '',
+      clients: formData.clients.map((client) => ({
+        ...client,
+        enabled: client.id === 'claude',
+        urlOverride: '',
+      })),
+      modelMappings: [{ pattern: 'claude-*', target: 'llama3.1:8b' }],
+      logo: undefined,
+    });
+    goToCustomConfig();
   };
 
   const handleApplyTemplate = (templateId: string) => {
@@ -242,7 +264,7 @@ export function SelectTypeStep() {
                 onClick={() => handleSelectType('custom')}
                 variant="ghost"
                 className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
-                  formData.type === 'custom'
+                  isPlainCustomSelected
                     ? 'border-provider-custom bg-provider-custom/10 shadow-sm'
                     : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
                 }`}
@@ -261,7 +283,36 @@ export function SelectTypeStep() {
                     </p>
                   </div>
 
-                  {formData.type === 'custom' && (
+                  {isPlainCustomSelected && (
+                    <CheckCircle2 className="size-5 text-provider-custom shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                  )}
+                </div>
+              </Button>
+
+              <Button
+                onClick={handleSelectOllama}
+                variant="ghost"
+                className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                  formData.type === 'custom' && formData.backend === 'ollama'
+                    ? 'border-provider-custom bg-provider-custom/10 shadow-sm'
+                    : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                }`}
+              >
+                <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                  <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-custom/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                    <Bot className="size-5 md:size-6 text-provider-custom" />
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                      {t('addProvider.ollama.name')}
+                    </h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                      {t('addProvider.ollama.description')}
+                    </p>
+                  </div>
+
+                  {formData.type === 'custom' && formData.backend === 'ollama' && (
                     <CheckCircle2 className="size-5 text-provider-custom shrink-0 self-center animate-in zoom-in-50 duration-200" />
                   )}
                 </div>
@@ -270,7 +321,7 @@ export function SelectTypeStep() {
           </div>
 
           {/* Section: Templates (Custom only) */}
-          {formData.type === 'custom' && (
+          {formData.type === 'custom' && formData.backend !== 'ollama' && (
             <div className="space-y-3 sm:space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-300">
               <div className="flex items-center justify-between border-b border-border/60 pb-2.5">
                 <h3 className="text-base sm:text-lg font-semibold text-foreground">

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { PageHeader } from '@/components/layout/page-header';
-import { PROVIDER_TYPE_CONFIGS, type ProviderTypeKey } from './types';
+import { isOllamaCustomProvider, PROVIDER_TYPE_CONFIGS, type ProviderTypeKey } from './types';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 import { CodexQuotasProvider } from '@/contexts/codex-quotas-context';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -133,7 +133,8 @@ export function ProvidersPage() {
       const query = searchQuery.toLowerCase();
       const config = PROVIDER_TYPE_CONFIGS[p.type as ProviderTypeKey];
       const displayInfo = config?.getDisplayInfo(p) || '';
-      return p.name.toLowerCase().includes(query) || displayInfo.toLowerCase().includes(query);
+      const backend = isOllamaCustomProvider(p) ? 'ollama' : '';
+      return p.name.toLowerCase().includes(query) || displayInfo.toLowerCase().includes(query) || backend.includes(query);
     });
 
     filteredProviders?.forEach((p) => {

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -95,6 +95,14 @@ export function getProviderTypeConfig(type: string): ProviderTypeConfig {
   return PROVIDER_TYPE_CONFIGS[type as ProviderTypeKey] || PROVIDER_TYPE_CONFIGS.custom;
 }
 
+export function isOllamaCustomProvider(provider: Provider): boolean {
+  return provider.type === 'custom' && provider.config?.custom?.backend === 'ollama';
+}
+
+export function getProviderDisplayType(provider: Provider): string {
+  return isOllamaCustomProvider(provider) ? 'Ollama' : provider.type;
+}
+
 // 获取显示图标（邮箱或 URL）
 export function getDisplayIcon(type: string): LucideIcon {
   const config = getProviderTypeConfig(type);


### PR DESCRIPTION
## Summary
- add a visible Ollama card to the provider creation type selector
- keep Ollama stored as a custom provider with `backend: "ollama"`, preserving the existing backend contract
- prefill Ollama setup with local endpoint `http://127.0.0.1:11434`, Claude client enabled, and `claude-* -> llama3.1:8b` model mapping
- show Ollama labels in provider list/detail UI and make provider search match Ollama custom providers
- add Ollama-specific configuration copy in en/zh locales

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- local Playwright screenshot check against Vite dev server with mocked admin auth:
  - provider creation page shows the Ollama card
  - selecting Ollama opens custom config with backend `ollama`
  - model mapping contains target `llama3.1:8b`

## Notes
- Screenshots were taken against a local mocked-auth dev environment, not a deployed instance.
- The default model mapping covers Claude-style model names (`claude-*`). Other client routes can add their own mappings if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 Ollama 提供商支持：可在添加提供商流程中快速选择并预设本地 Ollama 配置。
  * 在添加/详情/列表视图中以更友好的标签展示提供商类型，并在卡片/行中显示 “Ollama” 徽标以便识别。
  * 搜索结果现含 Ollama 提供商匹配。

* **文档 / 本地化**
  * 新增中英文配置说明文案，指导配置本地 Ollama。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->