### PR TITLE
feat: hide no-export provider URLs

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -977,6 +977,10 @@ func sanitizeProvider(provider *domain.Provider) *domain.Provider {
 	if config.Custom != nil {
 		custom := *config.Custom
 		custom.APIKey = ""
+		if provider.ExcludeFromExport {
+			custom.BaseURL = ""
+			custom.ClientBaseURL = nil
+		}
 		if custom.Disguise != nil {
 			disguise := *custom.Disguise
 			if disguise.ClaudeCode != nil {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -672,6 +672,9 @@ func TestSelfServiceHandler_ListProviders_MemberAllowed(t *testing.T) {
 						Custom: &domain.ProviderConfigCustom{
 							BaseURL: "https://example.com",
 							APIKey:  "secret-api-key",
+							ClientBaseURL: map[domain.ClientType]string{
+								domain.ClientTypeOpenAI: "https://openai.example.com/v1",
+							},
 						},
 					},
 				},
@@ -779,6 +782,12 @@ func TestSelfServiceHandler_GetProvider_AdminHidesExcludedProviderSecrets(t *tes
 	if provider.Config.Custom.APIKey != "" {
 		t.Fatalf("excluded provider API key leaked to admin: %+v", provider.Config.Custom)
 	}
+	if provider.Config.Custom.BaseURL != "" {
+		t.Fatalf("excluded provider base URL leaked to admin: %+v", provider.Config.Custom)
+	}
+	if len(provider.Config.Custom.ClientBaseURL) != 0 {
+		t.Fatalf("excluded provider client base URLs leaked to admin: %+v", provider.Config.Custom)
+	}
 }
 
 func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *testing.T) {
@@ -830,6 +839,68 @@ func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenSecret(t *test
 	}
 	if provider.Config.Custom.APIKey != "" {
 		t.Fatalf("update response leaked preserved API key: %+v", provider.Config.Custom)
+	}
+	if provider.Config.Custom.BaseURL != "" {
+		t.Fatalf("update response leaked hidden base URL: %+v", provider.Config.Custom)
+	}
+}
+
+func TestSelfServiceHandler_UpdateExcludedProvider_PreservesHiddenURLWhenBlank(t *testing.T) {
+	providerRepo := &selfServiceProviderRepo{
+		providers: []*domain.Provider{
+			{
+				ID:                1,
+				TenantID:          1,
+				Name:              "private-provider",
+				Type:              "custom",
+				ExcludeFromExport: true,
+				Config: &domain.ProviderConfig{
+					Custom: &domain.ProviderConfigCustom{
+						BaseURL: "https://hidden.example.com/v1",
+						APIKey:  "secret-api-key",
+						ClientBaseURL: map[domain.ClientType]string{
+							domain.ClientTypeOpenAI: "https://hidden-openai.example.com/v1",
+						},
+					},
+				},
+			},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo: providerRepo,
+		projectRepo:  &selfServiceProjectRepo{},
+	})
+
+	body := `{"name":"renamed-private-provider","type":"custom","excludeFromExport":false,"config":{"custom":{"baseURL":"","apiKey":""}},"supportedClientTypes":["openai"]}`
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPut, "/providers/1", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	stored := providerRepo.providers[0]
+	if got := stored.Config.Custom.BaseURL; got != "https://hidden.example.com/v1" {
+		t.Fatalf("stored base URL = %q, want preserved hidden URL", got)
+	}
+	if got := stored.Config.Custom.ClientBaseURL[domain.ClientTypeOpenAI]; got != "https://hidden-openai.example.com/v1" {
+		t.Fatalf("stored client base URL = %q, want preserved hidden client URL", got)
+	}
+	if !stored.ExcludeFromExport {
+		t.Fatalf("stored excludeFromExport = false, want hidden mode preserved")
+	}
+
+	var provider domain.Provider
+	if err := json.Unmarshal(rec.Body.Bytes(), &provider); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if provider.Config == nil || provider.Config.Custom == nil {
+		t.Fatalf("provider config missing: %+v", provider)
+	}
+	if provider.Config.Custom.BaseURL != "" {
+		t.Fatalf("update response leaked hidden base URL: %+v", provider.Config.Custom)
+	}
+	if len(provider.Config.Custom.ClientBaseURL) != 0 {
+		t.Fatalf("update response leaked hidden client URLs: %+v", provider.Config.Custom)
 	}
 }
 

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -187,6 +187,46 @@ func preserveExcludedProviderWriteOnlyMode(existing, incoming *domain.Provider) 
 		return
 	}
 	incoming.ExcludeFromExport = true
+	preserveEmptyExcludedProviderURLs(existing, incoming)
+}
+
+func preserveEmptyExcludedProviderURLs(existing, incoming *domain.Provider) {
+	if existing == nil || incoming == nil || existing.Config == nil || existing.Config.Custom == nil {
+		return
+	}
+	effectiveType := incoming.Type
+	if effectiveType == "" {
+		effectiveType = existing.Type
+	}
+	if effectiveType != "custom" || existing.Type != "custom" {
+		return
+	}
+	if incoming.Config == nil {
+		incoming.Config = &domain.ProviderConfig{}
+	}
+	if incoming.Config.Custom == nil {
+		custom := *existing.Config.Custom
+		incoming.Config.Custom = &custom
+		return
+	}
+
+	if incoming.Config.Custom.BaseURL == "" {
+		incoming.Config.Custom.BaseURL = existing.Config.Custom.BaseURL
+	}
+	if len(incoming.Config.Custom.ClientBaseURL) == 0 {
+		incoming.Config.Custom.ClientBaseURL = existing.Config.Custom.ClientBaseURL
+		return
+	}
+	merged := make(map[domain.ClientType]string, len(existing.Config.Custom.ClientBaseURL)+len(incoming.Config.Custom.ClientBaseURL))
+	for clientType, url := range existing.Config.Custom.ClientBaseURL {
+		merged[clientType] = url
+	}
+	for clientType, url := range incoming.Config.Custom.ClientBaseURL {
+		if url != "" {
+			merged[clientType] = url
+		}
+	}
+	incoming.Config.Custom.ClientBaseURL = merged
 }
 
 func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1324,7 +1324,9 @@
     "apiKeyEdit": "API Key (leave empty to keep current)",
     "apiKeyOptional": "API Key (optional)",
     "apiKeyExcludedHint": "This provider is set to \"Do not export this provider\". Saved API keys are not revealed on the edit page; leave this empty to keep the current key, or enter a new value to rotate it.",
+    "urlExcludedHint": "This provider is set to \"Do not export this provider\". Saved API endpoints are not revealed on the edit page; leave this empty to keep the current endpoint, or enter a new value to rotate it.",
     "keyPlaceholderWriteOnly": "Hidden; leave empty to keep the current key",
+    "endpointPlaceholderWriteOnly": "Hidden; leave empty to keep the current endpoint",
     "optionalUrlNote": "Optional if client-specific URLs are set below.",
     "namePlaceholder": "e.g. Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1338,6 +1340,7 @@
     "cloneSuffix": " (Copy)",
     "cloneSuccess": "Cloned \"{{name}}\" successfully.",
     "cloneWriteOnlyRequiresKey": "Enter a new API key before cloning this hidden-secret provider.",
+    "cloneOptions": "Clone options",
     "delete": "Delete",
     "cancel": "Cancel",
     "none": "None",
@@ -1354,7 +1357,8 @@
     "responsesPassthrough": "Passthrough Responses Path",
     "responsesPassthroughDesc": "For Codex Responses requests, forward the client's original path (e.g. /v1/responses) instead of a hardcoded /responses. Turn off only for upstreams that expect /responses, or when the Base URL already ends with /v1.",
     "excludeFromExport": "Do not export this provider",
-    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved provider secrets will not be revealed on the edit page. Enter a new value to rotate a secret.",
+    "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved API endpoints and provider secrets will not be revealed on the edit page. Enter a new value to rotate one.",
+    "cloneExcludeFromExportDesc": "Applies only to the newly cloned provider. When enabled, the clone will not be exported, and saved API endpoints and provider secrets will not be revealed on the edit page.",
     "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly."
   },
   "cooldown": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1323,7 +1323,9 @@
     "apiKeyEdit": "API 密钥（留空保持当前值）",
     "apiKeyOptional": "API 密钥（可选）",
     "apiKeyExcludedHint": "该提供商已设置为“不导出此提供商配置”。已保存的 API 密钥不会在编辑页回显；留空保存会保持当前密钥，输入新值则轮换。",
+    "urlExcludedHint": "该提供商已设置为“不导出此提供商配置”。已保存的 API 端点不会在编辑页回显；留空保存会保持当前端点，输入新值则轮换。",
     "keyPlaceholderWriteOnly": "已隐藏，留空保持当前密钥",
+    "endpointPlaceholderWriteOnly": "已隐藏，留空保持当前端点",
     "optionalUrlNote": "如果下面设置了客户端特定的 URL，则此项为可选。",
     "namePlaceholder": "例如：Production OpenAI",
     "endpointPlaceholder": "https://api.openai.com/v1",
@@ -1337,6 +1339,7 @@
     "cloneSuffix": "（副本）",
     "cloneSuccess": "已成功克隆「{{name}}」。",
     "cloneWriteOnlyRequiresKey": "克隆该隐藏密钥提供商前，请先输入新的 API 密钥。",
+    "cloneOptions": "克隆选项",
     "delete": "删除",
     "cancel": "取消",
     "none": "无",
@@ -1353,7 +1356,8 @@
     "responsesPassthrough": "透传 Responses 路径",
     "responsesPassthroughDesc": "Codex Responses 请求按客户端原始路径转发（如 /v1/responses），而不是硬编码 /responses。仅当上游只认 /responses、或 Base URL 已自带 /v1 时才需要关闭。",
     "excludeFromExport": "不导出此提供商配置",
-    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的提供商密钥也不会在编辑页回显，只能重新输入轮换。",
+    "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的 API 端点和提供商密钥也不会在编辑页回显，只能重新输入轮换。",
+    "cloneExcludeFromExportDesc": "仅用于新克隆出的提供商。开启后，克隆出的提供商不会被导出，且保存后的 API 端点和提供商密钥不会在编辑页回显。",
     "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。"
   },
   "cooldown": {

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -429,7 +429,7 @@ type EditFormData = {
   cloakSensitiveWords?: string;
   responseModelMapping: Record<string, string>;
   disableErrorCooldown?: boolean;
-  excludeFromExport?: boolean;
+  cloneExcludeFromExport?: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。
   responsesPassthrough?: boolean;
 };
@@ -453,7 +453,9 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     const supportedTypes = provider.supportedClientTypes || [];
     return defaultClients.map((client) => {
       const isEnabled = supportedTypes.includes(client.id);
-      const urlOverride = provider.config?.custom?.clientBaseURL?.[client.id] || '';
+      const urlOverride = provider.excludeFromExport
+        ? ''
+        : provider.config?.custom?.clientBaseURL?.[client.id] || '';
       const multiplier = provider.config?.custom?.clientMultiplier?.[client.id] || 10000;
       return { ...client, enabled: isEnabled, urlOverride, multiplier };
     });
@@ -480,9 +482,9 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     const cc = disguise?.claudeCode ?? legacyCloak;
     return {
       name: provider.name,
-      baseURL: provider.config?.custom?.baseURL || '',
+      baseURL: provider.excludeFromExport ? '' : provider.config?.custom?.baseURL || '',
       backend: provider.config?.custom?.backend === 'ollama' ? 'ollama' : 'http',
-      apiKey: provider.config?.custom?.apiKey || '',
+      apiKey: provider.excludeFromExport ? '' : provider.config?.custom?.apiKey || '',
       clients: initClients(),
       supportModels: provider.supportModels || [],
       disguiseType,
@@ -491,11 +493,11 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       cloakSensitiveWords: (cc?.sensitiveWords || []).join('\n'),
       responseModelMapping: provider.config?.custom?.responseModelMapping || {},
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
-      excludeFromExport: !!provider.excludeFromExport,
+      cloneExcludeFromExport: !!provider.excludeFromExport,
       responsesPassthrough: provider.config?.custom?.responsesPassthrough,
     };
   });
-  const secretsAreWriteOnly = !!provider.excludeFromExport || !!formData.excludeFromExport;
+  const providerConfigIsWriteOnly = !!provider.excludeFromExport;
 
   const updateClient = (clientId: ClientType, updates: Partial<ClientConfig>) => {
     setFormData((prev) => ({
@@ -504,12 +506,19 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     }));
   };
 
-  const isValid = () => {
+  const hasVisibleURL = () =>
+    formData.baseURL.trim() || formData.clients.some((c) => c.enabled && c.urlOverride.trim());
+
+  const isSaveValid = () => {
     if (!formData.name.trim()) return false;
     const hasEnabledClient = formData.clients.some((c) => c.enabled);
-    const hasUrl =
-      formData.baseURL.trim() || formData.clients.some((c) => c.enabled && c.urlOverride.trim());
-    return hasEnabledClient && hasUrl;
+    return hasEnabledClient && (providerConfigIsWriteOnly || !!hasVisibleURL());
+  };
+
+  const isCloneValid = () => {
+    if (!formData.name.trim()) return false;
+    const hasEnabledClient = formData.clients.some((c) => c.enabled);
+    return hasEnabledClient && !!hasVisibleURL();
   };
 
   // Build the disguise payload from current form state. Delegates to the
@@ -524,7 +533,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     );
 
   const handleSave = async () => {
-    if (!isValid()) return;
+    if (!isSaveValid()) return;
 
     setSaving(true);
     setSaveStatus('idle');
@@ -564,7 +573,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         },
         supportedClientTypes,
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
-        excludeFromExport: !!formData.excludeFromExport,
+        excludeFromExport: !!provider.excludeFromExport,
       };
 
       await updateProvider.mutateAsync({ id: Number(provider.id), data });
@@ -579,10 +588,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
   };
 
   const handleClone = async () => {
-    if (!isValid() || cloning) return;
+    if (!isCloneValid() || cloning) return;
 
     setCloneError(null);
-    if (secretsAreWriteOnly && !formData.apiKey.trim()) {
+    if (providerConfigIsWriteOnly && !formData.apiKey.trim()) {
       setCloneError(t('provider.cloneWriteOnlyRequiresKey'));
       return;
     }
@@ -617,7 +626,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
             apiKey:
               formData.apiKey.trim() ||
-              (secretsAreWriteOnly ? '' : provider.config?.custom?.apiKey) ||
+              (providerConfigIsWriteOnly ? '' : provider.config?.custom?.apiKey) ||
               '',
             responsesPassthrough: formData.responsesPassthrough,
             clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
@@ -632,7 +641,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         },
         supportedClientTypes,
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
-        excludeFromExport: !!formData.excludeFromExport,
+        excludeFromExport: !!formData.cloneExcludeFromExport,
       };
 
       const newProvider = await createProvider.mutateAsync(data);
@@ -794,7 +803,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         </Button>
         <Button
           onClick={handleClone}
-          disabled={cloning || saving || !isValid()}
+          disabled={cloning || saving || !isCloneValid()}
           variant={'outline'}
         >
           <Copy size={14} />
@@ -803,7 +812,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         <Button onClick={onClose} variant={'secondary'}>
           {t('provider.cancel')}
         </Button>
-        <Button onClick={handleSave} disabled={saving || !isValid()} variant={'default'}>
+        <Button onClick={handleSave} disabled={saving || !isSaveValid()} variant={'default'}>
           {saving ? (
             t('common.saving')
           ) : saveStatus === 'success' ? (
@@ -884,11 +893,17 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                         baseURL: e.target.value,
                       }))
                     }
-                    placeholder={t('provider.endpointPlaceholder')}
+                    placeholder={
+                      providerConfigIsWriteOnly
+                        ? t('provider.endpointPlaceholderWriteOnly')
+                        : t('provider.endpointPlaceholder')
+                    }
                     className="w-full"
                   />
                   <p className="text-xs text-muted-foreground mt-1">
-                    {t('provider.optionalUrlNote')}
+                    {providerConfigIsWriteOnly
+                      ? t('provider.urlExcludedHint')
+                      : t('provider.optionalUrlNote')}
                   </p>
                 </div>
 
@@ -905,14 +920,14 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                   </label>
                   <div className="relative">
                     <Input
-                      type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
+                      type={showApiKey && !providerConfigIsWriteOnly ? 'text' : 'password'}
                       value={formData.apiKey}
                       onChange={(e) => {
                         setCloneError(null);
                         setFormData((prev) => ({ ...prev, apiKey: e.target.value }));
                       }}
                       placeholder={
-                        secretsAreWriteOnly
+                        providerConfigIsWriteOnly
                           ? t('provider.keyPlaceholderWriteOnly')
                           : formData.backend === 'ollama'
                             ? t('provider.keyPlaceholderOptional')
@@ -920,7 +935,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                       }
                       className="w-full pr-10"
                     />
-                    {!secretsAreWriteOnly && (
+                    {!providerConfigIsWriteOnly && (
                       <button
                         type="button"
                         onClick={() => setShowApiKey(!showApiKey)}
@@ -931,7 +946,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                       </button>
                     )}
                   </div>
-                  {secretsAreWriteOnly && (
+                  {providerConfigIsWriteOnly && (
                     <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
                       {t('provider.apiKeyExcludedHint')}
                     </div>
@@ -1012,24 +1027,21 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
 
           <div className="space-y-6">
             <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
-              {t('provider.excludeFromExport')}
+              {t('provider.cloneOptions')}
             </h3>
             <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
               <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.excludeFromExport')}
+                </div>
                 <p className="text-xs text-muted-foreground mt-1">
-                  {t('provider.excludeFromExportDesc')}
+                  {t('provider.cloneExcludeFromExportDesc')}
                 </p>
-                {provider.excludeFromExport && (
-                  <p className="text-xs text-muted-foreground mt-2">
-                    {t('provider.excludeFromExportLockedDesc')}
-                  </p>
-                )}
               </div>
               <Switch
-                checked={!!formData.excludeFromExport}
-                disabled={!!provider.excludeFromExport}
+                checked={!!formData.cloneExcludeFromExport}
                 onCheckedChange={(checked) =>
-                  setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
+                  setFormData((prev) => ({ ...prev, cloneExcludeFromExport: checked }))
                 }
               />
             </div>


### PR DESCRIPTION
## Summary
- add write-only handling for providers marked `excludeFromExport`, hiding saved base URLs, client-specific URLs, and API keys from admin responses
- preserve the hidden provider URL/key when editing with blank values, and keep `excludeFromExport` irreversible for existing hidden providers
- move the edit-page switch to clone-only options while keeping the create-page switch, with updated Chinese/English copy

## Verification
- `go test ./...`
- `pnpm --dir web typecheck`
- `pnpm --dir web test`
- `pnpm --dir web build`
- `pnpm --dir web lint`

## UI evidence
- Create page shows the no-export switch
- Edit page hides excluded provider endpoint/key and keeps clone-only no-export option


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 增强了被排除导出的提供商配置的数据保护，确保相关 URL 和敏感信息不会在编辑或克隆时意外泄露。

* **Documentation**
  * 更新了中英文界面文案，新增关于排除导出、写入隐藏和克隆选项的提示说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->