### PR TITLE
fix: stop no-export clone state propagation

### DIFF
--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -429,7 +429,6 @@ type EditFormData = {
   cloakSensitiveWords?: string;
   responseModelMapping: Record<string, string>;
   disableErrorCooldown?: boolean;
-  cloneExcludeFromExport?: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。
   responsesPassthrough?: boolean;
 };
@@ -493,7 +492,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       cloakSensitiveWords: (cc?.sensitiveWords || []).join('\n'),
       responseModelMapping: provider.config?.custom?.responseModelMapping || {},
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
-      cloneExcludeFromExport: !!provider.excludeFromExport,
       responsesPassthrough: provider.config?.custom?.responsesPassthrough,
     };
   });
@@ -641,7 +639,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         },
         supportedClientTypes,
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
-        excludeFromExport: !!formData.cloneExcludeFromExport,
       };
 
       const newProvider = await createProvider.mutateAsync(data);
@@ -1025,27 +1022,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
             </div>
           </div>
 
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
-              {t('provider.cloneOptions')}
-            </h3>
-            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-              <div className="pr-4">
-                <div className="text-sm font-medium text-foreground">
-                  {t('provider.excludeFromExport')}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t('provider.cloneExcludeFromExportDesc')}
-                </p>
-              </div>
-              <Switch
-                checked={!!formData.cloneExcludeFromExport}
-                onCheckedChange={(checked) =>
-                  setFormData((prev) => ({ ...prev, cloneExcludeFromExport: checked }))
-                }
-              />
-            </div>
-          </div>
 
           {/* Provider Supported Models Filter */}
           <ProviderSupportModels


### PR DESCRIPTION
## Summary
- remove the no-export state from the provider clone flow
- remove the edit-page clone/no-export switch block that made the clone-only value look like an editable provider setting
- keep the already-merged create-time no-export behavior and hidden URL/key handling unchanged

## Verification
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web test`
- `pnpm --dir web build`

## Notes
This force-push replaces the previous Clone dialog direction. Clone should not introduce or persist a separate no-export state; the clone request now omits `excludeFromExport` instead of writing clone-specific state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 提供商编辑表单增加敏感词脱敏、响应模型映射和错误冷却禁用等配置选项。

* **用户界面变化**
  * 简化提供商克隆流程，移除导出排除项的手动选择功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->