### PR TITLE
fix(providers): share provider type grouping

### DIFF
--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -96,16 +96,12 @@ import {
 import { cn } from '@/lib/utils';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 import { CooldownsProvider } from '@/contexts/cooldowns-context';
-
-type ProviderTypeKey = 'antigravity' | 'kiro' | 'codex' | 'custom';
-
-const PROVIDER_TYPE_ORDER: ProviderTypeKey[] = ['antigravity', 'kiro', 'codex', 'custom'];
-
-const PROVIDER_TYPE_LABELS: Record<Exclude<ProviderTypeKey, 'custom'>, string> = {
-  antigravity: 'Antigravity',
-  kiro: 'Kiro',
-  codex: 'Codex',
-};
+import {
+  PROVIDER_TYPE_CONFIGS,
+  PROVIDER_TYPE_ORDER,
+  createProviderTypeGroups,
+  type ProviderTypeKey,
+} from '@/pages/providers/types';
 
 function isSameProviderStats(a: ProviderStats, b: ProviderStats): boolean {
   return (
@@ -645,13 +641,6 @@ function ClientTypeRoutesContentInner({
 
   // Get available providers (without routes yet), grouped by type and sorted alphabetically
   const groupedAvailableProviders = useMemo((): Record<ProviderTypeKey, Provider[]> => {
-    const groups: Record<ProviderTypeKey, Provider[]> = {
-      antigravity: [],
-      kiro: [],
-      codex: [],
-      custom: [],
-    };
-
     let available = providers.filter((p) => !routeByProviderId.has(Number(p.id)));
 
     // Apply search filter
@@ -663,22 +652,7 @@ function ClientTypeRoutesContentInner({
       );
     }
 
-    // Group by type
-    available.forEach((p) => {
-      const type = p.type as ProviderTypeKey;
-      if (groups[type]) {
-        groups[type].push(p);
-      } else {
-        groups.custom.push(p);
-      }
-    });
-
-    // Sort alphabetically within each group
-    for (const key of Object.keys(groups) as ProviderTypeKey[]) {
-      groups[key].sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    return groups;
+    return createProviderTypeGroups(available);
   }, [providers, normalizedQuery, routeByProviderId]);
 
   // Check if there are any available providers
@@ -996,7 +970,7 @@ function ClientTypeRoutesContentInner({
                         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                           {typeKey === 'custom'
                             ? t('routes.providerType.custom')
-                            : PROVIDER_TYPE_LABELS[typeKey]}
+                            : PROVIDER_TYPE_CONFIGS[typeKey].label}
                         </span>
                         <div className="h-px flex-1 bg-border/50" />
                       </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -318,6 +318,7 @@
       "open": "Delete selected",
       "selectVisible": "Select visible providers ({{count}})",
       "clearVisible": "Clear visible selection",
+      "invertVisible": "Invert visible selection",
       "selectedCount": "{{count}} provider(s) selected",
       "selectProvider": "Select provider {{name}}",
       "dialogTitle": "Delete selected providers?",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -315,6 +315,7 @@
       "open": "删除选中项",
       "selectVisible": "选择当前可见提供商（{{count}}）",
       "clearVisible": "清除当前可见选择",
+      "invertVisible": "反选当前可见",
       "selectedCount": "已选择 {{count}} 个提供商",
       "selectProvider": "选择提供商 {{name}}",
       "dialogTitle": "删除选中的提供商？",

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -70,6 +70,7 @@ import {
   toCreateProviderData,
   type BulkCustomProviderParseError,
 } from './utils/bulk-custom-provider-import';
+import { invertVisibleProviderSelection } from './utils/selection';
 
 type ManageProvidersButtonProps = Omit<ComponentProps<typeof Button>, 'disabled'> & {
   canManage: boolean;
@@ -397,6 +398,13 @@ export function ProvidersPage() {
     setBulkDeleteStatus(null);
   };
 
+  const handleInvertVisibleProviderSelection = () => {
+    setSelectedProviderIds((previous) =>
+      invertVisibleProviderSelection(previous, visibleProviderIds),
+    );
+    setBulkDeleteStatus(null);
+  };
+
   const handleClearProviderSelection = () => {
     setSelectedProviderIds(new Set());
     setBulkDeleteStatus(null);
@@ -570,6 +578,15 @@ export function ProvidersPage() {
                 {allVisibleProvidersSelected
                   ? t('providers.bulkDelete.clearVisible')
                   : t('providers.bulkDelete.selectVisible', { count: visibleProviderIds.length })}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleInvertVisibleProviderSelection}
+                disabled={visibleProviderIds.length === 0 || isBulkDeleting}
+              >
+                {t('providers.bulkDelete.invertVisible')}
               </Button>
               <div className="text-sm text-muted-foreground">
                 {t('providers.bulkDelete.selectedCount', {

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -54,7 +54,12 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Switch } from '@/components/ui/switch';
 import { PageHeader } from '@/components/layout/page-header';
-import { PROVIDER_TYPE_CONFIGS, type ProviderTypeKey } from './types';
+import {
+  PROVIDER_TYPE_CONFIGS,
+  PROVIDER_TYPE_ORDER,
+  createProviderTypeGroups,
+  type ProviderTypeKey,
+} from './types';
 import { AntigravityQuotasProvider } from '@/contexts/antigravity-quotas-context';
 import { CodexQuotasProvider } from '@/contexts/codex-quotas-context';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -190,17 +195,6 @@ export function ProvidersPage() {
   };
 
   const groupedProviders = useMemo(() => {
-    // 按类型分组，使用配置系统中定义的类型
-    const groups: Record<ProviderTypeKey, Provider[]> = {
-      antigravity: [],
-      bedrock: [],
-      kiro: [],
-      codex: [],
-      claude: [],
-      custom: [],
-    };
-
-    // Filter providers by search query
     const filteredProviders = providers?.filter((p) => {
       if (!searchQuery.trim()) return true;
       const query = searchQuery.toLowerCase();
@@ -208,28 +202,12 @@ export function ProvidersPage() {
       const displayInfo = config?.getDisplayInfo(p) || '';
       return p.name.toLowerCase().includes(query) || displayInfo.toLowerCase().includes(query);
     });
-
-    filteredProviders?.forEach((p) => {
-      const type = p.type as ProviderTypeKey;
-      if (groups[type]) {
-        groups[type].push(p);
-      } else {
-        // 未知类型归入 custom
-        groups.custom.push(p);
-      }
-    });
-
-    // 按名称字母顺序排列
-    for (const key of Object.keys(groups) as ProviderTypeKey[]) {
-      groups[key].sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    return groups;
+    return createProviderTypeGroups(filteredProviders);
   }, [providers, searchQuery]);
 
   const visibleProviderIds = useMemo(
     () =>
-      (Object.keys(PROVIDER_TYPE_CONFIGS) as ProviderTypeKey[]).flatMap((typeKey) =>
+      PROVIDER_TYPE_ORDER.flatMap((typeKey) =>
         groupedProviders[typeKey].map((provider) => provider.id),
       ),
     [groupedProviders],
@@ -648,7 +626,7 @@ export function ProvidersPage() {
               <CodexQuotasProvider>
                 <div className="space-y-8">
                   {/* 动态渲染各类型分组 */}
-                  {(Object.keys(PROVIDER_TYPE_CONFIGS) as ProviderTypeKey[]).map((typeKey) => {
+                  {PROVIDER_TYPE_ORDER.map((typeKey) => {
                     const typeProviders = groupedProviders[typeKey];
                     if (typeProviders.length === 0) return null;
 

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { PROVIDER_TYPE_ORDER, createProviderTypeGroups, getKnownProviderTypeKey } from './types';
+
+describe('provider type helpers', () => {
+  it('keeps every configured provider type available for grouped provider UIs', () => {
+    expect(PROVIDER_TYPE_ORDER).toEqual([
+      'antigravity',
+      'kiro',
+      'codex',
+      'claude',
+      'bedrock',
+      'custom',
+    ]);
+  });
+
+  it('groups all known provider types and falls unknown providers back to custom', () => {
+    const groups = createProviderTypeGroups([
+      { name: 'Zulu Custom', type: 'custom' },
+      { name: 'Codex Account', type: 'codex' },
+      { name: 'Claude Account', type: 'claude' },
+      { name: 'Bedrock Account', type: 'bedrock' },
+      { name: 'Antigravity Account', type: 'antigravity' },
+      { name: 'Kiro Account', type: 'kiro' },
+      { name: 'Alpha Unknown', type: 'future-provider' },
+    ]);
+
+    expect(groups.antigravity.map((provider) => provider.name)).toEqual(['Antigravity Account']);
+    expect(groups.kiro.map((provider) => provider.name)).toEqual(['Kiro Account']);
+    expect(groups.codex.map((provider) => provider.name)).toEqual(['Codex Account']);
+    expect(groups.claude.map((provider) => provider.name)).toEqual(['Claude Account']);
+    expect(groups.bedrock.map((provider) => provider.name)).toEqual(['Bedrock Account']);
+    expect(groups.custom.map((provider) => provider.name)).toEqual([
+      'Alpha Unknown',
+      'Zulu Custom',
+    ]);
+  });
+
+  it('normalizes unknown provider types to the custom bucket', () => {
+    expect(getKnownProviderTypeKey('codex')).toBe('codex');
+    expect(getKnownProviderTypeKey('custom')).toBe('custom');
+    expect(getKnownProviderTypeKey('future-provider')).toBe('custom');
+  });
+});

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -90,6 +90,34 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
   },
 };
 
+export const PROVIDER_TYPE_ORDER = Object.keys(PROVIDER_TYPE_CONFIGS) as ProviderTypeKey[];
+
+export function getKnownProviderTypeKey(type: string): ProviderTypeKey {
+  return type in PROVIDER_TYPE_CONFIGS ? (type as ProviderTypeKey) : 'custom';
+}
+
+export function createProviderTypeGroups<T extends Pick<Provider, 'name' | 'type'>>(
+  providers: readonly T[] | undefined,
+): Record<ProviderTypeKey, T[]> {
+  const groups = PROVIDER_TYPE_ORDER.reduce(
+    (acc, typeKey) => {
+      acc[typeKey] = [];
+      return acc;
+    },
+    {} as Record<ProviderTypeKey, T[]>,
+  );
+
+  providers?.forEach((provider) => {
+    groups[getKnownProviderTypeKey(provider.type)].push(provider);
+  });
+
+  for (const key of PROVIDER_TYPE_ORDER) {
+    groups[key].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  return groups;
+}
+
 // 获取 Provider 类型配置的辅助函数
 export function getProviderTypeConfig(type: string): ProviderTypeConfig {
   return PROVIDER_TYPE_CONFIGS[type as ProviderTypeKey] || PROVIDER_TYPE_CONFIGS.custom;

--- a/web/src/pages/providers/utils/selection.test.ts
+++ b/web/src/pages/providers/utils/selection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { invertVisibleProviderSelection } from './selection';
+
+describe('provider selection helpers', () => {
+  it('inverts only visible provider IDs and preserves hidden selections', () => {
+    const selected = new Set([1, 3, 99]);
+
+    const result = invertVisibleProviderSelection(selected, [1, 2, 3, 4]);
+
+    expect([...result].sort((a, b) => a - b)).toEqual([2, 4, 99]);
+    expect([...selected].sort((a, b) => a - b)).toEqual([1, 3, 99]);
+  });
+
+  it('does not clear hidden selections when no providers are visible', () => {
+    const result = invertVisibleProviderSelection(new Set([42]), []);
+
+    expect([...result]).toEqual([42]);
+  });
+});

--- a/web/src/pages/providers/utils/selection.ts
+++ b/web/src/pages/providers/utils/selection.ts
@@ -1,0 +1,16 @@
+export function invertVisibleProviderSelection(
+  selectedProviderIds: ReadonlySet<number>,
+  visibleProviderIds: readonly number[],
+): Set<number> {
+  const next = new Set(selectedProviderIds);
+
+  for (const providerId of visibleProviderIds) {
+    if (next.has(providerId)) {
+      next.delete(providerId);
+    } else {
+      next.add(providerId);
+    }
+  }
+
+  return next;
+}

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -75,17 +75,11 @@ import { PageHeader } from '@/components/layout/page-header';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useAuth } from '@/lib/auth-context';
 import { calculateVirtualRange } from './virtual-range';
-
-type ProviderTypeKey = 'antigravity' | 'kiro' | 'codex' | 'custom';
-
-const PROVIDER_TYPE_ORDER: ProviderTypeKey[] = ['antigravity', 'kiro', 'codex', 'custom'];
-
-const PROVIDER_TYPE_LABELS: Record<ProviderTypeKey, string> = {
-  antigravity: 'Antigravity',
-  kiro: 'Kiro',
-  codex: 'Codex',
-  custom: 'Custom',
-};
+import {
+  PROVIDER_TYPE_CONFIGS,
+  PROVIDER_TYPE_ORDER,
+  createProviderTypeGroups,
+} from '@/pages/providers/types';
 
 type RequestFilterMode = 'token' | 'provider' | 'project';
 
@@ -1409,28 +1403,7 @@ function ProviderFilter({
 
   // Group providers by type and sort alphabetically
   const groupedProviders = useMemo(() => {
-    const groups: Record<ProviderTypeKey, Provider[]> = {
-      antigravity: [],
-      kiro: [],
-      codex: [],
-      custom: [],
-    };
-
-    providers.forEach((p) => {
-      const type = p.type as ProviderTypeKey;
-      if (groups[type]) {
-        groups[type].push(p);
-      } else {
-        groups.custom.push(p);
-      }
-    });
-
-    // Sort alphabetically within each group
-    for (const key of Object.keys(groups) as ProviderTypeKey[]) {
-      groups[key].sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    return groups;
+    return createProviderTypeGroups<Provider>(providers);
   }, [providers]);
 
   // Get selected provider name for display
@@ -1458,7 +1431,7 @@ function ProviderFilter({
           if (typeProviders.length === 0) return null;
           return (
             <SelectGroup key={typeKey}>
-              <SelectLabel>{PROVIDER_TYPE_LABELS[typeKey]}</SelectLabel>
+              <SelectLabel>{PROVIDER_TYPE_CONFIGS[typeKey].label}</SelectLabel>
               {typeProviders.map((provider) => (
                 <SelectItem key={provider.id} value={String(provider.id)}>
                   {provider.name}

--- a/web/src/pages/routes/form.tsx
+++ b/web/src/pages/routes/form.tsx
@@ -4,17 +4,11 @@ import { Button, Input } from '@/components/ui';
 import { useCreateRoute, useUpdateRoute, useProviders, useProjects } from '@/hooks/queries';
 import type { ClientType, Route, Provider } from '@/lib/transport';
 import { ModelMappingEditor } from '@/pages/providers/components/model-mapping-editor';
-
-type ProviderTypeKey = 'antigravity' | 'kiro' | 'codex' | 'custom';
-
-const PROVIDER_TYPE_ORDER: ProviderTypeKey[] = ['antigravity', 'kiro', 'codex', 'custom'];
-
-const PROVIDER_TYPE_LABELS: Record<ProviderTypeKey, string> = {
-  antigravity: 'Antigravity',
-  kiro: 'Kiro',
-  codex: 'Codex',
-  custom: 'Custom',
-};
+import {
+  PROVIDER_TYPE_CONFIGS,
+  PROVIDER_TYPE_ORDER,
+  createProviderTypeGroups,
+} from '@/pages/providers/types';
 
 interface RouteFormProps {
   route?: Route;
@@ -41,28 +35,7 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
 
   // Group providers by type and sort alphabetically
   const groupedProviders = useMemo(() => {
-    const groups: Record<ProviderTypeKey, Provider[]> = {
-      antigravity: [],
-      kiro: [],
-      codex: [],
-      custom: [],
-    };
-
-    providers?.forEach((p) => {
-      const type = p.type as ProviderTypeKey;
-      if (groups[type]) {
-        groups[type].push(p);
-      } else {
-        groups.custom.push(p);
-      }
-    });
-
-    // Sort alphabetically within each group
-    for (const key of Object.keys(groups) as ProviderTypeKey[]) {
-      groups[key].sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    return groups;
+    return createProviderTypeGroups<Provider>(providers);
   }, [providers]);
 
   useEffect(() => {
@@ -141,7 +114,7 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
               const typeProviders = groupedProviders[typeKey];
               if (typeProviders.length === 0) return null;
               return (
-                <optgroup key={typeKey} label={PROVIDER_TYPE_LABELS[typeKey]}>
+                <optgroup key={typeKey} label={PROVIDER_TYPE_CONFIGS[typeKey].label}>
                   {typeProviders.map((p) => (
                     <option key={p.id} value={p.id}>
                       {p.name}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- share provider type grouping across provider list, route forms, request filters, and client route provider pickers
- keep provider row selection checkbox separate from provider client capability switches
- add **Invert visible selection** for provider bulk selection, scoped to the currently visible/search-filtered providers
- include all configured provider types (`antigravity`, `kiro`, `codex`, `claude`, `bedrock`, `custom`) and route unknown provider types into the custom bucket
- add regression coverage for provider type ordering/grouping, visible-selection inversion, and Vitest alias resolution

## Validation
- `pnpm --dir web test -- src/pages/providers/utils/selection.test.ts src/pages/providers/types.test.ts` (40 tests passed, including existing related suites run by config)
- `pnpm --dir web typecheck`
- `pnpm --dir web build`
- `pnpm --dir web lint`
- `go test ./internal/handler ./internal/service ./tests/e2e`
- local isolated Maxx instance on `127.0.0.1:9895` with seeded custom/codex/claude/bedrock providers
- Playwright UI smoke with system Chrome:
  - `/providers`: verified 4 provider row selection checkboxes
  - select visible → invert visible cleared all visible providers
  - one selected → invert visible selected the other 3 visible providers
  - search-filtered `Custom` view → invert visible flipped only the visible custom provider and preserved hidden selections
  - `/providers/1/edit`: verified internal client capability controls for `Claude`, `OpenAI`, `Codex`, and `Gemini` stay checked from seeded `supportedClientTypes`

## Screenshots
Captured locally during validation:
- `providers-all-selected-before-invert.png`
- `providers-invert-cleared.png`
- `providers-invert-partial-complement.png`
- `providers-invert-filtered-visible-only.png`
- `provider-edit-client-capabilities.png`