### PR TITLE
feat(routes): 在路由页展示生效策略并支持行内编辑权重

### DIFF
--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -5,7 +5,8 @@
 
 import { useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus, RefreshCw, Zap } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Plus, RefreshCw, Zap, Workflow, Settings2 } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -32,19 +33,21 @@ import {
   useUpdateRoutePositions,
   useProviderStats,
   useProxyRequestUpdates,
+  useRoutingStrategies,
   routeKeys,
 } from '@/hooks/queries';
 import { useQueryClient } from '@tanstack/react-query';
 import { useStreamingRequests } from '@/hooks/use-streaming';
 import { getClientName, getClientColor } from '@/components/icons/client-icons';
 import { getProviderColor, type ProviderType } from '@/lib/theme';
-import type { ClientType, Provider, ProviderStats } from '@/lib/transport';
+import type { ClientType, Provider, ProviderStats, RoutingStrategyType } from '@/lib/transport';
 import {
   SortableProviderRow,
   ProviderRowContent,
 } from '@/pages/client-routes/components/provider-row';
 import type { ProviderConfigItem } from '@/pages/client-routes/types';
-import { Button } from '../ui';
+import { Button, Badge, buttonVariants } from '../ui';
+import { cn } from '@/lib/utils';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 import { CooldownsProvider } from '@/contexts/cooldowns-context';
 
@@ -102,6 +105,56 @@ interface ClientTypeRoutesContentProps {
   searchQuery?: string; // Optional search query from parent
 }
 
+// Small banner above the routes list telling the user which routing strategy is
+// actually in effect for this scope (project-specific, else inherited global,
+// else the priority default) and what that means for ordering. Mirrors the
+// backend resolution order in router.getRoutingStrategy.
+function RoutingStrategyBanner({
+  type,
+  inherited,
+  isDefault,
+}: {
+  type: RoutingStrategyType;
+  inherited: boolean;
+  isDefault: boolean;
+}) {
+  const { t } = useTranslation();
+  const isWeighted = type === 'weighted_random';
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-xl border border-border/60 bg-muted/30 px-4 py-2.5">
+      <Workflow className="h-4 w-4 text-cyan-500 shrink-0" />
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        {t('routes.strategyLabel')}
+      </span>
+      <Badge variant={isWeighted ? 'warning' : 'info'}>
+        {isWeighted
+          ? t('routingStrategies.weightedRandom')
+          : t('routingStrategies.priorityByPosition')}
+      </Badge>
+      {inherited && (
+        <span className="text-[11px] text-muted-foreground/70">
+          ({t('routes.strategyInherited')})
+        </span>
+      )}
+      {isDefault && (
+        <span className="text-[11px] text-muted-foreground/70">
+          ({t('routes.strategyDefault')})
+        </span>
+      )}
+      <span className="text-[11px] text-muted-foreground min-w-0 flex-1 break-words">
+        {isWeighted ? t('routes.strategyWeightedHint') : t('routes.strategyPriorityHint')}
+      </span>
+      <Link
+        to="/routing-strategies"
+        className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'h-7 shrink-0 text-xs')}
+      >
+        <Settings2 className="mr-1.5 h-3.5 w-3.5" />
+        {t('routes.strategyConfigure')}
+      </Link>
+    </div>
+  );
+}
+
 // Wrapper component that provides the AntigravityQuotasProvider and CooldownsProvider
 export function ClientTypeRoutesContent(props: ClientTypeRoutesContentProps) {
   return (
@@ -141,6 +194,22 @@ function ClientTypeRoutesContentInner({
 
   const { data: allRoutes, isLoading: routesLoading } = useRoutes();
   const { data: providers = [], isLoading: providersLoading } = useProviders();
+  const { data: strategies = [] } = useRoutingStrategies();
+
+  // Resolve the effective strategy for this scope, mirroring the backend's
+  // order: project-specific first, then the global (projectID 0) strategy,
+  // then the built-in priority default.
+  const strategyInfo = useMemo(() => {
+    const own = strategies.find((s) => s.projectID === projectID);
+    const global = strategies.find((s) => s.projectID === 0);
+    const resolved = own ?? global;
+    return {
+      type: (resolved?.type ?? 'priority') as RoutingStrategyType,
+      inherited: !own && !!global && projectID !== 0,
+      isDefault: !resolved,
+    };
+  }, [strategies, projectID]);
+  const isWeighted = strategyInfo.type === 'weighted_random';
 
   const createRoute = useCreateRoute();
   const toggleRoute = useToggleRoute();
@@ -373,6 +442,13 @@ function ClientTypeRoutesContentInner({
     <div className="flex flex-col h-full min-h-0">
       <div className="flex-1 overflow-y-auto px-6 py-6">
         <div className="mx-auto max-w-[1400px] space-y-6">
+          {/* Effective routing strategy for this scope */}
+          <RoutingStrategyBanner
+            type={strategyInfo.type}
+            inherited={strategyInfo.inherited}
+            isDefault={strategyInfo.isDefault}
+          />
+
           {/* Routes List */}
           {items.length > 0 ? (
             <DndContext
@@ -394,6 +470,7 @@ function ClientTypeRoutesContentInner({
                       }
                       stats={stableProviderStats[item.provider.id]}
                       isToggling={toggleRoute.isPending || createRoute.isPending}
+                      showWeight={isWeighted}
                       onToggle={() => handleToggle(item)}
                       onDelete={item.route ? () => handleDeleteRoute(item.route!.id) : undefined}
                     />

--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -6,7 +6,7 @@
 import { useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Plus, RefreshCw, Zap, Workflow, Settings2 } from 'lucide-react';
+import { Plus, RefreshCw, Zap, Workflow, Settings2, Pin } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -40,7 +40,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useStreamingRequests } from '@/hooks/use-streaming';
 import { getClientName, getClientColor } from '@/components/icons/client-icons';
 import { getProviderColor, type ProviderType } from '@/lib/theme';
-import type { ClientType, Provider, ProviderStats, RoutingStrategyType } from '@/lib/transport';
+import type {
+  ClientType,
+  Provider,
+  ProviderStats,
+  RoutingStrategyType,
+  RoutingStickyScope,
+} from '@/lib/transport';
 import {
   SortableProviderRow,
   ProviderRowContent,
@@ -109,14 +115,30 @@ interface ClientTypeRoutesContentProps {
 // actually in effect for this scope (project-specific, else inherited global,
 // else the priority default) and what that means for ordering. Mirrors the
 // backend resolution order in router.getRoutingStrategy.
+// Render a sticky TTL as a compact, human-friendly duration (1800 → "30m",
+// 3600 → "1h", 90 → "90s"). Non-positive values fall back to the 30m default
+// the backend applies (sticky.TTLFromConfig).
+function formatTtl(seconds: number): string {
+  const s = seconds > 0 ? seconds : 1800;
+  if (s % 3600 === 0) return `${s / 3600}h`;
+  if (s % 60 === 0) return `${s / 60}m`;
+  return `${s}s`;
+}
+
 function RoutingStrategyBanner({
   type,
   inherited,
   isDefault,
+  stickyEnabled,
+  stickyScope,
+  stickyTTLSeconds,
 }: {
   type: RoutingStrategyType;
   inherited: boolean;
   isDefault: boolean;
+  stickyEnabled: boolean;
+  stickyScope: RoutingStickyScope;
+  stickyTTLSeconds: number;
 }) {
   const { t } = useTranslation();
   const isWeighted = type === 'weighted_random';
@@ -131,6 +153,27 @@ function RoutingStrategyBanner({
           ? t('routingStrategies.weightedRandom')
           : t('routingStrategies.priorityByPosition')}
       </Badge>
+      {/* Session affinity only takes effect under weighted_random, so only
+          surface its state there — otherwise the badge would be misleading. */}
+      {isWeighted &&
+        (stickyEnabled ? (
+          <Badge variant="success" title={t('routes.affinityTooltip')}>
+            <Pin className="mr-1 h-3 w-3" />
+            {t('routes.affinityOn')}
+            <span className="ml-1 font-normal opacity-80">
+              ·{' '}
+              {stickyScope === 'conversation'
+                ? t('routes.affinityScopeConversation')
+                : t('routes.affinityScopeToken')}{' '}
+              · {formatTtl(stickyTTLSeconds)}
+            </span>
+          </Badge>
+        ) : (
+          <Badge variant="outline" title={t('routes.affinityTooltip')}>
+            <Pin className="mr-1 h-3 w-3 opacity-50" />
+            {t('routes.affinityOff')}
+          </Badge>
+        ))}
       {inherited && (
         <span className="text-[11px] text-muted-foreground/70">
           ({t('routes.strategyInherited')})
@@ -203,10 +246,17 @@ function ClientTypeRoutesContentInner({
     const own = strategies.find((s) => s.projectID === projectID);
     const global = strategies.find((s) => s.projectID === 0);
     const resolved = own ?? global;
+    const cfg = resolved?.config ?? null;
     return {
       type: (resolved?.type ?? 'priority') as RoutingStrategyType,
       inherited: !own && !!global && projectID !== 0,
       isDefault: !resolved,
+      // Sticky / session-affinity is only honoured under weighted_random
+      // (priority is already deterministic — see router.go). Surface it so the
+      // effect of the routes' weights is understood in context.
+      stickyEnabled: !!cfg?.stickyEnabled,
+      stickyScope: cfg?.stickyScope ?? 'token',
+      stickyTTLSeconds: cfg?.stickyTTLSeconds ?? 1800,
     };
   }, [strategies, projectID]);
   const isWeighted = strategyInfo.type === 'weighted_random';
@@ -447,6 +497,9 @@ function ClientTypeRoutesContentInner({
             type={strategyInfo.type}
             inherited={strategyInfo.inherited}
             isDefault={strategyInfo.isDefault}
+            stickyEnabled={strategyInfo.stickyEnabled}
+            stickyScope={strategyInfo.stickyScope}
+            stickyTTLSeconds={strategyInfo.stickyTTLSeconds}
           />
 
           {/* Routes List */}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -627,7 +627,15 @@
     },
     "noRoutesForClient": "No routes configured for {{client}}",
     "addRouteToGetStarted": "Add a route below to get started",
-    "availableProviders": "Available Providers"
+    "availableProviders": "Available Providers",
+    "strategyLabel": "Routing strategy",
+    "strategyInherited": "inherited from Global",
+    "strategyDefault": "default",
+    "strategyConfigure": "Configure",
+    "strategyPriorityHint": "Drag rows to set the priority order.",
+    "strategyWeightedHint": "Order is weighted-random — adjust each route's weight.",
+    "weight": "Weight",
+    "weightTooltip": "Higher weight = higher chance of being picked (weighted_random strategy)."
   },
   "console": {
     "title": "Console",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -635,7 +635,12 @@
     "strategyPriorityHint": "Drag rows to set the priority order.",
     "strategyWeightedHint": "Order is weighted-random — adjust each route's weight.",
     "weight": "Weight",
-    "weightTooltip": "Higher weight = higher chance of being picked (weighted_random strategy)."
+    "weightTooltip": "Higher weight = higher chance of being picked (weighted_random strategy).",
+    "affinityOn": "Affinity on",
+    "affinityOff": "Affinity off",
+    "affinityScopeToken": "by token",
+    "affinityScopeConversation": "by conversation",
+    "affinityTooltip": "Session affinity (sticky): under weighted_random, a session keeps hitting the same provider within the TTL to maximize prompt-cache hits. Configure it on the Routing strategies page."
   },
   "console": {
     "title": "Console",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -634,7 +634,7 @@
     "strategyPriorityHint": "拖动各行以设置优先级顺序。",
     "strategyWeightedHint": "按权重随机排序——可调整每条路由的权重。",
     "weight": "权重",
-    "weightTooltip": "权重越大被选中的概率越高(加权随机策略)。",
+    "weightTooltip": "权重越大被选中的概率越高（加权随机策略）。",
     "affinityOn": "已开启亲和",
     "affinityOff": "亲和关闭",
     "affinityScopeToken": "按 token",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -634,7 +634,12 @@
     "strategyPriorityHint": "拖动各行以设置优先级顺序。",
     "strategyWeightedHint": "按权重随机排序——可调整每条路由的权重。",
     "weight": "权重",
-    "weightTooltip": "权重越大被选中的概率越高(加权随机策略)。"
+    "weightTooltip": "权重越大被选中的概率越高(加权随机策略)。",
+    "affinityOn": "已开启亲和",
+    "affinityOff": "亲和关闭",
+    "affinityScopeToken": "按 token",
+    "affinityScopeConversation": "按会话",
+    "affinityTooltip": "会话亲和(sticky):加权随机下,同一会话在 TTL 内持续命中同一 provider,以最大化 prompt 缓存命中。可在「路由策略」页配置。"
   },
   "console": {
     "title": "控制台",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -626,7 +626,15 @@
     },
     "noRoutesForClient": "未为 {{client}} 配置路由",
     "addRouteToGetStarted": "在下方添加路由以开始使用",
-    "availableProviders": "可用提供方"
+    "availableProviders": "可用提供方",
+    "strategyLabel": "路由策略",
+    "strategyInherited": "继承自全局",
+    "strategyDefault": "默认",
+    "strategyConfigure": "配置",
+    "strategyPriorityHint": "拖动各行以设置优先级顺序。",
+    "strategyWeightedHint": "按权重随机排序——可调整每条路由的权重。",
+    "weight": "权重",
+    "weightTooltip": "权重越大被选中的概率越高(加权随机策略)。"
   },
   "console": {
     "title": "控制台",

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -6,14 +6,81 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { getProviderColorVar, type ProviderType } from '@/lib/theme';
 import { cn } from '@/lib/utils';
-import type { ClientType, ProviderStats, AntigravityQuotaData, ProviderHealthLevel } from '@/lib/transport';
+import type {
+  ClientType,
+  ProviderStats,
+  AntigravityQuotaData,
+  ProviderHealthLevel,
+  Route,
+} from '@/lib/transport';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import type { ProviderConfigItem } from '../types';
 import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-context';
 import { useCooldownsContext } from '@/contexts/cooldowns-context';
+import { useUpdateRoute } from '@/hooks/queries';
 import { ProviderDetailsDialog } from '@/components/provider-details-dialog';
-import { useState, memo } from 'react';
+import { useEffect, useState, memo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+// Inline weight editor, shown on each route row only when the effective routing
+// strategy is weighted_random. Commits on blur / Enter and is debounced by the
+// fact that we only fire updateRoute when the value actually changes. Pointer
+// events are stopped so editing never triggers the row's drag or details click.
+function RouteWeightControlBase({ route }: { route: Route }) {
+  const { t } = useTranslation();
+  const updateRoute = useUpdateRoute();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(String(route.weight ?? 1));
+
+  // Keep the input in sync with server state, but never clobber what the user
+  // is mid-edit typing.
+  useEffect(() => {
+    if (!editing) setValue(String(route.weight ?? 1));
+  }, [route.weight, editing]);
+
+  const commit = () => {
+    setEditing(false);
+    let n = parseInt(value, 10);
+    if (!Number.isFinite(n) || n < 1) n = 1;
+    setValue(String(n));
+    if (n !== (route.weight ?? 1)) {
+      updateRoute.mutate({ id: route.id, data: { weight: n } });
+    }
+  };
+
+  return (
+    <div
+      className="relative z-10 flex items-center gap-1.5 shrink-0 pl-1"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      title={t('routes.weightTooltip')}
+    >
+      <span className="text-[9px] font-black text-muted-foreground/60 uppercase tracking-tight">
+        {t('routes.weight')}
+      </span>
+      <input
+        type="number"
+        min={1}
+        value={value}
+        onFocus={() => setEditing(true)}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            (e.target as HTMLInputElement).blur();
+          } else if (e.key === 'Escape') {
+            setEditing(false);
+            setValue(String(route.weight ?? 1));
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        disabled={updateRoute.isPending}
+        className="w-12 h-7 rounded-md border border-border bg-background px-1.5 text-center text-[12px] font-mono font-bold tabular-nums focus:border-ring focus:ring-1 focus:ring-ring/50 outline-none disabled:opacity-50"
+      />
+    </div>
+  );
+}
+const RouteWeightControl = memo(RouteWeightControlBase);
 
 // 格式化 Token 数量
 function formatTokens(count: number): string {
@@ -47,6 +114,7 @@ type SortableProviderRowProps = {
   streamingCount: number;
   stats?: ProviderStats;
   isToggling: boolean;
+  showWeight?: boolean;
   onToggle: () => void;
   onDelete?: () => void;
 };
@@ -61,7 +129,8 @@ function areSortableProviderRowEqual(
     prev.clientType === next.clientType &&
     prev.streamingCount === next.streamingCount &&
     prev.stats === next.stats &&
-    prev.isToggling === next.isToggling
+    prev.isToggling === next.isToggling &&
+    prev.showWeight === next.showWeight
   );
 }
 
@@ -72,6 +141,7 @@ function SortableProviderRowBase({
   streamingCount,
   stats,
   isToggling,
+  showWeight,
   onToggle,
   onDelete,
 }: SortableProviderRowProps) {
@@ -114,6 +184,7 @@ function SortableProviderRowBase({
           streamingCount={streamingCount}
           stats={stats}
           isToggling={isToggling}
+          showWeight={showWeight}
           onToggle={onToggle}
           onRowClick={handleRowClick}
           isInCooldown={activeCooldowns.length > 0}
@@ -156,6 +227,7 @@ type ProviderRowContentProps = {
   stats?: ProviderStats;
   isToggling: boolean;
   isOverlay?: boolean;
+  showWeight?: boolean;
   onToggle: () => void;
   onRowClick?: (e: React.MouseEvent) => void;
   isInCooldown?: boolean;
@@ -231,10 +303,7 @@ function formatLastUpdated(timestamp: number, t: (key: string) => string): strin
   return `${days}d`;
 }
 
-function areProviderRowContentEqual(
-  prev: ProviderRowContentProps,
-  next: ProviderRowContentProps,
-) {
+function areProviderRowContentEqual(prev: ProviderRowContentProps, next: ProviderRowContentProps) {
   return (
     prev.item === next.item &&
     prev.index === next.index &&
@@ -243,6 +312,7 @@ function areProviderRowContentEqual(
     prev.stats === next.stats &&
     prev.isToggling === next.isToggling &&
     prev.isOverlay === next.isOverlay &&
+    prev.showWeight === next.showWeight &&
     prev.isInCooldown === next.isInCooldown &&
     prev.isClearingCooldown === next.isClearingCooldown
   );
@@ -256,6 +326,7 @@ function ProviderRowContentBase({
   stats,
   isToggling,
   isOverlay: _isOverlay, // eslint-disable-line @typescript-eslint/no-unused-vars
+  showWeight,
   onToggle,
   onRowClick,
   isInCooldown: isInCooldownProp,
@@ -278,13 +349,14 @@ function ProviderRowContentBase({
   const providerCooldowns = getCooldownsForProvider(provider.id, clientType);
   const effectiveIsInCooldown = isInCooldownProp ?? providerCooldowns.length > 0;
 
-  const healthLevel: ProviderHealthLevel = providerCooldowns.length === 0
-    ? 'healthy'
-    : providerCooldowns.some((cd) => !cd.clientType && !cd.model)
-      ? 'frozen'
-      : providerCooldowns.some((cd) => cd.clientType && !cd.model)
-        ? 'limited'
-        : 'degraded';
+  const healthLevel: ProviderHealthLevel =
+    providerCooldowns.length === 0
+      ? 'healthy'
+      : providerCooldowns.some((cd) => !cd.clientType && !cd.model)
+        ? 'frozen'
+        : providerCooldowns.some((cd) => cd.clientType && !cd.model)
+          ? 'limited'
+          : 'degraded';
 
   const handleContentClick = (e: React.MouseEvent) => {
     // 所有状态都打开详情弹窗
@@ -297,7 +369,7 @@ function ProviderRowContentBase({
       onClick={handleContentClick}
       className={cn(
         'group relative flex flex-wrap items-center gap-x-4 gap-y-0 p-3 rounded-xl border transition-all duration-300 overflow-hidden w-full h-auto cursor-pointer active:cursor-grab',
-        (healthLevel === 'frozen' || healthLevel === 'limited')
+        healthLevel === 'frozen' || healthLevel === 'limited'
           ? 'bg-transparent border-slate-400/50 dark:border-slate-500/40 hover:bg-slate-200/50 dark:hover:bg-slate-700/30 hover:border-slate-500 dark:hover:border-slate-400 hover:shadow-md'
           : enabled
             ? streamingCount > 0
@@ -307,11 +379,15 @@ function ProviderRowContentBase({
       )}
       style={{
         borderColor:
-          healthLevel === 'frozen' ? 'rgb(6 182 212 / 0.3)'
-          : healthLevel === 'limited' ? 'rgb(234 179 8 / 0.3)'
-          : healthLevel === 'degraded' ? 'rgb(249 115 22 / 0.2)'
-          : !effectiveIsInCooldown && enabled && streamingCount > 0 ? `${color}40`
-          : undefined,
+          healthLevel === 'frozen'
+            ? 'rgb(6 182 212 / 0.3)'
+            : healthLevel === 'limited'
+              ? 'rgb(234 179 8 / 0.3)'
+              : healthLevel === 'degraded'
+                ? 'rgb(249 115 22 / 0.2)'
+                : !effectiveIsInCooldown && enabled && streamingCount > 0
+                  ? `${color}40`
+                  : undefined,
         boxShadow:
           !effectiveIsInCooldown && enabled && streamingCount > 0
             ? `0 0 20px ${color}15`
@@ -355,16 +431,22 @@ function ProviderRowContentBase({
         <div
           className={cn(
             'relative w-11 h-11 rounded-xl flex items-center justify-center shrink-0 transition-all duration-500 overflow-hidden',
-            (healthLevel === 'frozen' || healthLevel === 'limited')
+            healthLevel === 'frozen' || healthLevel === 'limited'
               ? 'bg-slate-200 dark:bg-slate-800 border border-slate-400/30 dark:border-slate-600/30'
               : 'bg-muted border border-border shadow-inner',
           )}
-          style={(healthLevel === 'healthy' || healthLevel === 'degraded') && enabled ? { color } : {}}
+          style={
+            (healthLevel === 'healthy' || healthLevel === 'degraded') && enabled ? { color } : {}
+          }
         >
           <span
             className={cn(
               'text-xl font-black transition-all',
-              (healthLevel === 'frozen' || healthLevel === 'limited') ? 'opacity-0' : enabled ? 'scale-100' : 'opacity-30 grayscale',
+              healthLevel === 'frozen' || healthLevel === 'limited'
+                ? 'opacity-0'
+                : enabled
+                  ? 'scale-100'
+                  : 'opacity-30 grayscale',
             )}
           >
             {provider.name.charAt(0).toUpperCase()}
@@ -502,24 +584,36 @@ function ProviderRowContentBase({
         {stats && stats.totalRequests > 0 ? (
           <>
             <div className="flex flex-col items-center min-w-[50px] px-2 py-1">
-              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">SR</span>
-              <span className={cn(
-                'font-mono font-black text-[12px]',
-                stats.successRate >= 95 ? 'text-emerald-500' : stats.successRate >= 90 ? 'text-blue-400' : 'text-amber-500',
-              )}>
+              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">
+                SR
+              </span>
+              <span
+                className={cn(
+                  'font-mono font-black text-[12px]',
+                  stats.successRate >= 95
+                    ? 'text-emerald-500'
+                    : stats.successRate >= 90
+                      ? 'text-blue-400'
+                      : 'text-amber-500',
+                )}
+              >
                 {Math.round(stats.successRate)}%
               </span>
             </div>
             <div className="w-[1px] h-6 bg-border/40" />
             <div className="flex flex-col items-center min-w-[50px] px-2 py-1">
-              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">TKN</span>
+              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">
+                TKN
+              </span>
               <span className="font-mono font-black text-[12px] text-blue-400">
                 {formatTokens(stats.totalInputTokens + stats.totalOutputTokens)}
               </span>
             </div>
             <div className="w-[1px] h-6 bg-border/40" />
             <div className="flex flex-col items-center min-w-[55px] px-2 py-1">
-              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">{t('common.cost')}</span>
+              <span className="text-[8px] font-bold text-muted-foreground uppercase tracking-tight">
+                {t('common.cost')}
+              </span>
               <span className="font-mono font-black text-[12px] text-purple-400">
                 {formatCost(stats.totalCost)}
               </span>
@@ -528,7 +622,9 @@ function ProviderRowContentBase({
         ) : (
           <div className="px-6 py-2 flex items-center gap-2 text-muted-foreground/30">
             <Activity size={12} />
-            <span className="text-[10px] font-bold uppercase tracking-widest">{t('common.noData')}</span>
+            <span className="text-[10px] font-bold uppercase tracking-widest">
+              {t('common.noData')}
+            </span>
           </div>
         )}
       </div>
@@ -538,6 +634,8 @@ function ProviderRowContentBase({
           <StreamingBadge count={streamingCount} color={color} />
         </div>
       )}
+      {/* Weight editor (weighted_random strategy only) */}
+      {showWeight && item.route && <RouteWeightControl route={item.route} />}
       {/* Switch */}
       <div
         className="relative z-10 flex items-center shrink-0 pl-2"
@@ -564,29 +662,40 @@ function ProviderRowContentBase({
                     !isFrozen && !isLimited && 'bg-orange-500/10 border-orange-500/20',
                   )}
                 >
-                  <Snowflake size={11} className={cn(
-                    isFrozen && 'text-cyan-500 animate-pulse',
-                    isLimited && 'text-yellow-500',
-                    !isFrozen && !isLimited && 'text-orange-500',
-                  )} />
-                  <span className={cn(
-                    'font-medium text-[11px]',
-                    isFrozen && 'text-cyan-500',
-                    isLimited && 'text-yellow-500',
-                    !isFrozen && !isLimited && 'text-orange-400',
-                  )}>
+                  <Snowflake
+                    size={11}
+                    className={cn(
+                      isFrozen && 'text-cyan-500 animate-pulse',
+                      isLimited && 'text-yellow-500',
+                      !isFrozen && !isLimited && 'text-orange-500',
+                    )}
+                  />
+                  <span
+                    className={cn(
+                      'font-medium text-[11px]',
+                      isFrozen && 'text-cyan-500',
+                      isLimited && 'text-yellow-500',
+                      !isFrozen && !isLimited && 'text-orange-400',
+                    )}
+                  >
                     {cd.model || (isFrozen ? 'Provider' : cd.clientType || 'Key')}
                   </span>
-                  <CooldownTimer cooldown={cd} className={cn(
-                    'font-mono font-bold text-[11px] tabular-nums',
-                    isFrozen && 'text-cyan-400',
-                    isLimited && 'text-yellow-400',
-                    !isFrozen && !isLimited && 'text-orange-500',
-                  )} />
+                  <CooldownTimer
+                    cooldown={cd}
+                    className={cn(
+                      'font-mono font-bold text-[11px] tabular-nums',
+                      isFrozen && 'text-cyan-400',
+                      isLimited && 'text-yellow-400',
+                      !isFrozen && !isLimited && 'text-orange-500',
+                    )}
+                  />
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
-                      onClearCooldown?.({ clientType: cd.clientType || undefined, model: cd.model || undefined });
+                      onClearCooldown?.({
+                        clientType: cd.clientType || undefined,
+                        model: cd.model || undefined,
+                      });
                     }}
                     disabled={isClearingCooldown}
                     className="p-0.5 rounded hover:bg-accent/50 transition-colors disabled:opacity-50"

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -19,7 +19,7 @@ import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-co
 import { useCooldownsContext } from '@/contexts/cooldowns-context';
 import { useUpdateRoute } from '@/hooks/queries';
 import { ProviderDetailsDialog } from '@/components/provider-details-dialog';
-import { useEffect, useState, memo } from 'react';
+import { useEffect, useRef, useState, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // Inline weight editor, shown on each route row only when the effective routing
@@ -31,6 +31,10 @@ function RouteWeightControlBase({ route }: { route: Route }) {
   const updateRoute = useUpdateRoute();
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(String(route.weight ?? 1));
+  // Set by Escape so the blur it triggers cancels instead of committing. A ref
+  // (not state) because blur fires synchronously within the keydown handler,
+  // before any state update from this render would be visible to commit().
+  const cancelRef = useRef(false);
 
   // Keep the input in sync with server state, but never clobber what the user
   // is mid-edit typing.
@@ -40,6 +44,11 @@ function RouteWeightControlBase({ route }: { route: Route }) {
 
   const commit = () => {
     setEditing(false);
+    if (cancelRef.current) {
+      cancelRef.current = false;
+      setValue(String(route.weight ?? 1));
+      return;
+    }
     let n = parseInt(value, 10);
     if (!Number.isFinite(n) || n < 1) n = 1;
     setValue(String(n));
@@ -69,8 +78,7 @@ function RouteWeightControlBase({ route }: { route: Route }) {
           if (e.key === 'Enter') {
             (e.target as HTMLInputElement).blur();
           } else if (e.key === 'Escape') {
-            setEditing(false);
-            setValue(String(route.weight ?? 1));
+            cancelRef.current = true;
             (e.target as HTMLInputElement).blur();
           }
         }}


### PR DESCRIPTION
## 背景

routes 页面(全局页和 project 页,二者共用 `ClientTypeRoutesContent`)一直存在两个缺口:

1. **看不到生效的路由策略** —— 站在某个 client/project 的路由列表前,无从得知走的是 `priority` 还是 `weighted_random`,策略配置和路由管理两个页面割裂。
2. **weight 不可见也不可编辑** —— 新建 route 时 `weight` 被硬编码为 1,列表里既不显示也无法修改,排序只能拖拽改 position。结果:即使把某 project 切到 `weighted_random`,纯前端用户也看不到它生效、更调不了权重(只能靠 CLI `route set-weight` 或 API)。

## 改动

- **策略横幅**:在路由列表顶部展示当前作用域**实际生效**的策略,解析顺序与后端 `router.getRoutingStrategy` 一致(project 专属 → 全局 → priority 默认),并标注「继承自全局」/「默认」,附带跳转到「路由策略」页的快捷入口。
- **行内权重编辑**:当生效策略为 `weighted_random` 时,每条路由行显示一个可编辑的权重输入框。失焦 / 回车提交,`<1` 归一到 1,值未变不发请求,Esc 取消;pointer 事件做了 `stopPropagation`,不会误触发拖拽或详情弹窗。复用已有的 `updateRoute` mutation(后端早已支持 weight 字段)。
- **会话亲和(sticky)状态**:`weighted_random` 下横幅额外显示 session 亲和是否开启及其 scope(token/conversation)和 TTL。亲和需要在策略 config 里**单独开启**(只切 `weighted_random` 不会自动生效 —— 见 `router.go` 的三段式 gating),过去 routes 页完全看不到它,导致"权重明明配了却看不出被亲和黏住"。现在一眼可见;priority 下不显示(那里亲和是 no-op)。
- 全局页与所有 project 页**自动同时生效**(共用同一组件,按 `projectID` 区分作用域)。
- `showWeight` 透传到 memo 化的行组件,并同步更新其 equality 比较函数,保持原有重渲染优化。
- 新增 en / zh 文案。

## 改动文件

- `web/src/components/routes/ClientTypeRoutesContent.tsx` —— 策略解析 + 横幅 + 传 `showWeight`
- `web/src/pages/client-routes/components/provider-row.tsx` —— `RouteWeightControl` 行内权重编辑 + prop 透传
- `web/src/locales/{en,zh}.json` —— 文案

## 验证

- `tsc` 类型检查通过
- `eslint` 干净
- `prettier` 通过(pre-commit lint-staged 已跑)
- `vite build` 生产构建成功

## 截图

> 截图取自本地实例 + 假数据(`Demo Provider Alpha/Bravo/...` + `api.example.com`),不含任何真实数据。

**`priority`(默认)** —— 横幅显示 `Priority (by position)` + `(default)`,提示拖拽排序,不显示权重:

![routes priority](https://raw.githubusercontent.com/awsl-project/maxx/e4699afc7e7470bf5576ca9ca35b285d943b9ede/routes-priority.png)

**`weighted_random`** —— 横幅切到 `Weighted Random`,每行多出可编辑的权重输入框(5 / 3 / 2 / 1):

![routes weighted](https://raw.githubusercontent.com/awsl-project/maxx/e4699afc7e7470bf5576ca9ca35b285d943b9ede/routes-weighted.png)

**`weighted_random` + 会话亲和开启** —— 横幅多出一枚 📌 `Affinity on · by conversation · 30m` 徽章,直接暴露 sticky 的开关状态、scope 和 TTL:

![routes affinity](https://raw.githubusercontent.com/awsl-project/maxx/0808805691e65cb5bdd3e963df7aa42a9881ae7a/routes-affinity.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在路由列表上方新增“有效路由策略”提示横幅，展示当前生效策略、继承/默认状态、并可跳转至配置页
  * 在加权随机策略下显示权重与会话亲和（sticky）状态，支持 Pin 标识与 TTL 显示
  * 在路由列表中新增内联权重编辑器，允许直接修改并提交路由权重（含取消/回退与输入校验）

* **文档/本地化**
  * 补充中/英文路由策略、权重与亲和相关的本地化文案与提示
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

