### PR TITLE
fix(codex): scope in-stream error events, don't freeze the whole provider

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -534,14 +534,26 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 			// frozen along with the failing one. Anything we can't classify
 			// confidently keeps the conservative ScopeProvider fallback.
 			if scope, reason, ok := classifyCodexStreamError(lastStreamErr); ok {
-				proxyErr.Scope = scope
-				proxyErr.Reason = reason
 				if scope == domain.ScopeModel {
 					proxyErr.Model = lastStreamErr.model
 					if proxyErr.Model == "" {
 						proxyErr.Model = model
 					}
+					if proxyErr.Model == "" {
+						proxyErr.Model = flow.GetMappedModel(c)
+					}
+					// Without a model to attribute, ScopeModel would collapse
+					// to a (provider,"","") cooldown key — i.e. provider-wide —
+					// defeating the point of refining the scope. Fall back to
+					// the conservative ScopeProvider in that case.
+					if proxyErr.Model == "" {
+						proxyErr.Scope = domain.ScopeProvider
+						proxyErr.Reason = domain.CooldownReasonNetworkError
+						return proxyErr
+					}
 				}
+				proxyErr.Scope = scope
+				proxyErr.Reason = reason
 			} else {
 				proxyErr.Scope = domain.ScopeProvider
 				proxyErr.Reason = domain.CooldownReasonNetworkError

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -459,6 +459,7 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 	// Incrementally extract metrics and model from SSE lines (no full-stream buffering)
 	var collector usage.StreamCollector
 	var model string
+	var lastStreamErr *codexStreamError
 	reader := bufio.NewReader(resp.Body)
 	firstChunkSent := false
 	responseCompleted := false
@@ -488,6 +489,10 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 
 			if isCodexResponseCompletedLine(line) {
 				responseCompleted = true
+			}
+
+			if e := parseCodexStreamErrorLine(line); e != nil {
+				lastStreamErr = e
 			}
 
 			// Write to client
@@ -523,8 +528,24 @@ func (a *CodexAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response) er
 				return proxyErr
 			}
 			proxyErr := domain.NewProxyErrorWithMessage(err, true, "stream closed before response.completed")
-			proxyErr.Scope = domain.ScopeProvider
-			proxyErr.Reason = domain.CooldownReasonNetworkError
+			// If the upstream emitted a structured error event in the stream
+			// (e.g. response.failed with code=model_not_supported), narrow the
+			// cooldown scope so an unrelated model on the same provider is not
+			// frozen along with the failing one. Anything we can't classify
+			// confidently keeps the conservative ScopeProvider fallback.
+			if scope, reason, ok := classifyCodexStreamError(lastStreamErr); ok {
+				proxyErr.Scope = scope
+				proxyErr.Reason = reason
+				if scope == domain.ScopeModel {
+					proxyErr.Model = lastStreamErr.model
+					if proxyErr.Model == "" {
+						proxyErr.Model = model
+					}
+				}
+			} else {
+				proxyErr.Scope = domain.ScopeProvider
+				proxyErr.Reason = domain.CooldownReasonNetworkError
+			}
 			return proxyErr
 		}
 	}

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -338,6 +338,70 @@ func TestHandleStreamResponseScopesModelOnInStreamModelError(t *testing.T) {
 	}
 }
 
+// TestHandleStreamResponseScopesModelOnFastAPIDetail covers the observed
+// ChatGPT-account Codex shape: a single SSE event with no `type` field and a
+// `detail` message naming the unsupported model. The error event itself
+// carries no model field, so the adapter must attribute the model from the
+// flow context's mapped model.
+func TestHandleStreamResponseScopesModelOnFastAPIDetail(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyMappedModel, "gpt-5.5-codex")
+
+	stream := `data: {"detail":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}` + "\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeModel {
+		t.Errorf("Scope = %q, want %q", proxyErr.Scope, domain.ScopeModel)
+	}
+	if proxyErr.Model != "gpt-5.5-codex" {
+		t.Errorf("Model = %q, want %q (must attribute from flow context when error event lacks model)", proxyErr.Model, "gpt-5.5-codex")
+	}
+}
+
+// TestHandleStreamResponseDowngradesToProviderWhenModelUnattributable guards
+// the safety net: if classifyCodexStreamError returns ScopeModel but no model
+// can be attributed from anywhere, ScopeModel with empty Model would collapse
+// to a (provider, "", "") cooldown key — i.e. provider-wide — defeating the
+// scope refinement. The adapter must fall back to the explicit ScopeProvider.
+func TestHandleStreamResponseDowngradesToProviderWhenModelUnattributable(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	// Deliberately do not set KeyMappedModel.
+
+	stream := `data: {"detail":"unknown model"}` + "\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Errorf("Scope = %q, want %q (unattributable model should not emit ScopeModel)", proxyErr.Scope, domain.ScopeProvider)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Errorf("Reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonNetworkError)
+	}
+}
+
 // TestHandleStreamResponseKeepsProviderScopeWithoutErrorEvent guards the
 // fallback: a stream that closes without ANY structured error signal should
 // still cool down the whole provider so genuine outages keep tripping the

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -295,6 +295,82 @@ func TestHandleStreamResponseReturnsProviderErrorOnReadErrorBeforeCompleted(t *t
 	}
 }
 
+// TestHandleStreamResponseScopesModelOnInStreamModelError exercises the path
+// where the upstream emits a structured "model not supported" event and then
+// closes the stream without response.completed. Without scope refinement the
+// adapter would freeze the entire provider; with it, only the failing model
+// should be cooled down.
+func TestHandleStreamResponseScopesModelOnInStreamModelError(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+
+	// Real-world shape observed for ChatGPT-account Codex on unsupported models:
+	// upstream returns 200 OK, sends an error event, then EOFs.
+	stream := strings.Join([]string{
+		`data: {"type":"response.created","response":{"model":"gpt-5.5-codex"}}`,
+		`data: {"type":"response.failed","response":{"model":"gpt-5.5-codex","error":{"code":"model_not_supported","message":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}}}`,
+		``,
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	if err == nil {
+		t.Fatal("expected stream close without response.completed to return error")
+	}
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeModel {
+		t.Errorf("Scope = %q, want %q (in-stream model error should narrow scope)", proxyErr.Scope, domain.ScopeModel)
+	}
+	if proxyErr.Reason != domain.CooldownReasonModelUnavailable {
+		t.Errorf("Reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonModelUnavailable)
+	}
+	if proxyErr.Model != "gpt-5.5-codex" {
+		t.Errorf("Model = %q, want %q", proxyErr.Model, "gpt-5.5-codex")
+	}
+}
+
+// TestHandleStreamResponseKeepsProviderScopeWithoutErrorEvent guards the
+// fallback: a stream that closes without ANY structured error signal should
+// still cool down the whole provider so genuine outages keep tripping the
+// wider cooldown.
+func TestHandleStreamResponseKeepsProviderScopeWithoutErrorEvent(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+
+	stream := `data: {"type":"response.output_text.delta","delta":"hello"}` + "\n"
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(stream)),
+	}
+
+	err := a.handleStreamResponse(ctx, resp)
+	if err == nil {
+		t.Fatal("expected error for incomplete stream")
+	}
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("expected ProxyError, got %T", err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Errorf("Scope = %q, want %q (no error event → provider-wide fallback)", proxyErr.Scope, domain.ScopeProvider)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Errorf("Reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonNetworkError)
+	}
+}
+
 func TestHandleStreamResponseAllowsCompletedStreamWithoutTrailingNewline(t *testing.T) {
 	a := &CodexAdapter{}
 	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)

--- a/internal/adapter/provider/codex/classify.go
+++ b/internal/adapter/provider/codex/classify.go
@@ -80,8 +80,8 @@ func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.Co
 	for _, p := range []string{
 		"model is not supported",
 		"model not supported",
+		"model is not available",
 		"model not available",
-		"is not available",
 		"no access to the model",
 		"does not have access to model",
 		"unknown model",

--- a/internal/adapter/provider/codex/classify.go
+++ b/internal/adapter/provider/codex/classify.go
@@ -93,7 +93,7 @@ func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.Co
 	}
 
 	// Key-level: bad token / account scope, no point retrying on the same key.
-	if code == "invalid_api_key" || code == "unauthorized" {
+	if code == "invalid_api_key" || code == "unauthorized" || code == "permission_denied" {
 		return domain.ScopeKey, domain.CooldownReasonAuthFailure, true
 	}
 	for _, p := range []string{
@@ -110,7 +110,7 @@ func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.Co
 	if code == "rate_limit_exceeded" || strings.Contains(msg, "rate limit") {
 		return domain.ScopeKey, domain.CooldownReasonRateLimitExceeded, true
 	}
-	if code == "insufficient_quota" {
+	if code == "insufficient_quota" || code == "billing_hard_limit_reached" {
 		return domain.ScopeKey, domain.CooldownReasonQuotaExhausted, true
 	}
 	for _, p := range []string{

--- a/internal/adapter/provider/codex/classify.go
+++ b/internal/adapter/provider/codex/classify.go
@@ -1,0 +1,118 @@
+package codex
+
+import (
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+// codexStreamError holds an SSE-emitted error signal we observed during the
+// Responses API stream. Used to refine the scope of a "stream closed before
+// response.completed" failure: an in-band model_not_supported event should
+// freeze only that model, not the whole provider.
+type codexStreamError struct {
+	typeStr string
+	code    string
+	message string
+	model   string // upstream-reported model when the event carries it
+}
+
+// parseCodexStreamErrorLine inspects a single SSE line and returns a captured
+// error if the line is a structured error event. Other lines return nil.
+//
+// Handles three observed wire shapes:
+//   - Responses API: data: {"type":"response.failed","response":{"error":{"code":...,"message":...}}}
+//   - Generic SSE error: data: {"type":"error","code":...,"message":...}
+//   - FastAPI-style detail: data: {"detail":"..."} (no type) — seen on
+//     "model not supported when using Codex with a ChatGPT account"
+func parseCodexStreamErrorLine(line string) *codexStreamError {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "data:") {
+		return nil
+	}
+	data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+	if data == "" || data == "[DONE]" || !gjson.Valid(data) {
+		return nil
+	}
+
+	switch t := gjson.Get(data, "type").String(); t {
+	case "response.failed", "response.error":
+		return &codexStreamError{
+			typeStr: t,
+			code:    gjson.Get(data, "response.error.code").String(),
+			message: gjson.Get(data, "response.error.message").String(),
+			model:   gjson.Get(data, "response.model").String(),
+		}
+	case "error":
+		return &codexStreamError{
+			typeStr: t,
+			code:    gjson.Get(data, "code").String(),
+			message: gjson.Get(data, "message").String(),
+			model:   gjson.Get(data, "model").String(),
+		}
+	case "":
+		if detail := gjson.Get(data, "detail").String(); detail != "" {
+			return &codexStreamError{message: detail}
+		}
+	}
+	return nil
+}
+
+// classifyCodexStreamError maps a captured error event to a refined
+// (scope, reason). Returns ok=false when the event does not match any known
+// signal — the caller should keep the default ScopeProvider/NetworkError.
+//
+// Patterns are kept narrow on purpose: only classify when the upstream's
+// signal is unambiguous. Anything we can't read confidently stays at
+// ScopeProvider so genuine outages still trip the wider cooldown.
+func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.CooldownReason, bool) {
+	if e == nil {
+		return "", "", false
+	}
+	code := strings.ToLower(e.code)
+	msg := strings.ToLower(e.message)
+
+	// Model-level: do not freeze unrelated models on the same provider.
+	if code == "model_not_found" || code == "model_not_supported" {
+		return domain.ScopeModel, domain.CooldownReasonModelUnavailable, true
+	}
+	for _, p := range []string{
+		"model is not supported",
+		"model not supported",
+		"model not available",
+		"is not available",
+		"no access to the model",
+		"does not have access to model",
+		"unknown model",
+		"model_not_found",
+	} {
+		if strings.Contains(msg, p) {
+			return domain.ScopeModel, domain.CooldownReasonModelUnavailable, true
+		}
+	}
+
+	// Key-level: bad token / account scope, no point retrying on the same key.
+	if code == "invalid_api_key" || code == "unauthorized" {
+		return domain.ScopeKey, domain.CooldownReasonAuthFailure, true
+	}
+	for _, p := range []string{
+		"invalid api key",
+		"unauthorized",
+		"authentication failed",
+	} {
+		if strings.Contains(msg, p) {
+			return domain.ScopeKey, domain.CooldownReasonAuthFailure, true
+		}
+	}
+
+	// Rate-limit / quota: short cooldown per key.
+	if code == "rate_limit_exceeded" || strings.Contains(msg, "rate limit") {
+		return domain.ScopeKey, domain.CooldownReasonRateLimitExceeded, true
+	}
+	if code == "insufficient_quota" || strings.Contains(msg, "quota") {
+		return domain.ScopeKey, domain.CooldownReasonQuotaExhausted, true
+	}
+
+	return "", "", false
+}

--- a/internal/adapter/provider/codex/classify.go
+++ b/internal/adapter/provider/codex/classify.go
@@ -84,8 +84,8 @@ func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.Co
 		"model not available",
 		"no access to the model",
 		"does not have access to model",
-		"unknown model",
 		"model_not_found",
+		"does not exist or you do not have access",
 	} {
 		if strings.Contains(msg, p) {
 			return domain.ScopeModel, domain.CooldownReasonModelUnavailable, true
@@ -110,8 +110,20 @@ func classifyCodexStreamError(e *codexStreamError) (domain.ErrorScope, domain.Co
 	if code == "rate_limit_exceeded" || strings.Contains(msg, "rate limit") {
 		return domain.ScopeKey, domain.CooldownReasonRateLimitExceeded, true
 	}
-	if code == "insufficient_quota" || strings.Contains(msg, "quota") {
+	if code == "insufficient_quota" {
 		return domain.ScopeKey, domain.CooldownReasonQuotaExhausted, true
+	}
+	for _, p := range []string{
+		"insufficient quota",
+		"quota exceeded",
+		"exceeded your current quota",
+		"exceeded your quota",
+		"out of quota",
+		"exhausted your quota",
+	} {
+		if strings.Contains(msg, p) {
+			return domain.ScopeKey, domain.CooldownReasonQuotaExhausted, true
+		}
 	}
 
 	return "", "", false

--- a/internal/adapter/provider/codex/classify_test.go
+++ b/internal/adapter/provider/codex/classify_test.go
@@ -178,6 +178,20 @@ func TestClassifyCodexStreamError(t *testing.T) {
 			wantOK:     true,
 		},
 		{
+			name:       "permission_denied by code",
+			err:        &codexStreamError{code: "permission_denied"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonAuthFailure,
+			wantOK:     true,
+		},
+		{
+			name:       "billing hard limit by code",
+			err:        &codexStreamError{code: "billing_hard_limit_reached"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonQuotaExhausted,
+			wantOK:     true,
+		},
+		{
 			name:   "unrecognized error stays unclassified",
 			err:    &codexStreamError{code: "weird_thing", message: "something went wrong"},
 			wantOK: false,

--- a/internal/adapter/provider/codex/classify_test.go
+++ b/internal/adapter/provider/codex/classify_test.go
@@ -1,0 +1,182 @@
+package codex
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestParseCodexStreamErrorLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantNil  bool
+		wantType string
+		wantCode string
+		wantMsg  string
+	}{
+		{
+			name:     "response.failed with nested error",
+			line:     `data: {"type":"response.failed","response":{"error":{"code":"model_not_supported","message":"gpt-5.5-codex is not supported"}}}`,
+			wantType: "response.failed",
+			wantCode: "model_not_supported",
+			wantMsg:  "gpt-5.5-codex is not supported",
+		},
+		{
+			name:     "response.error with nested error",
+			line:     `data: {"type":"response.error","response":{"error":{"code":"rate_limit_exceeded","message":"slow down"}}}`,
+			wantType: "response.error",
+			wantCode: "rate_limit_exceeded",
+			wantMsg:  "slow down",
+		},
+		{
+			name:     "generic error event",
+			line:     `data: {"type":"error","code":"insufficient_quota","message":"out of credit"}`,
+			wantType: "error",
+			wantCode: "insufficient_quota",
+			wantMsg:  "out of credit",
+		},
+		{
+			name:    "fastapi detail without type",
+			line:    `data: {"detail":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}`,
+			wantMsg: "The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account.",
+		},
+		{
+			name:    "non-error event ignored",
+			line:    `data: {"type":"response.output_text.delta","delta":"hello"}`,
+			wantNil: true,
+		},
+		{
+			name:    "completed event ignored",
+			line:    `data: {"type":"response.completed","response":{}}`,
+			wantNil: true,
+		},
+		{
+			name:    "DONE marker",
+			line:    `data: [DONE]`,
+			wantNil: true,
+		},
+		{
+			name:    "non-data line",
+			line:    `event: response.failed`,
+			wantNil: true,
+		},
+		{
+			name:    "invalid JSON",
+			line:    `data: not json`,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCodexStreamErrorLine(tt.line)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil")
+			}
+			if got.typeStr != tt.wantType {
+				t.Errorf("type = %q, want %q", got.typeStr, tt.wantType)
+			}
+			if got.code != tt.wantCode {
+				t.Errorf("code = %q, want %q", got.code, tt.wantCode)
+			}
+			if got.message != tt.wantMsg {
+				t.Errorf("message = %q, want %q", got.message, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestClassifyCodexStreamError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        *codexStreamError
+		wantScope  domain.ErrorScope
+		wantReason domain.CooldownReason
+		wantOK     bool
+	}{
+		{
+			name:   "nil event",
+			err:    nil,
+			wantOK: false,
+		},
+		{
+			name:       "model_not_supported by code",
+			err:        &codexStreamError{code: "model_not_supported"},
+			wantScope:  domain.ScopeModel,
+			wantReason: domain.CooldownReasonModelUnavailable,
+			wantOK:     true,
+		},
+		{
+			name:       "ChatGPT-account model error by message",
+			err:        &codexStreamError{message: "The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."},
+			wantScope:  domain.ScopeModel,
+			wantReason: domain.CooldownReasonModelUnavailable,
+			wantOK:     true,
+		},
+		{
+			name:       "unknown model by message",
+			err:        &codexStreamError{message: "Unknown model: foobar"},
+			wantScope:  domain.ScopeModel,
+			wantReason: domain.CooldownReasonModelUnavailable,
+			wantOK:     true,
+		},
+		{
+			name:       "rate limit",
+			err:        &codexStreamError{code: "rate_limit_exceeded"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonRateLimitExceeded,
+			wantOK:     true,
+		},
+		{
+			name:       "rate limit by message",
+			err:        &codexStreamError{message: "You hit the rate limit, retry later"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonRateLimitExceeded,
+			wantOK:     true,
+		},
+		{
+			name:       "quota exhausted",
+			err:        &codexStreamError{code: "insufficient_quota"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonQuotaExhausted,
+			wantOK:     true,
+		},
+		{
+			name:       "auth failure by code",
+			err:        &codexStreamError{code: "invalid_api_key"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonAuthFailure,
+			wantOK:     true,
+		},
+		{
+			name:   "unrecognized error stays unclassified",
+			err:    &codexStreamError{code: "weird_thing", message: "something went wrong"},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope, reason, ok := classifyCodexStreamError(tt.err)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if scope != tt.wantScope {
+				t.Errorf("scope = %q, want %q", scope, tt.wantScope)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tt.wantReason)
+			}
+		})
+	}
+}

--- a/internal/adapter/provider/codex/classify_test.go
+++ b/internal/adapter/provider/codex/classify_test.go
@@ -121,10 +121,32 @@ func TestClassifyCodexStreamError(t *testing.T) {
 			wantOK:     true,
 		},
 		{
-			name:       "unknown model by message",
-			err:        &codexStreamError{message: "Unknown model: foobar"},
+			name:       "openai model-does-not-exist message",
+			err:        &codexStreamError{message: "The model `foobar` does not exist or you do not have access to it"},
 			wantScope:  domain.ScopeModel,
 			wantReason: domain.CooldownReasonModelUnavailable,
+			wantOK:     true,
+		},
+		{
+			// Guard against the previous over-broad "unknown model" pattern:
+			// a tool/function-argument validation message that happens to
+			// mention "unknown model" should NOT cool a working model down.
+			name:   "tool validation mentioning unknown model is not a model cooldown",
+			err:    &codexStreamError{message: "function_call: unknown model parameter in tool spec"},
+			wantOK: false,
+		},
+		{
+			// Guard against the previous over-broad bare "quota" substring:
+			// a per-conversation budget message should NOT cool the key down.
+			name:   "conversation context quota is not a key cooldown",
+			err:    &codexStreamError{message: "context quota for this conversation exceeded"},
+			wantOK: false,
+		},
+		{
+			name:       "openai quota-exceeded message",
+			err:        &codexStreamError{message: "You exceeded your current quota, please check your plan"},
+			wantScope:  domain.ScopeKey,
+			wantReason: domain.CooldownReasonQuotaExhausted,
 			wantOK:     true,
 		},
 		{


### PR DESCRIPTION
## Summary

A request to an unsupported model on a ChatGPT-account-backed Codex provider freezes the entire provider for the cooldown window, even though the provider is healthy. Observed on a live setup where `gpt-5.5-codex` is rejected by ChatGPT-account Codex and the upstream returns:

```
{"detail":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}
```

For ~5 minutes afterward, the affected provider returns "no routes available" for *every* model, not just the rejected one. With two providers both on ChatGPT accounts (a common dual-account setup), both freeze simultaneously and all codex traffic dies.

## Root cause

The Codex Responses API returns 200 OK, emits a structured error event (e.g. `response.failed` with `code=model_not_supported`), and closes the stream. `handleStreamResponse` only watches for `response.completed` and hits the catch-all "stream closed before response.completed" path at `internal/adapter/provider/codex/adapter.go:525-528`, which sets `ScopeProvider + CooldownReasonNetworkError` unconditionally.

The status-code → scope mapping for non-stream responses already has nuanced logic (404 + `model` keyword → `ScopeModel`; 503 + `overloaded`/`model` → `ScopeModel`). The streaming-error path didn't.

## Change

Track the last structured error event observed during the SSE loop. On stream-close-without-completed, `classifyCodexStreamError` maps known signals to narrower scopes; anything not classified keeps the conservative `ScopeProvider + NetworkError` default so genuine outages still trip the wider cooldown.

| Signal | Scope | Reason |
|---|---|---|
| `model_not_supported` / `model_not_found` / "model is not supported" / "model not available" / "no access to the model" / "does not have access to model" / "unknown model" | `ScopeModel` | `ModelUnavailable` |
| `invalid_api_key` / "unauthorized" / "authentication failed" | `ScopeKey` | `AuthFailure` |
| `rate_limit_exceeded` / "rate limit" | `ScopeKey` | `RateLimitExceeded` |
| `insufficient_quota` / "quota" | `ScopeKey` | `QuotaExhausted` |
| unrecognized | `ScopeProvider` | `NetworkError` (unchanged) |

When a captured event narrows to `ScopeModel`, the model name is taken from the event itself (`response.failed.response.model` or `error.model`) since `extractModelFromSSELine` only reads top-level `model` and would miss the nested Responses API shape.

## Tests added

- `TestParseCodexStreamErrorLine` — three wire shapes (`response.failed` / `response.error`, generic `error`, FastAPI-style `detail`) plus non-error events / `[DONE]` / non-data / invalid JSON.
- `TestClassifyCodexStreamError` — table test covering each classification branch including "unrecognized stays unclassified".
- `TestHandleStreamResponseScopesModelOnInStreamModelError` — drives the real wire shape end-to-end and asserts `ScopeModel + ModelUnavailable + Model = gpt-5.5-codex`.
- `TestHandleStreamResponseKeepsProviderScopeWithoutErrorEvent` — guards the conservative fallback for unknown stream truncation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/adapter/provider/codex/...`
- [x] `go test -count=1 ./internal/adapter/provider/codex/... ./internal/executor/... ./internal/cooldown/...` — all green
- [ ] Live verification: stream a request for an unsupported model, confirm only that model is cooled down (other models on the same provider keep serving) and that the cooldown row carries the model name + `model_unavailable` reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改进

* **Bug 修复**
  * 增强了流式 API 错误检测机制，提升错误分类的精准度，改进故障诊断能力

* **测试**
  * 新增测试用例覆盖错误处理的多种场景

<!-- end of auto-generated comment: release notes by coderabbit.ai -->