### PR TITLE
feat(routes): add scoped bulk route deletion

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -421,6 +421,23 @@ type RoutePositionUpdate struct {
 	Position int    `json:"position"`
 }
 
+// RouteBulkDeleteRequest deletes route bindings within an explicit client/project scope.
+// The scope guard prevents a stale or malicious UI selection from deleting routes
+// from another client tab or project/global context.
+type RouteBulkDeleteRequest struct {
+	IDs        []uint64   `json:"ids"`
+	ClientType ClientType `json:"clientType"`
+	ProjectID  uint64     `json:"projectID"`
+}
+
+// RouteBulkDeleteResult reports what the scoped bulk delete actually changed.
+type RouteBulkDeleteResult struct {
+	DeletedCount int      `json:"deletedCount"`
+	DeletedIDs   []uint64 `json:"deletedIDs"`
+	SkippedIDs   []uint64 `json:"skippedIDs"`
+	NotFoundIDs  []uint64 `json:"notFoundIDs"`
+}
+
 type RequestInfo struct {
 	Method  string            `json:"method"`
 	Headers map[string]string `json:"headers"`

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -86,6 +86,8 @@ func (h *AdminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "routes":
 		if len(parts) > 2 && parts[2] == "batch-positions" {
 			h.handleBatchUpdateRoutePositions(w, r)
+		} else if len(parts) > 2 && parts[2] == "bulk-delete" {
+			h.handleBulkDeleteRoutes(w, r)
 		} else {
 			h.handleRoutes(w, r, id)
 		}
@@ -491,6 +493,28 @@ func (h *AdminHandler) handleBatchUpdateRoutePositions(w http.ResponseWriter, r 
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"message": "positions updated successfully"})
+}
+
+func (h *AdminHandler) handleBulkDeleteRoutes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req domain.RouteBulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	result, err := h.svc.BulkDeleteRoutes(tenantID, req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // Project handlers

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -108,6 +108,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleRoutes(w, r, 0)
 		case len(parts) == 3 && parts[2] == "batch-positions":
 			h.handleBatchUpdateRoutePositions(w, r)
+		case len(parts) == 3 && parts[2] == "bulk-delete":
+			h.handleBulkDeleteRoutes(w, r)
 		case len(parts) == 3:
 			id, ok := parseSelfServiceID(w, "route", parts[2])
 			if !ok {
@@ -612,6 +614,31 @@ func (h *SelfServiceHandler) handleBatchUpdateRoutePositions(w http.ResponseWrit
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"message": "positions updated successfully"})
+}
+
+func (h *SelfServiceHandler) handleBulkDeleteRoutes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	var req domain.RouteBulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	result, err := h.svc.BulkDeleteRoutes(tenantID, req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (h *SelfServiceHandler) handleRetryConfigs(w http.ResponseWriter, r *http.Request, id uint64) {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -207,6 +207,31 @@ func (r *selfServiceRouteRepo) Delete(tenantID uint64, id uint64) error {
 	return domain.ErrNotFound
 }
 
+func (r *selfServiceRouteRepo) BulkDelete(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	result := &domain.RouteBulkDeleteResult{}
+	requested := make(map[uint64]struct{}, len(req.IDs))
+	for _, id := range req.IDs {
+		requested[id] = struct{}{}
+	}
+
+	kept := r.routes[:0]
+	for _, route := range r.routes {
+		if _, ok := requested[route.ID]; !ok || route.TenantID != tenantID {
+			kept = append(kept, route)
+			continue
+		}
+		if route.ClientType != req.ClientType || route.ProjectID != req.ProjectID {
+			result.SkippedIDs = append(result.SkippedIDs, route.ID)
+			kept = append(kept, route)
+			continue
+		}
+		result.DeletedIDs = append(result.DeletedIDs, route.ID)
+	}
+	r.routes = kept
+	result.DeletedCount = len(result.DeletedIDs)
+	return result, nil
+}
+
 func (r *selfServiceRouteRepo) GetByID(tenantID uint64, id uint64) (*domain.Route, error) {
 	for _, route := range r.routes {
 		if route.ID == id && route.TenantID == tenantID {

--- a/internal/repository/cached/route.go
+++ b/internal/repository/cached/route.go
@@ -82,6 +82,35 @@ func (r *RouteRepository) Delete(tenantID uint64, id uint64) error {
 	return nil
 }
 
+func (r *RouteRepository) BulkDelete(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	result, err := r.repo.BulkDelete(tenantID, req)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil || len(result.DeletedIDs) == 0 {
+		return result, nil
+	}
+
+	deleted := make(map[uint64]struct{}, len(result.DeletedIDs))
+	for _, id := range result.DeletedIDs {
+		deleted[id] = struct{}{}
+	}
+
+	r.mu.Lock()
+	filtered := r.cache[:0]
+	for _, rt := range r.cache {
+		if _, ok := deleted[rt.ID]; ok && (tenantID == domain.TenantIDAll || rt.TenantID == tenantID) {
+			continue
+		}
+		filtered = append(filtered, rt)
+	}
+	r.cache = filtered
+	r.mu.Unlock()
+
+	r.bc.publish(OpReload, 0)
+	return result, nil
+}
+
 func (r *RouteRepository) BatchUpdatePositions(tenantID uint64, updates []domain.RoutePositionUpdate) error {
 	if err := r.repo.BatchUpdatePositions(tenantID, updates); err != nil {
 		return err

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -59,6 +59,7 @@ type RouteRepository interface {
 	Create(route *domain.Route) error
 	Update(route *domain.Route) error
 	Delete(tenantID uint64, id uint64) error
+	BulkDelete(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error)
 	GetByID(tenantID uint64, id uint64) (*domain.Route, error)
 	// FindByKey finds a route by the unique key (projectID, providerID, clientType)
 	FindByKey(tenantID uint64, projectID, providerID uint64, clientType domain.ClientType) (*domain.Route, error)

--- a/internal/repository/sqlite/route.go
+++ b/internal/repository/sqlite/route.go
@@ -45,6 +45,78 @@ func (r *RouteRepository) Delete(tenantID uint64, id uint64) error {
 		}).Error
 }
 
+func (r *RouteRepository) BulkDelete(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	result := &domain.RouteBulkDeleteResult{}
+	if len(req.IDs) == 0 {
+		return result, nil
+	}
+
+	seen := make(map[uint64]struct{}, len(req.IDs))
+	ids := make([]uint64, 0, len(req.IDs))
+	for _, id := range req.IDs {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	err := r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		var models []Route
+		if err := tenantScope(tx, tenantID).
+			Where("id IN ? AND deleted_at = 0", ids).
+			Find(&models).Error; err != nil {
+			return err
+		}
+
+		found := make(map[uint64]struct{}, len(models))
+		deleteIDs := make([]uint64, 0, len(models))
+		for _, model := range models {
+			found[model.ID] = struct{}{}
+			if model.ClientType == string(req.ClientType) && model.ProjectID == req.ProjectID {
+				deleteIDs = append(deleteIDs, model.ID)
+			} else {
+				result.SkippedIDs = append(result.SkippedIDs, model.ID)
+			}
+		}
+
+		for _, id := range ids {
+			if _, ok := found[id]; !ok {
+				result.NotFoundIDs = append(result.NotFoundIDs, id)
+			}
+		}
+
+		if len(deleteIDs) == 0 {
+			return nil
+		}
+
+		now := time.Now().UnixMilli()
+		if err := tenantScope(tx.Model(&Route{}), tenantID).
+			Where("id IN ? AND deleted_at = 0", deleteIDs).
+			Updates(map[string]any{
+				"deleted_at": now,
+				"updated_at": now,
+			}).Error; err != nil {
+			return err
+		}
+
+		result.DeletedIDs = deleteIDs
+		result.DeletedCount = len(deleteIDs)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (r *RouteRepository) BatchUpdatePositions(tenantID uint64, updates []domain.RoutePositionUpdate) error {
 	if len(updates) == 0 {
 		return nil

--- a/internal/repository/sqlite/route_test.go
+++ b/internal/repository/sqlite/route_test.go
@@ -1,0 +1,87 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestRouteRepositoryBulkDeleteScopesByTenantClientAndProject(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewRouteRepository(db)
+	routes := []*domain.Route{
+		{TenantID: 1, ProjectID: 0, ClientType: domain.ClientTypeClaude, ProviderID: 101, IsEnabled: true, IsNative: true, Position: 1, Weight: 1},
+		{TenantID: 1, ProjectID: 0, ClientType: domain.ClientTypeClaude, ProviderID: 102, IsEnabled: true, IsNative: false, Position: 2, Weight: 1},
+		{TenantID: 1, ProjectID: 7, ClientType: domain.ClientTypeClaude, ProviderID: 103, IsEnabled: true, IsNative: true, Position: 3, Weight: 1},
+		{TenantID: 1, ProjectID: 0, ClientType: domain.ClientTypeOpenAI, ProviderID: 104, IsEnabled: true, IsNative: true, Position: 4, Weight: 1},
+		{TenantID: 2, ProjectID: 0, ClientType: domain.ClientTypeClaude, ProviderID: 105, IsEnabled: true, IsNative: true, Position: 5, Weight: 1},
+	}
+	for _, route := range routes {
+		if err := repo.Create(route); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	result, err := repo.BulkDelete(1, domain.RouteBulkDeleteRequest{
+		IDs: []uint64{
+			routes[0].ID,
+			routes[1].ID,
+			routes[2].ID,
+			routes[3].ID,
+			routes[4].ID,
+			999999,
+			routes[0].ID,
+		},
+		ClientType: domain.ClientTypeClaude,
+		ProjectID:  0,
+	})
+	if err != nil {
+		t.Fatalf("BulkDelete() error = %v", err)
+	}
+
+	if result.DeletedCount != 2 {
+		t.Fatalf("DeletedCount = %d, want 2 (result: %#v)", result.DeletedCount, result)
+	}
+	assertContainsRouteID(t, result.DeletedIDs, routes[0].ID)
+	assertContainsRouteID(t, result.DeletedIDs, routes[1].ID)
+	assertContainsRouteID(t, result.SkippedIDs, routes[2].ID)
+	assertContainsRouteID(t, result.SkippedIDs, routes[3].ID)
+	assertContainsRouteID(t, result.NotFoundIDs, routes[4].ID)
+	assertContainsRouteID(t, result.NotFoundIDs, 999999)
+
+	remaining, err := repo.List(1)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("remaining tenant 1 routes = %d, want 2", len(remaining))
+	}
+	for _, route := range remaining {
+		if route.ProjectID == 0 && route.ClientType == domain.ClientTypeClaude {
+			t.Fatalf("deleted route still visible after BulkDelete: %#v", route)
+		}
+	}
+
+	otherTenantRoutes, err := repo.List(2)
+	if err != nil {
+		t.Fatalf("List(other tenant) error = %v", err)
+	}
+	if len(otherTenantRoutes) != 1 || otherTenantRoutes[0].ID != routes[4].ID {
+		t.Fatalf("other tenant route was affected: %#v", otherTenantRoutes)
+	}
+}
+
+func assertContainsRouteID(t *testing.T, ids []uint64, want uint64) {
+	t.Helper()
+	for _, id := range ids {
+		if id == want {
+			return
+		}
+	}
+	t.Fatalf("ids %v does not contain %d", ids, want)
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -412,6 +412,25 @@ func (s *AdminService) DeleteRoute(tenantID uint64, id uint64) error {
 	return s.routeRepo.Delete(tenantID, id)
 }
 
+func (s *AdminService) BulkDeleteRoutes(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	if len(req.IDs) == 0 {
+		return nil, fmt.Errorf("ids required")
+	}
+	if !isValidRouteClientType(req.ClientType) {
+		return nil, fmt.Errorf("invalid clientType")
+	}
+	return s.routeRepo.BulkDelete(tenantID, req)
+}
+
+func isValidRouteClientType(clientType domain.ClientType) bool {
+	switch clientType {
+	case domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeGemini:
+		return true
+	default:
+		return false
+	}
+}
+
 // ===== Project API =====
 
 func (s *AdminService) GetProjects(tenantID uint64) ([]*domain.Project, error) {

--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -3,10 +3,19 @@
  * Used by both global routes and project routes
  */
 
-import { useState, useMemo, useRef } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Plus, RefreshCw, Zap, Workflow, Settings2, Pin } from 'lucide-react';
+import {
+  AlertTriangle,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Zap,
+  Workflow,
+  Settings2,
+  Pin,
+} from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -30,10 +39,12 @@ import {
   useCreateRoute,
   useToggleRoute,
   useDeleteRoute,
+  useBulkDeleteRoutes,
   useUpdateRoutePositions,
   useProviderStats,
   useProxyRequestUpdates,
   useRoutingStrategies,
+  useProjects,
   routeKeys,
 } from '@/hooks/queries';
 import { useQueryClient } from '@tanstack/react-query';
@@ -52,7 +63,19 @@ import {
   ProviderRowContent,
 } from '@/pages/client-routes/components/provider-row';
 import type { ProviderConfigItem } from '@/pages/client-routes/types';
-import { Button, Badge, buttonVariants } from '../ui';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Badge,
+  buttonVariants,
+} from '../ui';
 import { cn } from '@/lib/utils';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 import { CooldownsProvider } from '@/contexts/cooldowns-context';
@@ -217,6 +240,8 @@ function ClientTypeRoutesContentInner({
 }: ClientTypeRoutesContentProps) {
   const { t } = useTranslation();
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [selectedRouteIds, setSelectedRouteIds] = useState<Set<number>>(() => new Set());
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const { data: providerStats = {} } = useProviderStats(clientType, projectID || undefined);
   const stableProviderStats = useStableProviderStats(providerStats);
   const queryClient = useQueryClient();
@@ -237,6 +262,7 @@ function ClientTypeRoutesContentInner({
 
   const { data: allRoutes, isLoading: routesLoading } = useRoutes();
   const { data: providers = [], isLoading: providersLoading } = useProviders();
+  const { data: projects = [] } = useProjects();
   const { data: strategies = [] } = useRoutingStrategies();
 
   // Resolve the effective strategy for this scope, mirroring the backend's
@@ -264,6 +290,7 @@ function ClientTypeRoutesContentInner({
   const createRoute = useCreateRoute();
   const toggleRoute = useToggleRoute();
   const deleteRoute = useDeleteRoute();
+  const bulkDeleteRoutes = useBulkDeleteRoutes();
   const updatePositions = useUpdateRoutePositions();
 
   const loading = routesLoading || providersLoading;
@@ -329,6 +356,50 @@ function ClientTypeRoutesContentInner({
 
   const streamingThrottleMs = items.length > 200 ? 1000 : 0;
   const { countsByProviderAndClient } = useStreamingRequests({ throttleMs: streamingThrottleMs });
+
+  const visibleRouteIds = useMemo(
+    () => items.flatMap((item) => (item.route ? [item.route.id] : [])),
+    [items],
+  );
+
+  const visibleRouteIdSet = useMemo(() => new Set(visibleRouteIds), [visibleRouteIds]);
+
+  useEffect(() => {
+    setSelectedRouteIds((prev) => {
+      const next = new Set<number>();
+      for (const id of prev) {
+        if (visibleRouteIdSet.has(id)) {
+          next.add(id);
+        }
+      }
+      return next.size === prev.size ? prev : next;
+    });
+  }, [visibleRouteIdSet]);
+
+  const selectedItems = useMemo(
+    () => items.filter((item) => item.route && selectedRouteIds.has(item.route.id)),
+    [items, selectedRouteIds],
+  );
+
+  const selectedProviderNames = useMemo(
+    () => selectedItems.map((item) => item.provider.name),
+    [selectedItems],
+  );
+
+  const selectedStreamingCount = useMemo(() => {
+    return selectedItems.reduce((total, item) => {
+      return total + (countsByProviderAndClient.get(`${item.provider.id}:${clientType}`) || 0);
+    }, 0);
+  }, [clientType, countsByProviderAndClient, selectedItems]);
+
+  const scopeName = useMemo(() => {
+    if (projectID === 0) return t('routes.globalScope');
+    return projects.find((project) => project.id === projectID)?.name ?? t('routes.projectScope');
+  }, [projectID, projects, t]);
+
+  const allVisibleSelected =
+    visibleRouteIds.length > 0 && selectedRouteIds.size === visibleRouteIds.length;
+  const someVisibleSelected = selectedRouteIds.size > 0 && !allVisibleSelected;
 
   // Get available providers (without routes yet), grouped by type and sorted alphabetically
   const groupedAvailableProviders = useMemo((): Record<ProviderTypeKey, Provider[]> => {
@@ -427,6 +498,37 @@ function ClientTypeRoutesContentInner({
     deleteRoute.mutate(routeId);
   };
 
+  const handleToggleRouteSelection = (routeId: number, checked: boolean) => {
+    setSelectedRouteIds((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(routeId);
+      } else {
+        next.delete(routeId);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAllVisible = (checked: boolean) => {
+    setSelectedRouteIds(checked ? new Set(visibleRouteIds) : new Set());
+  };
+
+  const handleConfirmBulkDelete = () => {
+    const ids = selectedItems.flatMap((item) => (item.route ? [item.route.id] : []));
+    if (ids.length === 0) return;
+
+    bulkDeleteRoutes.mutate(
+      { ids, clientType, projectID },
+      {
+        onSuccess: () => {
+          setSelectedRouteIds(new Set());
+          setBulkDeleteOpen(false);
+        },
+      },
+    );
+  };
+
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);
     document.body.classList.add('is-dragging');
@@ -502,6 +604,44 @@ function ClientTypeRoutesContentInner({
             stickyTTLSeconds={strategyInfo.stickyTTLSeconds}
           />
 
+          {items.length > 0 && (
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/80 px-4 py-3 shadow-sm">
+              <label className="flex items-center gap-3 text-sm text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={allVisibleSelected}
+                  aria-checked={someVisibleSelected ? 'mixed' : allVisibleSelected}
+                  onChange={(event) => handleToggleAllVisible(event.target.checked)}
+                  className="h-4 w-4 rounded border-border accent-destructive"
+                />
+                <span>
+                  {t('routes.bulkSelectVisible', { count: visibleRouteIds.length })}
+                  {normalizedQuery && (
+                    <span className="ml-1 text-muted-foreground/70">
+                      {t('routes.bulkFilteredSelection')}
+                    </span>
+                  )}
+                </span>
+              </label>
+              <div className="flex items-center gap-2">
+                {selectedRouteIds.size > 0 && (
+                  <span className="text-xs text-muted-foreground">
+                    {t('routes.bulkSelectedCount', { count: selectedRouteIds.size })}
+                  </span>
+                )}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={selectedRouteIds.size === 0 || bulkDeleteRoutes.isPending}
+                  onClick={() => setBulkDeleteOpen(true)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  {t('routes.bulkDelete')}
+                </Button>
+              </div>
+            </div>
+          )}
+
           {/* Routes List */}
           {items.length > 0 ? (
             <DndContext
@@ -513,20 +653,38 @@ function ClientTypeRoutesContentInner({
               <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
                 <div className="space-y-2">
                   {items.map((item, index) => (
-                    <SortableProviderRow
+                    <div
                       key={item.id}
-                      item={item}
-                      index={index}
-                      clientType={clientType}
-                      streamingCount={
-                        countsByProviderAndClient.get(`${item.provider.id}:${clientType}`) || 0
-                      }
-                      stats={stableProviderStats[item.provider.id]}
-                      isToggling={toggleRoute.isPending || createRoute.isPending}
-                      showWeight={isWeighted}
-                      onToggle={() => handleToggle(item)}
-                      onDelete={item.route ? () => handleDeleteRoute(item.route!.id) : undefined}
-                    />
+                      className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={item.route ? selectedRouteIds.has(item.route.id) : false}
+                        disabled={!item.route || bulkDeleteRoutes.isPending}
+                        aria-label={t('routes.selectRoute', { name: item.provider.name })}
+                        onPointerDown={(event) => event.stopPropagation()}
+                        onClick={(event) => event.stopPropagation()}
+                        onChange={(event) => {
+                          if (item.route) {
+                            handleToggleRouteSelection(item.route.id, event.target.checked);
+                          }
+                        }}
+                        className="h-4 w-4 rounded border-border accent-destructive"
+                      />
+                      <SortableProviderRow
+                        item={item}
+                        index={index}
+                        clientType={clientType}
+                        streamingCount={
+                          countsByProviderAndClient.get(`${item.provider.id}:${clientType}`) || 0
+                        }
+                        stats={stableProviderStats[item.provider.id]}
+                        isToggling={toggleRoute.isPending || createRoute.isPending}
+                        showWeight={isWeighted}
+                        onToggle={() => handleToggle(item)}
+                        onDelete={item.route ? () => handleDeleteRoute(item.route!.id) : undefined}
+                      />
+                    </div>
                   ))}
                 </div>
               </SortableContext>
@@ -644,6 +802,69 @@ function ClientTypeRoutesContentInner({
               </div>
             </div>
           )}
+
+          <AlertDialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>{t('routes.bulkDeleteDialog.title')}</AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t('routes.bulkDeleteDialog.description', {
+                    count: selectedItems.length,
+                    client: getClientName(clientType),
+                    scope: scopeName,
+                  })}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+
+              <div className="space-y-3 text-sm">
+                <div className="rounded-lg border border-border/60 bg-muted/30 p-3">
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    {t('routes.bulkDeleteDialog.providersPreview')}
+                  </div>
+                  <ul className="space-y-1 text-foreground">
+                    {selectedProviderNames.slice(0, 5).map((name, index) => (
+                      <li key={`${name}-${index}`} className="truncate">
+                        {name}
+                      </li>
+                    ))}
+                  </ul>
+                  {selectedProviderNames.length > 5 && (
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      {t('routes.bulkDeleteDialog.moreProviders', {
+                        count: selectedProviderNames.length - 5,
+                      })}
+                    </div>
+                  )}
+                </div>
+
+                {selectedStreamingCount > 0 && (
+                  <div className="flex gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-amber-700 dark:text-amber-300">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>
+                      {t('routes.bulkDeleteDialog.streamingWarning', {
+                        count: selectedStreamingCount,
+                      })}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={bulkDeleteRoutes.isPending}>
+                  {t('common.cancel')}
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  disabled={selectedItems.length === 0 || bulkDeleteRoutes.isPending}
+                  onClick={handleConfirmBulkDelete}
+                >
+                  {bulkDeleteRoutes.isPending
+                    ? t('routes.bulkDeleteDialog.deleting')
+                    : t('routes.bulkDeleteDialog.confirm')}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
     </div>

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -37,6 +37,7 @@ export {
   useCreateRoute,
   useUpdateRoute,
   useDeleteRoute,
+  useBulkDeleteRoutes,
   useToggleRoute,
   useUpdateRoutePositions,
 } from './use-routes';

--- a/web/src/hooks/queries/use-routes.ts
+++ b/web/src/hooks/queries/use-routes.ts
@@ -3,7 +3,12 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTransport, type Route, type CreateRouteData } from '@/lib/transport';
+import {
+  getTransport,
+  type Route,
+  type CreateRouteData,
+  type RouteBulkDeleteRequest,
+} from '@/lib/transport';
 
 // Query Keys
 export const routeKeys = {
@@ -63,6 +68,18 @@ export function useDeleteRoute() {
 
   return useMutation({
     mutationFn: (id: number) => getTransport().deleteRoute(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: routeKeys.lists() });
+    },
+  });
+}
+
+// 批量删除 Route
+export function useBulkDeleteRoutes() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: RouteBulkDeleteRequest) => getTransport().bulkDeleteRoutes(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: routeKeys.lists() });
     },

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -64,6 +64,8 @@ import type {
   APITokenCleanupResult,
   APITokenCreateResult,
   CreateAPITokenData,
+  RouteBulkDeleteRequest,
+  RouteBulkDeleteResult,
   RoutePositionUpdate,
   UsageStats,
   UsageStatsFilter,
@@ -312,6 +314,14 @@ export class HttpTransport implements Transport {
 
   async deleteRoute(id: number): Promise<void> {
     await this.client.delete(`/routes/${id}`);
+  }
+
+  async bulkDeleteRoutes(data: RouteBulkDeleteRequest): Promise<RouteBulkDeleteResult> {
+    const { data: result } = await this.client.post<RouteBulkDeleteResult>(
+      '/routes/bulk-delete',
+      data,
+    );
+    return result;
   }
 
   async batchUpdateRoutePositions(updates: RoutePositionUpdate[]): Promise<void> {
@@ -563,18 +573,14 @@ export class HttpTransport implements Transport {
     return data;
   }
 
-  async getBedrockDiscoveredModels(
-    providerId: number,
-  ): Promise<BedrockDiscoveredModelsResult> {
+  async getBedrockDiscoveredModels(providerId: number): Promise<BedrockDiscoveredModelsResult> {
     const { data } = await this.client.get<BedrockDiscoveredModelsResult>(
       `/providers/${providerId}/bedrock-models`,
     );
     return data;
   }
 
-  async refreshBedrockDiscoveredModels(
-    providerId: number,
-  ): Promise<BedrockDiscoveredModelsResult> {
+  async refreshBedrockDiscoveredModels(providerId: number): Promise<BedrockDiscoveredModelsResult> {
     // POST forces a fresh ListInferenceProfiles + ListFoundationModels
     // round-trip, bypassing the server-side TTL. Use this only when the
     // operator clicks the refresh button — routine page loads should
@@ -768,7 +774,10 @@ export class HttpTransport implements Transport {
     return this.expectArray<Cooldown>(data, '/cooldowns');
   }
 
-  async clearCooldown(providerId: number, options?: { clientType?: string; model?: string }): Promise<void> {
+  async clearCooldown(
+    providerId: number,
+    options?: { clientType?: string; model?: string },
+  ): Promise<void> {
     const searchParams = new URLSearchParams();
     if (options?.clientType) searchParams.set('clientType', options.clientType);
     if (options?.model) searchParams.set('model', options.model);
@@ -776,7 +785,12 @@ export class HttpTransport implements Transport {
     await this.adminClient.delete(`/cooldowns/${providerId}${qs ? `?${qs}` : ''}`);
   }
 
-  async setCooldown(providerId: number, untilTime: string, clientType?: string, model?: string): Promise<void> {
+  async setCooldown(
+    providerId: number,
+    untilTime: string,
+    clientType?: string,
+    model?: string,
+  ): Promise<void> {
     await this.adminClient.put(`/cooldowns/${providerId}`, { untilTime, clientType, model });
   }
 

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -20,6 +20,8 @@ export type {
   Route,
   CreateRouteData,
   RoutePositionUpdate,
+  RouteBulkDeleteRequest,
+  RouteBulkDeleteResult,
   RetryConfig,
   CreateRetryConfigData,
   RoutingStrategy,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -63,6 +63,8 @@ import type {
   APITokenCleanupResult,
   APITokenCreateResult,
   CreateAPITokenData,
+  RouteBulkDeleteRequest,
+  RouteBulkDeleteResult,
   RoutePositionUpdate,
   UsageStats,
   UsageStatsFilter,
@@ -104,6 +106,7 @@ export interface Transport {
   createRoute(data: CreateRouteData): Promise<Route>;
   updateRoute(id: number, data: Partial<Route>): Promise<Route>;
   deleteRoute(id: number): Promise<void>;
+  bulkDeleteRoutes(data: RouteBulkDeleteRequest): Promise<RouteBulkDeleteResult>;
   batchUpdateRoutePositions(updates: RoutePositionUpdate[]): Promise<void>;
 
   // ===== Session API =====
@@ -214,8 +217,16 @@ export interface Transport {
 
   // ===== Cooldown API =====
   getCooldowns(): Promise<Cooldown[]>;
-  clearCooldown(providerId: number, options?: { clientType?: string; model?: string }): Promise<void>;
-  setCooldown(providerId: number, untilTime: string, clientType?: string, model?: string): Promise<void>;
+  clearCooldown(
+    providerId: number,
+    options?: { clientType?: string; model?: string },
+  ): Promise<void>;
+  setCooldown(
+    providerId: number,
+    untilTime: string,
+    clientType?: string,
+    model?: string,
+  ): Promise<void>;
 
   // ===== Auth API =====
   getAuthStatus(): Promise<AuthStatus>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -214,6 +214,19 @@ export interface RoutePositionUpdate {
   position: number;
 }
 
+export interface RouteBulkDeleteRequest {
+  ids: number[];
+  clientType: ClientType;
+  projectID: number;
+}
+
+export interface RouteBulkDeleteResult {
+  deletedCount: number;
+  deletedIDs: number[];
+  skippedIDs: number[];
+  notFoundIDs: number[];
+}
+
 // ===== RetryConfig =====
 
 export interface RetryConfig {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -642,7 +642,23 @@
     "affinityOff": "Affinity off",
     "affinityScopeToken": "by token",
     "affinityScopeConversation": "by conversation",
-    "affinityTooltip": "Session affinity (sticky): under weighted_random, a session keeps hitting the same provider within the TTL to maximize prompt-cache hits. Configure it on the Routing strategies page."
+    "affinityTooltip": "Session affinity (sticky): under weighted_random, a session keeps hitting the same provider within the TTL to maximize prompt-cache hits. Configure it on the Routing strategies page.",
+    "globalScope": "Global",
+    "projectScope": "Project",
+    "bulkSelectVisible": "Select visible routes ({{count}})",
+    "bulkFilteredSelection": "filtered by current search",
+    "bulkSelectedCount": "{{count}} selected",
+    "bulkDelete": "Delete selected",
+    "selectRoute": "Select route for {{name}}",
+    "bulkDeleteDialog": {
+      "title": "Delete selected routes?",
+      "description": "This will remove {{count}} {{client}} route binding(s) from {{scope}} only. Provider records and credentials will not be deleted.",
+      "providersPreview": "Providers",
+      "moreProviders": "and {{count}} more",
+      "streamingWarning": "{{count}} active streaming request(s) are currently using selected provider(s). Deleting routes may interrupt new routing decisions.",
+      "confirm": "Delete routes",
+      "deleting": "Deleting..."
+    }
   },
   "console": {
     "title": "Console",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -641,7 +641,23 @@
     "affinityOff": "亲和关闭",
     "affinityScopeToken": "按 token",
     "affinityScopeConversation": "按会话",
-    "affinityTooltip": "会话亲和(sticky):加权随机下,同一会话在 TTL 内持续命中同一 provider,以最大化 prompt 缓存命中。可在「路由策略」页配置。"
+    "affinityTooltip": "会话亲和(sticky):加权随机下,同一会话在 TTL 内持续命中同一 provider,以最大化 prompt 缓存命中。可在「路由策略」页配置。",
+    "globalScope": "全局",
+    "projectScope": "项目",
+    "bulkSelectVisible": "选择当前可见路由（{{count}}）",
+    "bulkFilteredSelection": "已按当前搜索过滤",
+    "bulkSelectedCount": "已选择 {{count}} 条",
+    "bulkDelete": "删除所选",
+    "selectRoute": "选择 {{name}} 的路由",
+    "bulkDeleteDialog": {
+      "title": "删除所选路由？",
+      "description": "这只会从 {{scope}} 删除 {{count}} 条 {{client}} 路由绑定，不会删除 Provider 本体或凭据。",
+      "providersPreview": "提供商",
+      "moreProviders": "以及 {{count}} 个",
+      "streamingWarning": "当前有 {{count}} 个流式请求正在使用选中的提供商。删除路由可能影响后续路由决策。",
+      "confirm": "删除路由",
+      "deleting": "删除中..."
+    }
   },
   "console": {
     "title": "控制台",


### PR DESCRIPTION
## Summary
- Add a scoped bulk route deletion API for route bindings only.
- Wire admin/self-service handlers, service, sqlite/cached repositories, frontend transport, and React Query hooks.
- Add multi-select, select visible routes, and destructive confirmation UI in `ClientTypeRoutesContent` across Claude/OpenAI/Codex/Gemini route tabs.
- Include Chinese/English i18n and a SQLite regression test for tenant/client/project scoping.

## Validation
- `go test ./internal/repository/sqlite ./internal/handler ./internal/service`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web test`
- `pnpm --dir web build`
- `go test ./...`
- Manual browser E2E against a temporary local server: created 5 Global Claude routes, 1 Global OpenAI guard route, and 1 Project Claude guard route; bulk-deleted the visible Global Claude routes and confirmed only the scoped routes were removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 路由现支持批量删除功能，用户可一次性选中多条路由绑定进行删除
  * 路由列表新增批量选择交互，支持全选/反选当前可见路由
  * 批量删除前显示警告对话框，预览受影响的服务商及流式请求相关信息

* **Localization**
  * 新增英文和中文界面文案，支持批量选择和删除操作的多语言显示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->