### PR TITLE
fix: hide excluded provider secrets

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -229,7 +229,7 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		eventChan.SendRequestInfo(&domain.RequestInfo{
 			Method:  upstreamReq.Method,
 			URL:     upstreamURL,
-			Headers: flattenHeaders(upstreamReq.Header),
+			Headers: sanitizeHeadersForEvent(upstreamReq.Header),
 			Body:    string(requestBody),
 		})
 	}
@@ -374,7 +374,7 @@ func (a *CustomAdapter) retryWithFixer(
 			eventChan.SendRequestInfo(&domain.RequestInfo{
 				Method:  retryReq.Method,
 				URL:     retryReq.URL.String(),
-				Headers: flattenHeaders(retryReq.Header),
+				Headers: sanitizeHeadersForEvent(retryReq.Header),
 				Body:    string(fixedBody),
 			})
 		}
@@ -993,6 +993,36 @@ func flattenHeaders(h http.Header) map[string]string {
 		}
 	}
 	return result
+}
+
+// sanitizeHeadersForEvent returns a header map safe for request event logging,
+// redacting upstream credentials that may be injected from provider config.
+func sanitizeHeadersForEvent(h http.Header) map[string]string {
+	result := flattenHeaders(h)
+	for key := range result {
+		if isSensitiveEventHeader(key) {
+			result[key] = "[REDACTED]"
+		}
+	}
+	return result
+}
+
+func isSensitiveEventHeader(key string) bool {
+	switch strings.ToLower(key) {
+	case "authorization",
+		"proxy-authorization",
+		"x-api-key",
+		"x-goog-api-key",
+		"api-key",
+		"anthropic-api-key",
+		"openai-api-key",
+		"x-amz-security-token",
+		"cookie",
+		"set-cookie":
+		return true
+	default:
+		return false
+	}
 }
 
 // Headers to filter out - only privacy/proxy related, NOT application headers like anthropic-version

--- a/internal/adapter/provider/custom/adapter_headers_test.go
+++ b/internal/adapter/provider/custom/adapter_headers_test.go
@@ -29,3 +29,23 @@ func TestCopyHeadersFilteredDropsSensitiveHeaders(t *testing.T) {
 	}
 }
 
+func TestSanitizeHeadersForEventRedactsProviderCredentials(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Authorization", "Bearer sk-secret")
+	headers.Set("X-Api-Key", "sk-api")
+	headers.Set("x-goog-api-key", "gemini-secret")
+	headers.Set("X-Amz-Security-Token", "aws-session-token")
+	headers.Set("Cookie", "session=secret")
+	headers.Set("X-Custom", "ok")
+
+	sanitized := sanitizeHeadersForEvent(headers)
+
+	for _, key := range []string{"Authorization", "X-Api-Key", "X-Goog-Api-Key", "X-Amz-Security-Token", "Cookie"} {
+		if got := sanitized[key]; got != "[REDACTED]" {
+			t.Fatalf("%s = %q, want [REDACTED]; headers=%+v", key, got, sanitized)
+		}
+	}
+	if sanitized["X-Custom"] != "ok" {
+		t.Fatalf("X-Custom = %q, want preserved", sanitized["X-Custom"])
+	}
+}

--- a/internal/adapter/provider/custom/ollama.go
+++ b/internal/adapter/provider/custom/ollama.go
@@ -151,7 +151,7 @@ func (a *CustomAdapter) executeOllama(c *flow.Ctx, provider *domain.Provider) er
 		eventChan.SendRequestInfo(&domain.RequestInfo{
 			Method:  upstreamReq.Method,
 			URL:     upstreamURL,
-			Headers: flattenHeaders(upstreamReq.Header),
+			Headers: sanitizeHeadersForEvent(upstreamReq.Header),
 			Body:    string(payload),
 		})
 	}

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -182,14 +182,14 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
 				return
 			}
-			writeJSON(w, http.StatusOK, provider)
+			writeJSON(w, http.StatusOK, sanitizeProviderAfterMutation(provider))
 		} else {
 			providers, err := h.svc.GetProviders(tenantID)
 			if err != nil {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
-			writeJSON(w, http.StatusOK, providers)
+			writeJSON(w, http.StatusOK, sanitizeProvidersForRole(providers, true))
 		}
 	case http.MethodPost:
 		var provider domain.Provider
@@ -201,7 +201,7 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusCreated, provider)
+		writeJSON(w, http.StatusCreated, sanitizeProviderAfterMutation(&provider))
 	case http.MethodPut:
 		if id == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id required"})
@@ -228,7 +228,7 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusOK, provider)
+		writeJSON(w, http.StatusOK, sanitizeProviderAfterMutation(&provider))
 	case http.MethodDelete:
 		if id == 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "id required"})

--- a/internal/handler/admin_import_export_test.go
+++ b/internal/handler/admin_import_export_test.go
@@ -156,3 +156,44 @@ func TestAdminHandler_ProvidersExport_WithTrailingSlash(t *testing.T) {
 		t.Fatalf("providers = %+v, want excluded providers to be omitted", providers)
 	}
 }
+
+func TestAdminHandler_GetProvider_HidesExcludedProviderSecrets(t *testing.T) {
+	providerRepo := &adminTestProviderRepo{
+		providers: []*domain.Provider{{
+			ID:                1,
+			TenantID:          1,
+			Name:              "private-provider",
+			Type:              "custom",
+			ExcludeFromExport: true,
+			Config: &domain.ProviderConfig{
+				Custom: &domain.ProviderConfigCustom{
+					BaseURL: "https://example.com",
+					APIKey:  "secret-api-key",
+				},
+			},
+		}},
+	}
+	h := newAdminHandlerForProviderImportExportTests(providerRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/providers/1", nil)
+	ctx := maxxctx.WithUserRole(req.Context(), string(domain.UserRoleAdmin))
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var provider domain.Provider
+	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if provider.Config == nil || provider.Config.Custom == nil {
+		t.Fatalf("provider config missing: %+v", provider)
+	}
+	if provider.Config.Custom.APIKey != "" {
+		t.Fatalf("excluded provider API key leaked from admin endpoint: %+v", provider.Config.Custom)
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -233,7 +233,7 @@ func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Requ
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
 				return
 			}
-			if !isAdmin {
+			if shouldSanitizeProviderSecrets(provider, isAdmin) {
 				provider = sanitizeProvider(provider)
 			}
 			writeJSON(w, http.StatusOK, provider)
@@ -245,9 +245,7 @@ func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Requ
 			writeSelfServiceInternalError(w, "GetProviders failed", err)
 			return
 		}
-		if !isAdmin {
-			providers = sanitizeProviders(providers)
-		}
+		providers = sanitizeProvidersForRole(providers, isAdmin)
 		if providers == nil {
 			providers = []*domain.Provider{}
 		}
@@ -265,7 +263,7 @@ func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Requ
 			writeSelfServiceInternalError(w, "CreateProvider failed", err)
 			return
 		}
-		writeJSON(w, http.StatusCreated, provider)
+		writeJSON(w, http.StatusCreated, sanitizeProviderAfterMutation(&provider))
 	case http.MethodPut:
 		if !h.requireAdmin(w, r) {
 			return
@@ -292,7 +290,7 @@ func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Requ
 			writeSelfServiceInternalError(w, "UpdateProvider failed", err)
 			return
 		}
-		writeJSON(w, http.StatusOK, provider)
+		writeJSON(w, http.StatusOK, sanitizeProviderAfterMutation(&provider))
 	case http.MethodDelete:
 		if !h.requireAdmin(w, r) {
 			return
@@ -994,6 +992,11 @@ func sanitizeProvider(provider *domain.Provider) *domain.Provider {
 		antigravity.RefreshToken = ""
 		config.Antigravity = &antigravity
 	}
+	if config.Bedrock != nil {
+		bedrock := *config.Bedrock
+		bedrock.SecretAccessKey = ""
+		config.Bedrock = &bedrock
+	}
 	if config.Kiro != nil {
 		kiro := *config.Kiro
 		kiro.RefreshToken = ""
@@ -1023,6 +1026,35 @@ func sanitizeProviders(providers []*domain.Provider) []*domain.Provider {
 	sanitized := make([]*domain.Provider, 0, len(providers))
 	for _, provider := range providers {
 		sanitized = append(sanitized, sanitizeProvider(provider))
+	}
+	return sanitized
+}
+
+func shouldSanitizeProviderSecrets(provider *domain.Provider, isAdmin bool) bool {
+	if provider == nil {
+		return false
+	}
+	return !isAdmin || provider.ExcludeFromExport
+}
+
+func sanitizeProviderAfterMutation(provider *domain.Provider) *domain.Provider {
+	if provider == nil || !provider.ExcludeFromExport {
+		return provider
+	}
+	return sanitizeProvider(provider)
+}
+
+func sanitizeProvidersForRole(providers []*domain.Provider, isAdmin bool) []*domain.Provider {
+	if len(providers) == 0 {
+		return providers
+	}
+	sanitized := make([]*domain.Provider, 0, len(providers))
+	for _, provider := range providers {
+		if shouldSanitizeProviderSecrets(provider, isAdmin) {
+			sanitized = append(sanitized, sanitizeProvider(provider))
+			continue
+		}
+		sanitized = append(sanitized, provider)
 	}
 	return sanitized
 }

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -833,6 +833,58 @@ func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *test
 	}
 }
 
+func TestSelfServiceHandler_UpdateProviderType_DoesNotPreserveOldTypeSecrets(t *testing.T) {
+	providerRepo := &selfServiceProviderRepo{
+		providers: []*domain.Provider{
+			{
+				ID:       1,
+				TenantID: 1,
+				Name:     "custom-provider",
+				Type:     "custom",
+				Config: &domain.ProviderConfig{
+					Custom: &domain.ProviderConfigCustom{
+						BaseURL: "https://example.com",
+						APIKey:  "old-custom-secret",
+					},
+				},
+			},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo: providerRepo,
+		projectRepo:  &selfServiceProjectRepo{},
+	})
+
+	body := `{"name":"bedrock-provider","type":"bedrock","config":{"bedrock":{"accessKeyId":"AKIATEST","secretAccessKey":"new-bedrock-secret","region":"us-east-1"}},"supportedClientTypes":["claude"]}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPut, "/providers/1", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := providerRepo.providers[0]
+	if stored.Type != "bedrock" {
+		t.Fatalf("stored type = %q, want bedrock", stored.Type)
+	}
+	if stored.Config == nil || stored.Config.Bedrock == nil {
+		t.Fatalf("stored bedrock config missing: %+v", stored.Config)
+	}
+	if got := stored.Config.Bedrock.SecretAccessKey; got != "new-bedrock-secret" {
+		t.Fatalf("stored bedrock secret = %q, want submitted secret", got)
+	}
+	if stored.Config.Custom != nil {
+		t.Fatalf("old custom config was preserved after type switch: %+v", stored.Config.Custom)
+	}
+
+	var provider domain.Provider
+	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if provider.Config != nil && provider.Config.Custom != nil {
+		t.Fatalf("response preserved old custom config after type switch: %+v", provider.Config.Custom)
+	}
+}
+
 func TestSelfServiceHandler_MemberForbiddenOnSensitiveProviderOperations(t *testing.T) {
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
 		providerRepo: &selfServiceProviderRepo{

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -804,7 +804,7 @@ func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *test
 		projectRepo:  &selfServiceProjectRepo{},
 	})
 
-	body := `{"name":"renamed-private-provider","type":"custom","excludeFromExport":true,"config":{"custom":{"baseURL":"https://new.example.com","apiKey":""}},"supportedClientTypes":["openai"]}`
+	body := `{"name":"renamed-private-provider","type":"custom","excludeFromExport":false,"config":{"custom":{"baseURL":"https://new.example.com","apiKey":""}},"supportedClientTypes":["openai"]}`
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPut, "/providers/1", body))
 
@@ -814,6 +814,9 @@ func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *test
 	if got := providerRepo.providers[0].Config.Custom.APIKey; got != "secret-api-key" {
 		t.Fatalf("stored API key = %q, want preserved secret", got)
 	}
+	if !providerRepo.providers[0].ExcludeFromExport {
+		t.Fatalf("stored excludeFromExport = false, want existing write-only mode to remain locked")
+	}
 
 	var provider domain.Provider
 	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
@@ -821,6 +824,9 @@ func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *test
 	}
 	if provider.Config == nil || provider.Config.Custom == nil {
 		t.Fatalf("provider config missing: %+v", provider)
+	}
+	if !provider.ExcludeFromExport {
+		t.Fatalf("response excludeFromExport = false, want existing write-only mode to remain locked")
 	}
 	if provider.Config.Custom.APIKey != "" {
 		t.Fatalf("update response leaked preserved API key: %+v", provider.Config.Custom)

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -647,6 +647,11 @@ func newSelfServiceAdminRequest(method, path string) *http.Request {
 	return withSelfServiceContext(req, domain.UserRoleAdmin)
 }
 
+func newSelfServiceAdminRequestWithBody(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	return withSelfServiceContext(req, domain.UserRoleAdmin)
+}
+
 func withSelfServiceContext(req *http.Request, role domain.UserRole) *http.Request {
 	ctx := maxxctx.WithTenantID(req.Context(), 1)
 	ctx = maxxctx.WithUserID(ctx, 9)
@@ -732,6 +737,93 @@ func TestSelfServiceHandler_GetProvider_AdminKeepsSecrets(t *testing.T) {
 	}
 	if provider.Config == nil || provider.Config.Custom == nil || provider.Config.Custom.APIKey != "secret-api-key" {
 		t.Fatalf("admin provider config = %+v, want unredacted secret", provider.Config)
+	}
+}
+
+func TestSelfServiceHandler_GetProvider_AdminHidesExcludedProviderSecrets(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo: &selfServiceProviderRepo{
+			providers: []*domain.Provider{
+				{
+					ID:                1,
+					TenantID:          1,
+					Name:              "private-provider",
+					Type:              "custom",
+					ExcludeFromExport: true,
+					Config: &domain.ProviderConfig{
+						Custom: &domain.ProviderConfigCustom{
+							BaseURL: "https://example.com",
+							APIKey:  "secret-api-key",
+						},
+					},
+				},
+			},
+		},
+		projectRepo: &selfServiceProjectRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequest(http.MethodGet, "/providers/1"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var provider domain.Provider
+	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if provider.Config == nil || provider.Config.Custom == nil {
+		t.Fatalf("provider config missing: %+v", provider)
+	}
+	if provider.Config.Custom.APIKey != "" {
+		t.Fatalf("excluded provider API key leaked to admin: %+v", provider.Config.Custom)
+	}
+}
+
+func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *testing.T) {
+	providerRepo := &selfServiceProviderRepo{
+		providers: []*domain.Provider{
+			{
+				ID:                1,
+				TenantID:          1,
+				Name:              "private-provider",
+				Type:              "custom",
+				ExcludeFromExport: true,
+				Config: &domain.ProviderConfig{
+					Custom: &domain.ProviderConfigCustom{
+						BaseURL: "https://example.com",
+						APIKey:  "secret-api-key",
+					},
+				},
+			},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo: providerRepo,
+		projectRepo:  &selfServiceProjectRepo{},
+	})
+
+	body := `{"name":"renamed-private-provider","type":"custom","excludeFromExport":true,"config":{"custom":{"baseURL":"https://new.example.com","apiKey":""}},"supportedClientTypes":["openai"]}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPut, "/providers/1", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := providerRepo.providers[0].Config.Custom.APIKey; got != "secret-api-key" {
+		t.Fatalf("stored API key = %q, want preserved secret", got)
+	}
+
+	var provider domain.Provider
+	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if provider.Config == nil || provider.Config.Custom == nil {
+		t.Fatalf("provider config missing: %+v", provider)
+	}
+	if provider.Config.Custom.APIKey != "" {
+		t.Fatalf("update response leaked preserved API key: %+v", provider.Config.Custom)
 	}
 }
 

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -147,6 +147,12 @@ func (s *AdminService) CreateProvider(tenantID uint64, provider *domain.Provider
 }
 
 func (s *AdminService) UpdateProvider(tenantID uint64, provider *domain.Provider) error {
+	existing, err := s.providerRepo.GetByID(tenantID, provider.ID)
+	if err != nil {
+		return err
+	}
+	preserveEmptyProviderSecrets(existing, provider)
+
 	// Auto-set SupportedClientTypes based on provider type
 	s.autoSetSupportedClientTypes(provider)
 
@@ -173,6 +179,80 @@ func (s *AdminService) DeleteProvider(tenantID uint64, id uint64) error {
 		s.adapterRefresher.RemoveAdapter(id)
 	}
 	return s.providerRepo.Delete(tenantID, id)
+}
+
+func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
+	if existing == nil || incoming == nil || existing.Config == nil {
+		return
+	}
+	if incoming.Config == nil {
+		incoming.Config = existing.Config
+		return
+	}
+
+	if existing.Config.Custom != nil {
+		if incoming.Config.Custom == nil {
+			custom := *existing.Config.Custom
+			incoming.Config.Custom = &custom
+		} else if incoming.Config.Custom.APIKey == "" {
+			incoming.Config.Custom.APIKey = existing.Config.Custom.APIKey
+		}
+	}
+	if existing.Config.Antigravity != nil {
+		if incoming.Config.Antigravity == nil {
+			antigravity := *existing.Config.Antigravity
+			incoming.Config.Antigravity = &antigravity
+		} else if incoming.Config.Antigravity.RefreshToken == "" {
+			incoming.Config.Antigravity.RefreshToken = existing.Config.Antigravity.RefreshToken
+		}
+	}
+	if existing.Config.Bedrock != nil {
+		if incoming.Config.Bedrock == nil {
+			bedrock := *existing.Config.Bedrock
+			incoming.Config.Bedrock = &bedrock
+		} else if incoming.Config.Bedrock.SecretAccessKey == "" {
+			incoming.Config.Bedrock.SecretAccessKey = existing.Config.Bedrock.SecretAccessKey
+		}
+	}
+	if existing.Config.Kiro != nil {
+		if incoming.Config.Kiro == nil {
+			kiro := *existing.Config.Kiro
+			incoming.Config.Kiro = &kiro
+		} else {
+			if incoming.Config.Kiro.RefreshToken == "" {
+				incoming.Config.Kiro.RefreshToken = existing.Config.Kiro.RefreshToken
+			}
+			if incoming.Config.Kiro.ClientSecret == "" {
+				incoming.Config.Kiro.ClientSecret = existing.Config.Kiro.ClientSecret
+			}
+		}
+	}
+	if existing.Config.Codex != nil {
+		if incoming.Config.Codex == nil {
+			codex := *existing.Config.Codex
+			incoming.Config.Codex = &codex
+		} else {
+			if incoming.Config.Codex.RefreshToken == "" {
+				incoming.Config.Codex.RefreshToken = existing.Config.Codex.RefreshToken
+			}
+			if incoming.Config.Codex.AccessToken == "" {
+				incoming.Config.Codex.AccessToken = existing.Config.Codex.AccessToken
+			}
+		}
+	}
+	if existing.Config.Claude != nil {
+		if incoming.Config.Claude == nil {
+			claude := *existing.Config.Claude
+			incoming.Config.Claude = &claude
+		} else {
+			if incoming.Config.Claude.RefreshToken == "" {
+				incoming.Config.Claude.RefreshToken = existing.Config.Claude.RefreshToken
+			}
+			if incoming.Config.Claude.AccessToken == "" {
+				incoming.Config.Claude.AccessToken = existing.Config.Claude.AccessToken
+			}
+		}
+	}
 }
 
 // ExportProviders exports all providers for backup/transfer

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -193,71 +193,85 @@ func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
 	if existing == nil || incoming == nil || existing.Config == nil {
 		return
 	}
-	if incoming.Config == nil {
-		incoming.Config = existing.Config
+	effectiveType := incoming.Type
+	if effectiveType == "" {
+		effectiveType = existing.Type
+	}
+	if effectiveType != existing.Type {
 		return
 	}
+	if incoming.Config == nil {
+		incoming.Config = &domain.ProviderConfig{}
+	}
 
-	if existing.Config.Custom != nil {
-		if incoming.Config.Custom == nil {
-			custom := *existing.Config.Custom
-			incoming.Config.Custom = &custom
-		} else if incoming.Config.Custom.APIKey == "" {
-			incoming.Config.Custom.APIKey = existing.Config.Custom.APIKey
-		}
-	}
-	if existing.Config.Antigravity != nil {
-		if incoming.Config.Antigravity == nil {
-			antigravity := *existing.Config.Antigravity
-			incoming.Config.Antigravity = &antigravity
-		} else if incoming.Config.Antigravity.RefreshToken == "" {
-			incoming.Config.Antigravity.RefreshToken = existing.Config.Antigravity.RefreshToken
-		}
-	}
-	if existing.Config.Bedrock != nil {
-		if incoming.Config.Bedrock == nil {
-			bedrock := *existing.Config.Bedrock
-			incoming.Config.Bedrock = &bedrock
-		} else if incoming.Config.Bedrock.SecretAccessKey == "" {
-			incoming.Config.Bedrock.SecretAccessKey = existing.Config.Bedrock.SecretAccessKey
-		}
-	}
-	if existing.Config.Kiro != nil {
-		if incoming.Config.Kiro == nil {
-			kiro := *existing.Config.Kiro
-			incoming.Config.Kiro = &kiro
-		} else {
-			if incoming.Config.Kiro.RefreshToken == "" {
-				incoming.Config.Kiro.RefreshToken = existing.Config.Kiro.RefreshToken
-			}
-			if incoming.Config.Kiro.ClientSecret == "" {
-				incoming.Config.Kiro.ClientSecret = existing.Config.Kiro.ClientSecret
+	switch effectiveType {
+	case "custom":
+		if existing.Config.Custom != nil {
+			if incoming.Config.Custom == nil {
+				custom := *existing.Config.Custom
+				incoming.Config.Custom = &custom
+			} else if incoming.Config.Custom.APIKey == "" {
+				incoming.Config.Custom.APIKey = existing.Config.Custom.APIKey
 			}
 		}
-	}
-	if existing.Config.Codex != nil {
-		if incoming.Config.Codex == nil {
-			codex := *existing.Config.Codex
-			incoming.Config.Codex = &codex
-		} else {
-			if incoming.Config.Codex.RefreshToken == "" {
-				incoming.Config.Codex.RefreshToken = existing.Config.Codex.RefreshToken
-			}
-			if incoming.Config.Codex.AccessToken == "" {
-				incoming.Config.Codex.AccessToken = existing.Config.Codex.AccessToken
+	case "antigravity":
+		if existing.Config.Antigravity != nil {
+			if incoming.Config.Antigravity == nil {
+				antigravity := *existing.Config.Antigravity
+				incoming.Config.Antigravity = &antigravity
+			} else if incoming.Config.Antigravity.RefreshToken == "" {
+				incoming.Config.Antigravity.RefreshToken = existing.Config.Antigravity.RefreshToken
 			}
 		}
-	}
-	if existing.Config.Claude != nil {
-		if incoming.Config.Claude == nil {
-			claude := *existing.Config.Claude
-			incoming.Config.Claude = &claude
-		} else {
-			if incoming.Config.Claude.RefreshToken == "" {
-				incoming.Config.Claude.RefreshToken = existing.Config.Claude.RefreshToken
+	case "bedrock":
+		if existing.Config.Bedrock != nil {
+			if incoming.Config.Bedrock == nil {
+				bedrock := *existing.Config.Bedrock
+				incoming.Config.Bedrock = &bedrock
+			} else if incoming.Config.Bedrock.SecretAccessKey == "" {
+				incoming.Config.Bedrock.SecretAccessKey = existing.Config.Bedrock.SecretAccessKey
 			}
-			if incoming.Config.Claude.AccessToken == "" {
-				incoming.Config.Claude.AccessToken = existing.Config.Claude.AccessToken
+		}
+	case "kiro":
+		if existing.Config.Kiro != nil {
+			if incoming.Config.Kiro == nil {
+				kiro := *existing.Config.Kiro
+				incoming.Config.Kiro = &kiro
+			} else {
+				if incoming.Config.Kiro.RefreshToken == "" {
+					incoming.Config.Kiro.RefreshToken = existing.Config.Kiro.RefreshToken
+				}
+				if incoming.Config.Kiro.ClientSecret == "" {
+					incoming.Config.Kiro.ClientSecret = existing.Config.Kiro.ClientSecret
+				}
+			}
+		}
+	case "codex":
+		if existing.Config.Codex != nil {
+			if incoming.Config.Codex == nil {
+				codex := *existing.Config.Codex
+				incoming.Config.Codex = &codex
+			} else {
+				if incoming.Config.Codex.RefreshToken == "" {
+					incoming.Config.Codex.RefreshToken = existing.Config.Codex.RefreshToken
+				}
+				if incoming.Config.Codex.AccessToken == "" {
+					incoming.Config.Codex.AccessToken = existing.Config.Codex.AccessToken
+				}
+			}
+		}
+	case "claude":
+		if existing.Config.Claude != nil {
+			if incoming.Config.Claude == nil {
+				claude := *existing.Config.Claude
+				incoming.Config.Claude = &claude
+			} else {
+				if incoming.Config.Claude.RefreshToken == "" {
+					incoming.Config.Claude.RefreshToken = existing.Config.Claude.RefreshToken
+				}
+				if incoming.Config.Claude.AccessToken == "" {
+					incoming.Config.Claude.AccessToken = existing.Config.Claude.AccessToken
+				}
 			}
 		}
 	}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -151,6 +151,7 @@ func (s *AdminService) UpdateProvider(tenantID uint64, provider *domain.Provider
 	if err != nil {
 		return err
 	}
+	preserveExcludedProviderWriteOnlyMode(existing, provider)
 	preserveEmptyProviderSecrets(existing, provider)
 
 	// Auto-set SupportedClientTypes based on provider type
@@ -179,6 +180,13 @@ func (s *AdminService) DeleteProvider(tenantID uint64, id uint64) error {
 		s.adapterRefresher.RemoveAdapter(id)
 	}
 	return s.providerRepo.Delete(tenantID, id)
+}
+
+func preserveExcludedProviderWriteOnlyMode(existing, incoming *domain.Provider) {
+	if existing == nil || incoming == nil || !existing.ExcludeFromExport {
+		return
+	}
+	incoming.ExcludeFromExport = true
 }
 
 func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1335,6 +1335,7 @@
     "cloning": "Cloning...",
     "cloneSuffix": " (Copy)",
     "cloneSuccess": "Cloned \"{{name}}\" successfully.",
+    "cloneWriteOnlyRequiresKey": "Enter a new API key before cloning this hidden-secret provider.",
     "delete": "Delete",
     "cancel": "Cancel",
     "none": "None",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1321,7 +1321,8 @@
     "apiKey": "API Key",
     "apiKeyEdit": "API Key (leave empty to keep current)",
     "apiKeyOptional": "API Key (optional)",
-    "apiKeyExcludedHint": "This provider is set to \"Do not export this provider\". You can still rotate the API key here, but this provider and its configuration will not be included in provider exports or system backups.",
+    "apiKeyExcludedHint": "This provider is set to \"Do not export this provider\". Saved API keys are not revealed on the edit page; leave this empty to keep the current key, or enter a new value to rotate it.",
+    "keyPlaceholderWriteOnly": "Hidden; leave empty to keep the current key",
     "optionalUrlNote": "Optional if client-specific URLs are set below.",
     "namePlaceholder": "e.g. Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1348,7 +1349,8 @@
     "disableErrorCooldown": "Disable Error Cooldown",
     "disableErrorCooldownDesc": "When enabled, errors won't trigger automatic cooldown. Manual freezes and explicit cooldown times still apply.",
     "excludeFromExport": "Do not export this provider",
-    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups. This only affects the current provider and does not reduce the export of other data such as API tokens or system settings."
+    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved provider secrets will not be revealed on the edit page. Enter a new value to rotate a secret.",
+    "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1334,6 +1334,7 @@
     "cloning": "克隆中...",
     "cloneSuffix": "（副本）",
     "cloneSuccess": "已成功克隆「{{name}}」。",
+    "cloneWriteOnlyRequiresKey": "克隆该隐藏密钥提供商前，请先输入新的 API 密钥。",
     "delete": "删除",
     "cancel": "取消",
     "none": "无",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1320,7 +1320,8 @@
     "apiKey": "API 密钥",
     "apiKeyEdit": "API 密钥（留空保持当前值）",
     "apiKeyOptional": "API 密钥（可选）",
-    "apiKeyExcludedHint": "该提供商已设置为“不导出此提供商配置”。您仍可在这里轮换 API 密钥，但当前提供商及其配置不会被包含在提供商导出或系统备份中。",
+    "apiKeyExcludedHint": "该提供商已设置为“不导出此提供商配置”。已保存的 API 密钥不会在编辑页回显；留空保存会保持当前密钥，输入新值则轮换。",
+    "keyPlaceholderWriteOnly": "已隐藏，留空保持当前密钥",
     "optionalUrlNote": "如果下面设置了客户端特定的 URL，则此项为可选。",
     "namePlaceholder": "例如：Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1347,7 +1348,8 @@
     "disableErrorCooldown": "禁用错误冷冻",
     "disableErrorCooldownDesc": "开启后，错误将不再触发自动冷冻；手动冷冻与上游明确冷冻时间仍会生效。",
     "excludeFromExport": "不导出此提供商配置",
-    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中。仅影响当前提供商，不影响 API Token、系统设置等其他数据的导出。"
+    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的提供商密钥也不会在编辑页回显，只能重新输入轮换。",
+    "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。"
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -439,6 +439,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
   const [cloning, setCloning] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [cloneError, setCloneError] = useState<string | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const createProvider = useCreateProvider();
   const updateProvider = useUpdateProvider();
@@ -576,6 +577,12 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
   const handleClone = async () => {
     if (!isValid() || cloning) return;
 
+    setCloneError(null);
+    if (secretsAreWriteOnly && !formData.apiKey.trim()) {
+      setCloneError(t('provider.cloneWriteOnlyRequiresKey'));
+      return;
+    }
+
     setCloning(true);
 
     try {
@@ -604,7 +611,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
-            apiKey: formData.apiKey.trim() || provider.config?.custom?.apiKey || '',
+            apiKey:
+              formData.apiKey.trim() ||
+              (secretsAreWriteOnly ? '' : provider.config?.custom?.apiKey) ||
+              '',
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -892,7 +902,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                     <Input
                       type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
                       value={formData.apiKey}
-                      onChange={(e) => setFormData((prev) => ({ ...prev, apiKey: e.target.value }))}
+                      onChange={(e) => {
+                        setCloneError(null);
+                        setFormData((prev) => ({ ...prev, apiKey: e.target.value }));
+                      }}
                       placeholder={
                         secretsAreWriteOnly
                           ? t('provider.keyPlaceholderWriteOnly')
@@ -916,6 +929,11 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                   {secretsAreWriteOnly && (
                     <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
                       {t('provider.apiKeyExcludedHint')}
+                    </div>
+                  )}
+                  {cloneError && (
+                    <div className="mt-2 p-3 bg-error/10 border border-error/30 rounded-lg text-xs text-error">
+                      {cloneError}
                     </div>
                   )}
                 </div>

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -257,9 +257,7 @@ function ResponseModelMappings({
       </div>
 
       <div className="bg-card border border-border rounded-xl p-4">
-        <p className="text-xs text-muted-foreground mb-4">
-          {t('responseModelMappings.pageDesc')}
-        </p>
+        <p className="text-xs text-muted-foreground mb-4">{t('responseModelMappings.pageDesc')}</p>
 
         {entries.length > 0 && (
           <div className="space-y-2 mb-4">
@@ -296,9 +294,7 @@ function ResponseModelMappings({
 
         {entries.length === 0 && (
           <div className="text-center py-6 mb-4">
-            <p className="text-muted-foreground text-sm">
-              {t('responseModelMappings.noMappings')}
-            </p>
+            <p className="text-muted-foreground text-sm">{t('responseModelMappings.noMappings')}</p>
           </div>
         )}
 
@@ -433,6 +429,7 @@ type EditFormData = {
   cloakSensitiveWords?: string;
   responseModelMapping: Record<string, string>;
   disableErrorCooldown?: boolean;
+  excludeFromExport?: boolean;
 };
 
 export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
@@ -466,16 +463,17 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     // before the migration continue to display their previous settings.
     const customCfg = provider.config?.custom as
       | (NonNullable<typeof provider.config>['custom'] & {
-          cloak?: { mode?: 'auto' | 'always' | 'never'; strictMode?: boolean; sensitiveWords?: string[] };
+          cloak?: {
+            mode?: 'auto' | 'always' | 'never';
+            strictMode?: boolean;
+            sensitiveWords?: string[];
+          };
         })
       | undefined;
     const disguise = customCfg?.disguise;
     const legacyCloak = customCfg?.cloak;
     // Default disguiseType: 'claude-code' (preserves legacy auto-cloak behavior).
-    const disguiseType = (disguise?.type ?? 'claude-code') as
-      | 'none'
-      | 'claude-code'
-      | 'bedrock';
+    const disguiseType = (disguise?.type ?? 'claude-code') as 'none' | 'claude-code' | 'bedrock';
     const cc = disguise?.claudeCode ?? legacyCloak;
     return {
       name: provider.name,
@@ -490,8 +488,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       cloakSensitiveWords: (cc?.sensitiveWords || []).join('\n'),
       responseModelMapping: provider.config?.custom?.responseModelMapping || {},
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
+      excludeFromExport: !!provider.excludeFromExport,
     };
   });
+  const secretsAreWriteOnly = !!provider.excludeFromExport || !!formData.excludeFromExport;
 
   const updateClient = (clientId: ClientType, updates: Partial<ClientConfig>) => {
     setFormData((prev) => ({
@@ -546,7 +546,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
-            apiKey: formData.apiKey || provider.config?.custom?.apiKey || '',
+            apiKey: formData.apiKey.trim() || '',
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -559,7 +559,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         },
         supportedClientTypes,
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
-        excludeFromExport: !!provider.excludeFromExport,
+        excludeFromExport: !!formData.excludeFromExport,
       };
 
       await updateProvider.mutateAsync({ id: Number(provider.id), data });
@@ -604,7 +604,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
-            apiKey: formData.apiKey || provider.config?.custom?.apiKey || '',
+            apiKey: formData.apiKey.trim() || provider.config?.custom?.apiKey || '',
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -617,7 +617,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         },
         supportedClientTypes,
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
-        excludeFromExport: !!provider.excludeFromExport,
+        excludeFromExport: !!formData.excludeFromExport,
       };
 
       const newProvider = await createProvider.mutateAsync(data);
@@ -890,26 +890,30 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                   </label>
                   <div className="relative">
                     <Input
-                      type={showApiKey ? 'text' : 'password'}
+                      type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
                       value={formData.apiKey}
                       onChange={(e) => setFormData((prev) => ({ ...prev, apiKey: e.target.value }))}
                       placeholder={
-                        formData.backend === 'ollama'
-                          ? t('provider.keyPlaceholderOptional')
-                          : t('provider.keyPlaceholder')
+                        secretsAreWriteOnly
+                          ? t('provider.keyPlaceholderWriteOnly')
+                          : formData.backend === 'ollama'
+                            ? t('provider.keyPlaceholderOptional')
+                            : t('provider.keyPlaceholder')
                       }
                       className="w-full pr-10"
                     />
-                    <button
-                      type="button"
-                      onClick={() => setShowApiKey(!showApiKey)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                      aria-label={showApiKey ? t('common.hide') : t('common.show')}
-                    >
-                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                    </button>
+                    {!secretsAreWriteOnly && (
+                      <button
+                        type="button"
+                        onClick={() => setShowApiKey(!showApiKey)}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                      >
+                        {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    )}
                   </div>
-                  {provider.excludeFromExport && (
+                  {secretsAreWriteOnly && (
                     <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
                       {t('provider.apiKeyExcludedHint')}
                     </div>
@@ -962,6 +966,31 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                 checked={!!formData.disableErrorCooldown}
                 onCheckedChange={(checked) =>
                   setFormData((prev) => ({ ...prev, disableErrorCooldown: checked }))
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.excludeFromExport')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.excludeFromExportDesc')}
+                </p>
+                {provider.excludeFromExport && (
+                  <p className="text-xs text-muted-foreground mt-2">
+                    {t('provider.excludeFromExportLockedDesc')}
+                  </p>
+                )}
+              </div>
+              <Switch
+                checked={!!formData.excludeFromExport}
+                disabled={!!provider.excludeFromExport}
+                onCheckedChange={(checked) =>
+                  setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
                 }
               />
             </div>


### PR DESCRIPTION
## Summary
- Treat `excludeFromExport=true` providers as write-only for saved secrets in admin and self-service provider APIs.
- Preserve existing provider secrets when edit requests submit an empty secret, so editing other fields does not clear hidden credentials.
- Keep existing write-only mode locked on provider update, so a direct API `PUT` cannot turn `excludeFromExport` back off and reveal preserved secrets.
- Hide the API key on the custom provider edit page when provider secrets are write-only, remove the reveal button, and lock the exclude-from-export switch after it is enabled.
- Redact custom-provider request event headers before logging/request-detail delivery, including `Authorization`, `X-Api-Key`, `X-Goog-Api-Key`, AWS session tokens, and cookies.
- Update zh/en copy and add regression tests for excluded provider reads, updates, exports, and event-header redaction.

## Validation
- `go test ./internal/handler ./internal/service`
- `go test ./internal/adapter/provider/custom ./internal/handler ./internal/service`
- `go test ./...`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passed with existing Vite chunk-size warning)
- Manual E2E against local backend `:9880` and Vite frontend `:3000` using temporary DBs:
  - created a custom provider with `excludeFromExport=true`
  - confirmed `/api/providers` and `/api/providers/:id` redact the saved API key
  - confirmed edit page does not reveal the saved API key and has no reveal button near the API key input
  - saved an edit with empty API key and confirmed the DB still preserves the original test secret
  - attempted a direct malicious `PUT /api/providers/:id` with `excludeFromExport=false`; response and follow-up read kept `excludeFromExport=true` and redacted the API key
  - confirmed `/api/providers/export`, `/api/admin/providers/export`, and `/api/admin/backup/export` do not include the excluded provider
  - scanned edit page text, HTML, localStorage, and sessionStorage for the test secret; no leak found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“排除从导出”选项与“仅写入”密钥模式：编辑页不回显已保存密钥，输入新值可轮换；克隆/保存流程考虑该模式。

* **隐私/改进**
  * 列表/详情/API 写入响应按角色与导出排除策略条件性隐藏敏感字段。
  * 事件/日志中的请求头敏感字段将被脱敏，不再明文记录凭证。

* **测试**
  * 新增多项测试覆盖密钥隐藏、更新保留与头部脱敏行为。

* **本地化**
  * 更新中/英文文案，说明密钥隐藏与写入模式操作提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->