### PR TITLE
feat(routes): add custom provider key quick edit

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -747,6 +747,16 @@
       "globalTargetWarning": "The target is Default routes. This may affect every project that inherits global routing.",
       "failed": "Failed to sync routes",
       "confirm": "Sync routes"
+    },
+    "customProviderKey": {
+      "button": "Edit key",
+      "tooltip": "Quickly update this custom provider API key",
+      "title": "Edit custom provider key",
+      "description": "Update the API key saved on custom provider {{name}}. Leave empty to keep the current key.",
+      "scopeHint": "Non-empty values update the provider-level key. Every route using this custom provider will use the new key.",
+      "updateFailed": "Failed to update the custom provider key.",
+      "save": "Save key",
+      "placeholder": "Leave empty to keep current key"
     }
   },
   "console": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -744,6 +744,16 @@
       "globalTargetWarning": "目标是默认路由，可能影响所有继承全局路由的项目。",
       "failed": "同步路由失败",
       "confirm": "同步路由"
+    },
+    "customProviderKey": {
+      "button": "改 Key",
+      "tooltip": "快速修改该自定义提供商的 API Key",
+      "title": "修改自定义提供商 Key",
+      "description": "更新自定义提供商「{{name}}」上保存的 API Key；留空则保持当前 Key 不变。",
+      "scopeHint": "输入非空值时会修改提供商级 Key，所有引用该自定义提供商的路由都会使用新 Key。",
+      "updateFailed": "自定义提供商 Key 更新失败。",
+      "save": "保存 Key",
+      "placeholder": "留空保持当前 Key"
     }
   },
   "console": {

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -1,5 +1,16 @@
-import { GripVertical, Zap, RefreshCw, Activity, Snowflake, Info } from 'lucide-react';
-import { Button, Switch } from '@/components/ui';
+import { GripVertical, Zap, RefreshCw, Activity, Snowflake, Info, KeyRound } from 'lucide-react';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Switch,
+} from '@/components/ui';
 import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { MarqueeBackground } from '@/components/ui/marquee-background';
 import { useSortable } from '@dnd-kit/sortable';
@@ -17,10 +28,15 @@ import { CooldownTimer } from '@/components/cooldown-timer';
 import type { ProviderConfigItem } from '../types';
 import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-context';
 import { useCooldownsContext } from '@/contexts/cooldowns-context';
-import { useUpdateRoute } from '@/hooks/queries';
+import { useUpdateProvider, useUpdateRoute } from '@/hooks/queries';
 import { ProviderDetailsDialog } from '@/components/provider-details-dialog';
 import { useEffect, useRef, useState, memo } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  buildCustomProviderApiKeyUpdate,
+  canQuickEditCustomProviderKey,
+  normalizeCustomProviderApiKeyInput,
+} from '../utils/custom-provider-key';
 
 // Inline weight editor, shown on each route row only when the effective routing
 // strategy is weighted_random. Commits on blur / Enter and is debounced by the
@@ -89,6 +105,109 @@ function RouteWeightControlBase({ route }: { route: Route }) {
   );
 }
 const RouteWeightControl = memo(RouteWeightControlBase);
+
+function CustomProviderKeyQuickEdit({ provider }: { provider: ProviderConfigItem['provider'] }) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+  const [open, setOpen] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const close = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setApiKey('');
+      setError(null);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const nextKey = normalizeCustomProviderApiKeyInput(apiKey);
+    if (!nextKey) {
+      close(false);
+      return;
+    }
+
+    setError(null);
+    try {
+      await updateProvider.mutateAsync({
+        id: provider.id,
+        data: buildCustomProviderApiKeyUpdate(provider, nextKey),
+      });
+      close(false);
+    } catch (err) {
+      console.error('Failed to update custom provider key:', err);
+      setError(t('routes.customProviderKey.updateFailed'));
+    }
+  };
+
+  return (
+    <div
+      className="relative z-10 flex items-center shrink-0"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-disabled={updateProvider.isPending}
+        data-testid={`custom-provider-key-edit-${provider.id}`}
+        className={cn(
+          'inline-flex h-6 items-center justify-center gap-1 rounded-full border border-transparent bg-muted/45 px-2 text-[10px] font-bold text-muted-foreground transition-colors hover:border-primary/20 hover:bg-primary/10 hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:ring-[2px] outline-none',
+          updateProvider.isPending && 'pointer-events-none opacity-50',
+        )}
+        onClick={() => close(true)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            close(true);
+          }
+        }}
+        title={t('routes.customProviderKey.tooltip')}
+      >
+        <KeyRound size={11} />
+        {t('routes.customProviderKey.button')}
+      </div>
+      <Dialog open={open} onOpenChange={close}>
+        <DialogContent className="sm:max-w-md" onClick={(e) => e.stopPropagation()}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <DialogHeader>
+              <DialogTitle>{t('routes.customProviderKey.title')}</DialogTitle>
+              <DialogDescription>
+                {t('routes.customProviderKey.description', { name: provider.name })}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor={`custom-provider-key-${provider.id}`}>{t('provider.apiKey')}</Label>
+              <Input
+                id={`custom-provider-key-${provider.id}`}
+                type="password"
+                autoComplete="off"
+                value={apiKey}
+                placeholder={t('routes.customProviderKey.placeholder')}
+                onChange={(e) => setApiKey(e.target.value)}
+                autoFocus
+              />
+              <p className="text-xs text-muted-foreground">
+                {t('routes.customProviderKey.scopeHint')}
+              </p>
+              {error && <p className="text-xs text-destructive">{error}</p>}
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => close(false)}>
+                {t('provider.cancel')}
+              </Button>
+              <Button type="submit" disabled={updateProvider.isPending}>
+                {updateProvider.isPending ? t('common.saving') : t('routes.customProviderKey.save')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
 
 // 格式化 Token 数量
 function formatTokens(count: number): string {
@@ -641,6 +760,10 @@ function ProviderRowContentBase({
         <div className="relative z-10 flex items-center shrink-0">
           <StreamingBadge count={streamingCount} color={color} />
         </div>
+      )}
+      {/* Custom provider key quick edit: route UI edits provider-level key only. */}
+      {item.route && canQuickEditCustomProviderKey(provider) && (
+        <CustomProviderKeyQuickEdit provider={provider} />
       )}
       {/* Weight editor (weighted_random strategy only) */}
       {showWeight && item.route && <RouteWeightControl route={item.route} />}

--- a/web/src/pages/client-routes/utils/custom-provider-key-i18n.test.ts
+++ b/web/src/pages/client-routes/utils/custom-provider-key-i18n.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import en from '../../../locales/en.json';
+import zh from '../../../locales/zh.json';
+
+const requiredKeys = [
+  'button',
+  'tooltip',
+  'title',
+  'description',
+  'placeholder',
+  'scopeHint',
+  'updateFailed',
+  'save',
+] as const;
+
+type CustomProviderKeyMessages = Record<(typeof requiredKeys)[number], string>;
+
+function customProviderKeyMessages(locale: unknown): CustomProviderKeyMessages {
+  return (locale as { routes: { customProviderKey: CustomProviderKeyMessages } }).routes
+    .customProviderKey;
+}
+
+describe('custom provider key quick edit i18n', () => {
+  it.each([
+    ['en', customProviderKeyMessages(en)],
+    ['zh', customProviderKeyMessages(zh)],
+  ])('%s locale defines every quick-edit message', (_locale, messages) => {
+    for (const key of requiredKeys) {
+      expect(messages[key], key).toEqual(expect.any(String));
+      expect(messages[key].trim(), key).not.toBe('');
+    }
+  });
+
+  it('keeps the blank-key no-op hint localized', () => {
+    expect(customProviderKeyMessages(en).description).toContain('Leave empty');
+    expect(customProviderKeyMessages(en).placeholder).toContain('Leave empty');
+    expect(customProviderKeyMessages(zh).description).toContain('留空');
+    expect(customProviderKeyMessages(zh).placeholder).toContain('留空');
+  });
+});

--- a/web/src/pages/client-routes/utils/custom-provider-key.test.ts
+++ b/web/src/pages/client-routes/utils/custom-provider-key.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Provider } from '@/lib/transport';
+import {
+  buildCustomProviderApiKeyUpdate,
+  canQuickEditCustomProviderKey,
+  normalizeCustomProviderApiKeyInput,
+} from './custom-provider-key';
+
+const baseProvider: Provider = {
+  id: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  type: 'custom',
+  name: 'Custom Relay',
+  config: {
+    disableErrorCooldown: true,
+    custom: {
+      baseURL: 'https://relay.example/v1',
+      apiKey: 'old-key',
+      backend: 'ollama',
+      clientBaseURL: { claude: 'https://relay.example/claude' },
+      clientMultiplier: { claude: 12000 },
+      modelMapping: { '*': 'upstream-model' },
+      responseModelMapping: { upstream: 'client' },
+      responsesPassthrough: false,
+    },
+  },
+  supportedClientTypes: ['claude'],
+};
+
+describe('custom provider key quick edit helpers', () => {
+  it('updates only the custom provider api key while preserving existing config', () => {
+    const update = buildCustomProviderApiKeyUpdate(baseProvider, 'new-key');
+
+    expect(update.config?.disableErrorCooldown).toBe(true);
+    expect(update.config?.custom).toEqual({
+      ...baseProvider.config?.custom,
+      apiKey: 'new-key',
+    });
+  });
+
+  it('allows quick edit only for configured custom providers', () => {
+    expect(canQuickEditCustomProviderKey(baseProvider)).toBe(true);
+    expect(canQuickEditCustomProviderKey({ ...baseProvider, type: 'codex' })).toBe(false);
+    expect(canQuickEditCustomProviderKey({ ...baseProvider, config: null })).toBe(false);
+  });
+
+  it('treats a blank quick-edit key as no change', () => {
+    expect(normalizeCustomProviderApiKeyInput('')).toBeNull();
+    expect(normalizeCustomProviderApiKeyInput('   ')).toBeNull();
+    expect(normalizeCustomProviderApiKeyInput('\n\t')).toBeNull();
+    expect(normalizeCustomProviderApiKeyInput('  new-key  ')).toBe('new-key');
+  });
+});

--- a/web/src/pages/client-routes/utils/custom-provider-key.ts
+++ b/web/src/pages/client-routes/utils/custom-provider-key.ts
@@ -1,0 +1,25 @@
+import type { Provider } from '@/lib/transport';
+
+export function normalizeCustomProviderApiKeyInput(apiKey: string): string | null {
+  const trimmed = apiKey.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function buildCustomProviderApiKeyUpdate(
+  provider: Provider,
+  apiKey: string,
+): Pick<Provider, 'config'> {
+  return {
+    config: {
+      ...(provider.config ?? {}),
+      custom: {
+        ...(provider.config?.custom ?? { baseURL: '', apiKey: '' }),
+        apiKey,
+      },
+    },
+  };
+}
+
+export function canQuickEditCustomProviderKey(provider: Provider): boolean {
+  return provider.type === 'custom' && !!provider.config?.custom;
+}


### PR DESCRIPTION
## Summary
- add an inline quick-edit action for configured custom providers on route rows
- update only the provider-level `config.custom.apiKey` when a non-empty key is submitted
- treat blank/whitespace key input as no change, matching the existing provider edit behavior
- add English/Chinese locale strings and focused JS/TS tests for helper behavior and i18n keys

## Validation
- `pnpm --dir web test -- src/pages/client-routes/utils/custom-provider-key.test.ts src/pages/client-routes/utils/custom-provider-key-i18n.test.ts`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`
- Manual web check on local dev UI:
  - Chinese and English quick-edit dialog text renders from locale files
  - blank save closes the dialog without sending `PUT /api/providers/:id`
  - temporary screenshot provider/route data was deleted after verification

## Scope notes
- This is limited to configured custom providers (`provider.type === "custom"` and `provider.config.custom`).
- It does not add route-level key overrides or change provider import/export data structure.
