### PR TITLE
feat(requests): add error filters and stats dialog

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -871,12 +871,84 @@ func parseTimeQuery(raw, name string) (*time.Time, error) {
 	return nil, errors.New("invalid " + name + ": expected millisecond timestamp or RFC3339")
 }
 
+func parseProxyRequestFilter(r *http.Request) (*repository.ProxyRequestFilter, error) {
+	providerIDStr := r.URL.Query().Get("providerId")
+	statusStr := r.URL.Query().Get("status")
+	apiTokenIDStr := r.URL.Query().Get("apiTokenId")
+	projectIDStr := r.URL.Query().Get("projectId")
+	startTimeStr := r.URL.Query().Get("startTime")
+	endTimeStr := r.URL.Query().Get("endTime")
+	errorModeStr := r.URL.Query().Get("errorMode")
+
+	if providerIDStr == "" && statusStr == "" && apiTokenIDStr == "" && projectIDStr == "" && startTimeStr == "" && endTimeStr == "" && errorModeStr == "" {
+		return nil, nil
+	}
+
+	filter := &repository.ProxyRequestFilter{}
+	if providerIDStr != "" {
+		providerID, err := strconv.ParseUint(providerIDStr, 10, 64)
+		if err != nil {
+			return nil, errors.New("invalid providerId")
+		}
+		filter.ProviderID = &providerID
+	}
+	if statusStr != "" {
+		filter.Status = &statusStr
+	}
+	if apiTokenIDStr != "" {
+		apiTokenID, err := strconv.ParseUint(apiTokenIDStr, 10, 64)
+		if err != nil {
+			return nil, errors.New("invalid apiTokenId")
+		}
+		filter.APITokenID = &apiTokenID
+	}
+	if projectIDStr != "" {
+		projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
+		if err != nil {
+			return nil, errors.New("invalid projectId")
+		}
+		filter.ProjectID = &projectID
+	}
+	if startTimeStr != "" {
+		startTime, err := parseTimeQuery(startTimeStr, "startTime")
+		if err != nil {
+			return nil, err
+		}
+		filter.StartTime = startTime
+	}
+	if endTimeStr != "" {
+		endTime, err := parseTimeQuery(endTimeStr, "endTime")
+		if err != nil {
+			return nil, err
+		}
+		filter.EndTime = endTime
+	}
+	if filter.StartTime != nil && filter.EndTime != nil && filter.EndTime.Before(*filter.StartTime) {
+		return nil, errors.New("endTime must be greater than or equal to startTime")
+	}
+	if errorModeStr != "" {
+		switch repository.ProxyRequestErrorMode(errorModeStr) {
+		case repository.ProxyRequestErrorModeAll, repository.ProxyRequestErrorModeOnly, repository.ProxyRequestErrorModeExclude:
+			filter.ErrorMode = repository.ProxyRequestErrorMode(errorModeStr)
+		default:
+			return nil, errors.New("invalid errorMode")
+		}
+	}
+	return filter, nil
+}
+
 // ProxyRequest handlers
-// Routes: /admin/requests, /admin/requests/count, /admin/requests/active, /admin/requests/{id}, /admin/requests/{id}/attempts, /admin/requests/{id}/recalculate-cost
+// Routes: /admin/requests, /admin/requests/count, /admin/requests/error-stats, /admin/requests/active, /admin/requests/{id}, /admin/requests/{id}/attempts, /admin/requests/{id}/recalculate-cost
 func (h *AdminHandler) handleProxyRequests(w http.ResponseWriter, r *http.Request, id uint64, parts []string) {
 	// Check for count endpoint: /admin/requests/count
 	if len(parts) > 2 && parts[2] == "count" {
 		h.handleProxyRequestsCount(w, r)
+		return
+	}
+
+	// Check for error stats endpoint: /admin/requests/error-stats
+	if len(parts) > 2 && parts[2] == "error-stats" {
+		h.handleProxyRequestsErrorStats(w, r)
 		return
 	}
 
@@ -922,64 +994,10 @@ func (h *AdminHandler) handleProxyRequests(w http.ResponseWriter, r *http.Reques
 				after, _ = strconv.ParseUint(a, 10, 64)
 			}
 
-			// 构建过滤条件
-			var filter *repository.ProxyRequestFilter
-			providerIDStr := r.URL.Query().Get("providerId")
-			statusStr := r.URL.Query().Get("status")
-			apiTokenIDStr := r.URL.Query().Get("apiTokenId")
-			projectIDStr := r.URL.Query().Get("projectId")
-			startTimeStr := r.URL.Query().Get("startTime")
-			endTimeStr := r.URL.Query().Get("endTime")
-
-			if providerIDStr != "" || statusStr != "" || apiTokenIDStr != "" || projectIDStr != "" || startTimeStr != "" || endTimeStr != "" {
-				filter = &repository.ProxyRequestFilter{}
-				if providerIDStr != "" {
-					providerID, err := strconv.ParseUint(providerIDStr, 10, 64)
-					if err != nil {
-						writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid providerId"})
-						return
-					}
-					filter.ProviderID = &providerID
-				}
-				if statusStr != "" {
-					filter.Status = &statusStr
-				}
-				if apiTokenIDStr != "" {
-					apiTokenID, err := strconv.ParseUint(apiTokenIDStr, 10, 64)
-					if err != nil {
-						writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid apiTokenId"})
-						return
-					}
-					filter.APITokenID = &apiTokenID
-				}
-				if projectIDStr != "" {
-					projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
-					if err != nil {
-						writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid projectId"})
-						return
-					}
-					filter.ProjectID = &projectID
-				}
-				if startTimeStr != "" {
-					startTime, err := parseTimeQuery(startTimeStr, "startTime")
-					if err != nil {
-						writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-						return
-					}
-					filter.StartTime = startTime
-				}
-				if endTimeStr != "" {
-					endTime, err := parseTimeQuery(endTimeStr, "endTime")
-					if err != nil {
-						writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-						return
-					}
-					filter.EndTime = endTime
-				}
-				if filter.StartTime != nil && filter.EndTime != nil && filter.EndTime.Before(*filter.StartTime) {
-					writeJSON(w, http.StatusBadRequest, map[string]string{"error": "endTime must be greater than or equal to startTime"})
-					return
-				}
+			filter, err := parseProxyRequestFilter(r)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
 			}
 
 			result, err := h.svc.GetProxyRequestsCursor(tenantID, limit, before, after, filter)
@@ -1003,64 +1021,10 @@ func (h *AdminHandler) handleProxyRequestsCount(w http.ResponseWriter, r *http.R
 
 	tenantID := maxxctx.GetTenantID(r.Context())
 
-	// 解析过滤参数
-	var filter *repository.ProxyRequestFilter
-	providerIDStr := r.URL.Query().Get("providerId")
-	statusStr := r.URL.Query().Get("status")
-	apiTokenIDStr := r.URL.Query().Get("apiTokenId")
-	projectIDStr := r.URL.Query().Get("projectId")
-	startTimeStr := r.URL.Query().Get("startTime")
-	endTimeStr := r.URL.Query().Get("endTime")
-
-	if providerIDStr != "" || statusStr != "" || apiTokenIDStr != "" || projectIDStr != "" || startTimeStr != "" || endTimeStr != "" {
-		filter = &repository.ProxyRequestFilter{}
-		if providerIDStr != "" {
-			providerID, err := strconv.ParseUint(providerIDStr, 10, 64)
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid providerId"})
-				return
-			}
-			filter.ProviderID = &providerID
-		}
-		if statusStr != "" {
-			filter.Status = &statusStr
-		}
-		if apiTokenIDStr != "" {
-			apiTokenID, err := strconv.ParseUint(apiTokenIDStr, 10, 64)
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid apiTokenId"})
-				return
-			}
-			filter.APITokenID = &apiTokenID
-		}
-		if projectIDStr != "" {
-			projectID, err := strconv.ParseUint(projectIDStr, 10, 64)
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid projectId"})
-				return
-			}
-			filter.ProjectID = &projectID
-		}
-		if startTimeStr != "" {
-			startTime, err := parseTimeQuery(startTimeStr, "startTime")
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-				return
-			}
-			filter.StartTime = startTime
-		}
-		if endTimeStr != "" {
-			endTime, err := parseTimeQuery(endTimeStr, "endTime")
-			if err != nil {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-				return
-			}
-			filter.EndTime = endTime
-		}
-		if filter.StartTime != nil && filter.EndTime != nil && filter.EndTime.Before(*filter.StartTime) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "endTime must be greater than or equal to startTime"})
-			return
-		}
+	filter, err := parseProxyRequestFilter(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
 	}
 
 	count, err := h.svc.GetProxyRequestsCountWithFilter(tenantID, filter)
@@ -1069,6 +1033,30 @@ func (h *AdminHandler) handleProxyRequestsCount(w http.ResponseWriter, r *http.R
 		return
 	}
 	writeJSON(w, http.StatusOK, count)
+}
+
+func (h *AdminHandler) handleProxyRequestsErrorStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	filter, err := parseProxyRequestFilter(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if filter != nil {
+		filter.ErrorMode = repository.ProxyRequestErrorModeAll
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	stats, err := h.svc.GetProxyRequestErrorStats(tenantID, filter)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, stats)
 }
 
 // ActiveProxyRequests handler - returns all requests with PENDING or IN_PROGRESS status

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -125,6 +125,48 @@ type ProxyRequestFilter struct {
 	ProjectID  *uint64 // Project ID，nil 表示不过滤
 	StartTime  *time.Time
 	EndTime    *time.Time
+	ErrorMode  ProxyRequestErrorMode // 错误请求过滤模式
+}
+
+type ProxyRequestErrorMode string
+
+const (
+	ProxyRequestErrorModeAll     ProxyRequestErrorMode = "all"
+	ProxyRequestErrorModeOnly    ProxyRequestErrorMode = "only"
+	ProxyRequestErrorModeExclude ProxyRequestErrorMode = "exclude"
+)
+
+type ProxyRequestCountBucket struct {
+	Name  string `json:"name"`
+	Count int64  `json:"count"`
+}
+
+type ProxyRequestHTTPStatusBucket struct {
+	StatusCode int   `json:"statusCode"`
+	Count      int64 `json:"count"`
+}
+
+type ProxyRequestProviderBucket struct {
+	ProviderID uint64 `json:"providerId"`
+	Count      int64  `json:"count"`
+}
+
+type ProxyRequestTrendPoint struct {
+	StartTime     int64 `json:"startTime"`
+	EndTime       int64 `json:"endTime"`
+	TotalRequests int64 `json:"totalRequests"`
+	ErrorRequests int64 `json:"errorRequests"`
+}
+
+type ProxyRequestErrorStats struct {
+	TotalRequests    int64                          `json:"totalRequests"`
+	ErrorRequests    int64                          `json:"errorRequests"`
+	ErrorRate        float64                        `json:"errorRate"`
+	StatusCounts     []ProxyRequestCountBucket      `json:"statusCounts"`
+	HTTPStatusCounts []ProxyRequestHTTPStatusBucket `json:"httpStatusCounts"`
+	ProviderCounts   []ProxyRequestProviderBucket   `json:"providerCounts"`
+	ModelCounts      []ProxyRequestCountBucket      `json:"modelCounts"`
+	Trend            []ProxyRequestTrendPoint       `json:"trend"`
 }
 
 func (f *ProxyRequestFilter) IsEmpty() bool {
@@ -137,7 +179,8 @@ func (f *ProxyRequestFilter) IsEmpty() bool {
 		f.APITokenID == nil &&
 		f.ProjectID == nil &&
 		f.StartTime == nil &&
-		f.EndTime == nil
+		f.EndTime == nil &&
+		(f.ErrorMode == "" || f.ErrorMode == ProxyRequestErrorModeAll)
 }
 
 type ProxyRequestRepository interface {
@@ -155,6 +198,8 @@ type ProxyRequestRepository interface {
 	Count(tenantID uint64) (int64, error)
 	// CountWithFilter 带过滤条件的计数
 	CountWithFilter(tenantID uint64, filter *ProxyRequestFilter) (int64, error)
+	// GetErrorStats 获取错误请求统计
+	GetErrorStats(tenantID uint64, filter *ProxyRequestFilter) (*ProxyRequestErrorStats, error)
 	// UpdateProjectIDBySessionID 批量更新指定 sessionID 的所有请求的 projectID
 	UpdateProjectIDBySessionID(tenantID uint64, sessionID string, projectID uint64) (int64, error)
 	// MarkStaleAsFailed marks IN_PROGRESS/PENDING requests as FAILED when their

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -19,6 +19,73 @@ type ProxyRequestRepository struct {
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
 
+var proxyRequestErrorStatuses = []string{"FAILED", "REJECTED"}
+
+func cloneProxyRequestFilter(filter *repository.ProxyRequestFilter) *repository.ProxyRequestFilter {
+	if filter == nil {
+		return &repository.ProxyRequestFilter{}
+	}
+	cloned := *filter
+	return &cloned
+}
+
+func applyProxyRequestErrorMode(query *gorm.DB, mode repository.ProxyRequestErrorMode) *gorm.DB {
+	switch mode {
+	case repository.ProxyRequestErrorModeOnly:
+		return query.Where("status IN ? OR status_code >= ?", proxyRequestErrorStatuses, 400)
+	case repository.ProxyRequestErrorModeExclude:
+		return query.Where("status NOT IN ? AND status_code < ?", proxyRequestErrorStatuses, 400)
+	default:
+		return query
+	}
+}
+
+func applyProxyRequestFilter(query *gorm.DB, filter *repository.ProxyRequestFilter) *gorm.DB {
+	if filter == nil {
+		return query
+	}
+	if filter.ProviderID != nil {
+		query = query.Where("provider_id = ?", *filter.ProviderID)
+	}
+	if filter.Status != nil {
+		query = query.Where("status = ?", *filter.Status)
+	}
+	if filter.APITokenID != nil {
+		query = query.Where("api_token_id = ?", *filter.APITokenID)
+	}
+	if filter.ProjectID != nil {
+		query = query.Where("project_id = ?", *filter.ProjectID)
+	}
+	if filter.StartTime != nil {
+		query = query.Where("created_at >= ?", toTimestamp(*filter.StartTime))
+	}
+	if filter.EndTime != nil {
+		query = query.Where("created_at <= ?", toTimestamp(*filter.EndTime))
+	}
+	return applyProxyRequestErrorMode(query, filter.ErrorMode)
+}
+
+func proxyRequestTrendBucketSize(startMs, endMs int64) int64 {
+	if endMs <= startMs {
+		return int64(time.Hour / time.Millisecond)
+	}
+	duration := endMs - startMs
+	for _, bucket := range []int64{
+		int64(time.Minute / time.Millisecond),
+		int64(5 * time.Minute / time.Millisecond),
+		int64(15 * time.Minute / time.Millisecond),
+		int64(time.Hour / time.Millisecond),
+		int64(6 * time.Hour / time.Millisecond),
+		int64(24 * time.Hour / time.Millisecond),
+		int64(7 * 24 * time.Hour / time.Millisecond),
+	} {
+		if duration/bucket <= 30 {
+			return bucket
+		}
+	}
+	return int64(30 * 24 * time.Hour / time.Millisecond)
+}
+
 func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
 	r := &ProxyRequestRepository{db: db}
 	// 初始化时从数据库加载计数
@@ -108,26 +175,7 @@ func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, 
 	}
 
 	// 应用过滤条件
-	if filter != nil {
-		if filter.ProviderID != nil {
-			baseQuery = baseQuery.Where("provider_id = ?", *filter.ProviderID)
-		}
-		if filter.Status != nil {
-			baseQuery = baseQuery.Where("status = ?", *filter.Status)
-		}
-		if filter.APITokenID != nil {
-			baseQuery = baseQuery.Where("api_token_id = ?", *filter.APITokenID)
-		}
-		if filter.ProjectID != nil {
-			baseQuery = baseQuery.Where("project_id = ?", *filter.ProjectID)
-		}
-		if filter.StartTime != nil {
-			baseQuery = baseQuery.Where("created_at >= ?", toTimestamp(*filter.StartTime))
-		}
-		if filter.EndTime != nil {
-			baseQuery = baseQuery.Where("created_at <= ?", toTimestamp(*filter.EndTime))
-		}
-	}
+	baseQuery = applyProxyRequestFilter(baseQuery, filter)
 
 	orderBy := "id DESC"
 	if after > 0 {
@@ -176,30 +224,147 @@ func (r *ProxyRequestRepository) CountWithFilter(tenantID uint64, filter *reposi
 	// 有过滤条件时需要查询数据库
 	var count int64
 	query := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID)
-	if filter != nil {
-		if filter.ProviderID != nil {
-			query = query.Where("provider_id = ?", *filter.ProviderID)
-		}
-		if filter.Status != nil {
-			query = query.Where("status = ?", *filter.Status)
-		}
-		if filter.APITokenID != nil {
-			query = query.Where("api_token_id = ?", *filter.APITokenID)
-		}
-		if filter.ProjectID != nil {
-			query = query.Where("project_id = ?", *filter.ProjectID)
-		}
-		if filter.StartTime != nil {
-			query = query.Where("created_at >= ?", toTimestamp(*filter.StartTime))
-		}
-		if filter.EndTime != nil {
-			query = query.Where("created_at <= ?", toTimestamp(*filter.EndTime))
-		}
-	}
+	query = applyProxyRequestFilter(query, filter)
 	if err := query.Count(&count).Error; err != nil {
 		return 0, err
 	}
 	return count, nil
+}
+
+func (r *ProxyRequestRepository) GetErrorStats(tenantID uint64, filter *repository.ProxyRequestFilter) (*repository.ProxyRequestErrorStats, error) {
+	baseFilter := cloneProxyRequestFilter(filter)
+	baseFilter.ErrorMode = repository.ProxyRequestErrorModeAll
+
+	totalRequests, err := r.CountWithFilter(tenantID, baseFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	errorFilter := cloneProxyRequestFilter(baseFilter)
+	errorFilter.ErrorMode = repository.ProxyRequestErrorModeOnly
+	errorRequests, err := r.CountWithFilter(tenantID, errorFilter)
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &repository.ProxyRequestErrorStats{
+		TotalRequests:    totalRequests,
+		ErrorRequests:    errorRequests,
+		StatusCounts:     []repository.ProxyRequestCountBucket{},
+		HTTPStatusCounts: []repository.ProxyRequestHTTPStatusBucket{},
+		ProviderCounts:   []repository.ProxyRequestProviderBucket{},
+		ModelCounts:      []repository.ProxyRequestCountBucket{},
+		Trend:            []repository.ProxyRequestTrendPoint{},
+	}
+	if totalRequests > 0 {
+		stats.ErrorRate = float64(errorRequests) / float64(totalRequests)
+	}
+
+	statusQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+		Select("status AS name, COUNT(*) AS count").
+		Group("status").
+		Order("count DESC")
+	statusQuery = applyProxyRequestFilter(statusQuery, errorFilter)
+	if err := statusQuery.Scan(&stats.StatusCounts).Error; err != nil {
+		return nil, err
+	}
+
+	httpStatusQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+		Select("status_code AS status_code, COUNT(*) AS count").
+		Where("status_code >= ?", 400).
+		Group("status_code").
+		Order("count DESC").
+		Limit(20)
+	httpStatusQuery = applyProxyRequestFilter(httpStatusQuery, baseFilter)
+	if err := httpStatusQuery.Scan(&stats.HTTPStatusCounts).Error; err != nil {
+		return nil, err
+	}
+
+	providerQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+		Select("provider_id AS provider_id, COUNT(*) AS count").
+		Group("provider_id").
+		Order("count DESC").
+		Limit(10)
+	providerQuery = applyProxyRequestFilter(providerQuery, errorFilter)
+	if err := providerQuery.Scan(&stats.ProviderCounts).Error; err != nil {
+		return nil, err
+	}
+
+	modelQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+		Select("request_model AS name, COUNT(*) AS count").
+		Where("request_model <> ''").
+		Group("request_model").
+		Order("count DESC").
+		Limit(10)
+	modelQuery = applyProxyRequestFilter(modelQuery, errorFilter)
+	if err := modelQuery.Scan(&stats.ModelCounts).Error; err != nil {
+		return nil, err
+	}
+
+	startMs := int64(0)
+	endMs := int64(0)
+	if baseFilter.StartTime != nil {
+		startMs = toTimestamp(*baseFilter.StartTime)
+	}
+	if baseFilter.EndTime != nil {
+		endMs = toTimestamp(*baseFilter.EndTime)
+	}
+	if startMs == 0 || endMs == 0 {
+		var bounds struct {
+			MinCreatedAt int64
+			MaxCreatedAt int64
+		}
+		boundsQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+			Select("COALESCE(MIN(created_at), 0) AS min_created_at, COALESCE(MAX(created_at), 0) AS max_created_at")
+		boundsQuery = applyProxyRequestFilter(boundsQuery, baseFilter)
+		if err := boundsQuery.Scan(&bounds).Error; err != nil {
+			return nil, err
+		}
+		if startMs == 0 {
+			startMs = bounds.MinCreatedAt
+		}
+		if endMs == 0 {
+			endMs = bounds.MaxCreatedAt
+		}
+	}
+
+	if startMs > 0 && endMs >= startMs {
+		bucketSize := proxyRequestTrendBucketSize(startMs, endMs)
+		bucketStart := (startMs / bucketSize) * bucketSize
+		for bucketStart <= endMs {
+			bucketEnd := bucketStart + bucketSize - 1
+			if bucketEnd > endMs {
+				bucketEnd = endMs
+			}
+
+			bucketStartTime := time.UnixMilli(bucketStart).UTC()
+			bucketEndTime := time.UnixMilli(bucketEnd).UTC()
+			bucketFilter := cloneProxyRequestFilter(baseFilter)
+			bucketFilter.StartTime = &bucketStartTime
+			bucketFilter.EndTime = &bucketEndTime
+			total, err := r.CountWithFilter(tenantID, bucketFilter)
+			if err != nil {
+				return nil, err
+			}
+
+			bucketErrorFilter := cloneProxyRequestFilter(bucketFilter)
+			bucketErrorFilter.ErrorMode = repository.ProxyRequestErrorModeOnly
+			errors, err := r.CountWithFilter(tenantID, bucketErrorFilter)
+			if err != nil {
+				return nil, err
+			}
+
+			stats.Trend = append(stats.Trend, repository.ProxyRequestTrendPoint{
+				StartTime:     bucketStart,
+				EndTime:       bucketEnd,
+				TotalRequests: total,
+				ErrorRequests: errors,
+			})
+			bucketStart += bucketSize
+		}
+	}
+
+	return stats, nil
 }
 
 // 死实例孤儿请求的回收宽限期。当一个请求的 instance_id 不在活实例列表里时,

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -724,3 +724,144 @@ func TestProxyUpstreamAttemptClearDetailOlderThan_UsesSentinelIndex(t *testing.T
 		t.Fatalf("plan should not require TEMP B-TREE sort, got:\n%s", plan)
 	}
 }
+
+func TestProxyRequestErrorModeFiltersStatusAndHTTPFailures(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	requests := []*domain.ProxyRequest{
+		buildTestProxyRequest("COMPLETED", 1),
+		buildTestProxyRequest("FAILED", 2),
+		buildTestProxyRequest("REJECTED", 3),
+		buildTestProxyRequest("COMPLETED", 4),
+		buildTestProxyRequest("CANCELLED", 5),
+	}
+	requests[3].StatusCode = 502
+	for _, request := range requests {
+		if err := repo.Create(request); err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+	}
+
+	errorFilter := &repository.ProxyRequestFilter{ErrorMode: repository.ProxyRequestErrorModeOnly}
+	errorCount, err := repo.CountWithFilter(1, errorFilter)
+	if err != nil {
+		t.Fatalf("CountWithFilter only failed: %v", err)
+	}
+	if errorCount != 3 {
+		t.Fatalf("error count = %d, want 3", errorCount)
+	}
+
+	errorItems, err := repo.ListCursor(1, 10, 0, 0, errorFilter)
+	if err != nil {
+		t.Fatalf("ListCursor only failed: %v", err)
+	}
+	expectedErrorIDs := []uint64{requests[3].ID, requests[2].ID, requests[1].ID}
+	if got := collectRequestIDs(errorItems); fmt.Sprint(got) != fmt.Sprint(expectedErrorIDs) {
+		t.Fatalf("error ids = %v, want %v", got, expectedErrorIDs)
+	}
+
+	excludeFilter := &repository.ProxyRequestFilter{ErrorMode: repository.ProxyRequestErrorModeExclude}
+	nonErrorCount, err := repo.CountWithFilter(1, excludeFilter)
+	if err != nil {
+		t.Fatalf("CountWithFilter exclude failed: %v", err)
+	}
+	if nonErrorCount != 2 {
+		t.Fatalf("non-error count = %d, want 2", nonErrorCount)
+	}
+
+	nonErrorItems, err := repo.ListCursor(1, 10, 0, 0, excludeFilter)
+	if err != nil {
+		t.Fatalf("ListCursor exclude failed: %v", err)
+	}
+	expectedNonErrorIDs := []uint64{requests[4].ID, requests[0].ID}
+	if got := collectRequestIDs(nonErrorItems); fmt.Sprint(got) != fmt.Sprint(expectedNonErrorIDs) {
+		t.Fatalf("non-error ids = %v, want %v", got, expectedNonErrorIDs)
+	}
+}
+
+func TestProxyRequestErrorStatsAggregatesCurrentFilter(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	requests := []*domain.ProxyRequest{
+		buildTestProxyRequest("COMPLETED", 1),
+		buildTestProxyRequest("FAILED", 2),
+		buildTestProxyRequest("REJECTED", 3),
+		buildTestProxyRequest("COMPLETED", 4),
+		buildTestProxyRequest("CANCELLED", 5),
+	}
+	requests[0].ProviderID = 7
+	requests[0].RequestModel = "claude-sonnet"
+	requests[1].ProviderID = 7
+	requests[1].RequestModel = "claude-sonnet"
+	requests[2].ProviderID = 8
+	requests[2].RequestModel = "gpt-5"
+	requests[3].ProviderID = 7
+	requests[3].RequestModel = "claude-sonnet"
+	requests[3].StatusCode = 502
+	requests[4].ProviderID = 9
+	requests[4].RequestModel = "cancelled-model"
+	for _, request := range requests {
+		if err := repo.Create(request); err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+	}
+
+	stats, err := repo.GetErrorStats(1, nil)
+	if err != nil {
+		t.Fatalf("GetErrorStats failed: %v", err)
+	}
+	if stats.TotalRequests != 5 {
+		t.Fatalf("total requests = %d, want 5", stats.TotalRequests)
+	}
+	if stats.ErrorRequests != 3 {
+		t.Fatalf("error requests = %d, want 3", stats.ErrorRequests)
+	}
+	if stats.ErrorRate != 0.6 {
+		t.Fatalf("error rate = %v, want 0.6", stats.ErrorRate)
+	}
+
+	statusCounts := map[string]int64{}
+	for _, item := range stats.StatusCounts {
+		statusCounts[item.Name] = item.Count
+	}
+	if statusCounts["FAILED"] != 1 || statusCounts["REJECTED"] != 1 || statusCounts["COMPLETED"] != 1 || statusCounts["CANCELLED"] != 0 {
+		t.Fatalf("unexpected status counts: %#v", statusCounts)
+	}
+
+	httpCounts := map[int]int64{}
+	for _, item := range stats.HTTPStatusCounts {
+		httpCounts[item.StatusCode] = item.Count
+	}
+	if httpCounts[502] != 1 {
+		t.Fatalf("unexpected HTTP status counts: %#v", httpCounts)
+	}
+
+	providerCounts := map[uint64]int64{}
+	for _, item := range stats.ProviderCounts {
+		providerCounts[item.ProviderID] = item.Count
+	}
+	if providerCounts[7] != 2 || providerCounts[8] != 1 {
+		t.Fatalf("unexpected provider counts: %#v", providerCounts)
+	}
+
+	modelCounts := map[string]int64{}
+	for _, item := range stats.ModelCounts {
+		modelCounts[item.Name] = item.Count
+	}
+	if modelCounts["claude-sonnet"] != 2 || modelCounts["gpt-5"] != 1 {
+		t.Fatalf("unexpected model counts: %#v", modelCounts)
+	}
+	if len(stats.Trend) == 0 {
+		t.Fatal("expected non-empty trend")
+	}
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -864,6 +864,10 @@ func (s *AdminService) GetProxyRequestsCountWithFilter(tenantID uint64, filter *
 	return s.proxyRequestRepo.CountWithFilter(tenantID, filter)
 }
 
+func (s *AdminService) GetProxyRequestErrorStats(tenantID uint64, filter *repository.ProxyRequestFilter) (*repository.ProxyRequestErrorStats, error) {
+	return s.proxyRequestRepo.GetErrorStats(tenantID, filter)
+}
+
 func (s *AdminService) GetProxyRequest(tenantID uint64, id uint64) (*domain.ProxyRequest, error) {
 	return s.proxyRequestRepo.GetByID(tenantID, id)
 }

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -77,6 +77,7 @@ export {
   useProxyRequests,
   useInfiniteProxyRequests,
   useProxyRequestsCount,
+  useProxyRequestErrorStats,
   useProxyRequest,
   useProxyUpstreamAttempts,
   useProxyRequestUpdates,

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -8,6 +8,7 @@ import {
   getTransport,
   type ProxyRequest,
   type ProxyUpstreamAttempt,
+  type ProxyRequestErrorMode,
   type CursorPaginationParams,
   type CursorPaginationResult,
 } from '@/lib/transport';
@@ -18,12 +19,36 @@ export const requestKeys = {
   all: ['requests'] as const,
   lists: () => [...requestKeys.all, 'list'] as const,
   list: (params?: CursorPaginationParams) => [...requestKeys.lists(), params] as const,
-  infinite: (providerId?: number, status?: string, apiTokenId?: number, projectId?: number, startTime?: string, endTime?: string) =>
-    [...requestKeys.all, 'infinite', providerId, status, apiTokenId, projectId, startTime, endTime] as const,
+  infinite: (
+    providerId?: number,
+    status?: string,
+    apiTokenId?: number,
+    projectId?: number,
+    startTime?: string,
+    endTime?: string,
+    errorMode?: ProxyRequestErrorMode,
+  ) =>
+    [
+      ...requestKeys.all,
+      'infinite',
+      providerId,
+      status,
+      apiTokenId,
+      projectId,
+      startTime,
+      endTime,
+      errorMode,
+    ] as const,
+  errorStats: (params?: CursorPaginationParams) =>
+    [...requestKeys.all, 'error-stats', params] as const,
   details: () => [...requestKeys.all, 'detail'] as const,
   detail: (id: number) => [...requestKeys.details(), id] as const,
   attempts: (id: number) => [...requestKeys.detail(id), 'attempts'] as const,
 };
+
+function isProxyRequestError(request: ProxyRequest): boolean {
+  return request.status === 'FAILED' || request.status === 'REJECTED' || request.statusCode >= 400;
+}
 
 function matchesRequestTimeRange(
   request: ProxyRequest,
@@ -62,10 +87,19 @@ export function useInfiniteProxyRequests(
   projectId?: number,
   startTime?: string,
   endTime?: string,
+  errorMode?: ProxyRequestErrorMode,
   enabled = true,
 ) {
   return useInfiniteQuery({
-    queryKey: requestKeys.infinite(providerId, status, apiTokenId, projectId, startTime, endTime),
+    queryKey: requestKeys.infinite(
+      providerId,
+      status,
+      apiTokenId,
+      projectId,
+      startTime,
+      endTime,
+      errorMode,
+    ),
     queryFn: ({ pageParam }) =>
       getTransport().getProxyRequests({
         limit: 100,
@@ -76,6 +110,7 @@ export function useInfiniteProxyRequests(
         projectId,
         startTime,
         endTime,
+        errorMode: errorMode === 'all' ? undefined : errorMode,
       }),
     getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.lastId : undefined),
     initialPageParam: undefined as number | undefined,
@@ -95,16 +130,43 @@ export function useProxyRequestsCount(
   projectId?: number,
   startTime?: string,
   endTime?: string,
+  errorMode?: ProxyRequestErrorMode,
   enabled = true,
 ) {
   return useQuery({
-    queryKey: ['requestsCount', providerId, status, apiTokenId, projectId, startTime, endTime] as const,
+    queryKey: [
+      'requestsCount',
+      providerId,
+      status,
+      apiTokenId,
+      projectId,
+      startTime,
+      endTime,
+      errorMode,
+    ] as const,
     queryFn: () =>
-      getTransport().getProxyRequestsCount(providerId, status, apiTokenId, projectId, startTime, endTime),
+      getTransport().getProxyRequestsCount(
+        providerId,
+        status,
+        apiTokenId,
+        projectId,
+        startTime,
+        endTime,
+        errorMode,
+      ),
     enabled,
     staleTime: 5_000,
     refetchInterval: enabled ? 10_000 : false,
     refetchIntervalInBackground: false,
+  });
+}
+
+export function useProxyRequestErrorStats(params?: CursorPaginationParams, enabled = true) {
+  return useQuery({
+    queryKey: requestKeys.errorStats(params),
+    queryFn: () => getTransport().getProxyRequestErrorStats(params),
+    enabled,
+    staleTime: 5_000,
   });
 }
 
@@ -244,6 +306,7 @@ export function useProxyRequestUpdates() {
           const filterProjectId = params?.projectId;
           const filterStartTime = params?.startTime;
           const filterEndTime = params?.endTime;
+          const filterErrorMode = params?.errorMode;
 
           const matchesFilter = (request: ProxyRequest) => {
             if (filterProviderId !== undefined && request.providerID !== filterProviderId) {
@@ -259,6 +322,12 @@ export function useProxyRequestUpdates() {
               return false;
             }
             if (!matchesRequestTimeRange(request, filterStartTime, filterEndTime)) {
+              return false;
+            }
+            if (filterErrorMode === 'only' && !isProxyRequestError(request)) {
+              return false;
+            }
+            if (filterErrorMode === 'exclude' && isProxyRequestError(request)) {
               return false;
             }
             return true;
@@ -324,6 +393,7 @@ export function useProxyRequestUpdates() {
           const filterProjectId = queryKey[5] as number | undefined;
           const filterStartTime = queryKey[6] as string | undefined;
           const filterEndTime = queryKey[7] as string | undefined;
+          const filterErrorMode = queryKey[8] as ProxyRequestErrorMode | undefined;
 
           const matchesFilter = (request: ProxyRequest) => {
             if (filterProviderId !== undefined && request.providerID !== filterProviderId) {
@@ -339,6 +409,12 @@ export function useProxyRequestUpdates() {
               return false;
             }
             if (!matchesRequestTimeRange(request, filterStartTime, filterEndTime)) {
+              return false;
+            }
+            if (filterErrorMode === 'only' && !isProxyRequestError(request)) {
+              return false;
+            }
+            if (filterErrorMode === 'exclude' && isProxyRequestError(request)) {
               return false;
             }
             return true;
@@ -413,19 +489,32 @@ export function useProxyRequestUpdates() {
               const filterProjectId = query.queryKey[4] as number | undefined;
               const filterStartTime = query.queryKey[5] as string | undefined;
               const filterEndTime = query.queryKey[6] as string | undefined;
-              if (filterProviderId !== undefined && updatedRequest.providerID !== filterProviderId) {
+              const filterErrorMode = query.queryKey[7] as ProxyRequestErrorMode | undefined;
+              if (
+                filterProviderId !== undefined &&
+                updatedRequest.providerID !== filterProviderId
+              ) {
                 continue;
               }
               if (filterStatus !== undefined && updatedRequest.status !== filterStatus) {
                 continue;
               }
-              if (filterAPITokenId !== undefined && updatedRequest.apiTokenID !== filterAPITokenId) {
+              if (
+                filterAPITokenId !== undefined &&
+                updatedRequest.apiTokenID !== filterAPITokenId
+              ) {
                 continue;
               }
               if (filterProjectId !== undefined && updatedRequest.projectID !== filterProjectId) {
                 continue;
               }
               if (!matchesRequestTimeRange(updatedRequest, filterStartTime, filterEndTime)) {
+                continue;
+              }
+              if (filterErrorMode === 'only' && !isProxyRequestError(updatedRequest)) {
+                continue;
+              }
+              if (filterErrorMode === 'exclude' && isProxyRequestError(updatedRequest)) {
                 continue;
               }
               queryClient.setQueryData<number>(query.queryKey, (old) => (old ?? 0) + 1);
@@ -451,6 +540,7 @@ export function useProxyRequestUpdates() {
       if (invalidateCooldowns) {
         queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
       }
+      queryClient.invalidateQueries({ queryKey: [...requestKeys.all, 'error-stats'] });
 
       flushAttempts();
     };
@@ -465,10 +555,13 @@ export function useProxyRequestUpdates() {
       }, flushIntervalMs);
     };
 
-    const unsubscribeRequest = transport.subscribe<ProxyRequest>('proxy_request_update', (updatedRequest) => {
-      pendingRequests.set(updatedRequest.id, updatedRequest);
-      scheduleFlush();
-    });
+    const unsubscribeRequest = transport.subscribe<ProxyRequest>(
+      'proxy_request_update',
+      (updatedRequest) => {
+        pendingRequests.set(updatedRequest.id, updatedRequest);
+        scheduleFlush();
+      },
+    );
 
     // 订阅 ProxyUpstreamAttempt 更新事件
     const unsubscribeAttempt = transport.subscribe<ProxyUpstreamAttempt>(
@@ -503,7 +596,10 @@ export function useProxyRequestUpdates() {
       knownRequestIds.clear();
 
       void queryClient.refetchQueries({ queryKey: requestKeys.lists(), type: 'active' });
-      void queryClient.refetchQueries({ queryKey: [...requestKeys.all, 'infinite'], type: 'active' });
+      void queryClient.refetchQueries({
+        queryKey: [...requestKeys.all, 'infinite'],
+        type: 'active',
+      });
       void queryClient.refetchQueries({ queryKey: requestKeys.details(), type: 'active' });
       void queryClient.refetchQueries({ queryKey: ['requestsCount'], type: 'active' });
       void queryClient.refetchQueries({ queryKey: ['dashboard'], type: 'active' });

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -18,6 +18,8 @@ import type {
   RoutingStrategy,
   CreateRoutingStrategyData,
   ProxyRequest,
+  ProxyRequestErrorMode,
+  ProxyRequestErrorStats,
   ProxyUpstreamAttempt,
   ProxyStatus,
   ProviderStats,
@@ -439,6 +441,7 @@ export class HttpTransport implements Transport {
     projectId?: number,
     startTime?: string,
     endTime?: string,
+    errorMode?: ProxyRequestErrorMode,
   ): Promise<number> {
     const params: Record<string, string> = {};
     if (providerId !== undefined) {
@@ -459,8 +462,31 @@ export class HttpTransport implements Transport {
     if (endTime !== undefined) {
       params.endTime = endTime;
     }
+    if (errorMode !== undefined && errorMode !== 'all') {
+      params.errorMode = errorMode;
+    }
     const { data } = await this.adminClient.get<number>('/requests/count', { params });
     return data ?? 0;
+  }
+
+  async getProxyRequestErrorStats(
+    params?: CursorPaginationParams,
+  ): Promise<ProxyRequestErrorStats> {
+    const { data } = await this.adminClient.get<ProxyRequestErrorStats>('/requests/error-stats', {
+      params,
+    });
+    return (
+      data ?? {
+        totalRequests: 0,
+        errorRequests: 0,
+        errorRate: 0,
+        statusCounts: [],
+        httpStatusCounts: [],
+        providerCounts: [],
+        modelCounts: [],
+        trend: [],
+      }
+    );
   }
 
   async getActiveProxyRequests(): Promise<ProxyRequest[]> {

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -33,6 +33,8 @@ export type {
   RoutingStickyScope,
   CreateRoutingStrategyData,
   ProxyRequest,
+  ProxyRequestErrorMode,
+  ProxyRequestErrorStats,
   ProxyRequestStatus,
   ProxyUpstreamAttempt,
   ProxyUpstreamAttemptStatus,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -16,6 +16,8 @@ import type {
   RoutingStrategy,
   CreateRoutingStrategyData,
   ProxyRequest,
+  ProxyRequestErrorMode,
+  ProxyRequestErrorStats,
   ProxyUpstreamAttempt,
   CursorPaginationParams,
   CursorPaginationResult,
@@ -143,7 +145,9 @@ export interface Transport {
     projectId?: number,
     startTime?: string,
     endTime?: string,
+    errorMode?: ProxyRequestErrorMode,
   ): Promise<number>;
+  getProxyRequestErrorStats(params?: CursorPaginationParams): Promise<ProxyRequestErrorStats>;
   getActiveProxyRequests(): Promise<ProxyRequest[]>;
   getProxyRequest(id: number): Promise<ProxyRequest>;
   getProxyUpstreamAttempts(proxyRequestId: number): Promise<ProxyUpstreamAttempt[]>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -318,6 +318,41 @@ export type ProxyRequestStatus =
   | 'CANCELLED'
   | 'REJECTED';
 
+export type ProxyRequestErrorMode = 'all' | 'only' | 'exclude';
+
+export interface ProxyRequestCountBucket {
+  name: string;
+  count: number;
+}
+
+export interface ProxyRequestHTTPStatusBucket {
+  statusCode: number;
+  count: number;
+}
+
+export interface ProxyRequestProviderBucket {
+  providerId: number;
+  count: number;
+}
+
+export interface ProxyRequestTrendPoint {
+  startTime: number;
+  endTime: number;
+  totalRequests: number;
+  errorRequests: number;
+}
+
+export interface ProxyRequestErrorStats {
+  totalRequests: number;
+  errorRequests: number;
+  errorRate: number;
+  statusCounts: ProxyRequestCountBucket[];
+  httpStatusCounts: ProxyRequestHTTPStatusBucket[];
+  providerCounts: ProxyRequestProviderBucket[];
+  modelCounts: ProxyRequestCountBucket[];
+  trend: ProxyRequestTrendPoint[];
+}
+
 export interface ProxyRequest {
   id: number;
   createdAt: string;
@@ -424,6 +459,8 @@ export interface CursorPaginationParams {
   startTime?: string;
   /** 按创建时间终点过滤（ISO 字符串或毫秒时间戳字符串） */
   endTime?: string;
+  /** 错误请求过滤模式 */
+  errorMode?: ProxyRequestErrorMode;
 }
 
 /** 游标分页响应 */

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "common": {
     "save": "Save",
     "cancel": "Cancel",
@@ -59,7 +59,8 @@
     "clear": "Clear",
     "unknown": "Unknown",
     "back": "Back",
-    "useCLIProxyAPI": "Use CLIProxyAPI"
+    "useCLIProxyAPI": "Use CLIProxyAPI",
+    "count": "Count"
   },
   "clientTypes": {
     "claude": "Claude",
@@ -262,6 +263,26 @@
       "unchanged": "Unchanged",
       "lines": "lines",
       "button": "Diff"
+    },
+    "errorMode": {
+      "all": "All",
+      "only": "Errors only",
+      "exclude": "Hide errors"
+    },
+    "errorStats": {
+      "action": "Error stats",
+      "title": "Error request statistics",
+      "description": "Summarizes error requests, status codes, providers, models, and trends for the current filters.",
+      "empty": "No request data for the current filters",
+      "noData": "No data",
+      "totalRequests": "Total requests",
+      "errorRequests": "Error requests",
+      "errorRate": "Error rate",
+      "statusDistribution": "Status distribution",
+      "httpStatusDistribution": "HTTP status distribution",
+      "providerTop": "Provider error top",
+      "modelTop": "Model error top",
+      "trend": "Request/error trend"
     }
   },
   "providers": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "common": {
     "save": "保存",
     "cancel": "取消",
@@ -59,7 +59,8 @@
     "clear": "清除",
     "unknown": "未知",
     "back": "返回",
-    "useCLIProxyAPI": "使用 CLIProxyAPI"
+    "useCLIProxyAPI": "使用 CLIProxyAPI",
+    "count": "数量"
   },
   "clientTypes": {
     "claude": "Claude",
@@ -261,6 +262,26 @@
       "unchanged": "未变更",
       "lines": "行",
       "button": "差异"
+    },
+    "errorMode": {
+      "all": "全部",
+      "only": "只看错误",
+      "exclude": "隐藏错误"
+    },
+    "errorStats": {
+      "action": "错误统计",
+      "title": "错误请求统计",
+      "description": "基于当前筛选条件统计错误请求、状态码、Provider、模型和时间趋势。",
+      "empty": "当前筛选条件下暂无请求数据",
+      "noData": "无数据",
+      "totalRequests": "总请求数",
+      "errorRequests": "错误请求数",
+      "errorRate": "错误率",
+      "statusDistribution": "状态分布",
+      "httpStatusDistribution": "HTTP 状态码分布",
+      "providerTop": "Provider 错误 Top",
+      "modelTop": "模型错误 Top",
+      "trend": "请求/错误趋势"
     }
   },
   "providers": {

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -1,9 +1,11 @@
-﻿import { useState, useMemo, useRef, useEffect, type UIEvent } from 'react';
+﻿import { useState, useMemo, useRef, useEffect, type UIEvent, type ReactNode } from 'react';
 import { useCallback, memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import {
   useInfiniteProxyRequests,
+  useProxyRequestErrorStats,
   useProxyRequestUpdates,
   useProxyRequestsCount,
   useProviders,
@@ -21,12 +23,25 @@ import {
   CalendarRange,
   X,
   Clock,
+  BarChart3,
 } from 'lucide-react';
 import { format as formatDate } from 'date-fns';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import type {
   APIToken,
   Project,
+  CursorPaginationParams,
   ProxyRequest,
+  ProxyRequestErrorMode,
+  ProxyRequestErrorStats,
   ProxyRequestStatus,
   Provider,
 } from '@/lib/transport';
@@ -47,6 +62,11 @@ import {
   SelectGroup,
   SelectLabel,
   Input,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from '@/components/ui';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -236,6 +256,8 @@ export function RequestsPage() {
   );
   // Status 过滤器
   const [selectedStatus, setSelectedStatus] = useState<string | undefined>(undefined);
+  const [errorMode, setErrorMode] = useState<ProxyRequestErrorMode>('all');
+  const [errorStatsOpen, setErrorStatsOpen] = useState(false);
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
 
@@ -264,7 +286,9 @@ export function RequestsPage() {
   const waitingProjectFilterValidation =
     filterMode === 'project' && selectedProjectId !== undefined && !projectsIsSuccess;
   const waitingFilterValidation =
-    waitingProviderFilterValidation || waitingTokenFilterValidation || waitingProjectFilterValidation;
+    waitingProviderFilterValidation ||
+    waitingTokenFilterValidation ||
+    waitingProjectFilterValidation;
   const requestsQueryEnabled = !waitingFilterValidation;
 
   // 使用 Infinite Query
@@ -276,6 +300,7 @@ export function RequestsPage() {
       activeProjectId,
       activeStartTime,
       activeEndTime,
+      errorMode,
       requestsQueryEnabled,
     );
 
@@ -286,6 +311,7 @@ export function RequestsPage() {
     activeProjectId,
     activeStartTime,
     activeEndTime,
+    errorMode,
     requestsQueryEnabled,
   );
 
@@ -307,6 +333,29 @@ export function RequestsPage() {
   const projectMap = useMemo(() => new Map(projects.map((p) => [p.id, p.name])), [projects]);
   // Create API Token ID to name mapping
   const tokenMap = useMemo(() => new Map(apiTokens.map((t) => [t.id, t.name])), [apiTokens]);
+
+  const errorStatsParams = useMemo<CursorPaginationParams>(() => {
+    const params: CursorPaginationParams = {};
+    if (activeProviderId !== undefined) params.providerId = activeProviderId;
+    if (selectedStatus !== undefined) params.status = selectedStatus;
+    if (activeTokenId !== undefined) params.apiTokenId = activeTokenId;
+    if (activeProjectId !== undefined) params.projectId = activeProjectId;
+    if (activeStartTime !== undefined) params.startTime = activeStartTime;
+    if (activeEndTime !== undefined) params.endTime = activeEndTime;
+    return params;
+  }, [
+    activeEndTime,
+    activeProjectId,
+    activeProviderId,
+    activeStartTime,
+    activeTokenId,
+    selectedStatus,
+  ]);
+
+  const { data: errorStats, isFetching: errorStatsFetching } = useProxyRequestErrorStats(
+    errorStatsParams,
+    errorStatsOpen && requestsQueryEnabled,
+  );
 
   // 使用 totalCount
   const total = typeof totalCount === 'number' ? totalCount : 0;
@@ -573,6 +622,11 @@ export function RequestsPage() {
     scrollContainerRef.current?.scrollTo({ top: 0 });
   };
 
+  const handleErrorModeChange = (mode: ProxyRequestErrorMode) => {
+    setErrorMode(mode);
+    scrollContainerRef.current?.scrollTo({ top: 0 });
+  };
+
   const handleTimeRangeChange = (nextStart: Date | undefined, nextEnd: Date | undefined) => {
     setStartDate(nextStart);
     setEndDate(nextEnd);
@@ -667,6 +721,17 @@ export function RequestsPage() {
         )}
         {/* Status Filter */}
         <StatusFilter selectedStatus={selectedStatus} onSelect={handleStatusFilterChange} />
+        <ErrorModeFilter mode={errorMode} onSelect={handleErrorModeChange} />
+        <button
+          onClick={() => setErrorStatsOpen(true)}
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+            'bg-error/10 hover:bg-error/15 border border-error/30 text-error',
+          )}
+        >
+          <BarChart3 size={14} />
+          <span>{t('requests.errorStats.action')}</span>
+        </button>
         <TimeRangeFilter
           startDate={startDate}
           endDate={endDate}
@@ -687,6 +752,14 @@ export function RequestsPage() {
           <span>{t('requests.refresh')}</span>
         </button>
       </PageHeader>
+
+      <ErrorStatsDialog
+        open={errorStatsOpen}
+        onOpenChange={setErrorStatsOpen}
+        stats={errorStats}
+        loading={errorStatsFetching}
+        providerMap={providerMap}
+      />
 
       {/* Content */}
       <div className="flex-1 min-h-0 flex flex-col">
@@ -1521,12 +1594,7 @@ function DateTimePicker({
         <span>{value ? formatDate(value, 'MM/dd HH:mm') : label}</span>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
-        <Calendar
-          mode="single"
-          selected={value}
-          onSelect={handleDateSelect}
-          autoFocus
-        />
+        <Calendar mode="single" selected={value} onSelect={handleDateSelect} autoFocus />
         <div className="flex items-center gap-2 border-t border-border px-3 py-2">
           <Clock size={14} className="text-muted-foreground" />
           <Input
@@ -1579,6 +1647,260 @@ function TimeRangeFilter({
           <X size={13} />
         </button>
       )}
+    </div>
+  );
+}
+
+function formatStatusLabel(status: string, t: TFunction): string {
+  const key = status.toLowerCase();
+  const label = t(`requests.status.${key}`);
+  return label === `requests.status.${key}` ? status : label;
+}
+
+function formatRequestNumber(value: number | undefined): string {
+  return (value ?? 0).toLocaleString();
+}
+
+function formatErrorRate(value: number | undefined): string {
+  return `${((value ?? 0) * 100).toFixed(1)}%`;
+}
+
+function ErrorModeFilter({
+  mode,
+  onSelect,
+}: {
+  mode: ProxyRequestErrorMode;
+  onSelect: (mode: ProxyRequestErrorMode) => void;
+}) {
+  const { t } = useTranslation();
+  const options: ProxyRequestErrorMode[] = ['all', 'only', 'exclude'];
+
+  return (
+    <div className="flex items-center rounded-lg border border-border/50 bg-muted/40 p-0.5">
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onSelect(option)}
+          className={cn(
+            'px-2.5 py-1 rounded-md text-xs md:text-sm font-medium transition-all whitespace-nowrap',
+            mode === option
+              ? 'bg-error/15 text-error shadow-sm'
+              : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+          )}
+        >
+          {t(`requests.errorMode.${option}`)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ErrorStatsDialog({
+  open,
+  onOpenChange,
+  stats,
+  loading,
+  providerMap,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  stats: ProxyRequestErrorStats | undefined;
+  loading: boolean;
+  providerMap: Map<number, string>;
+}) {
+  const { t } = useTranslation();
+  const statusData = useMemo(
+    () =>
+      (stats?.statusCounts ?? []).map((item) => ({
+        name: formatStatusLabel(item.name, t),
+        count: item.count,
+      })),
+    [stats?.statusCounts, t],
+  );
+  const httpStatusData = useMemo(
+    () =>
+      (stats?.httpStatusCounts ?? []).map((item) => ({
+        name: String(item.statusCode),
+        count: item.count,
+      })),
+    [stats?.httpStatusCounts],
+  );
+  const providerData = useMemo(
+    () =>
+      (stats?.providerCounts ?? []).map((item) => ({
+        name: providerMap.get(item.providerId) ?? `#${item.providerId || '-'}`,
+        count: item.count,
+      })),
+    [providerMap, stats?.providerCounts],
+  );
+  const modelData = useMemo(
+    () =>
+      (stats?.modelCounts ?? []).map((item) => ({
+        name: item.name || t('common.unknown'),
+        count: item.count,
+      })),
+    [stats?.modelCounts, t],
+  );
+  const trendData = useMemo(
+    () =>
+      (stats?.trend ?? []).map((item) => ({
+        time: formatDate(new Date(item.startTime), 'MM-dd HH:mm'),
+        totalRequests: item.totalRequests,
+        errorRequests: item.errorRequests,
+      })),
+    [stats?.trend],
+  );
+
+  const empty = !loading && (!stats || stats.totalRequests === 0);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(72rem,calc(100vw-1.5rem))] max-w-[min(72rem,calc(100vw-1.5rem))] max-h-[calc(100vh-2rem)] overflow-y-auto grid-cols-[minmax(0,1fr)]">
+        <DialogHeader>
+          <DialogTitle>{t('requests.errorStats.title')}</DialogTitle>
+          <DialogDescription>{t('requests.errorStats.description')}</DialogDescription>
+        </DialogHeader>
+
+        {loading && !stats ? (
+          <div className="flex items-center justify-center py-16 text-muted-foreground">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            {t('common.loading')}
+          </div>
+        ) : empty ? (
+          <div className="rounded-xl border border-border bg-muted/20 p-8 text-center text-muted-foreground">
+            {t('requests.errorStats.empty')}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-3">
+              <StatCard
+                label={t('requests.errorStats.totalRequests')}
+                value={formatRequestNumber(stats?.totalRequests)}
+              />
+              <StatCard
+                label={t('requests.errorStats.errorRequests')}
+                value={formatRequestNumber(stats?.errorRequests)}
+                tone="error"
+              />
+              <StatCard
+                label={t('requests.errorStats.errorRate')}
+                value={formatErrorRate(stats?.errorRate)}
+                tone="error"
+              />
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-2">
+              <ChartPanel title={t('requests.errorStats.statusDistribution')}>
+                <DistributionList data={statusData} />
+              </ChartPanel>
+              <ChartPanel title={t('requests.errorStats.httpStatusDistribution')}>
+                <DistributionList data={httpStatusData} />
+              </ChartPanel>
+              <ChartPanel title={t('requests.errorStats.providerTop')}>
+                <DistributionList data={providerData} />
+              </ChartPanel>
+              <ChartPanel title={t('requests.errorStats.modelTop')}>
+                <DistributionList data={modelData} />
+              </ChartPanel>
+            </div>
+
+            <ChartPanel title={t('requests.errorStats.trend')}>
+              <div className="h-72">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={trendData} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                    <XAxis dataKey="time" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
+                    <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                    <Tooltip />
+                    <Line
+                      type="monotone"
+                      dataKey="totalRequests"
+                      name={t('requests.errorStats.totalRequests')}
+                      stroke="var(--color-chart-1)"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="errorRequests"
+                      name={t('requests.errorStats.errorRequests')}
+                      stroke="var(--color-chart-6)"
+                      strokeWidth={2}
+                      dot={false}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </ChartPanel>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'error';
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={cn('mt-1 text-2xl font-semibold', tone === 'error' && 'text-error')}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ChartPanel({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-xl border border-border bg-card p-4 min-w-0">
+      <h3 className="text-sm font-semibold mb-3">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function DistributionList({ data }: { data: { name: string; count: number }[] }) {
+  const { t } = useTranslation();
+  const maxCount = Math.max(...data.map((item) => item.count), 0);
+
+  if (data.length === 0 || maxCount === 0) {
+    return (
+      <div className="flex min-h-36 items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/20 text-sm text-muted-foreground">
+        {t('requests.errorStats.noData')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 py-1">
+      {data.map((item) => {
+        const percent = Math.max(6, (item.count / maxCount) * 100);
+        return (
+          <div key={item.name} className="space-y-1.5">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="min-w-0 truncate text-foreground/90">{item.name}</span>
+              <span className="font-mono text-xs font-medium text-muted-foreground">
+                {formatRequestNumber(item.count)}
+              </span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-[var(--color-chart-6)]"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add backend `errorMode=all|only|exclude` filtering for request list/count using the shared error definition
- add `/admin/requests/error-stats` for filtered error statistics
- add request page controls for all/errors-only/hide-errors and an error statistics modal
- add repository regression tests for error filtering and statistics aggregation

## Error definition
- `FAILED`
- `REJECTED`
- `status_code >= 400`
- `CANCELLED` is not treated as an error unless it also has an HTTP error status

## Validation
- `go test ./...`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm exec prettier --check src/lib/transport/types.ts src/lib/transport/interface.ts src/lib/transport/http-transport.ts src/lib/transport/index.ts src/hooks/queries/use-requests.ts src/hooks/queries/index.ts src/pages/requests/index.tsx src/locales/zh.json src/locales/en.json`
- `git diff --check`
- local UI screenshot validation for default list, errors-only list, and the error stats modal

## Notes
- `pnpm run build` still reports the existing Vite large chunk warning; the build exits successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 新增代理请求错误过滤功能，支持查看所有请求、仅错误请求或隐藏错误请求三种模式
* 新增错误统计面板，展示错误率、请求状态分布、供应商分布、模型分布及错误趋势数据

<!-- end of auto-generated comment: release notes by coderabbit.ai -->