### PR TITLE
feat(codex): passthrough Responses path to custom downstreams + toggle

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -140,16 +140,39 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	}
 	requestBody = payloadoverride.ApplyGlobal(requestBody, "codex", flow.GetMappedModel(c))
 
-	// Build upstream URL and stream mode
+	// Build upstream URL and stream mode.
+	//
+	// Custom downstream with passthrough on (default): forward the exact Responses
+	// path the client used (preserving /v1, since New API / OpenAI-compatible
+	// gateways serve /v1/responses, not /responses). Stream vs non-stream is
+	// conveyed via the body's "stream" flag, not /responses/compact (which is
+	// ChatGPT-specific and 404s elsewhere).
+	//
+	// Official ChatGPT backend (no custom BaseURL), or custom downstream with
+	// passthrough explicitly disabled: use the ChatGPT contract — /responses for
+	// streaming, /responses/compact for non-streaming.
+	upstreamStream := clientWantsStream
 	baseURL := CodexBaseURL
-	if config.BaseURL != "" {
+	custom := config.BaseURL != ""
+	if custom {
 		baseURL = strings.TrimRight(config.BaseURL, "/")
 	}
-	upstreamURL := baseURL + "/responses"
-	upstreamStream := true
-	if !clientWantsStream {
-		upstreamURL = baseURL + "/responses/compact"
-		upstreamStream = false
+
+	var upstreamURL string
+	if custom && domain.ResponsesPassthroughEnabled(config.ResponsesPassthrough) {
+		path := flow.GetResponsesClientPath(c)
+		if path == "" {
+			// No client Responses path captured (e.g. converted from another
+			// client type) — default to the OpenAI-compatible endpoint.
+			path = "/v1/responses"
+		}
+		upstreamURL = baseURL + path
+	} else {
+		upstreamURL = baseURL + "/responses"
+		if !clientWantsStream {
+			upstreamURL = baseURL + "/responses/compact"
+			upstreamStream = false
+		}
 	}
 	if len(requestBody) > 0 {
 		if updated, err := sjson.SetBytes(requestBody, "stream", upstreamStream); err == nil {

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -74,6 +74,17 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	baseURL := a.getBaseURL(clientType)
 	requestURI := flow.GetRequestURI(c)
 
+	// Codex Responses passthrough: the proxy layer normalizes /v1/responses down
+	// to /responses. When forwarding to a codex downstream as-is (no format
+	// conversion), honor the client's original path so OpenAI-compatible gateways
+	// that serve /v1/responses (e.g. New API) are hit at the right path instead of
+	// a 404-ing /responses. Gated by the per-provider switch (default on).
+	if clientType == domain.ClientTypeCodex && domain.ResponsesPassthroughEnabled(a.customPassthroughFlag()) {
+		if p := flow.GetResponsesClientPath(c); p != "" {
+			requestURI = p
+		}
+	}
+
 	// Apply model mapping if configured
 	var err error
 	if mappedModel != "" {
@@ -426,6 +437,15 @@ func (a *CustomAdapter) getBaseURL(clientType domain.ClientType) string {
 		return url
 	}
 	return config.BaseURL
+}
+
+// customPassthroughFlag returns the provider's Codex Responses passthrough flag
+// (nil when unconfigured → treated as default-on by ResponsesPassthroughEnabled).
+func (a *CustomAdapter) customPassthroughFlag() *bool {
+	if cfg := a.provider.Config.Custom; cfg != nil {
+		return cfg.ResponsesPassthrough
+	}
+	return nil
 }
 
 func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response, clientType domain.ClientType, isOAuthToken bool) error {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -48,6 +48,12 @@ type ProviderConfigCustom struct {
 
 	// ResponseModel 映射: UpstreamResponseModel → ClientResponseModel
 	ResponseModelMapping map[string]string `json:"responseModelMapping,omitempty"`
+
+	// ResponsesPassthrough 控制 Codex Responses 请求转发到本下游时是否透传客户端
+	// 原始路径(/v1/responses 原样转,而不是被归一化成 /responses)。
+	// 不设置(nil)= 默认透传;显式 false = 用旧的、被砍掉 /v1 的 /responses。
+	// 用于适配只认 /responses 的特殊上游,或修正 base_url 已含 /v1 的旧配置。
+	ResponsesPassthrough *bool `json:"responsesPassthrough,omitempty"`
 }
 
 // Disguise type constants. Use these instead of magic strings when dispatching
@@ -232,6 +238,12 @@ type ProviderConfigCodex struct {
 	// 自定义 Codex API Base URL（默认使用官方地址）
 	BaseURL string `json:"baseURL,omitempty"`
 
+	// ResponsesPassthrough 控制配置了自定义 BaseURL 时,是否透传客户端原始
+	// Responses 路径(/v1/responses 原样转,而不是硬编码 /responses)。
+	// 不设置(nil)= 默认透传;显式 false = 切回旧的硬编码 /responses(+ /responses/compact)。
+	// 官方 ChatGPT 后端(未配 BaseURL)不受此开关影响。
+	ResponsesPassthrough *bool `json:"responsesPassthrough,omitempty"`
+
 	// 强制 reasoning effort（覆盖请求中的值）
 	// 可选值: "low", "medium", "high"
 	Reasoning string `json:"reasoning,omitempty"`
@@ -239,6 +251,13 @@ type ProviderConfigCodex struct {
 	// 强制 service_tier（覆盖请求中的值）
 	// 可选值: "auto", "default", "flex", "priority"
 	ServiceTier string `json:"serviceTier,omitempty"`
+}
+
+// ResponsesPassthroughEnabled reports whether Codex Responses path passthrough is
+// on for the given config flag. Unset (nil) defaults to true (passthrough); only
+// an explicit false restores the legacy hardcoded /responses path.
+func ResponsesPassthroughEnabled(flag *bool) bool {
+	return flag == nil || *flag
 }
 
 // ProviderConfigCLIProxyAPIAntigravity CLIProxyAPI Antigravity 内部配置

--- a/internal/flow/helpers.go
+++ b/internal/flow/helpers.go
@@ -97,6 +97,18 @@ func GetRequestURI(c *Ctx) string {
 	return ""
 }
 
+// GetResponsesClientPath returns the client's original Responses API path
+// captured before /v1 normalization (e.g. "/v1/responses" or "/responses"),
+// or "" when the request was not a Responses call.
+func GetResponsesClientPath(c *Ctx) string {
+	if v, ok := c.Get(KeyResponsesClientPath); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 func GetIsStream(c *Ctx) bool {
 	if v, ok := c.Get(KeyIsStream); ok {
 		if s, ok := v.(bool); ok {

--- a/internal/flow/keys.go
+++ b/internal/flow/keys.go
@@ -16,6 +16,11 @@ const (
 	KeyOriginalRequestBody = "original_request_body"
 	KeyRequestHeaders      = "request_headers"
 	KeyRequestURI          = "request_uri"
+	// KeyResponsesClientPath holds the client's original Responses API request URI
+	// — path + query (e.g. "/v1/responses" or "/responses?source=codex-cli") —
+	// captured before any /v1 normalization, so a custom Codex downstream can be
+	// forwarded the path the client actually used instead of a hardcoded one.
+	KeyResponsesClientPath = "responses_client_path"
 	KeyIsStream            = "is_stream"
 	KeyAPITokenID          = "api_token_id"
 	KeyAPITokenDevMode     = "api_token_dev_mode"

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -106,6 +106,13 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		return
 	}
 
+	// Capture the client's original Responses request URI (path + query) before
+	// normalizing /v1 away, so a custom Codex downstream can be forwarded the exact
+	// path the client used (passthrough) rather than a hardcoded one.
+	if strings.HasPrefix(r.URL.Path, "/responses") || strings.HasPrefix(r.URL.Path, "/v1/responses") {
+		c.Set(flow.KeyResponsesClientPath, r.URL.RequestURI())
+	}
+
 	if strings.HasPrefix(r.URL.Path, "/v1/responses") {
 		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/v1")
 	}

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1626,3 +1626,83 @@ func TestCooldown_GeminiProtocol(t *testing.T) {
 		t.Errorf("no cooldown for Gemini provider %d: %s", providerID, cdBody)
 	}
 }
+
+// TestProxyCodexResponsesPathPassthrough verifies that a Codex client's original
+// Responses path is forwarded verbatim to a custom (OpenAI-compatible, e.g. New
+// API) downstream — /v1/responses stays /v1/responses rather than being rewritten
+// to a hardcoded /responses. Regression for New API serving /v1/responses.
+func TestProxyCodexResponsesPathPassthrough(t *testing.T) {
+	cases := []struct {
+		name       string
+		clientPath string
+		wantUp     string
+	}{
+		{"v1_prefixed", "/v1/responses", "/v1/responses"},
+		{"bare", "/responses", "/responses"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			captured := &capturedRequest{}
+			mock := newMockCodexUpstream(t, captured)
+			defer mock.Close()
+
+			env := NewProxyTestEnv(t)
+			providerID := createProvider(t, env, "mock-newapi", mock.URL, []string{"codex"})
+			createRoute(t, env, "codex", providerID)
+
+			resp := env.ProxyPost(tc.clientPath, codexRequest("gpt-5"), nil)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+			}
+			_, upPath, _, _ := captured.Get()
+			if upPath != tc.wantUp {
+				t.Fatalf("client %s: upstream path=%q, want %q", tc.clientPath, upPath, tc.wantUp)
+			}
+		})
+	}
+}
+
+// TestProxyCodexResponsesPassthroughDisabled verifies the per-provider switch:
+// with responsesPassthrough=false the legacy hardcoded /responses path is used
+// even when the client sent /v1/responses.
+func TestProxyCodexResponsesPassthroughDisabled(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockCodexUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "mock-legacy",
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL":              mock.URL,
+				"apiKey":               "sk-mock-test-key",
+				"responsesPassthrough": false,
+			},
+		},
+		"supportedClientTypes": []string{"codex"},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create provider: status=%d body=%s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &created)
+	createRoute(t, env, "codex", created.ID)
+
+	r := env.ProxyPost("/v1/responses", codexRequest("gpt-5"), nil)
+	body, _ := io.ReadAll(r.Body)
+	r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", r.StatusCode, body)
+	}
+	_, upPath, _, _ := captured.Get()
+	if upPath != "/responses" {
+		t.Fatalf("passthrough disabled: upstream path=%q, want /responses", upPath)
+	}
+}

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -19,11 +19,12 @@ import (
 
 // capturedRequest stores the last request received by a mock upstream.
 type capturedRequest struct {
-	mu      sync.Mutex
-	Method  string
-	Path    string
-	Headers http.Header
-	Body    []byte
+	mu       sync.Mutex
+	Method   string
+	Path     string
+	RawQuery string
+	Headers  http.Header
+	Body     []byte
 }
 
 func (c *capturedRequest) Set(r *http.Request) {
@@ -31,6 +32,7 @@ func (c *capturedRequest) Set(r *http.Request) {
 	defer c.mu.Unlock()
 	c.Method = r.Method
 	c.Path = r.URL.Path
+	c.RawQuery = r.URL.RawQuery
 	c.Headers = r.Header.Clone()
 	c.Body, _ = io.ReadAll(r.Body)
 }
@@ -39,6 +41,13 @@ func (c *capturedRequest) Get() (string, string, http.Header, []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.Method, c.Path, c.Headers, c.Body
+}
+
+// GetRawQuery returns the captured upstream request's raw query string.
+func (c *capturedRequest) GetRawQuery() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.RawQuery
 }
 
 // createProvider creates a custom provider via admin API and returns the provider ID.
@@ -1630,15 +1639,19 @@ func TestCooldown_GeminiProtocol(t *testing.T) {
 // TestProxyCodexResponsesPathPassthrough verifies that a Codex client's original
 // Responses path is forwarded verbatim to a custom (OpenAI-compatible, e.g. New
 // API) downstream — /v1/responses stays /v1/responses rather than being rewritten
-// to a hardcoded /responses. Regression for New API serving /v1/responses.
+// to a hardcoded /responses. The query string must be preserved too, since the
+// passthrough captures the full request URI (path + query). Regression for New
+// API serving /v1/responses.
 func TestProxyCodexResponsesPathPassthrough(t *testing.T) {
 	cases := []struct {
 		name       string
 		clientPath string
 		wantUp     string
+		wantQuery  string
 	}{
-		{"v1_prefixed", "/v1/responses", "/v1/responses"},
-		{"bare", "/responses", "/responses"},
+		{"v1_prefixed", "/v1/responses", "/v1/responses", ""},
+		{"bare", "/responses", "/responses", ""},
+		{"with_query", "/v1/responses?source=codex-cli", "/v1/responses", "source=codex-cli"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1659,6 +1672,9 @@ func TestProxyCodexResponsesPathPassthrough(t *testing.T) {
 			_, upPath, _, _ := captured.Get()
 			if upPath != tc.wantUp {
 				t.Fatalf("client %s: upstream path=%q, want %q", tc.clientPath, upPath, tc.wantUp)
+			}
+			if gotQuery := captured.GetRawQuery(); gotQuery != tc.wantQuery {
+				t.Fatalf("client %s: upstream query=%q, want %q", tc.clientPath, gotQuery, tc.wantQuery)
 			}
 		})
 	}

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -44,6 +44,9 @@ export interface ProviderConfigCustom {
   clientMultiplier?: Partial<Record<ClientType, number>>; // 10000=1倍
   modelMapping?: Record<string, string>;
   responseModelMapping?: Record<string, string>;
+  // Codex Responses 请求是否透传客户端原始路径(/v1/responses)。
+  // 不设置=默认透传;false=用旧的、被砍掉 /v1 的 /responses。
+  responsesPassthrough?: boolean;
 }
 
 export interface ProviderConfigAntigravity {
@@ -82,6 +85,9 @@ export interface ProviderConfigCodex {
   baseURL?: string;
   reasoning?: string; // "low", "medium", "high"
   serviceTier?: string; // "auto", "default", "flex", "priority"
+  // 转发到自定义 baseURL 时是否透传客户端原始 Responses 路径(/v1/responses)。
+  // 不设置=默认透传;false=用旧的硬编码 /responses。
+  responsesPassthrough?: boolean;
 }
 
 export interface ProviderConfigClaude {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -312,7 +312,9 @@
       "serviceTierAuto": "Auto",
       "serviceTierDefault": "Default",
       "serviceTierFlex": "Flex",
-      "serviceTierPriority": "Priority"
+      "serviceTierPriority": "Priority",
+      "responsesPassthrough": "Passthrough Responses Path",
+      "responsesPassthroughDesc": "When forwarding to a custom Base URL, send the client's original path (e.g. /v1/responses) instead of a hardcoded /responses. Turn off only for upstreams that expect /responses, or when the Base URL already ends with /v1. No effect on the official ChatGPT backend."
     },
     "projectId": "Project ID",
     "endpoint": "Endpoint",
@@ -1349,6 +1351,8 @@
     "errorCooldownTitle": "3. Error Cooldown",
     "disableErrorCooldown": "Disable Error Cooldown",
     "disableErrorCooldownDesc": "When enabled, errors won't trigger automatic cooldown. Manual freezes and explicit cooldown times still apply.",
+    "responsesPassthrough": "Passthrough Responses Path",
+    "responsesPassthroughDesc": "For Codex Responses requests, forward the client's original path (e.g. /v1/responses) instead of a hardcoded /responses. Turn off only for upstreams that expect /responses, or when the Base URL already ends with /v1.",
     "excludeFromExport": "Do not export this provider",
     "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved provider secrets will not be revealed on the edit page. Enter a new value to rotate a secret.",
     "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly."

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -311,7 +311,9 @@
       "serviceTierAuto": "自动",
       "serviceTierDefault": "默认",
       "serviceTierFlex": "弹性",
-      "serviceTierPriority": "优先"
+      "serviceTierPriority": "优先",
+      "responsesPassthrough": "透传 Responses 路径",
+      "responsesPassthroughDesc": "转发到自定义 Base URL 时,按客户端原始路径转发(如 /v1/responses),而不是硬编码 /responses。仅当上游只认 /responses、或 Base URL 已自带 /v1 时才需要关闭。官方 ChatGPT 后端不受影响。"
     },
     "projectId": "项目 ID",
     "endpoint": "端点",
@@ -1348,6 +1350,8 @@
     "errorCooldownTitle": "3. 错误冷冻",
     "disableErrorCooldown": "禁用错误冷冻",
     "disableErrorCooldownDesc": "开启后，错误将不再触发自动冷冻；手动冷冻与上游明确冷冻时间仍会生效。",
+    "responsesPassthrough": "透传 Responses 路径",
+    "responsesPassthroughDesc": "Codex Responses 请求按客户端原始路径转发（如 /v1/responses），而不是硬编码 /responses。仅当上游只认 /responses、或 Base URL 已自带 /v1 时才需要关闭。",
     "excludeFromExport": "不导出此提供商配置",
     "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的提供商密钥也不会在编辑页回显，只能重新输入轮换。",
     "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。"

--- a/web/src/pages/providers/components/codex-provider-view.tsx
+++ b/web/src/pages/providers/components/codex-provider-view.tsx
@@ -355,14 +355,16 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
   const config = provider.config?.codex;
   const updateProvider = useUpdateProvider();
 
-  const [useCLIProxyAPI, setUseCLIProxyAPI] = useState(
-    () => config?.useCLIProxyAPI ?? false,
-  );
+  const [useCLIProxyAPI, setUseCLIProxyAPI] = useState(() => config?.useCLIProxyAPI ?? false);
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     () => provider.config?.disableErrorCooldown ?? false,
   );
   const [reasoning, setReasoning] = useState(() => config?.reasoning ?? '');
   const [serviceTier, setServiceTier] = useState(() => config?.serviceTier ?? '');
+  // undefined/true = 默认透传;仅显式 false 关闭。
+  const [responsesPassthrough, setResponsesPassthrough] = useState(
+    () => config?.responsesPassthrough !== false,
+  );
 
   useEffect(() => {
     setUseCLIProxyAPI(config?.useCLIProxyAPI ?? false);
@@ -376,6 +378,9 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
   useEffect(() => {
     setServiceTier(config?.serviceTier ?? '');
   }, [config?.serviceTier]);
+  useEffect(() => {
+    setResponsesPassthrough(config?.responsesPassthrough !== false);
+  }, [config?.responsesPassthrough]);
 
   const handleToggleCLIProxyAPI = async (checked: boolean) => {
     if (!config) return;
@@ -467,6 +472,29 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
       });
     } catch {
       setServiceTier(prev);
+    }
+  };
+
+  const handleToggleResponsesPassthrough = async (checked: boolean) => {
+    if (!config) return;
+    const prev = responsesPassthrough;
+    setResponsesPassthrough(checked);
+    try {
+      await updateProvider.mutateAsync({
+        id: provider.id,
+        data: {
+          ...provider,
+          config: {
+            ...provider.config,
+            codex: {
+              ...config,
+              responsesPassthrough: checked,
+            },
+          },
+        },
+      });
+    } catch {
+      setResponsesPassthrough(prev);
     }
   };
 
@@ -703,6 +731,22 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
                   <option value="flex">{t('providers.codex.serviceTierFlex')}</option>
                   <option value="priority">{t('providers.codex.serviceTierPriority')}</option>
                 </select>
+              </div>
+
+              <div className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border">
+                <div className="pr-4">
+                  <div className="text-sm font-medium text-foreground">
+                    {t('providers.codex.responsesPassthrough')}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {t('providers.codex.responsesPassthroughDesc')}
+                  </p>
+                </div>
+                <Switch
+                  checked={responsesPassthrough}
+                  onCheckedChange={handleToggleResponsesPassthrough}
+                  disabled={updateProvider.isPending}
+                />
               </div>
             </div>
           </div>

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { Globe, ChevronLeft, Key, Check, Plus, Trash2, ArrowRight, Eye, EyeOff } from 'lucide-react';
+import {
+  Globe,
+  ChevronLeft,
+  Key,
+  Check,
+  Plus,
+  Trash2,
+  ArrowRight,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
 import type { ClientType, CreateProviderData } from '@/lib/transport';
@@ -73,6 +83,7 @@ export function CustomConfigStep() {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
             apiKey: formData.apiKey,
+            responsesPassthrough: formData.responsesPassthrough,
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -273,6 +284,20 @@ export function CustomConfigStep() {
               <Switch
                 checked={!!formData.disableErrorCooldown}
                 onCheckedChange={(checked) => updateFormData({ disableErrorCooldown: checked })}
+              />
+            </div>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.responsesPassthrough')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.responsesPassthroughDesc')}
+                </p>
+              </div>
+              <Switch
+                checked={formData.responsesPassthrough !== false}
+                onCheckedChange={(checked) => updateFormData({ responsesPassthrough: checked })}
               />
             </div>
           </div>

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -430,6 +430,8 @@ type EditFormData = {
   responseModelMapping: Record<string, string>;
   disableErrorCooldown?: boolean;
   excludeFromExport?: boolean;
+  // undefined = 默认透传;false = 旧的硬编码 /responses。
+  responsesPassthrough?: boolean;
 };
 
 export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
@@ -490,6 +492,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       responseModelMapping: provider.config?.custom?.responseModelMapping || {},
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
       excludeFromExport: !!provider.excludeFromExport,
+      responsesPassthrough: provider.config?.custom?.responsesPassthrough,
     };
   });
   const secretsAreWriteOnly = !!provider.excludeFromExport || !!formData.excludeFromExport;
@@ -548,6 +551,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
             apiKey: formData.apiKey.trim() || '',
+            responsesPassthrough: formData.responsesPassthrough,
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -615,6 +619,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
               formData.apiKey.trim() ||
               (secretsAreWriteOnly ? '' : provider.config?.custom?.apiKey) ||
               '',
+            responsesPassthrough: formData.responsesPassthrough,
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
             clientMultiplier:
               Object.keys(clientMultiplier).length > 0 ? clientMultiplier : undefined,
@@ -984,6 +989,22 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                 checked={!!formData.disableErrorCooldown}
                 onCheckedChange={(checked) =>
                   setFormData((prev) => ({ ...prev, disableErrorCooldown: checked }))
+                }
+              />
+            </div>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.responsesPassthrough')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.responsesPassthroughDesc')}
+                </p>
+              </div>
+              <Switch
+                checked={formData.responsesPassthrough !== false}
+                onCheckedChange={(checked) =>
+                  setFormData((prev) => ({ ...prev, responsesPassthrough: checked }))
                 }
               />
             </div>

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -254,6 +254,8 @@ export type ProviderFormData = {
   logo?: string; // Logo URL
   disableErrorCooldown?: boolean;
   excludeFromExport?: boolean;
+  // undefined = 默认透传;false = 旧的硬编码 /responses。
+  responsesPassthrough?: boolean;
 };
 
 // Create step type


### PR DESCRIPTION
## 问题

Codex adapter 把上游 Responses 路径**硬编码**成 `/responses`(非流式 `/responses/compact`),这套是给官方 ChatGPT 后端(base 为 `.../backend-api/codex`)设计的。

当自定义 `base_url` 指向一个 OpenAI 兼容网关(例如 **New API**,它的端点是 `/v1/responses`)时,maxx 去打了不存在的 `/responses`,网关直接返回它的 SPA 首页 HTML —— 于是四种入口路径全挂:`/responses`、`/v1/responses`、`/project/{slug}/responses`、`/project/{slug}/v1/responses`。

`/v1/chat/completions` 正常但 `/responses` 不正常这个对照,正是因为 codex 走的是这条专有路径逻辑。

## 改动

**透传客户端原始 Responses 路径**(仅当配置了自定义 `base_url`):
- `/v1/responses` 原样转 `/v1/responses`,`/responses` 原样转 `/responses`;
- 流式/非流式通过 body 的 `stream` 标志区分,不再用 ChatGPT 专有的 `/responses/compact`;
- 官方 ChatGPT 后端路径**完全不变**;
- 覆盖 codex 类型和 custom 类型两种 provider。

**每个 provider 一个开关** `responsesPassthrough`(`*bool`,默认透传;显式 `false` 回退旧的硬编码 `/responses`):
- 用 `*bool` 让"不设置 = 默认透传",同时保留显式关闭的能力;
- 也给已经用 `base_url=/v1` 手动绕过的老用户一个回退选项,避免双 `/v1`;
- 前端 codex / custom provider 表单(详情页 + 编辑流 + 创建向导)都加了 UI 开关 + 中英文案。

## 实现要点
- 在 `/v1` 归一化前,把客户端原始 Responses URI 存进 flow context;
- codex / custom 两个 adapter 按路径和开关取舍;
- `domain.ResponsesPassthroughEnabled()` 统一判定。

## 测试
- e2e 回归:透传开(`/v1/responses`、`/responses` 两条路径)+ 关(回退旧 `/responses`);
- Go `./internal/... ./tests/...` 0 失败;前端 typecheck / eslint / build 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 为 Codex 与自定义提供商新增 `responsesPassthrough` 配置：可在转发到自定义 Base URL 时控制是否使用客户端原始 `/v1/responses` 路径（含查询）进行转发。
  * 默认开启；显式设置为 `false` 时将回退到传统固定的 `/responses` 行为。
* **改进**
  * 代理在遇到 `/responses` 与 `/v1/responses` 时，能更准确保留客户端实际使用的路径与参数。
* **测试**
  * 新增端到端测试覆盖路径透传与透传关闭两种场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->