### PR TITLE
fix(providers): constrain bulk import dialog height

### DIFF
--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -819,13 +819,16 @@ export function ProvidersPage() {
       </div>
 
       <Dialog open={isBulkImportOpen} onOpenChange={handleBulkImportOpenChange}>
-        <DialogContent className="max-w-3xl" showCloseButton={!isBulkImporting}>
-          <DialogHeader>
+        <DialogContent
+          className="grid max-h-[calc(100dvh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0 sm:max-w-3xl"
+          showCloseButton={!isBulkImporting}
+        >
+          <DialogHeader className="px-6 pt-6 pr-12 pb-4">
             <DialogTitle>{t('providers.bulkImport.title')}</DialogTitle>
             <DialogDescription>{t('providers.bulkImport.description')}</DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
+          <div className="min-h-0 space-y-4 overflow-y-auto px-6 py-4">
             <div className="rounded-lg border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
               <div className="mb-2 font-medium text-foreground">
                 {t('providers.bulkImport.exampleTitle')}
@@ -844,7 +847,7 @@ export function ProvidersPage() {
                 setBulkImportStatus(null);
               }}
               placeholder={t('providers.bulkImport.placeholder')}
-              className="min-h-52 font-mono text-xs"
+              className="h-52 max-h-72 overflow-y-auto field-sizing-fixed font-mono text-xs"
             />
 
             <div className="rounded-lg border border-border p-3">
@@ -926,7 +929,7 @@ export function ProvidersPage() {
             </div>
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="border-t border-border bg-background px-6 py-4">
             <Button
               variant="secondary"
               onClick={() => handleBulkImportOpenChange(false)}


### PR DESCRIPTION
## Summary
- Constrain the bulk custom provider import dialog to the viewport height.
- Keep the dialog header/footer visible while the command input and preview area scroll in the middle.
- Stop the bulk command textarea from auto-growing with pasted content by using fixed field sizing.

## Validation
- Reproduced the old layout issue with ~42 `provider add` lines: dialog height grew to about 5696px in a 1280×800 viewport.
- Verified fixed desktop layout at 1280×800: dialog stays within viewport and footer remains visible.
- Verified fixed narrow layout at 390×700: footer remains fully visible.
- `pnpm test src/pages/providers/utils/bulk-custom-provider-import.test.ts` — 6/6 passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed

Note: the first PR (#628) was closed because it was opened from an old feature branch that carried stale commits and conflicted with current `main`. This PR is based on current `main` and contains only the dialog height fix.
