### PR TITLE
perf(proxy): bound response-body capture to cut memory amplification

### DIFF
--- a/internal/executor/response_capture.go
+++ b/internal/executor/response_capture.go
@@ -142,8 +142,11 @@ func trimTrailingPartialRune(b []byte) []byte {
 		if !utf8.RuneStart(b[start]) {
 			continue
 		}
-		if r, size := utf8.DecodeRune(b[start:]); r != utf8.RuneError && start+size == len(b) {
-			return b // 末尾 rune 完整
+		// DecodeRune 对非法/残缺编码返回 (RuneError, 1),而对一个**合法编码**的
+		// U+FFFD 本身返回 (RuneError, 3)。故"残缺"的判据是 size==1 的 RuneError,
+		// 不能只看 r==RuneError——否则末尾一个合法的 3 字节 U+FFFD 会被误当残缺丢掉。
+		if r, size := utf8.DecodeRune(b[start:]); !(r == utf8.RuneError && size == 1) && start+size == len(b) {
+			return b // 末尾 rune 完整(含合法编码的 U+FFFD)
 		}
 		return b[:start] // 末尾 rune 残缺,去掉
 	}

--- a/internal/executor/response_capture.go
+++ b/internal/executor/response_capture.go
@@ -2,8 +2,29 @@ package executor
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 )
+
+// responseSnapshotMaxBytes 限制 ResponseCapture 缓冲(进而写入 ResponseInfo.Body)
+// 的响应体快照最大字节数。这是请求侧 domain.RequestBodySnapshot 的对称兜底:
+// 此前 ResponseCapture.Write 对每个写给客户端的 chunk 都无条件 body.Write,流式
+// (SSE)与大 base64 图片响应也不例外——整个响应体被缓冲进内存,大小 ∝ 响应体 ×
+// 并发,且不受上传准入控制约束,是典型的 OOM 来源。这里把缓冲上界 clamp 住:超过
+// 上限的字节照常转发给客户端,但不再进缓冲,只在快照末尾留截断占位。
+// 经 MAXX_RESPONSE_SNAPSHOT_MAX_BYTES 调整,默认 256 KiB:正常对话/补全响应足够
+// 保留完整审计,异常超大响应(图片 base64、超长 SSE)才被截断。0 表示不限(不推荐)。
+var responseSnapshotMaxBytes = func() int {
+	if v := strings.TrimSpace(os.Getenv("MAXX_RESPONSE_SNAPSHOT_MAX_BYTES")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 256 << 10
+}()
 
 // ResponseCapture wraps http.ResponseWriter to capture the response
 // This allows us to record the actual response sent to the client
@@ -12,6 +33,13 @@ type ResponseCapture struct {
 	statusCode int
 	body       bytes.Buffer
 	headers    http.Header
+
+	// maxBytes 是 body 缓冲的上界(字节);超过后停止缓冲但继续转发。0 表示不限。
+	maxBytes int
+	// total 记录已成功写给客户端的总字节数,用于截断占位里的 "N bytes total"。
+	total int64
+	// truncated 标记响应体是否因超过 maxBytes 被截断(快照非完整)。
+	truncated bool
 }
 
 // NewResponseCapture creates a new ResponseCapture wrapper
@@ -20,6 +48,7 @@ func NewResponseCapture(w http.ResponseWriter) *ResponseCapture {
 		ResponseWriter: w,
 		statusCode:     http.StatusOK, // Default status
 		headers:        make(http.Header),
+		maxBytes:       responseSnapshotMaxBytes,
 	}
 }
 
@@ -29,10 +58,37 @@ func (rc *ResponseCapture) WriteHeader(code int) {
 	rc.ResponseWriter.WriteHeader(code)
 }
 
-// Write captures the body and forwards to underlying writer
+// Write forwards every byte to the client and buffers up to maxBytes for the
+// stored response snapshot. Bytes beyond the cap are still sent downstream but
+// not retained, bounding memory to ~maxBytes per request regardless of response
+// size or stream length. Only the bytes the underlying writer actually accepted
+// (n) are captured, so a short write / error never records unsent bytes.
 func (rc *ResponseCapture) Write(b []byte) (int, error) {
+	n, err := rc.ResponseWriter.Write(b)
+	if n > 0 {
+		rc.captureBounded(b[:n])
+	}
+	return n, err
+}
+
+// captureBounded appends b to the snapshot buffer without exceeding maxBytes.
+func (rc *ResponseCapture) captureBounded(b []byte) {
+	rc.total += int64(len(b))
+	if rc.maxBytes <= 0 { // unbounded (opt-out via env)
+		rc.body.Write(b)
+		return
+	}
+	remaining := rc.maxBytes - rc.body.Len()
+	if remaining <= 0 {
+		rc.truncated = true
+		return
+	}
+	if len(b) > remaining {
+		rc.body.Write(b[:remaining])
+		rc.truncated = true
+		return
+	}
 	rc.body.Write(b)
-	return rc.ResponseWriter.Write(b)
 }
 
 // Header returns the header map (for setting headers)
@@ -52,9 +108,21 @@ func (rc *ResponseCapture) StatusCode() int {
 	return rc.statusCode
 }
 
-// Body returns the captured response body
+// Body returns the captured response body. When the response exceeded the
+// snapshot cap it returns the retained prefix followed by a truncation marker
+// so the stored detail signals it is partial rather than silently incomplete.
+// 注:截断时返回值是「上限以内前缀 + 固定占位尾巴」,因此略大于 maxBytes 一个常量;
+// 目的是防 OOM / 防撑爆 DB TEXT 列,不是字节级硬上限。按字节截断可能切断多字节
+// 字符,故前缀经 ToValidUTF8 清洗,避免快照里出现非法 UTF-8(与请求侧一致)。
 func (rc *ResponseCapture) Body() string {
-	return rc.body.String()
+	if !rc.truncated {
+		return rc.body.String()
+	}
+	prefix := strings.ToValidUTF8(rc.body.String(), "�")
+	return fmt.Sprintf(
+		"%s…<response body truncated, %d bytes total, snapshot cap %d>",
+		prefix, rc.total, rc.maxBytes,
+	)
 }
 
 // CapturedHeaders returns the headers that were set

--- a/internal/executor/response_capture.go
+++ b/internal/executor/response_capture.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // responseSnapshotMaxBytes 限制 ResponseCapture 缓冲(进而写入 ResponseInfo.Body)
@@ -28,6 +29,11 @@ var responseSnapshotMaxBytes = func() int {
 
 // ResponseCapture wraps http.ResponseWriter to capture the response
 // This allows us to record the actual response sent to the client
+//
+// 并发约定:与 http.ResponseWriter 本身一致,假定由单个请求处理 goroutine 串行
+// 写入;StatusCode()/Body()/CapturedHeaders() 在响应写完后(dispatch 收尾)读取,
+// 不与 Write 并发。故 body/total/truncated 不加锁——这也与本类型加上界改造前的
+// 行为一致(原本就直接用非并发安全的 bytes.Buffer)。
 type ResponseCapture struct {
 	http.ResponseWriter
 	statusCode int
@@ -113,16 +119,35 @@ func (rc *ResponseCapture) StatusCode() int {
 // so the stored detail signals it is partial rather than silently incomplete.
 // 注:截断时返回值是「上限以内前缀 + 固定占位尾巴」,因此略大于 maxBytes 一个常量;
 // 目的是防 OOM / 防撑爆 DB TEXT 列,不是字节级硬上限。按字节截断可能切断多字节
-// 字符,故前缀经 ToValidUTF8 清洗,避免快照里出现非法 UTF-8(与请求侧一致)。
+// 字符:先丢掉末尾被切断的不完整 rune(而非让 ToValidUTF8 把它替换成 3 字节的 �
+// 反而把快照撑过上限),再对内部残留的非法字节做清洗,保持前缀 ~maxBytes。
 func (rc *ResponseCapture) Body() string {
 	if !rc.truncated {
 		return rc.body.String()
 	}
-	prefix := strings.ToValidUTF8(rc.body.String(), "�")
+	prefix := strings.ToValidUTF8(string(trimTrailingPartialRune(rc.body.Bytes())), "�")
 	return fmt.Sprintf(
 		"%s…<response body truncated, %d bytes total, snapshot cap %d>",
 		prefix, rc.total, rc.maxBytes,
 	)
+}
+
+// trimTrailingPartialRune 丢掉 b 末尾因按字节截断而残缺的最后一个 UTF-8 rune。
+// 一个合法 rune 至多 utf8.UTFMax 字节,故从末尾回溯至多这么多字节找到最后一个
+// rune 起始字节:若该 rune 完整则原样返回,残缺则连同它一起去掉。全是续字节
+// (畸形数据)则不动,交由调用方的 ToValidUTF8 兜底。
+func trimTrailingPartialRune(b []byte) []byte {
+	for i := 0; i < utf8.UTFMax && i < len(b); i++ {
+		start := len(b) - 1 - i
+		if !utf8.RuneStart(b[start]) {
+			continue
+		}
+		if r, size := utf8.DecodeRune(b[start:]); r != utf8.RuneError && start+size == len(b) {
+			return b // 末尾 rune 完整
+		}
+		return b[:start] // 末尾 rune 残缺,去掉
+	}
+	return b
 }
 
 // CapturedHeaders returns the headers that were set

--- a/internal/executor/response_capture_test.go
+++ b/internal/executor/response_capture_test.go
@@ -74,6 +74,27 @@ func TestResponseCaptureUnboundedOptOut(t *testing.T) {
 	}
 }
 
+// TestResponseCaptureTruncationKeepsLegitReplacementChar 锁住边界:截断恰好落在
+// 一个**合法编码**的 U+FFFD(3 字节 EF BF BD)末尾时,它是完整 rune,必须保留,
+// 不能因为 DecodeRune 返回 RuneError 就被 trimTrailingPartialRune 误当残缺丢掉。
+func TestResponseCaptureTruncationKeepsLegitReplacementChar(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rc := NewResponseCapture(recorder)
+	rc.maxBytes = 3 // 恰好容下一个完整的 U+FFFD
+
+	payload := "�xx" // 3 字节合法 U+FFFD + 2 字节,共 5 字节 > 3
+	if _, err := rc.Write([]byte(payload)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	body := rc.Body()
+	if !strings.HasPrefix(body, "�…") {
+		t.Fatalf("legit trailing U+FFFD should be kept, got %q", body)
+	}
+	if !strings.Contains(body, "5 bytes total") {
+		t.Fatalf("snapshot missing accurate total: %q", body)
+	}
+}
+
 // shortWriter 模拟底层 ResponseWriter 短写(只接受前 accept 字节)并返回 err。
 type shortWriter struct {
 	http.ResponseWriter

--- a/internal/executor/response_capture_test.go
+++ b/internal/executor/response_capture_test.go
@@ -130,6 +130,15 @@ func TestResponseCaptureTruncationKeepsValidUTF8(t *testing.T) {
 	if !utf8.ValidString(body) {
 		t.Fatalf("snapshot is not valid UTF-8: %q", body)
 	}
+	// 被切断的第二个 "你" 必须被整体丢弃,而不是替换成 U+FFFD("�")——后者会把
+	// 前缀撑过上限,正是 trimTrailingPartialRune 要避免的。只断言 ValidString 不够
+	// (替换后仍是合法 UTF-8),这里把"丢弃而非替换"的契约钉死。
+	if strings.ContainsRune(body, '�') {
+		t.Fatalf("truncated partial rune should be dropped, not replaced with U+FFFD: %q", body)
+	}
+	if !strings.HasPrefix(body, "你…") {
+		t.Fatalf("expected dropped-rune prefix %q, got %q", "你…", body)
+	}
 	if !strings.Contains(body, "9 bytes total") {
 		t.Fatalf("snapshot missing accurate total: %q", body)
 	}

--- a/internal/executor/response_capture_test.go
+++ b/internal/executor/response_capture_test.go
@@ -1,0 +1,94 @@
+package executor
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestResponseCaptureBoundsSnapshotButForwardsFull 锁住核心契约:超过快照上限的
+// 响应体仍整份转发给客户端,但缓冲只保留上限以内的前缀 + 截断占位,避免整个响应体
+// 常驻内存(OOM 来源)同时把超大 body 灌进 DB TEXT 列。
+func TestResponseCaptureBoundsSnapshotButForwardsFull(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rc := NewResponseCapture(recorder)
+	rc.maxBytes = 16 // 测试用小上限
+
+	chunk1 := strings.Repeat("a", 10)
+	chunk2 := strings.Repeat("b", 20) // 累计 30 > 16
+
+	if _, err := rc.Write([]byte(chunk1)); err != nil {
+		t.Fatalf("write chunk1: %v", err)
+	}
+	if _, err := rc.Write([]byte(chunk2)); err != nil {
+		t.Fatalf("write chunk2: %v", err)
+	}
+
+	// 客户端必须收到完整 30 字节。
+	if got := recorder.Body.String(); got != chunk1+chunk2 {
+		t.Fatalf("client body = %q, want full %q", got, chunk1+chunk2)
+	}
+
+	body := rc.Body()
+	if !strings.HasPrefix(body, "aaaaaaaaaabbbbbb") { // 10 a + 6 b = 16 字节前缀
+		t.Fatalf("snapshot prefix not clamped to cap: %q", body)
+	}
+	if !strings.Contains(body, "truncated") {
+		t.Fatalf("snapshot missing truncation marker: %q", body)
+	}
+	if !strings.Contains(body, "30 bytes total") {
+		t.Fatalf("snapshot missing accurate total: %q", body)
+	}
+}
+
+// TestResponseCaptureWithinCapIsExact 上限以内的响应体应原样保留,不加占位。
+func TestResponseCaptureWithinCapIsExact(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rc := NewResponseCapture(recorder)
+	rc.maxBytes = 1024
+
+	payload := `{"content":[{"type":"text","text":"ok"}]}`
+	if _, err := rc.Write([]byte(payload)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := rc.Body(); got != payload {
+		t.Fatalf("snapshot = %q, want exact %q", got, payload)
+	}
+}
+
+// TestResponseCaptureUnboundedOptOut maxBytes<=0 时保留旧的不限行为(env 显式 opt-out)。
+func TestResponseCaptureUnboundedOptOut(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rc := NewResponseCapture(recorder)
+	rc.maxBytes = 0
+
+	payload := strings.Repeat("x", 4096)
+	if _, err := rc.Write([]byte(payload)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := rc.Body(); got != payload {
+		t.Fatalf("unbounded snapshot truncated unexpectedly: len=%d", len(got))
+	}
+}
+
+// TestResponseCaptureTruncationKeepsValidUTF8 按字节截断可能切断多字节字符,
+// 快照前缀必须经 ToValidUTF8 清洗,不得在末尾留下半个 rune 的非法字节。
+func TestResponseCaptureTruncationKeepsValidUTF8(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rc := NewResponseCapture(recorder)
+	// "你" 占 3 字节;上限 4 会把第二个 "你" 从中间切断。
+	rc.maxBytes = 4
+
+	payload := "你你你" // 9 字节
+	if _, err := rc.Write([]byte(payload)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	body := rc.Body()
+	if !utf8.ValidString(body) {
+		t.Fatalf("snapshot is not valid UTF-8: %q", body)
+	}
+	if !strings.Contains(body, "9 bytes total") {
+		t.Fatalf("snapshot missing accurate total: %q", body)
+	}
+}

--- a/internal/executor/response_capture_test.go
+++ b/internal/executor/response_capture_test.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -69,6 +71,46 @@ func TestResponseCaptureUnboundedOptOut(t *testing.T) {
 	}
 	if got := rc.Body(); got != payload {
 		t.Fatalf("unbounded snapshot truncated unexpectedly: len=%d", len(got))
+	}
+}
+
+// shortWriter 模拟底层 ResponseWriter 短写(只接受前 accept 字节)并返回 err。
+type shortWriter struct {
+	http.ResponseWriter
+	accept int
+	err    error
+}
+
+func (s *shortWriter) Write(b []byte) (int, error) {
+	n := len(b)
+	if n > s.accept {
+		n = s.accept
+	}
+	written, _ := s.ResponseWriter.Write(b[:n])
+	return written, s.err
+}
+
+// TestResponseCaptureCapturesOnlyAcceptedBytes 锁住短写/出错契约:底层只接受
+// b[:n] 时,快照与 total 都只计入 n 字节,且 n/err 原样透传给调用方——不能把
+// 没真正发出去的字节记进审计快照。
+func TestResponseCaptureCapturesOnlyAcceptedBytes(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	sw := &shortWriter{ResponseWriter: recorder, accept: 3, err: io.ErrShortWrite}
+	rc := NewResponseCapture(sw)
+	rc.maxBytes = 1024
+
+	n, err := rc.Write([]byte("abcdef"))
+	if n != 3 || err != io.ErrShortWrite {
+		t.Fatalf("passthrough wrong: n=%d err=%v, want n=3 err=ErrShortWrite", n, err)
+	}
+	if rc.total != 3 {
+		t.Fatalf("total should count only accepted bytes, got %d", rc.total)
+	}
+	if got := rc.Body(); got != "abc" {
+		t.Fatalf("snapshot should only contain accepted bytes, got %q", got)
+	}
+	if got := recorder.Body.String(); got != "abc" {
+		t.Fatalf("client got %q, want only accepted bytes %q", got, "abc")
 	}
 }
 


### PR DESCRIPTION
## 背景

请求侧的 OOM 兜底(`RequestBodySnapshot` 截断 + 大上传准入控制)已合入 `main`(`bff8a26`)。本 PR 补上**对称的响应侧兜底**。

`ResponseCapture.Write` 此前对每个写给客户端的 chunk 都**无条件**缓冲进 `bytes.Buffer`,流式(SSE)与大 base64 图片响应也不例外——整个响应体常驻内存,大小 `∝ 响应体 × 并发`,且不受上传准入控制约束(那是按请求 Content-Length 闸的),是请求侧之外的另一处 OOM 来源;同时大响应整份 `stringify` 进 SQLite 的 TEXT 列。

## 改动

给捕获缓冲加上界(默认 256 KiB,经 `MAXX_RESPONSE_SNAPSHOT_MAX_BYTES` 调整,设 `0` 退回不限),作为请求侧 `domain.RequestBodySnapshot` 的对称物:

- **超过上限的字节照常完整转发给客户端**,仅不再进缓冲;每请求常驻内存从 `∝ 响应体` 降为 `~maxBytes`,不随 SSE 长度 / 大图片线性增长。
- `Body()` 返回的快照同样有界;截断时追加占位 `…<response body truncated, N bytes total, snapshot cap M>`,存进 DB 的响应详情也有界。
- 只捕获底层 writer 实际接受的 `b[:n]`,短写/出错不记录未发出的字节。
- 截断前缀经 `strings.ToValidUTF8` 清洗,避免按字节切断多字节字符产生非法 UTF-8(与请求侧一致)。
- `NewResponseCapture` 签名不变,**零调用点改动**。

## 测试

`internal/executor/response_capture_test.go` 新增 4 个用例:超限时客户端收完整 body 而快照被截断+占位+总字节准确、限内原样保留、`maxBytes<=0` 退回不限、UTF-8 截断不产生非法字节。`go vet` + 全 `internal/executor` 包测试通过。

## 范围说明

刻意只做响应侧内存兜底,保持单一主题。请求体落盘/流式(原 #3)经评估对转换/Bedrock 签名路径不成立(都需完整 body 在内存 unmarshal/签名),且内存峰值已被准入控制钉死,故不在本 PR;准入控制调参(#4,运维)与 routeMatch alloc(#5,需 profile 数据)亦另议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 新功能
  * 新增响应体快照字节上限，可通过环境变量配置（默认 256 KiB，设为 0 表示不限制）。
  * 超限时客户端仍接收完整响应，快照仅保留前缀并附固定截断提示，包含累计写出总字节数与上限。
  * 截断时对 UTF-8 前缀回退并清洗，保证返回合法 UTF-8。
* Bug 修复
  * 快照与统计仅基于底层实际写出的字节，短写/出错场景下结果一致。
* 测试
  * 增加上限、无上限、短写与 UTF-8 边界等覆盖用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->