### PR TITLE
fix(requests): use viewport width for error stats dialog

### DIFF
--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -1756,7 +1756,7 @@ function ErrorStatsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[min(96rem,calc(100vw-2rem))] max-w-[min(96rem,calc(100vw-2rem))] sm:max-w-[min(96rem,calc(100vw-2rem))] max-h-[calc(100vh-2rem)] overflow-y-auto grid-cols-[minmax(0,1fr)]">
+      <DialogContent className="w-[max(72vw,96rem)] max-w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto grid-cols-[minmax(0,1fr)]">
         <DialogHeader>
           <DialogTitle>{t('requests.errorStats.title')}</DialogTitle>
           <DialogDescription>{t('requests.errorStats.description')}</DialogDescription>


### PR DESCRIPTION
## Summary
- Make the Requests tab error stats dialog scale by viewport width instead of staying capped to a fixed 96rem-only layout.
- Use `w-[max(72vw,96rem)]` with `max-w-[calc(100vw-2rem)]` / `sm:max-w-[calc(100vw-2rem)]`, so large screens keep at least 70% visible width with margin for browser/layout rounding.

## Verification
- Screenshot smoke test at 1600px viewport: dialog width 1536px (~96%).
- Screenshot smoke test at 2560px viewport: dialog width 1843px (~72%).
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build` (passed; existing large chunk warning only)
- `git diff --check`
