### PR TITLE
fix(codex): forward CacheReadCount end-to-end

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -412,6 +412,7 @@ func (a *CodexAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response)
 		})
 		// Extract token usage from response
 		if metrics := usage.ExtractFromResponse(string(body)); metrics != nil {
+			metrics = usage.AdjustForClientType(metrics, domain.ClientTypeCodex)
 			eventChan.SendMetrics(&domain.AdapterMetrics{
 				InputTokens:    metrics.InputTokens,
 				OutputTokens:   metrics.OutputTokens,
@@ -557,10 +558,11 @@ func (a *CodexAdapter) sendFinalStreamEvents(eventChan domain.AdapterEventChan, 
 
 	// Send token usage collected incrementally
 	if collector.Metrics != nil && !collector.Metrics.IsEmpty() {
+		metrics := usage.AdjustForClientType(collector.Metrics, domain.ClientTypeCodex)
 		eventChan.SendMetrics(&domain.AdapterMetrics{
-			InputTokens:    collector.Metrics.InputTokens,
-			OutputTokens:   collector.Metrics.OutputTokens,
-			CacheReadCount: collector.Metrics.CacheReadCount,
+			InputTokens:    metrics.InputTokens,
+			OutputTokens:   metrics.OutputTokens,
+			CacheReadCount: metrics.CacheReadCount,
 		})
 	}
 

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -413,8 +413,9 @@ func (a *CodexAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response)
 		// Extract token usage from response
 		if metrics := usage.ExtractFromResponse(string(body)); metrics != nil {
 			eventChan.SendMetrics(&domain.AdapterMetrics{
-				InputTokens:  metrics.InputTokens,
-				OutputTokens: metrics.OutputTokens,
+				InputTokens:    metrics.InputTokens,
+				OutputTokens:   metrics.OutputTokens,
+				CacheReadCount: metrics.CacheReadCount,
 			})
 		}
 		// Extract model from response
@@ -557,8 +558,9 @@ func (a *CodexAdapter) sendFinalStreamEvents(eventChan domain.AdapterEventChan, 
 	// Send token usage collected incrementally
 	if collector.Metrics != nil && !collector.Metrics.IsEmpty() {
 		eventChan.SendMetrics(&domain.AdapterMetrics{
-			InputTokens:  collector.Metrics.InputTokens,
-			OutputTokens: collector.Metrics.OutputTokens,
+			InputTokens:    collector.Metrics.InputTokens,
+			OutputTokens:   collector.Metrics.OutputTokens,
+			CacheReadCount: collector.Metrics.CacheReadCount,
 		})
 	}
 

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -321,7 +321,7 @@ func TestHandleNonStreamResponseForwardsCacheReadCount(t *testing.T) {
 	eventChan := domain.NewAdapterEventChan()
 	ctx.Set(flow.KeyEventChan, eventChan)
 
-	body := `{"model":"gpt-5","usage":{"prompt_tokens":120,"completion_tokens":40,"prompt_tokens_details":{"cached_tokens":80}}}`
+	body := `{"id":"resp_1","object":"response","model":"gpt-5","usage":{"input_tokens":120,"output_tokens":40,"input_tokens_details":{"cached_tokens":80}}}`
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     make(http.Header),

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -336,8 +336,11 @@ func TestHandleNonStreamResponseForwardsCacheReadCount(t *testing.T) {
 	if metrics == nil {
 		t.Fatal("expected EventMetrics to be emitted")
 	}
-	if metrics.InputTokens != 120 || metrics.OutputTokens != 40 {
-		t.Fatalf("input/output mismatch: got input=%d output=%d", metrics.InputTokens, metrics.OutputTokens)
+	// Codex usage.input_tokens includes cached_tokens; AdjustForClientType
+	// subtracts so pricing does not bill the cached portion at the input rate
+	// on top of the cache-read rate. Expect input_tokens (120) - cached (80) = 40.
+	if metrics.InputTokens != 40 || metrics.OutputTokens != 40 {
+		t.Fatalf("input/output mismatch: got input=%d output=%d, want input=40 output=40", metrics.InputTokens, metrics.OutputTokens)
 	}
 	if metrics.CacheReadCount != 80 {
 		t.Fatalf("expected CacheReadCount=80, got %d", metrics.CacheReadCount)
@@ -373,8 +376,9 @@ func TestHandleStreamResponseForwardsCacheReadCount(t *testing.T) {
 	if metrics == nil {
 		t.Fatal("expected EventMetrics to be emitted from response.completed")
 	}
-	if metrics.InputTokens != 200 || metrics.OutputTokens != 50 {
-		t.Fatalf("input/output mismatch: got input=%d output=%d", metrics.InputTokens, metrics.OutputTokens)
+	// After AdjustForClientType: input_tokens (200) - cached (150) = 50.
+	if metrics.InputTokens != 50 || metrics.OutputTokens != 50 {
+		t.Fatalf("input/output mismatch: got input=%d output=%d, want input=50 output=50", metrics.InputTokens, metrics.OutputTokens)
 	}
 	if metrics.CacheReadCount != 150 {
 		t.Fatalf("expected CacheReadCount=150, got %d", metrics.CacheReadCount)

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -10,8 +10,24 @@ import (
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/usage"
 	"github.com/tidwall/gjson"
 )
+
+// collectMetricsEvent drains an AdapterEventChan and returns the first
+// EventMetrics payload it finds, or nil if none was sent.
+func collectMetricsEvent(ch domain.AdapterEventChan) *domain.AdapterMetrics {
+	for {
+		select {
+		case ev := <-ch:
+			if ev != nil && ev.Type == domain.EventMetrics {
+				return ev.Metrics
+			}
+		default:
+			return nil
+		}
+	}
+}
 
 type scriptedReadCloser struct {
 	chunks [][]byte
@@ -294,5 +310,102 @@ func TestHandleStreamResponseAllowsCompletedStreamWithoutTrailingNewline(t *test
 
 	if err := a.handleStreamResponse(ctx, resp); err != nil {
 		t.Fatalf("expected completed stream without trailing newline to succeed, got %v", err)
+	}
+}
+
+func TestHandleNonStreamResponseForwardsCacheReadCount(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	eventChan := domain.NewAdapterEventChan()
+	ctx.Set(flow.KeyEventChan, eventChan)
+
+	body := `{"model":"gpt-5","usage":{"prompt_tokens":120,"completion_tokens":40,"prompt_tokens_details":{"cached_tokens":80}}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	if err := a.handleNonStreamResponse(ctx, resp); err != nil {
+		t.Fatalf("handleNonStreamResponse: %v", err)
+	}
+
+	metrics := collectMetricsEvent(eventChan)
+	if metrics == nil {
+		t.Fatal("expected EventMetrics to be emitted")
+	}
+	if metrics.InputTokens != 120 || metrics.OutputTokens != 40 {
+		t.Fatalf("input/output mismatch: got input=%d output=%d", metrics.InputTokens, metrics.OutputTokens)
+	}
+	if metrics.CacheReadCount != 80 {
+		t.Fatalf("expected CacheReadCount=80, got %d", metrics.CacheReadCount)
+	}
+}
+
+func TestHandleStreamResponseForwardsCacheReadCount(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	eventChan := domain.NewAdapterEventChan()
+	ctx.Set(flow.KeyEventChan, eventChan)
+
+	// Real Codex Responses SSE: usage is only carried on the terminating
+	// response.completed event.
+	stream := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"hi"}`,
+		`data: {"type":"response.completed","response":{"model":"gpt-5","usage":{"input_tokens":200,"output_tokens":50,"input_tokens_details":{"cached_tokens":150}}}}`,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	if err := a.handleStreamResponse(ctx, resp); err != nil {
+		t.Fatalf("handleStreamResponse: %v", err)
+	}
+
+	metrics := collectMetricsEvent(eventChan)
+	if metrics == nil {
+		t.Fatal("expected EventMetrics to be emitted from response.completed")
+	}
+	if metrics.InputTokens != 200 || metrics.OutputTokens != 50 {
+		t.Fatalf("input/output mismatch: got input=%d output=%d", metrics.InputTokens, metrics.OutputTokens)
+	}
+	if metrics.CacheReadCount != 150 {
+		t.Fatalf("expected CacheReadCount=150, got %d", metrics.CacheReadCount)
+	}
+}
+
+// A cache-only metric (no fresh input/output tokens, just a prompt-cache hit)
+// must still flow through sendFinalStreamEvents. Metrics.IsEmpty is the gate;
+// regressing it to drop cache-only metrics would silently zero out cache stats
+// for some streams.
+func TestSendFinalStreamEventsEmitsCacheOnlyMetrics(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	_ = flow.NewCtx(rec, req)
+	eventChan := domain.NewAdapterEventChan()
+
+	collector := &usage.StreamCollector{Metrics: &usage.Metrics{CacheReadCount: 42}}
+	model := ""
+	resp := &http.Response{StatusCode: http.StatusOK, Header: make(http.Header)}
+
+	a.sendFinalStreamEvents(eventChan, collector, &model, resp)
+
+	metrics := collectMetricsEvent(eventChan)
+	if metrics == nil {
+		t.Fatal("expected EventMetrics for cache-only metrics")
+	}
+	if metrics.CacheReadCount != 42 {
+		t.Fatalf("expected CacheReadCount=42, got %d", metrics.CacheReadCount)
+	}
+	if metrics.InputTokens != 0 || metrics.OutputTokens != 0 {
+		t.Fatalf("expected zero input/output tokens, got input=%d output=%d", metrics.InputTokens, metrics.OutputTokens)
 	}
 }

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -172,16 +172,27 @@ func extractUsageFromMap(data map[string]interface{}) *Metrics {
 	return nil
 }
 
-// isOpenAIUsage reports whether a usage map uses OpenAI chat-completions naming
-// (prompt_tokens / completion_tokens). These keys are absent from Claude and
-// from the OpenAI Images API (which both use input_tokens / output_tokens), so
-// their presence is a reliable discriminator.
+// isOpenAIUsage reports whether a usage map uses an OpenAI extractor shape.
+// prompt_tokens / completion_tokens identify chat-completions; those keys are
+// absent from Claude and from the OpenAI Images API (both use
+// input_tokens / output_tokens), so their presence is a reliable discriminator.
+//
+// The Responses API (Codex) also uses input_tokens / output_tokens at the top
+// level, colliding with Claude, but carries cached_tokens under
+// input_tokens_details — a sub-key Claude never emits. Routing on its presence
+// lets extractOpenAIUsage pick up the cache read instead of silently dropping
+// it via extractClaudeUsage.
 func isOpenAIUsage(usage map[string]interface{}) bool {
 	if _, ok := usage["prompt_tokens"]; ok {
 		return true
 	}
 	if _, ok := usage["completion_tokens"]; ok {
 		return true
+	}
+	if details, ok := usage["input_tokens_details"].(map[string]interface{}); ok {
+		if _, ok := details["cached_tokens"]; ok {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -4,7 +4,60 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
 )
+
+// TestAdjustForClientType_Codex pins the subtraction contract that
+// codex/adapter.go now relies on directly. Codex usage.input_tokens includes
+// cached_tokens, so InputTokens must be reduced by CacheReadCount before
+// metrics reach pricing — otherwise the cached portion is billed at both the
+// input rate and the cache-read rate.
+func TestAdjustForClientType_Codex(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        Metrics
+		wantInput uint64
+	}{
+		{"input greater than cache", Metrics{InputTokens: 200, CacheReadCount: 150}, 50},
+		{"input equals cache", Metrics{InputTokens: 150, CacheReadCount: 150}, 0},
+		{"cache zero is no-op", Metrics{InputTokens: 200, CacheReadCount: 0}, 200},
+		// Defensive: relays occasionally report cached > input. Skipping the
+		// subtraction is preferred over clamping to zero — clamping would
+		// silently underbill fresh input on a broken relay; skipping leaves
+		// the metric visible and consistent with what the upstream sent.
+		{"input less than cache is skipped", Metrics{InputTokens: 100, CacheReadCount: 150}, 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.in
+			got := AdjustForClientType(&m, domain.ClientTypeCodex)
+			if got.InputTokens != tc.wantInput {
+				t.Errorf("InputTokens = %d, want %d", got.InputTokens, tc.wantInput)
+			}
+			if got.CacheReadCount != tc.in.CacheReadCount {
+				t.Errorf("CacheReadCount changed from %d to %d", tc.in.CacheReadCount, got.CacheReadCount)
+			}
+		})
+	}
+}
+
+func TestAdjustForClientType_NonCodexIsNoOp(t *testing.T) {
+	for _, ct := range []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeGemini, domain.ClientTypeOpenAI} {
+		m := Metrics{InputTokens: 200, CacheReadCount: 150}
+		got := AdjustForClientType(&m, ct)
+		if got.InputTokens != 200 {
+			t.Errorf("clientType=%s: InputTokens = %d, want 200 (unchanged)", ct, got.InputTokens)
+		}
+	}
+}
+
+func TestAdjustForClientType_NilMetricsSafe(t *testing.T) {
+	if got := AdjustForClientType(nil, domain.ClientTypeCodex); got != nil {
+		t.Errorf("nil input must return nil, got %+v", got)
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Functional tests for StreamCollector

--- a/internal/usage/extractor_test.go
+++ b/internal/usage/extractor_test.go
@@ -304,6 +304,36 @@ func TestExtractFromResponse_GptImageEditsTokenSplit(t *testing.T) {
 // {"usage": ...} branch unconditionally ran the Claude extractor, which only
 // looks for input_tokens / output_tokens — so prompt_tokens / completion_tokens
 // were silently dropped and the request billed at zero.
+// TestExtractFromResponse_CodexResponsesAPI pins the dispatcher contract for
+// non-streaming Codex / OpenAI Responses API bodies. Their usage uses
+// input_tokens / output_tokens at the top level (colliding with Claude and
+// the Images API) but carries cached_tokens under input_tokens_details — a
+// sub-key Claude never emits. isOpenAIUsage must route on that marker so the
+// cache_read count reaches the executor.
+func TestExtractFromResponse_CodexResponsesAPI(t *testing.T) {
+	body := `{
+		"id": "resp_abc",
+		"object": "response",
+		"model": "gpt-5",
+		"usage": {
+			"input_tokens": 200,
+			"output_tokens": 50,
+			"input_tokens_details": {"cached_tokens": 150}
+		}
+	}`
+
+	m := ExtractFromResponse(body)
+	if m == nil {
+		t.Fatal("expected metrics for Responses API body, got nil")
+	}
+	if m.InputTokens != 200 || m.OutputTokens != 50 {
+		t.Errorf("tokens = in %d / out %d, want 200 / 50", m.InputTokens, m.OutputTokens)
+	}
+	if m.CacheReadCount != 150 {
+		t.Errorf("CacheReadCount = %d, want 150", m.CacheReadCount)
+	}
+}
+
 func TestExtractFromResponse_OpenAIChatCompletions(t *testing.T) {
 	body := `{
 		"id": "chatcmpl-xyz",


### PR DESCRIPTION
## Summary

Codex provider requests record `cache_read_count = 0` in `proxy_upstream_attempts`, even when sticky sessions land real upstream prompt-cache hits, so the provider-stats UI is permanently zero for cache reads. Three independent bugs collude to swallow the value end-to-end (the third one only fires once the first two are fixed); this PR fixes all of them.

## Bug A — codex adapter drops the field on SendMetrics

`internal/adapter/provider/codex/adapter.go` built `AdapterMetrics` with only `InputTokens` / `OutputTokens` in both:

- `handleNonStreamResponse` (~line 415)
- `sendFinalStreamEvents` (~line 559)

The extractor already populates `Metrics.CacheReadCount` from `prompt_tokens_details.cached_tokens`, `input_tokens_details.cached_tokens`, and top-level `cache_read_input_tokens`, but the value was dropped before reaching the executor.

The Claude and custom adapters already forward every cache field; only codex was missing it.

Fix: include `CacheReadCount` in both `SendMetrics` sites. Other cache fields (creation / 5m / 1h) are Anthropic-only and the codex extractor never sets them.

## Bug B — non-streaming Codex usage misrouted in the extractor dispatcher

`extractUsageFromMap` sees a top-level `"usage"` map and calls `isOpenAIUsage` to choose between `extractOpenAIUsage` and `extractClaudeUsage`. `isOpenAIUsage` only looked for `prompt_tokens` / `completion_tokens`. The Codex / OpenAI Responses API non-stream body uses `input_tokens` / `output_tokens` at the top level (matching Claude shape) and carries cached tokens under `input_tokens_details.cached_tokens`, a key `extractClaudeUsage` does not know about. Result: even with Bug A fixed, non-streaming codex still records `CacheReadCount = 0`.

Streaming was already correct — `StreamCollector` handles `response.completed` explicitly and calls `extractOpenAIUsage` directly.

Fix: extend `isOpenAIUsage` to also route when `input_tokens_details.cached_tokens` is present. This is a sub-key Claude never emits, so its presence reliably disambiguates Codex / OpenAI Responses from Claude. The OpenAI Images API uses `input_tokens_details` with `text_tokens` / `image_tokens` (no `cached_tokens`) and is unaffected.

## Bug C — input over-billing once cache flows through

This bug only fires *after* Bugs A and B are fixed, which was caught in an adversarial review of the patch above.

Codex `usage.input_tokens` INCLUDES the cached tokens by API contract. `internal/usage/extractor.go::AdjustForClientType` exists to subtract the cached portion from `InputTokens` so pricing does not bill the cached part at both the input rate and the cache-read rate.

The `custom` and `cliproxyapi_codex` adapters already call this function before `SendMetrics` (`custom/adapter.go:494, :594`; `cliproxyapi_codex/adapter.go:325, :408`). `codex/adapter.go` did not — harmless while `CacheReadCount` was being dropped (Bug A), but with the end-to-end fix above the bare adapter would now double-bill the cached portion on every cached request.

Fix: call `usage.AdjustForClientType(metrics, domain.ClientTypeCodex)` before `SendMetrics` in both Codex sites, matching the existing convention.

## Tests added

Extractor unit tests:
- `TestExtractFromResponse_CodexResponsesAPI` — pins the dispatcher contract for a real non-streaming Codex Responses body.
- `TestAdjustForClientType_Codex` — table test for the four interesting cases: `input > cached`, `input == cached`, `cached == 0`, `input < cached` (broken relay; subtraction skipped).
- `TestAdjustForClientType_NonCodexIsNoOp` — Claude / Gemini / OpenAI client types pass through unchanged.
- `TestAdjustForClientType_NilMetricsSafe` — nil input returns nil.

Codex adapter-level tests:
- `TestHandleNonStreamResponseForwardsCacheReadCount` — drives `handleNonStreamResponse` with a Codex Responses body, asserts the emitted `AdapterMetrics` carries `CacheReadCount` and that `InputTokens` is the post-`AdjustForClientType` value.
- `TestHandleStreamResponseForwardsCacheReadCount` — drives the streaming path with an SSE that emits final usage only on `response.completed`, asserts the same.
- `TestSendFinalStreamEventsEmitsCacheOnlyMetrics` — feeds the stream finalizer a `Metrics` whose only nonzero field is `CacheReadCount`; guards against an `IsEmpty` regression that would zero cache-only events.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/adapter/provider/codex/...`
- [x] `go test -count=1 ./internal/usage/... ./internal/adapter/provider/codex/... ./internal/executor/...`
- [x] Full regression on every consumer of the extractor: `go test -count=1 ./internal/adapter/provider/{antigravity,bedrock,claude,cliproxyapi_codex,codex,custom}/... ./internal/pricing/... ./internal/usage/...` — all green
- [ ] Live verification on a server: stream a few codex requests through a sticky session, confirm `proxy_upstream_attempts.cache_read_count` becomes nonzero on the second+ requests, provider-stats UI reflects the cache reads, and per-request `input_token_count` reflects fresh input only (not fresh + cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了API调用使用指标的追踪准确性，确保缓存命中的统计数据能够正确报告和调整。

* **Tests**
  * 添加了缓存相关的使用指标测试覆盖，验证缓存读取计数和token调整的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->