### PR TITLE
fix(api-tokens): add expired token cleanup

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -981,10 +981,27 @@ type APIToken struct {
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 }
 
+// APITokenInactiveExpiry is the inactivity window after a token was last used.
+// Tokens without LastUsedAt are not affected by this rule.
+const APITokenInactiveExpiry = 10 * 24 * time.Hour
+
 // APITokenCreateResult 创建 Token 的返回结果（包含明文 Token，仅返回一次）
 type APITokenCreateResult struct {
 	Token    string    `json:"token"`    // 明文 Token（仅创建时返回）
 	APIToken *APIToken `json:"apiToken"` // Token 元数据
+}
+
+// APITokenCleanupItem is the public summary returned for a token removed by a cleanup operation.
+type APITokenCleanupItem struct {
+	ID          uint64 `json:"id"`
+	Name        string `json:"name"`
+	TokenPrefix string `json:"tokenPrefix"`
+}
+
+// APITokenCleanupResult reports the outcome of a bulk expired-token cleanup.
+type APITokenCleanupResult struct {
+	DeletedCount int                   `json:"deletedCount"`
+	Tokens       []APITokenCleanupItem `json:"tokens"`
 }
 
 // ModelMappingScope 模型映射作用域

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1303,6 +1303,11 @@ func (h *AdminHandler) handleCooldowns(w http.ResponseWriter, r *http.Request, p
 // API Token handlers
 func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, id uint64) {
 	tenantID := maxxctx.GetTenantID(r.Context())
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	if strings.HasSuffix(path, "/api-tokens/cleanup-expired") {
+		h.handleCleanupExpiredAPITokens(w, r, tenantID)
+		return
+	}
 
 	switch r.Method {
 	case http.MethodGet:
@@ -1422,6 +1427,21 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+func (h *AdminHandler) handleCleanupExpiredAPITokens(w http.ResponseWriter, r *http.Request, tenantID uint64) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	result, err := h.svc.CleanupExpiredAPITokens(tenantID, time.Now())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 // Model Mapping handlers

--- a/internal/handler/admin_api_tokens_test.go
+++ b/internal/handler/admin_api_tokens_test.go
@@ -1,0 +1,108 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
+	"github.com/awsl-project/maxx/internal/service"
+)
+
+func newAdminHandlerForAPITokenTests(t *testing.T) (*AdminHandler, *sqlite.APITokenRepository) {
+	t.Helper()
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	baseRepo := sqlite.NewAPITokenRepository(db)
+	apiTokenRepo := cached.NewAPITokenRepository(baseRepo)
+	adminSvc := service.NewAdminService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		apiTokenRepo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+	return NewAdminHandler(adminSvc, nil, ""), baseRepo
+}
+
+func newAdminAPITokenRequest(method string, path string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	ctx := maxxctx.WithUserRole(req.Context(), string(domain.UserRoleAdmin))
+	ctx = maxxctx.WithTenantID(ctx, 1)
+	return req.WithContext(ctx)
+}
+
+func TestAdminHandlerCleanupExpiredAPITokens(t *testing.T) {
+	h, repo := newAdminHandlerForAPITokenTests(t)
+	now := time.Now().UTC()
+	expiredAt := now.Add(-time.Hour)
+	futureAt := now.Add(time.Hour)
+	oldLastUsedAt := now.Add(-domain.APITokenInactiveExpiry - time.Minute)
+
+	seed := []*domain.APIToken{
+		{TenantID: 1, Token: "maxx_expired_by_date", TokenPrefix: "maxx_exp", Name: "expired-by-date", IsEnabled: true, ExpiresAt: &expiredAt},
+		{TenantID: 1, Token: "maxx_expired_by_inactivity", TokenPrefix: "maxx_ina", Name: "expired-by-inactivity", IsEnabled: true, LastUsedAt: &oldLastUsedAt},
+		{TenantID: 1, Token: "maxx_active", TokenPrefix: "maxx_act", Name: "active", IsEnabled: true, ExpiresAt: &futureAt},
+	}
+	for _, token := range seed {
+		if err := repo.Create(token); err != nil {
+			t.Fatalf("Create(%s) error = %v", token.Name, err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newAdminAPITokenRequest(http.MethodPost, "/admin/api-tokens/cleanup-expired"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var result domain.APITokenCleanupResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.DeletedCount != 2 || len(result.Tokens) != 2 {
+		t.Fatalf("cleanup result = %#v, want two deleted tokens", result)
+	}
+
+	remaining, err := repo.List(1)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].Name != "active" {
+		t.Fatalf("remaining = %#v, want only active token", remaining)
+	}
+}
+
+func TestAdminHandlerCleanupExpiredAPITokensRejectsNonPost(t *testing.T) {
+	h, _ := newAdminHandlerForAPITokenTests(t)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newAdminAPITokenRequest(http.MethodGet, "/admin/api-tokens/cleanup-expired"))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusMethodNotAllowed, rec.Body.String())
+	}
+	if got := rec.Header().Get("Allow"); got != http.MethodPost {
+		t.Fatalf("Allow = %q, want %q", got, http.MethodPost)
+	}
+}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -409,6 +409,10 @@ func (r *selfServiceAPITokenRepo) Delete(tenantID uint64, id uint64) error {
 	return domain.ErrNotFound
 }
 
+func (r *selfServiceAPITokenRepo) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	return []*domain.APIToken{}, nil
+}
+
 func (r *selfServiceAPITokenRepo) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
 	for _, token := range r.tokens {
 		if token.ID == id && token.TenantID == tenantID {

--- a/internal/handler/token_auth.go
+++ b/internal/handler/token_auth.go
@@ -22,9 +22,6 @@ const (
 	TokenPrefix = "maxx_"
 	// TokenPrefixDisplayLen is the length of token prefix to display (including "maxx_")
 	TokenPrefixDisplayLen = 12
-	// APITokenInactiveExpiry is the inactivity window after a token was last used.
-	// Tokens without LastUsedAt are not affected by this rule.
-	APITokenInactiveExpiry = 10 * 24 * time.Hour
 )
 
 var (
@@ -150,7 +147,7 @@ func isInactiveAPITokenExpired(apiToken *domain.APIToken, now time.Time) bool {
 	if apiToken == nil || apiToken.LastUsedAt == nil || apiToken.LastUsedAt.IsZero() {
 		return false
 	}
-	return now.After(apiToken.LastUsedAt.Add(APITokenInactiveExpiry))
+	return now.After(apiToken.LastUsedAt.Add(domain.APITokenInactiveExpiry))
 }
 
 // ResolveToken resolves the token attached to a request without assuming a specific client type.

--- a/internal/handler/token_auth_test.go
+++ b/internal/handler/token_auth_test.go
@@ -68,6 +68,10 @@ func (r *tokenAuthTestRepo) Update(token *domain.APIToken) error {
 
 func (r *tokenAuthTestRepo) Delete(tenantID uint64, id uint64) error { return nil }
 
+func (r *tokenAuthTestRepo) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	return []*domain.APIToken{}, nil
+}
+
 func (r *tokenAuthTestRepo) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
 	if r.token == nil || r.token.ID != id {
 		return nil, domain.ErrNotFound
@@ -231,10 +235,10 @@ func TestInactiveAPITokenExpiredBoundary(t *testing.T) {
 		want       bool
 	}{
 		{name: "missing last used", want: false},
-		{name: "exactly ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry)), want: false},
-		{name: "over ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry - time.Nanosecond)), want: true},
+		{name: "exactly ten days", lastUsedAt: ptrTime(now.Add(-domain.APITokenInactiveExpiry)), want: false},
+		{name: "over ten days", lastUsedAt: ptrTime(now.Add(-domain.APITokenInactiveExpiry - time.Nanosecond)), want: true},
 		{name: "fifteen days", lastUsedAt: ptrTime(now.Add(-15 * 24 * time.Hour)), want: true},
-		{name: "within ten days", lastUsedAt: ptrTime(now.Add(-APITokenInactiveExpiry + time.Nanosecond)), want: false},
+		{name: "within ten days", lastUsedAt: ptrTime(now.Add(-domain.APITokenInactiveExpiry + time.Nanosecond)), want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/repository/cached/api_token.go
+++ b/internal/repository/cached/api_token.go
@@ -82,6 +82,25 @@ func (r *APITokenRepository) Delete(tenantID uint64, id uint64) error {
 	return nil
 }
 
+func (r *APITokenRepository) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	tokens, err := r.repo.DeleteExpired(tenantID, now, inactiveExpiry)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return tokens, nil
+	}
+
+	r.mu.Lock()
+	for _, t := range tokens {
+		delete(r.cache, t.ID)
+		delete(r.tokenCache, t.Token)
+	}
+	r.mu.Unlock()
+	r.bc.publish(OpReload, 0)
+	return tokens, nil
+}
+
 func (r *APITokenRepository) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
 	r.mu.RLock()
 	if t, ok := r.cache[id]; ok && (tenantID == domain.TenantIDAll || t.TenantID == tenantID) {

--- a/internal/repository/cached/api_token_test.go
+++ b/internal/repository/cached/api_token_test.go
@@ -28,6 +28,15 @@ func (r *apiTokenTestRepo) Update(token *domain.APIToken) error {
 
 func (r *apiTokenTestRepo) Delete(tenantID uint64, id uint64) error { return nil }
 
+func (r *apiTokenTestRepo) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	if r.token == nil {
+		return []*domain.APIToken{}, nil
+	}
+	clone := *r.token
+	r.token = nil
+	return []*domain.APIToken{&clone}, nil
+}
+
 func (r *apiTokenTestRepo) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
 	if r.token == nil || r.token.ID != id {
 		return nil, domain.ErrNotFound
@@ -104,5 +113,34 @@ func TestAPITokenRepositoryUpdateLastSeenKeepsLastIPWhenIPIsEmpty(t *testing.T) 
 	}
 	if cachedToken.LastIPAt == nil || !cachedToken.LastIPAt.Equal(firstSeenAt) {
 		t.Fatalf("LastIPAt = %v, want %v", cachedToken.LastIPAt, firstSeenAt)
+	}
+}
+
+func TestAPITokenRepositoryDeleteExpiredClearsTokenCache(t *testing.T) {
+	baseRepo := &apiTokenTestRepo{}
+	repo := NewAPITokenRepository(baseRepo)
+	token := &domain.APIToken{
+		TenantID:    1,
+		Token:       "maxx_expired_cached_token",
+		TokenPrefix: "maxx_exp...",
+		Name:        "expired-cached-token",
+		IsEnabled:   true,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := repo.GetByToken(1, token.Token); err != nil {
+		t.Fatalf("GetByToken(before cleanup) error = %v", err)
+	}
+
+	deleted, err := repo.DeleteExpired(1, time.Now(), domain.APITokenInactiveExpiry)
+	if err != nil {
+		t.Fatalf("DeleteExpired() error = %v", err)
+	}
+	if len(deleted) != 1 {
+		t.Fatalf("deleted count = %d, want 1", len(deleted))
+	}
+	if _, err := repo.GetByToken(1, token.Token); err != domain.ErrNotFound {
+		t.Fatalf("GetByToken(after cleanup) error = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -282,6 +282,7 @@ type APITokenRepository interface {
 	Create(token *domain.APIToken) error
 	Update(token *domain.APIToken) error
 	Delete(tenantID uint64, id uint64) error
+	DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error)
 	GetByID(tenantID uint64, id uint64) (*domain.APIToken, error)
 	GetByToken(tenantID uint64, token string) (*domain.APIToken, error)
 	List(tenantID uint64) ([]*domain.APIToken, error)

--- a/internal/repository/sqlite/api_token.go
+++ b/internal/repository/sqlite/api_token.go
@@ -55,6 +55,43 @@ func (r *APITokenRepository) Delete(tenantID uint64, id uint64) error {
 		}).Error
 }
 
+func (r *APITokenRepository) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	nowMs := now.UnixMilli()
+	inactiveBeforeMs := now.Add(-inactiveExpiry).UnixMilli()
+
+	var models []APIToken
+	query := tenantScope(r.db.gorm, tenantID).
+		Where("deleted_at = 0").
+		Where("(expires_at > 0 AND expires_at < ?) OR (last_used_at > 0 AND last_used_at < ?)", nowMs, inactiveBeforeMs).
+		Order("created_at DESC")
+	if err := query.Find(&models).Error; err != nil {
+		return nil, err
+	}
+	if len(models) == 0 {
+		return []*domain.APIToken{}, nil
+	}
+
+	ids := make([]uint64, 0, len(models))
+	tokens := make([]*domain.APIToken, 0, len(models))
+	for _, model := range models {
+		ids = append(ids, model.ID)
+		tokens = append(tokens, r.toDomain(&model))
+	}
+
+	deletedAt := time.Now().UnixMilli()
+	if err := tenantScope(r.db.gorm.Model(&APIToken{}), tenantID).
+		Where("id IN ?", ids).
+		Where("deleted_at = 0").
+		Updates(map[string]any{
+			"deleted_at": deletedAt,
+			"updated_at": deletedAt,
+		}).Error; err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
 func (r *APITokenRepository) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
 	var model APIToken
 	if err := tenantScope(r.db.gorm, tenantID).First(&model, id).Error; err != nil {

--- a/internal/repository/sqlite/api_token_cleanup_test.go
+++ b/internal/repository/sqlite/api_token_cleanup_test.go
@@ -1,0 +1,80 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestAPITokenRepositoryDeleteExpiredUsesExplicitAndInactiveExpiry(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	repo := NewAPITokenRepository(db)
+
+	now := time.Date(2026, 6, 21, 13, 0, 0, 0, time.UTC)
+	expiredAt := now.Add(-time.Hour)
+	futureExpiry := now.Add(time.Hour)
+	inactiveAt := now.Add(-domain.APITokenInactiveExpiry - time.Minute)
+	stillActiveAt := now.Add(-domain.APITokenInactiveExpiry + time.Minute)
+
+	seed := []*domain.APIToken{
+		{TenantID: 1, Token: "maxx_explicit_expired", TokenPrefix: "maxx_exp", Name: "explicit-expired", IsEnabled: true, ExpiresAt: &expiredAt},
+		{TenantID: 1, Token: "maxx_inactive_expired", TokenPrefix: "maxx_ina", Name: "inactive-expired", IsEnabled: true, LastUsedAt: &inactiveAt},
+		{TenantID: 1, Token: "maxx_future", TokenPrefix: "maxx_fut", Name: "future", IsEnabled: true, ExpiresAt: &futureExpiry},
+		{TenantID: 1, Token: "maxx_recent", TokenPrefix: "maxx_rec", Name: "recent", IsEnabled: true, LastUsedAt: &stillActiveAt},
+		{TenantID: 1, Token: "maxx_never_used", TokenPrefix: "maxx_nev", Name: "never-used", IsEnabled: true},
+		{TenantID: 2, Token: "maxx_other_tenant_expired", TokenPrefix: "maxx_oth", Name: "other-tenant-expired", IsEnabled: true, ExpiresAt: &expiredAt},
+	}
+	for _, token := range seed {
+		if err := repo.Create(token); err != nil {
+			t.Fatalf("Create(%s) error = %v", token.Name, err)
+		}
+	}
+
+	deleted, err := repo.DeleteExpired(1, now, domain.APITokenInactiveExpiry)
+	if err != nil {
+		t.Fatalf("DeleteExpired() error = %v", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("deleted count = %d, want 2", len(deleted))
+	}
+	deletedNames := map[string]bool{}
+	for _, token := range deleted {
+		deletedNames[token.Name] = true
+	}
+	for _, name := range []string{"explicit-expired", "inactive-expired"} {
+		if !deletedNames[name] {
+			t.Fatalf("deleted tokens missing %q: %#v", name, deletedNames)
+		}
+	}
+
+	remaining, err := repo.List(1)
+	if err != nil {
+		t.Fatalf("List(tenant 1) error = %v", err)
+	}
+	remainingNames := map[string]bool{}
+	for _, token := range remaining {
+		remainingNames[token.Name] = true
+	}
+	for _, name := range []string{"future", "recent", "never-used"} {
+		if !remainingNames[name] {
+			t.Fatalf("remaining tokens missing %q: %#v", name, remainingNames)
+		}
+	}
+	for _, name := range []string{"explicit-expired", "inactive-expired"} {
+		if remainingNames[name] {
+			t.Fatalf("expired token %q still listed after cleanup", name)
+		}
+	}
+
+	otherTenant, err := repo.List(2)
+	if err != nil {
+		t.Fatalf("List(tenant 2) error = %v", err)
+	}
+	if len(otherTenant) != 1 || otherTenant[0].Name != "other-tenant-expired" {
+		t.Fatalf("other tenant tokens = %#v, want untouched expired token", otherTenant)
+	}
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -816,6 +816,27 @@ func (s *AdminService) DeleteAPIToken(tenantID uint64, id uint64) error {
 	return s.apiTokenRepo.Delete(tenantID, id)
 }
 
+func (s *AdminService) CleanupExpiredAPITokens(tenantID uint64, now time.Time) (*domain.APITokenCleanupResult, error) {
+	deletedTokens, err := s.apiTokenRepo.DeleteExpired(tenantID, now, domain.APITokenInactiveExpiry)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]domain.APITokenCleanupItem, 0, len(deletedTokens))
+	for _, token := range deletedTokens {
+		items = append(items, domain.APITokenCleanupItem{
+			ID:          token.ID,
+			Name:        token.Name,
+			TokenPrefix: token.TokenPrefix,
+		})
+	}
+
+	return &domain.APITokenCleanupResult{
+		DeletedCount: len(items),
+		Tokens:       items,
+	}, nil
+}
+
 // ===== Invite Code API =====
 
 func (s *AdminService) GetInviteCodes(tenantID uint64) ([]*domain.InviteCode, error) {

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -108,6 +108,7 @@ export {
   useCreateAPIToken,
   useUpdateAPIToken,
   useDeleteAPIToken,
+  useCleanupExpiredAPITokens,
 } from './use-api-tokens';
 
 // Invite Code hooks

--- a/web/src/hooks/queries/use-api-tokens.ts
+++ b/web/src/hooks/queries/use-api-tokens.ts
@@ -75,3 +75,15 @@ export function useDeleteAPIToken() {
     },
   });
 }
+
+// 清理过期 API Tokens
+export function useCleanupExpiredAPITokens() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => getTransport().cleanupExpiredAPITokens(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() });
+    },
+  });
+}

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -61,6 +61,7 @@ import type {
   UpdateInviteCodeData,
   InviteCodeCreateResult,
   APIToken,
+  APITokenCleanupResult,
   APITokenCreateResult,
   CreateAPITokenData,
   RoutePositionUpdate,
@@ -945,6 +946,13 @@ export class HttpTransport implements Transport {
 
   async deleteAPIToken(id: number): Promise<void> {
     await this.adminClient.delete(`/api-tokens/${id}`);
+  }
+
+  async cleanupExpiredAPITokens(): Promise<APITokenCleanupResult> {
+    const { data } = await this.adminClient.post<APITokenCleanupResult>(
+      '/api-tokens/cleanup-expired',
+    );
+    return data;
   }
 
   // ===== Invite Code API =====

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -96,6 +96,8 @@ export type {
   InviteCodeCreateResult,
   // API Token
   APIToken,
+  APITokenCleanupItem,
+  APITokenCleanupResult,
   APITokenCreateResult,
   CreateAPITokenData,
   // Usage Stats

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -60,6 +60,7 @@ import type {
   CreateUserData,
   UpdateUserData,
   APIToken,
+  APITokenCleanupResult,
   APITokenCreateResult,
   CreateAPITokenData,
   RoutePositionUpdate,
@@ -253,6 +254,7 @@ export interface Transport {
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
   updateAPIToken(id: number, data: Partial<APIToken>): Promise<APIToken>;
   deleteAPIToken(id: number): Promise<void>;
+  cleanupExpiredAPITokens(): Promise<APITokenCleanupResult>;
 
   // ===== Invite Code API =====
   getInviteCodes(): Promise<InviteCode[]>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -904,6 +904,17 @@ export interface APITokenCreateResult {
   apiToken: APIToken;
 }
 
+export interface APITokenCleanupItem {
+  id: number;
+  name: string;
+  tokenPrefix: string;
+}
+
+export interface APITokenCleanupResult {
+  deletedCount: number;
+  tokens: APITokenCleanupItem[];
+}
+
 export interface CreateAPITokenData {
   name: string;
   description?: string;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1170,6 +1170,7 @@
     "title": "API Tokens",
     "description": "Manage API tokens for proxy authentication",
     "createToken": "Create Token",
+    "listTitle": "Token List",
     "noTokens": "No API tokens",
     "noTokensHint": "Create a token to authenticate proxy requests",
     "authEnabled": "API Token Authentication",
@@ -1189,6 +1190,8 @@
     "never": "Never",
     "active": "Active",
     "expired": "Expired",
+    "expiredSummary": "{{count}} expired token(s) can be cleaned up",
+    "noExpiredTokens": "No expired tokens right now",
     "global": "Global",
     "notSpecified": "Not Specified",
     "generateCodexConfig": "Generate Codex Config",
@@ -1208,6 +1211,14 @@
     "deleteDialog": {
       "title": "Delete API Token",
       "description": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone. Any applications using this token will no longer be able to authenticate."
+    },
+    "cleanupExpired": {
+      "button": "Clean up expired tokens ({{count}})",
+      "title": "Clean Up Expired Tokens",
+      "description": "This will delete {{count}} expired API token(s). This action cannot be undone, and applications using these tokens will no longer authenticate.",
+      "confirm": "Clean up {{count}} token(s)",
+      "more": "and {{count}} more token(s)",
+      "lastResult": "Last cleanup removed {{count}} expired token(s)."
     },
     "newTokenDialog": {
       "title": "Token Created Successfully",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1169,6 +1169,7 @@
     "title": "API 令牌",
     "description": "管理用于代理身份验证的 API 令牌",
     "createToken": "创建令牌",
+    "listTitle": "令牌列表",
     "noTokens": "暂无 API 令牌",
     "noTokensHint": "创建令牌以进行代理请求身份验证",
     "authEnabled": "API 令牌身份验证",
@@ -1188,6 +1189,8 @@
     "never": "从未",
     "active": "活跃",
     "expired": "已过期",
+    "expiredSummary": "当前有 {{count}} 个已过期令牌可清理",
+    "noExpiredTokens": "当前没有已过期令牌",
     "global": "全局",
     "notSpecified": "未指定",
     "generateCodexConfig": "生成 Codex 配置",
@@ -1207,6 +1210,14 @@
     "deleteDialog": {
       "title": "删除 API 令牌",
       "description": "确定要删除「{{name}}」吗？此操作无法撤销。使用此令牌的任何应用程序将无法再进行身份验证。"
+    },
+    "cleanupExpired": {
+      "button": "清理已过期令牌 ({{count}})",
+      "title": "清理已过期令牌",
+      "description": "将删除 {{count}} 个已过期 API 令牌。此操作无法撤销，使用这些令牌的应用将无法再通过身份验证。",
+      "confirm": "清理 {{count}} 个令牌",
+      "more": "以及另外 {{count}} 个令牌",
+      "lastResult": "上次已清理 {{count}} 个已过期令牌。"
     },
     "newTokenDialog": {
       "title": "令牌创建成功",

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -25,6 +25,7 @@ import {
   useCreateAPIToken,
   useUpdateAPIToken,
   useDeleteAPIToken,
+  useCleanupExpiredAPITokens,
   useProjects,
   useProxyStatus,
   useSettings,
@@ -70,6 +71,7 @@ export function APITokensPage() {
   const createToken = useCreateAPIToken();
   const updateToken = useUpdateAPIToken();
   const deleteToken = useDeleteAPIToken();
+  const cleanupExpiredTokens = useCleanupExpiredAPITokens();
 
   const apiTokenAuthEnabled = settings?.api_token_auth_enabled === 'true';
 
@@ -83,6 +85,8 @@ export function APITokensPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingToken, setEditingToken] = useState<APIToken | null>(null);
   const [deletingToken, setDeletingToken] = useState<APIToken | null>(null);
+  const [cleanupExpiredDialogOpen, setCleanupExpiredDialogOpen] = useState(false);
+  const [lastCleanupCount, setLastCleanupCount] = useState<number | null>(null);
   const [newTokenDialog, setNewTokenDialog] = useState<{
     token: string;
     name: string;
@@ -104,6 +108,10 @@ export function APITokensPage() {
   const [expiresAt, setExpiresAt] = useState('');
   const [devMode, setDevMode] = useState(false);
   const [showProjectPicker, setShowProjectPicker] = useState(false);
+
+  const isExpired = (token: APIToken) => isAPITokenExpired(token);
+  const expiredTokens = useMemo(() => (tokens ?? []).filter(isExpired), [tokens]);
+  const expiredTokenCount = expiredTokens.length;
 
   const resetForm = () => {
     setName('');
@@ -176,6 +184,15 @@ export function APITokensPage() {
     if (!deletingToken) return;
     deleteToken.mutate(deletingToken.id, {
       onSuccess: () => setDeletingToken(null),
+    });
+  };
+
+  const handleCleanupExpiredTokens = () => {
+    cleanupExpiredTokens.mutate(undefined, {
+      onSuccess: (result) => {
+        setCleanupExpiredDialogOpen(false);
+        setLastCleanupCount(result.deletedCount);
+      },
     });
   };
 
@@ -273,8 +290,6 @@ export function APITokensPage() {
     return project?.name || t('apiTokens.unknownProject', { id: projectId });
   };
 
-  const isExpired = (token: APIToken) => isAPITokenExpired(token);
-
   const formatDateTime = (value?: string) => {
     if (!value) return t('apiTokens.never');
     return new Date(value).toLocaleString(i18n.resolvedLanguage ?? i18n.language, {
@@ -368,6 +383,35 @@ export function APITokensPage() {
               </div>
             ) : tokens && tokens.length > 0 ? (
               <Card className="border-border bg-surface-primary">
+                <div className="flex flex-col gap-3 border-b border-border px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0 space-y-1">
+                    <p className="font-medium">{t('apiTokens.listTitle')}</p>
+                    <p className="text-sm text-text-muted">
+                      {expiredTokenCount > 0
+                        ? t('apiTokens.expiredSummary', { count: expiredTokenCount })
+                        : t('apiTokens.noExpiredTokens')}
+                    </p>
+                    {lastCleanupCount !== null && (
+                      <p className="text-xs text-text-muted">
+                        {t('apiTokens.cleanupExpired.lastResult', { count: lastCleanupCount })}
+                      </p>
+                    )}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setCleanupExpiredDialogOpen(true)}
+                    disabled={expiredTokenCount === 0 || cleanupExpiredTokens.isPending}
+                    className="self-start text-destructive hover:text-destructive sm:self-auto"
+                  >
+                    {cleanupExpiredTokens.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="mr-2 h-4 w-4" />
+                    )}
+                    {t('apiTokens.cleanupExpired.button', { count: expiredTokenCount })}
+                  </Button>
+                </div>
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -729,6 +773,53 @@ export function APITokensPage() {
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Cleanup Expired Confirmation */}
+      <Dialog
+        open={cleanupExpiredDialogOpen}
+        onOpenChange={(open: boolean) => !open && setCleanupExpiredDialogOpen(false)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('apiTokens.cleanupExpired.title')}</DialogTitle>
+            <DialogDescription>
+              {t('apiTokens.cleanupExpired.description', {
+                count: expiredTokenCount,
+              })}
+            </DialogDescription>
+            {expiredTokenCount > 0 && (
+              <ul className="space-y-1 rounded-lg border border-border bg-surface-secondary p-3 text-xs text-text-secondary">
+                {expiredTokens.slice(0, 5).map((token) => (
+                  <li key={token.id} className="flex items-center justify-between gap-3">
+                    <span className="truncate">{token.name}</span>
+                    <code className="shrink-0 font-mono text-text-muted">{token.tokenPrefix}</code>
+                  </li>
+                ))}
+                {expiredTokenCount > 5 && (
+                  <li className="text-text-muted">
+                    {t('apiTokens.cleanupExpired.more', { count: expiredTokenCount - 5 })}
+                  </li>
+                )}
+              </ul>
+            )}
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCleanupExpiredDialogOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleCleanupExpiredTokens}
+              disabled={cleanupExpiredTokens.isPending || expiredTokenCount === 0}
+            >
+              {cleanupExpiredTokens.isPending && (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              )}
+              {t('apiTokens.cleanupExpired.confirm', { count: expiredTokenCount })}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 


### PR DESCRIPTION
## Summary
- add a tenant-scoped backend endpoint to bulk cleanup expired API tokens
- reuse the server-side API token expiry rule for explicit expiry and 10-day inactive expiry
- add a token-list cleanup button with count, confirmation dialog, refresh, and i18n text
- cover repository/cache/handler/token-auth paths with tests

## Validation
- `go test ./internal/repository/sqlite ./internal/repository/cached ./internal/handler ./internal/service`
- `go test ./...`
- `pnpm test && pnpm typecheck && pnpm build` in `web/`
- `git diff --check`
- Real E2E on local Maxx server: created one expired token and two valid tokens through admin API, opened `/api-tokens` in Chromium, clicked cleanup, confirmed only the expired token disappeared, verified second cleanup returned `deletedCount: 0`, and checked SQLite soft-delete state.

## E2E screenshots
- before cleanup: `/tmp/openclaw/maxx-cleanup-expired-e2e/screens/01-token-list-before-cleanup.png`
- confirm dialog: `/tmp/openclaw/maxx-cleanup-expired-e2e/screens/02-confirm-cleanup-dialog.png`
- after cleanup: `/tmp/openclaw/maxx-cleanup-expired-e2e/screens/03-token-list-after-cleanup.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了清理过期API令牌功能，支持按失效时间和不活跃期限自动识别和清除过期令牌
  * 在API令牌管理页面新增过期令牌摘要展示、清理按钮、确认对话框和清理结果反馈

<!-- end of auto-generated comment: release notes by coderabbit.ai -->