### PR TITLE
fix(custom): retry Codex responses on OpenAI path

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -11,6 +11,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -243,6 +244,12 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
 		proxyErr.Message = "failed to connect to upstream"
 		return proxyErr
+	}
+
+	if retryResp, retryErr := retryCodexResponsesWithV1IfHTML(ctx, client, upstreamReq, resp, baseURL, requestURI, requestBody, clientType); retryErr != nil {
+		return retryErr
+	} else if retryResp != nil {
+		resp = retryResp
 	}
 	defer resp.Body.Close()
 
@@ -858,6 +865,84 @@ func updateModelInMultipartForm(body []byte, req *http.Request, model string) ([
 
 func buildUpstreamURL(baseURL string, requestPath string) string {
 	return strings.TrimSuffix(baseURL, "/") + requestPath
+}
+
+func splitRequestURI(requestURI string) (string, string) {
+	u, err := url.ParseRequestURI(requestURI)
+	if err == nil {
+		return u.Path, u.RawQuery
+	}
+	if strings.Contains(requestURI, "?") {
+		parts := strings.SplitN(requestURI, "?", 2)
+		return parts[0], parts[1]
+	}
+	return requestURI, ""
+}
+
+func retryCodexResponsesWithV1IfHTML(
+	ctx context.Context,
+	client *http.Client,
+	upstreamReq *http.Request,
+	resp *http.Response,
+	baseURL string,
+	requestURI string,
+	requestBody []byte,
+	clientType domain.ClientType,
+) (*http.Response, error) {
+	if clientType != domain.ClientTypeCodex || !isHTMLResponse(resp) {
+		return nil, nil
+	}
+
+	retryURI, ok := codexResponsesV1URI(requestURI)
+	if !ok {
+		return nil, nil
+	}
+
+	_ = resp.Body.Close()
+	retryURL := buildUpstreamURL(baseURL, retryURI)
+	retryReq := upstreamReq.Clone(ctx)
+	parsedURL, err := url.Parse(retryURL)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to create upstream retry request")
+		proxyErr.Scope = domain.ScopeEndpoint
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return nil, proxyErr
+	}
+	retryReq.URL = parsedURL
+	retryReq.Body = io.NopCloser(bytes.NewReader(requestBody))
+	retryReq.ContentLength = int64(len(requestBody))
+
+	log.Printf("[CustomAdapter] Codex /responses returned HTML, retrying OpenAI Responses path: %s", retryURI)
+	retryResp, err := client.Do(retryReq)
+	if err != nil {
+		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
+		proxyErr.Message = "failed to connect to upstream"
+		return nil, proxyErr
+	}
+	return retryResp, nil
+}
+
+func isHTMLResponse(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/html")
+}
+
+func codexResponsesV1URI(requestURI string) (string, bool) {
+	path, rawQuery := splitRequestURI(requestURI)
+	switch {
+	case path == "/responses":
+		path = "/v1/responses"
+	case strings.HasPrefix(path, "/responses/"):
+		path = "/v1" + path
+	default:
+		return "", false
+	}
+	if rawQuery == "" {
+		return path, true
+	}
+	return path + "?" + rawQuery, true
 }
 
 // isMultipartForm reports whether the request body is multipart/form-data

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -86,6 +86,44 @@ func createRoute(t *testing.T, env *ProxyTestEnv, clientType string, providerID 
 	return result.ID
 }
 
+func createProject(t *testing.T, env *ProxyTestEnv, name, slug string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/projects", map[string]any{
+		"name":                name,
+		"slug":                slug,
+		"enabledCustomRoutes": []string{},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Failed to create project %s: status=%d body=%s", name, resp.StatusCode, body)
+	}
+	var result struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &result)
+	return result.ID
+}
+
+func createProjectRoute(t *testing.T, env *ProxyTestEnv, clientType string, providerID uint64, projectID uint64) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"clientType": clientType,
+		"providerID": providerID,
+		"projectID":  projectID,
+		"position":   1,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Failed to create project route: status=%d body=%s", resp.StatusCode, body)
+	}
+	var result struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &result)
+	return result.ID
+}
+
 // --- Mock Upstream Servers ---
 
 // newMockClaudeUpstream creates a mock server that returns Claude-format responses.
@@ -169,6 +207,35 @@ func newMockCodexUpstream(t *testing.T, captured *capturedRequest) *httptest.Ser
 				"output_tokens": 8,
 				"total_tokens":  18,
 			},
+		})
+	}))
+}
+
+func newMockOpenAIResponsesUpstream(t *testing.T, captured *capturedRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Set(r)
+		if r.URL.Path != "/v1/responses" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = io.WriteString(w, `<!doctype html><title>New API</title>`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":         "resp_mock_001",
+			"object":     "response",
+			"created_at": 1700000000,
+			"model":      "gpt-4o",
+			"output": []map[string]any{
+				{
+					"type": "message",
+					"role": "assistant",
+					"content": []map[string]any{
+						{"type": "output_text", "text": "Hello from mock OpenAI Responses!"},
+					},
+				},
+			},
+			"status": "completed",
 		})
 	}))
 }
@@ -556,6 +623,41 @@ func TestProxyCodexPassthrough(t *testing.T) {
 	respBody, _ := io.ReadAll(resp.Body)
 	if gjson.GetBytes(respBody, "object").String() != "response" {
 		t.Errorf("Response should have object=response, got: %s", string(respBody))
+	}
+}
+
+func TestProxyCodexResponsesOpenAICompatibleBaseURL(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockOpenAIResponsesUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-openai-responses", mock.URL, []string{"codex"})
+	createRoute(t, env, "codex", providerID)
+	projectID := createProject(t, env, "code-x", "code-x")
+	createProjectRoute(t, env, "codex", providerID, projectID)
+
+	for _, path := range []string{
+		"/v1/responses",
+		"/responses",
+		"/project/code-x/v1/responses",
+		"/project/code-x/responses",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp := env.ProxyPost(path, codexRequest("gpt-4o"), nil)
+			defer resp.Body.Close()
+			assertStatus(t, resp, http.StatusOK)
+
+			_, upstreamPath, _, _ := captured.Get()
+			if upstreamPath != "/v1/responses" {
+				t.Fatalf("Expected upstream path /v1/responses, got %s", upstreamPath)
+			}
+
+			respBody, _ := io.ReadAll(resp.Body)
+			if gjson.GetBytes(respBody, "object").String() != "response" {
+				t.Fatalf("Response should have object=response, got: %s", string(respBody))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- retry custom Codex /responses requests on /v1/responses when the upstream returns an HTML SPA fallback
- keep native Codex /responses passthrough behavior when the upstream returns a real API response
- add e2e coverage for /v1/responses, /responses, /project/<slug>/v1/responses, and /project/<slug>/responses against an OpenAI/NewAPI-style upstream

## Validation
- git diff --check
- Go tests not run locally: Go toolchain is not installed in this environment, and temporary Go download from go.dev stalled before transfer started

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 为 Codex 响应增加了自动重试机制，支持自动映射到 OpenAI v1 兼容路径。

* **测试**
  * 为 Codex Responses OpenAI API 兼容性添加了完整的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->