### PR TITLE
Modernize generated Homebrew cask

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -75,10 +75,12 @@ jobs:
 
             name "maxx"
             desc "maxx"
-            if Hardware::CPU.intel?
+            on_intel do
               url "https://github.com/awsl-project/maxx/releases/download/v#{version}/maxx-macOS-amd64.dmg"
               sha256 "${AMD64_SHA}"
-            else
+            end
+
+            on_arm do
               url "https://github.com/awsl-project/maxx/releases/download/v#{version}/maxx-macOS-arm64.dmg"
               sha256 "${ARM64_SHA}"
             end


### PR DESCRIPTION
Updates the generated Homebrew cask template to use Homebrew's on_intel/on_arm conditionals instead of Hardware::CPU.intel?.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 优化了 Homebrew 发行版本的构建工作流配置，改进了不同处理器架构的下载逻辑定义。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->