### PR TITLE
Expire inactive API tokens after last use

### DIFF
--- a/internal/handler/token_auth.go
+++ b/internal/handler/token_auth.go
@@ -22,6 +22,9 @@ const (
 	TokenPrefix = "maxx_"
 	// TokenPrefixDisplayLen is the length of token prefix to display (including "maxx_")
 	TokenPrefixDisplayLen = 12
+	// APITokenInactiveExpiry is the inactivity window after a token was last used.
+	// Tokens without LastUsedAt are not affected by this rule.
+	APITokenInactiveExpiry = 10 * 24 * time.Hour
 )
 
 var (
@@ -137,7 +140,17 @@ func (m *TokenAuthMiddleware) validateExtractedToken(token string) (*domain.APIT
 	if apiToken.ExpiresAt != nil && time.Now().After(*apiToken.ExpiresAt) {
 		return nil, ErrTokenExpired
 	}
+	if isInactiveAPITokenExpired(apiToken, time.Now()) {
+		return nil, ErrTokenExpired
+	}
 	return apiToken, nil
+}
+
+func isInactiveAPITokenExpired(apiToken *domain.APIToken, now time.Time) bool {
+	if apiToken == nil || apiToken.LastUsedAt == nil || apiToken.LastUsedAt.IsZero() {
+		return false
+	}
+	return now.After(apiToken.LastUsedAt.Add(APITokenInactiveExpiry))
 }
 
 // ResolveToken resolves the token attached to a request without assuming a specific client type.

--- a/internal/handler/token_auth_test.go
+++ b/internal/handler/token_auth_test.go
@@ -152,6 +152,102 @@ func TestTokenAuthValidateRequestUpdatesLastSeenWithClientIP(t *testing.T) {
 	}
 }
 
+func TestTokenAuthInactiveExpiry(t *testing.T) {
+	repo := newTokenAuthTestRepo()
+	cachedRepo := cached.NewAPITokenRepository(repo)
+	lastUsedAt := time.Now().Add(-APITokenInactiveExpiry - time.Minute)
+	token := &domain.APIToken{
+		TenantID:    domain.DefaultTenantID,
+		Token:       "maxx_test_token_inactive",
+		TokenPrefix: "maxx_test...",
+		Name:        "inactive-token",
+		IsEnabled:   true,
+		LastUsedAt:  &lastUsedAt,
+	}
+	if err := cachedRepo.Create(token); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	middleware := NewTokenAuthMiddleware(cachedRepo, tokenAuthTestSettingRepo{})
+	req := httptest.NewRequest("POST", "http://example.test/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+
+	validated, err := middleware.ValidateRequest(req, domain.ClientTypeOpenAI)
+	if err != ErrTokenExpired {
+		t.Fatalf("ValidateRequest() error = %v, want %v", err, ErrTokenExpired)
+	}
+	if validated != nil {
+		t.Fatalf("ValidateRequest() token = %#v, want nil", validated)
+	}
+
+	select {
+	case update := <-repo.updates:
+		t.Fatalf("expired token should not update last seen, got %#v", update)
+	default:
+	}
+}
+
+func TestTokenAuthInactiveExpiryIgnoresMissingLastUsedAt(t *testing.T) {
+	repo := newTokenAuthTestRepo()
+	cachedRepo := cached.NewAPITokenRepository(repo)
+	token := &domain.APIToken{
+		TenantID:    domain.DefaultTenantID,
+		Token:       "maxx_test_token_no_last_used",
+		TokenPrefix: "maxx_test...",
+		Name:        "no-last-used-token",
+		IsEnabled:   true,
+	}
+	if err := cachedRepo.Create(token); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	middleware := NewTokenAuthMiddleware(cachedRepo, tokenAuthTestSettingRepo{})
+	req := httptest.NewRequest("POST", "http://example.test/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+
+	validated, err := middleware.ValidateRequest(req, domain.ClientTypeOpenAI)
+	if err != nil {
+		t.Fatalf("ValidateRequest() error = %v", err)
+	}
+	if validated == nil || validated.Token != token.Token {
+		t.Fatalf("ValidateRequest() token = %#v, want %q", validated, token.Token)
+	}
+
+	select {
+	case update := <-repo.updates:
+		if update.lastSeenAt.IsZero() {
+			t.Fatal("lastSeenAt should be set")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for UpdateLastSeen call")
+	}
+}
+
+func TestInactiveAPITokenExpiredBoundary(t *testing.T) {
+	now := time.Date(2026, 6, 17, 11, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		lastUsedAt *time.Time
+		want       bool
+	}{
+		{name: "missing last used", want: false},
+		{name: "exactly ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry)), want: false},
+		{name: "over ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry - time.Nanosecond)), want: true},
+		{name: "within ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry + time.Nanosecond)), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInactiveAPITokenExpired(&domain.APIToken{LastUsedAt: tt.lastUsedAt}, now)
+			if got != tt.want {
+				t.Fatalf("isInactiveAPITokenExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
 func TestTokenAuthConcurrentLimitDefaultsToFive(t *testing.T) {
 	repo := newTokenAuthTestRepo()
 	cachedRepo := cached.NewAPITokenRepository(repo)

--- a/internal/handler/token_auth_test.go
+++ b/internal/handler/token_auth_test.go
@@ -152,10 +152,10 @@ func TestTokenAuthValidateRequestUpdatesLastSeenWithClientIP(t *testing.T) {
 	}
 }
 
-func TestTokenAuthInactiveExpiry(t *testing.T) {
+func TestTokenAuthInactiveExpiryRejectsTokenLastUsedFifteenDaysAgo(t *testing.T) {
 	repo := newTokenAuthTestRepo()
 	cachedRepo := cached.NewAPITokenRepository(repo)
-	lastUsedAt := time.Now().Add(-APITokenInactiveExpiry - time.Minute)
+	lastUsedAt := time.Now().Add(-15 * 24 * time.Hour)
 	token := &domain.APIToken{
 		TenantID:    domain.DefaultTenantID,
 		Token:       "maxx_test_token_inactive",
@@ -233,6 +233,7 @@ func TestInactiveAPITokenExpiredBoundary(t *testing.T) {
 		{name: "missing last used", want: false},
 		{name: "exactly ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry)), want: false},
 		{name: "over ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry - time.Nanosecond)), want: true},
+		{name: "fifteen days", lastUsedAt: ptrTime(now.Add(-15 * 24 * time.Hour)), want: true},
 		{name: "within ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry + time.Nanosecond)), want: false},
 	}
 

--- a/web/src/lib/api-token-expiry.test.ts
+++ b/web/src/lib/api-token-expiry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { API_TOKEN_INACTIVE_EXPIRY_MS, isAPITokenExpired } from './api-token-expiry';
+
+describe('isAPITokenExpired', () => {
+  const now = new Date('2026-06-17T12:00:00Z');
+
+  it('expires a token last used fifteen days ago', () => {
+    expect(
+      isAPITokenExpired(
+        { lastUsedAt: new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000).toISOString() },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not apply inactivity expiry when lastUsedAt is missing', () => {
+    expect(isAPITokenExpired({}, now)).toBe(false);
+  });
+
+  it('keeps the exact ten-day boundary valid', () => {
+    expect(
+      isAPITokenExpired(
+        { lastUsedAt: new Date(now.getTime() - API_TOKEN_INACTIVE_EXPIRY_MS).toISOString() },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('still honors explicit expiresAt', () => {
+    expect(isAPITokenExpired({ expiresAt: '2026-06-16T12:00:00Z' }, now)).toBe(true);
+  });
+});

--- a/web/src/lib/api-token-expiry.ts
+++ b/web/src/lib/api-token-expiry.ts
@@ -1,0 +1,13 @@
+import type { APIToken } from '@/lib/transport';
+
+export const API_TOKEN_INACTIVE_EXPIRY_MS = 10 * 24 * 60 * 60 * 1000;
+
+export function isAPITokenExpired(token: Pick<APIToken, 'expiresAt' | 'lastUsedAt'>, now = new Date()): boolean {
+  if (token.expiresAt && new Date(token.expiresAt) < now) {
+    return true;
+  }
+  if (!token.lastUsedAt) {
+    return false;
+  }
+  return now.getTime() > new Date(token.lastUsedAt).getTime() + API_TOKEN_INACTIVE_EXPIRY_MS;
+}

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -48,6 +48,7 @@ import {
   CircleAlert,
 } from 'lucide-react';
 import { PageHeader } from '@/components/layout';
+import { isAPITokenExpired } from '@/lib/api-token-expiry';
 import type { APIToken } from '@/lib/transport';
 import { buildCodexConfigBundle, buildProxyBaseUrl } from '@/lib/codex-config';
 
@@ -56,6 +57,7 @@ type CodexConfigDialogState = {
   tokenValue: string;
   isEnabled: boolean;
   expiresAt?: string;
+  lastUsedAt?: string;
 };
 
 export function APITokensPage() {
@@ -202,8 +204,7 @@ export function APITokensPage() {
     });
   }, [codexConfigDialog, codexBaseUrl]);
 
-  const isCodexTokenExpired =
-    !!codexConfigDialog?.expiresAt && new Date(codexConfigDialog.expiresAt) < new Date();
+  const isCodexTokenExpired = codexConfigDialog ? isAPITokenExpired(codexConfigDialog) : false;
 
   const codexPreflightChecks = useMemo(
     () => [
@@ -231,6 +232,7 @@ export function APITokensPage() {
     token: string;
     isEnabled: boolean;
     expiresAt?: string;
+    lastUsedAt?: string;
   }) => {
     setCopiedCodexSection(null);
     setCodexConfigDialog({
@@ -238,6 +240,7 @@ export function APITokensPage() {
       tokenValue: token.token,
       isEnabled: token.isEnabled,
       expiresAt: token.expiresAt,
+      lastUsedAt: token.lastUsedAt,
     });
   };
 
@@ -270,10 +273,7 @@ export function APITokensPage() {
     return project?.name || t('apiTokens.unknownProject', { id: projectId });
   };
 
-  const isExpired = (token: APIToken) => {
-    if (!token.expiresAt) return false;
-    return new Date(token.expiresAt) < new Date();
-  };
+  const isExpired = (token: APIToken) => isAPITokenExpired(token);
 
   const formatDateTime = (value?: string) => {
     if (!value) return t('apiTokens.never');
@@ -496,6 +496,7 @@ export function APITokensPage() {
                                   token: token.token,
                                   isEnabled: token.isEnabled,
                                   expiresAt: token.expiresAt,
+                                  lastUsedAt: token.lastUsedAt,
                                 })
                               }
                               title={t('apiTokens.generateCodexConfig')}


### PR DESCRIPTION
## Summary
- expire API tokens when `LastUsedAt` exists and is more than 10 days old
- keep tokens without `LastUsedAt` on the existing behavior path
- avoid updating last-seen metadata for tokens rejected by inactivity expiry

## Tests
- `go test ./internal/handler -run 'TestTokenAuth'`
- `go test ./internal/handler`
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能增强**
  * API 令牌新增“非活跃过期”机制：当令牌存在上次使用时间且已超过 10 天未使用，将返回过期错误并需要重新获取。
  * 仍保留原有按到期时间失效的行为。
* **测试**
  * 新增用例覆盖：按“最后使用时间”拒绝、缺失上次使用时间的处理，以及 10 天边界/超出/未超出等场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->