### PR TITLE
Fix Ollama streaming keepalive for Claude Code

### DIFF
--- a/internal/adapter/provider/custom/ollama.go
+++ b/internal/adapter/provider/custom/ollama.go
@@ -485,6 +485,21 @@ func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Respo
 	responseModel := model
 	stopReason := "end_turn"
 	firstTokenSent := false
+	textBlockOpen := true
+	nextBlockIndex := 1
+	closeTextBlock := func() error {
+		if !textBlockOpen {
+			return nil
+		}
+		textBlockOpen = false
+		return sendSSE("content_block_stop", map[string]interface{}{"type": "content_block_stop", "index": 0})
+	}
+	sendFirstTokenOnce := func() {
+		if eventChan != nil && !firstTokenSent {
+			eventChan.SendFirstToken(time.Now().UnixMilli())
+			firstTokenSent = true
+		}
+	}
 	for {
 		var line string
 		var readErr error
@@ -539,10 +554,7 @@ func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Respo
 			responseModel = chunk.Model
 		}
 		if chunk.Message.Content != "" {
-			if eventChan != nil && !firstTokenSent {
-				eventChan.SendFirstToken(time.Now().UnixMilli())
-				firstTokenSent = true
-			}
+			sendFirstTokenOnce()
 			if err := sendSSE("content_block_delta", map[string]interface{}{
 				"type":  "content_block_delta",
 				"index": 0,
@@ -551,18 +563,59 @@ func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Respo
 				return clientDisconnectedErr(err)
 			}
 		}
+		if len(chunk.Message.ToolCalls) > 0 {
+			if err := closeTextBlock(); err != nil {
+				return clientDisconnectedErr(err)
+			}
+			for _, call := range chunk.Message.ToolCalls {
+				name := strings.TrimSpace(call.Function.Name)
+				if name == "" {
+					continue
+				}
+				sendFirstTokenOnce()
+				index := nextBlockIndex
+				nextBlockIndex++
+				partialJSON := strings.TrimSpace(string(call.Function.Arguments))
+				if partialJSON == "" || !json.Valid([]byte(partialJSON)) {
+					partialJSON = "{}"
+				}
+				if err := sendSSE("content_block_start", map[string]interface{}{
+					"type":  "content_block_start",
+					"index": index,
+					"content_block": map[string]interface{}{
+						"type":  "tool_use",
+						"id":    "toolu_" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+						"name":  name,
+						"input": map[string]interface{}{},
+					},
+				}); err != nil {
+					return clientDisconnectedErr(err)
+				}
+				if err := sendSSE("content_block_delta", map[string]interface{}{
+					"type":  "content_block_delta",
+					"index": index,
+					"delta": map[string]string{"type": "input_json_delta", "partial_json": partialJSON},
+				}); err != nil {
+					return clientDisconnectedErr(err)
+				}
+				if err := sendSSE("content_block_stop", map[string]interface{}{"type": "content_block_stop", "index": index}); err != nil {
+					return clientDisconnectedErr(err)
+				}
+				stopReason = "tool_use"
+			}
+		}
 		if chunk.PromptEvalCount > 0 {
 			inputTokens = chunk.PromptEvalCount
 		}
 		if chunk.EvalCount > 0 {
 			outputTokens = chunk.EvalCount
 		}
-		if chunk.DoneReason != "" {
+		if chunk.DoneReason != "" && stopReason != "tool_use" {
 			stopReason = ollamaStopReasonToClaude(chunk.DoneReason)
 		}
 	}
 
-	if err := sendSSE("content_block_stop", map[string]interface{}{"type": "content_block_stop", "index": 0}); err != nil {
+	if err := closeTextBlock(); err != nil {
 		return clientDisconnectedErr(err)
 	}
 	if err := sendSSE("message_delta", map[string]interface{}{

--- a/internal/adapter/provider/custom/ollama.go
+++ b/internal/adapter/provider/custom/ollama.go
@@ -24,6 +24,7 @@ const (
 )
 
 var ollamaHTTPClient = &http.Client{Timeout: 10 * time.Minute}
+var ollamaStreamPingInterval = 15 * time.Second
 
 type claudeMessageRequest struct {
 	Model         string               `json:"model"`
@@ -90,6 +91,11 @@ type ollamaChatResponse struct {
 	PromptEvalCount int           `json:"prompt_eval_count,omitempty"`
 	EvalCount       int           `json:"eval_count,omitempty"`
 	Error           string        `json:"error,omitempty"`
+}
+
+type ollamaStreamLineResult struct {
+	line string
+	err  error
 }
 
 type ollamaOptionsConfig struct {
@@ -396,6 +402,10 @@ func (a *CustomAdapter) handleOllamaNonStreamResponse(c *flow.Ctx, resp *http.Re
 }
 
 func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Response, claudeReq *claudeMessageRequest, model string) error {
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
 	eventChan := flow.GetEventChan(c)
 	if eventChan != nil {
 		eventChan.SendResponseInfo(&domain.ResponseInfo{Status: resp.StatusCode, Headers: flattenHeaders(resp.Header), Body: "[streaming]"})
@@ -461,13 +471,39 @@ func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Respo
 		})
 	}
 
-	lineReader := newOllamaLineReader(resp.Body)
+	done := make(chan struct{})
+	defer close(done)
+	lineResults := readOllamaStreamLines(ctx, resp.Body, done)
+	var pingTicker *time.Ticker
+	var pingC <-chan time.Time
+	if ollamaStreamPingInterval > 0 {
+		pingTicker = time.NewTicker(ollamaStreamPingInterval)
+		defer pingTicker.Stop()
+		pingC = pingTicker.C
+	}
 	inputTokens, outputTokens := 0, 0
 	responseModel := model
 	stopReason := "end_turn"
 	firstTokenSent := false
 	for {
-		line, readErr := lineReader.readLine()
+		var line string
+		var readErr error
+		select {
+		case <-ctx.Done():
+			return clientDisconnectedErr(ctx.Err())
+		case <-pingC:
+			if err := sendSSE("ping", map[string]string{"type": "ping"}); err != nil {
+				return clientDisconnectedErr(err)
+			}
+			continue
+		case result, ok := <-lineResults:
+			if !ok {
+				readErr = io.EOF
+			} else {
+				line = result.line
+				readErr = result.err
+			}
+		}
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
 				break
@@ -551,6 +587,29 @@ func (a *CustomAdapter) handleOllamaStreamResponse(c *flow.Ctx, resp *http.Respo
 	}
 	_ = claudeReq
 	return nil
+}
+
+func readOllamaStreamLines(ctx context.Context, body io.Reader, done <-chan struct{}) <-chan ollamaStreamLineResult {
+	out := make(chan ollamaStreamLineResult, 1)
+	go func() {
+		defer close(out)
+		lineReader := newOllamaLineReader(body)
+		for {
+			line, err := lineReader.readLine()
+			result := ollamaStreamLineResult{line: line, err: err}
+			select {
+			case out <- result:
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return out
 }
 
 type ollamaLineReader struct {

--- a/internal/adapter/provider/custom/ollama_test.go
+++ b/internal/adapter/provider/custom/ollama_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -163,6 +164,56 @@ func TestOllamaBackendStreamHandlesLargeChunk(t *testing.T) {
 	}
 	if !strings.Contains(bodyText, "message_stop") {
 		t.Fatalf("stream body missing message_stop")
+	}
+}
+
+func TestOllamaBackendStreamPingsDuringUpstreamSilence(t *testing.T) {
+	originalInterval := ollamaStreamPingInterval
+	ollamaStreamPingInterval = 10 * time.Millisecond
+	defer func() { ollamaStreamPingInterval = originalInterval }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("test server writer does not support flushing")
+		}
+		_, _ = w.Write([]byte(`{"model":"qwen","message":{"role":"assistant","content":"hello"}}` + "\n"))
+		flusher.Flush()
+		time.Sleep(35 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"model":"qwen","message":{"role":"assistant","content":" world"}}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"qwen","done":true,"done_reason":"stop","prompt_eval_count":7,"eval_count":11}` + "\n"))
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{
+		Name: "local ollama",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: server.URL,
+			Backend: customBackendOllama,
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+	adapter := &CustomAdapter{provider: provider}
+
+	body := []byte(`{"model":"qwen","stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body))))
+	ctx.Set(flow.KeyClientType, domain.ClientTypeClaude)
+	ctx.Set(flow.KeyRequestBody, body)
+
+	if err := adapter.Execute(ctx, provider); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	bodyText := rec.Body.String()
+	if !strings.Contains(bodyText, "event: ping") || !strings.Contains(bodyText, `"type":"ping"`) {
+		t.Fatalf("stream body missing ping during upstream silence: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, `"text":"hello"`) || !strings.Contains(bodyText, `"text":" world"`) {
+		t.Fatalf("stream body missing ordered content deltas: %s", bodyText)
+	}
+	if !strings.Contains(bodyText, "message_stop") {
+		t.Fatalf("stream body missing message_stop: %s", bodyText)
 	}
 }
 

--- a/internal/adapter/provider/custom/ollama_test.go
+++ b/internal/adapter/provider/custom/ollama_test.go
@@ -217,6 +217,51 @@ func TestOllamaBackendStreamPingsDuringUpstreamSilence(t *testing.T) {
 	}
 }
 
+func TestOllamaBackendStreamConvertsToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"model":"qwen","message":{"role":"assistant","tool_calls":[{"function":{"name":"Read","arguments":{"file_path":"tasklib/utils.py"}}}]}}` + "\n"))
+		_, _ = w.Write([]byte(`{"model":"qwen","done":true,"done_reason":"stop","prompt_eval_count":7,"eval_count":11}` + "\n"))
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{
+		Name: "local ollama",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: server.URL,
+			Backend: customBackendOllama,
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+	adapter := &CustomAdapter{provider: provider}
+
+	body := []byte(`{"model":"qwen","stream":true,"messages":[{"role":"user","content":"inspect the file"}],"tools":[{"name":"Read","input_schema":{"type":"object","properties":{"file_path":{"type":"string"}}}}]}`)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body))))
+	ctx.Set(flow.KeyClientType, domain.ClientTypeClaude)
+	ctx.Set(flow.KeyRequestBody, body)
+
+	if err := adapter.Execute(ctx, provider); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	bodyText := rec.Body.String()
+	for _, want := range []string{
+		`"type":"tool_use"`,
+		`"name":"Read"`,
+		`"type":"input_json_delta"`,
+		`\"file_path\":\"tasklib/utils.py\"`,
+		`"stop_reason":"tool_use"`,
+		"message_stop",
+	} {
+		if !strings.Contains(bodyText, want) {
+			t.Fatalf("stream body missing %s: %s", want, bodyText)
+		}
+	}
+}
+
 func TestCustomBackendEmptyKeepsHTTPRelayPassthrough(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/chat/completions" {


### PR DESCRIPTION
## Summary
- add Anthropic Messages SSE `ping` events while waiting for silent Ollama streaming chunks
- move Ollama NDJSON line reads off the writer loop so downstream keepalive can flush independently
- convert Ollama streaming `tool_calls` into Claude Messages SSE `tool_use` blocks with `input_json_delta`
- add regression coverage for upstream silence followed by ordered text deltas, `message_stop`, and streaming tool-call conversion

## Validation
- `go test ./internal/adapter/provider/custom -run 'Ollama|CustomBackendEmpty'`
- `go test ./internal/executor ./internal/handler ./internal/adapter/provider/custom`
- `go test ./...`
- Real Claude Code CLI validation via `claude_code_version=2.1.63` with `ANTHROPIC_BASE_URL=http://127.0.0.1:9880/provider/178`, maxx provider proxy, and Ollama upstream `http://27.154.56.162:11434/api/chat`: completed with `status=COMPLETED`, `statusCode=200`, `isStream=true`, `providerID=178`, `apiTokenID=110`
- Upstream attempt confirmed `request_model=claude-sonnet-4-5`, `mapped_model=minimax-m3:cloud`, `response_model=minimax-m3:cloud`, upstream URL `http://27.154.56.162:11434/api/chat`, response `application/x-ndjson`
- Raw SSE silence probe through maxx provider proxy captured `message_start -> content_block_start -> event: ping -> content_block_delta -> content_block_stop -> message_delta -> message_stop`
- End-to-end Claude Code implementation validation: created a temporary Python project with failing `unittest` tests, routed Claude Code through maxx Ollama provider `181`, observed real `Read` and `Write` tool use, and independently verified the implementation with corrected standard-library `unittest` expectations (`python3 -m unittest discover -s tests -v` passed)

## Notes
- The real Ollama upstream response in the manual Claude Code run had TTFT below the default ping interval, so the raw SSE ping assertion used a temporary local Ollama-compatible upstream that intentionally stayed silent for 20 seconds before returning NDJSON.
- The implementation E2E exposed that streaming Ollama `tool_calls` were previously not converted to Claude `tool_use` blocks; this PR now fixes that path as well.
- Temporary validation providers/tokens were local test artifacts only and are not part of this PR.
