### PR TITLE
fix(proxy): preserve provider fallback on upstream disconnect

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -519,7 +519,11 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 	// Copy upstream headers (except those we override)
 	copyResponseHeaders(c.Writer.Header(), resp.Header)
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, _ = c.Writer.Write(body)
+	if _, err := c.Writer.Write(body); err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "client disconnected")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
 	return nil
 }
 
@@ -782,7 +786,16 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 			if sseError != nil {
 				return sseError
 			}
-			return nil // Upstream closed normally
+			if !firstChunkSent {
+				proxyErr := domain.NewProxyErrorWithMessage(err, true, "upstream stream read error before response started")
+				proxyErr.Scope = domain.ScopeProvider
+				proxyErr.Reason = domain.CooldownReasonNetworkError
+				return proxyErr
+			}
+			proxyErr := domain.NewProxyErrorWithMessage(err, false, "upstream stream read error after response started")
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonNetworkError
+			return proxyErr
 		}
 	}
 }

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -313,6 +313,29 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			}
 
 			proxyErr, ok := err.(*domain.ProxyError)
+			if responseCapture.WroteToClient() {
+				log.Printf("[Executor] Response already committed; not failing over after provider %d error: %v", matchedRoute.Provider.ID, err)
+				proxyReq.Status = "FAILED"
+				proxyReq.EndTime = time.Now()
+				proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
+				proxyReq.Error = err.Error()
+				proxyReq.StatusCode = responseCapture.StatusCode()
+				if !clearDetail {
+					proxyReq.ResponseInfo = &domain.ResponseInfo{
+						Status:  responseCapture.StatusCode(),
+						Headers: responseCapture.CapturedHeaders(),
+						Body:    responseCapture.Body(),
+					}
+				}
+				clearProxyRequestDetail(proxyReq, clearDetail)
+				_ = e.proxyRequestRepo.Update(proxyReq)
+				if e.broadcaster != nil {
+					e.broadcaster.BroadcastProxyRequest(proxyReq)
+				}
+				state.lastErr = err
+				c.Err = err
+				return
+			}
 			if ok && ctx.Err() != nil {
 				proxyReq.Status = "CANCELLED"
 				proxyReq.EndTime = time.Now()
@@ -331,6 +354,25 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				}
 				state.lastErr = ctx.Err()
 				c.Err = state.lastErr
+				return
+			}
+
+			if ok && proxyErr.Scope == domain.ScopeRequest && !proxyErr.Retryable {
+				log.Printf("[Executor] Request-scoped non-retryable error; not failing over after provider %d: %v", matchedRoute.Provider.ID, err)
+				proxyReq.Status = "FAILED"
+				proxyReq.EndTime = time.Now()
+				proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
+				proxyReq.Error = err.Error()
+				if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+					proxyReq.StatusCode = proxyErr.HTTPStatusCode
+				}
+				clearProxyRequestDetail(proxyReq, clearDetail)
+				_ = e.proxyRequestRepo.Update(proxyReq)
+				if e.broadcaster != nil {
+					e.broadcaster.BroadcastProxyRequest(proxyReq)
+				}
+				state.lastErr = err
+				c.Err = err
 				return
 			}
 

--- a/internal/executor/response_capture.go
+++ b/internal/executor/response_capture.go
@@ -39,6 +39,7 @@ type ResponseCapture struct {
 	statusCode int
 	body       bytes.Buffer
 	headers    http.Header
+	wrote      bool
 
 	// maxBytes 是 body 缓冲的上界(字节);超过后停止缓冲但继续转发。0 表示不限。
 	maxBytes int
@@ -61,6 +62,7 @@ func NewResponseCapture(w http.ResponseWriter) *ResponseCapture {
 // WriteHeader captures the status code and forwards to underlying writer
 func (rc *ResponseCapture) WriteHeader(code int) {
 	rc.statusCode = code
+	rc.wrote = true
 	rc.ResponseWriter.WriteHeader(code)
 }
 
@@ -72,9 +74,18 @@ func (rc *ResponseCapture) WriteHeader(code int) {
 func (rc *ResponseCapture) Write(b []byte) (int, error) {
 	n, err := rc.ResponseWriter.Write(b)
 	if n > 0 {
+		rc.wrote = true
 		rc.captureBounded(b[:n])
 	}
 	return n, err
+}
+
+// WroteToClient reports whether any response header or body byte has already
+// been forwarded to the downstream client. Once true, the executor must not
+// transparently fail over to another provider: doing so could splice two
+// upstream responses into one client-visible stream.
+func (rc *ResponseCapture) WroteToClient() bool {
+	return rc.wrote
 }
 
 // captureBounded appends b to the snapshot buffer without exceeding maxBytes.

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -6,6 +6,7 @@ package e2e_test
 // The captured "verify> ..." log lines are the evidence.
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -347,6 +348,73 @@ func togglableMock() (*httptest.Server, *hitMock, func(int)) {
 		})
 	}))
 	return hm.server, hm, func(code int) { status.Store(int32(code)) }
+}
+
+func TestVerifyRoutingStreamDisconnectBeforeFirstChunkFailsOver(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	var brokenHits atomic.Int64
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		brokenHits.Add(1)
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("test server does not support hijacking")
+		}
+		conn, bufrw, err := hj.Hijack()
+		if err != nil {
+			t.Fatalf("hijack upstream connection: %v", err)
+		}
+		_, _ = fmt.Fprint(bufrw, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n")
+		_ = bufrw.Flush()
+		_ = conn.Close()
+	}))
+	defer broken.Close()
+
+	var fallbackHits atomic.Int64
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"chatcmpl-fallback\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"fallback-ok\"}}]}\n\n")
+		_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer fallback.Close()
+
+	brokenID := createProvider(t, env, "broken-stream", broken.URL, []string{"openai"})
+	fallbackID := createProvider(t, env, "fallback-stream", fallback.URL, []string{"openai"})
+
+	for i, pid := range []uint64{brokenID, fallbackID} {
+		resp := env.AdminPost("/api/admin/routes", map[string]any{
+			"isEnabled":  true,
+			"clientType": "openai",
+			"providerID": pid,
+			"position":   i + 1,
+			"weight":     1,
+		})
+		if resp.StatusCode != http.StatusCreated {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("create route %d: status=%d body=%s", i+1, resp.StatusCode, body)
+		}
+		resp.Body.Close()
+	}
+
+	req := openaiRequest("gpt-4o")
+	req["stream"] = true
+	resp := env.ProxyPost("/v1/chat/completions", req, nil)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxy status=%d body=%s", resp.StatusCode, body)
+	}
+	if brokenHits.Load() != 1 {
+		t.Fatalf("broken upstream hits=%d, want 1", brokenHits.Load())
+	}
+	if fallbackHits.Load() != 1 {
+		t.Fatalf("fallback upstream hits=%d, want 1", fallbackHits.Load())
+	}
+	if !bytes.Contains(body, []byte("fallback-ok")) {
+		t.Fatalf("fallback response body missing marker: %s", body)
+	}
 }
 
 // TestVerifyRoutingErrorClass exercises the failure / sticky-update story:


### PR DESCRIPTION
## Summary
- distinguish upstream stream read failures before the first downstream write from downstream client disconnects
- stop transparent provider fallback once a response has been committed to the client
- surface downstream write failures from the custom adapter instead of treating them as success
- add an e2e regression for SSE upstream disconnect before the first chunk falling back to the next provider

## Tests
- `go test ./internal/executor ./internal/adapter/provider/custom ./tests/e2e -run 'Test(ResponseCapture|VerifyRoutingStreamDisconnectBeforeFirstChunkFailsOver|ProxyCustom|Custom|Cooldown_429TriggersKeyLevelCooldown)' -v`
- `go test ./...`

## Notes
- Fallback remains allowed only before any header/body has been written to the downstream client.
- After response commit, the executor stops instead of stitching multiple provider streams into one response.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了流式响应中断时的处理：如果在首个数据块发送前连接断开，系统现在会更可靠地切换到备用路由。
  * 改进了客户端写入失败的识别，避免在响应已开始后仍继续走不合适的失败处理流程。
  * 当请求已部分返回或出现不可重试错误时，会更及时地记录失败状态并结束处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->