### PR TITLE
fix(routes): stabilize Claude batch provider removal

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -816,6 +816,7 @@
       "failedExistingDescription": "These existing Claude providers failed the test. Select and confirm removal to delete them globally from the Providers tab and clean up routes/project references that use them.",
       "removeSelectedFailedExisting": "Remove selected failed items ({{count}})",
       "confirmRemoveFailedExisting": "Remove {{count}} existing provider(s)? This deletes them globally from the Providers tab and cleans up {{routeCount}} route/project reference(s). This cannot be undone.",
+      "removeFailedExistingError": "Failed to remove {{count}} provider(s)",
       "routeReferenceCount": "Routes {{count}}"
     },
     "customProviderKey": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -813,6 +813,7 @@
       "failedExistingDescription": "这些已存在 Claude provider 未通过测试。勾选后确认移除，会从 Providers tab 全局删除，并清理引用它们的 route/project 配置。",
       "removeSelectedFailedExisting": "移除选中失败项（{{count}}）",
       "confirmRemoveFailedExisting": "确认移除 {{count}} 个已存在 provider？这会从 Providers tab 全局删除，并清理 {{routeCount}} 条引用 route/project 配置。此操作不可撤销。",
+      "removeFailedExistingError": "{{count}} 个 provider 移除失败",
       "routeReferenceCount": "引用 route {{count}}"
     },
     "customProviderKey": {

--- a/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
+++ b/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
@@ -35,7 +35,9 @@ import {
   filterRemovedExistingResults,
   getClaudeBatchCandidateResultKey,
   getClaudeBatchExistingResultKey,
+  getClaudeBatchOccurrenceMatchKeys,
   getClaudeBatchResultKey,
+  getFailedExistingResultSignature,
   summarizeClaudeBatchDisplayResults,
 } from '@/pages/client-routes/utils/claude-provider-batch-test';
 
@@ -133,8 +135,15 @@ function resultKeyForItem(item: PreviewItem) {
   return getClaudeBatchCandidateResultKey(item.name, item.baseURL);
 }
 
-function resultByPreviewKey(results: ClaudeProviderBatchProviderResult[] | undefined) {
-  return new Map((results ?? []).map((result) => [getClaudeBatchResultKey(result), result]));
+function resultByPreviewMatchKey(results: ClaudeProviderBatchProviderResult[] | undefined) {
+  const items = results ?? [];
+  const matchKeys = getClaudeBatchOccurrenceMatchKeys(items.map(getClaudeBatchResultKey));
+  return new Map(matchKeys.map((matchKey, index) => [matchKey, items[index]]));
+}
+
+function previewResultMatchKeys(items: PreviewItem[]) {
+  const matchKeys = getClaudeBatchOccurrenceMatchKeys(items.map(resultKeyForItem));
+  return new Map(matchKeys.map((matchKey, index) => [items[index].key, matchKey]));
 }
 
 export function ClaudeProviderBatchTestDialog({
@@ -152,6 +161,7 @@ export function ClaudeProviderBatchTestDialog({
   const [selectedFailedExistingIDs, setSelectedFailedExistingIDs] = useState<number[]>([]);
   const [removedExistingIDs, setRemovedExistingIDs] = useState<number[]>([]);
   const [removalError, setRemovalError] = useState<string | null>(null);
+  const [isRemovingFailedExisting, setIsRemovingFailedExisting] = useState(false);
   const [createRoutes, setCreateRoutes] = useState(true);
   const [overwriteExisting, setOverwriteExisting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -301,7 +311,11 @@ export function ClaudeProviderBatchTestDialog({
     () => filterRemovedExistingResults(batchTest.data?.results, removedExistingIDSet),
     [batchTest.data?.results, removedExistingIDSet],
   );
-  const resultMap = resultByPreviewKey(displayResults);
+  const resultMap = resultByPreviewMatchKey(displayResults);
+  const previewResultMatchKeyMap = useMemo(
+    () => previewResultMatchKeys(previewItems),
+    [previewItems],
+  );
   const displaySummary = summarizeClaudeBatchDisplayResults(displayResults);
   const failedExistingResults = useMemo(
     () =>
@@ -321,13 +335,14 @@ export function ClaudeProviderBatchTestDialog({
     (count, result) => count + (routeCountByProviderID.get(result.existingID ?? 0) ?? 0),
     0,
   );
+  const failedExistingResultSignature = getFailedExistingResultSignature(failedExistingResults);
   const canRun =
     previewItems.some((item) => item.selected && !item.error) && parsePreview.errors.length === 0;
 
   useEffect(() => {
     if (failedExistingResults.length === 0) return;
     failedExistingSectionRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  }, [failedExistingResults.length]);
+  }, [failedExistingResults.length, failedExistingResultSignature]);
 
   const handleToggleExisting = (providerID: number, checked: boolean) => {
     setSelectedExistingIDs((current) =>
@@ -377,7 +392,7 @@ export function ClaudeProviderBatchTestDialog({
 
   const handleRemoveSelectedFailedExisting = async () => {
     const targets = selectedFailedExistingResults.filter((result) => result.existingID);
-    if (targets.length === 0) return;
+    if (targets.length === 0 || isRemovingFailedExisting) return;
     const confirmed = window.confirm(
       t('routes.claudeBatchTest.confirmRemoveFailedExisting', {
         count: targets.length,
@@ -387,29 +402,34 @@ export function ClaudeProviderBatchTestDialog({
     if (!confirmed) return;
 
     setRemovalError(null);
-    const settled = await Promise.allSettled(
-      targets.map((result) => deleteProvider.mutateAsync(result.existingID!)),
-    );
-    const removedIDs = collectSuccessfulRemovedExistingIDs(targets, settled);
-    const failedCount = settled.filter((result) => result.status === 'rejected').length;
-
-    if (removedIDs.length > 0) {
-      setRemovedExistingIDs((current) => [...new Set([...current, ...removedIDs])]);
-      setSelectedFailedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
-      setSelectedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
-    }
-
-    if (failedCount > 0) {
-      const firstFailure = settled.find(
-        (result): result is PromiseRejectedResult => result.status === 'rejected',
+    setIsRemovingFailedExisting(true);
+    try {
+      const settled = await Promise.allSettled(
+        targets.map((result) => deleteProvider.mutateAsync(result.existingID!)),
       );
-      setRemovalError(
-        `${t('routes.claudeBatchTest.removeFailedExistingError', { count: failedCount })}: ${
-          firstFailure?.reason instanceof Error
-            ? firstFailure.reason.message
-            : String(firstFailure?.reason ?? '')
-        }`,
-      );
+      const removedIDs = collectSuccessfulRemovedExistingIDs(targets, settled);
+      const failedCount = settled.filter((result) => result.status === 'rejected').length;
+
+      if (removedIDs.length > 0) {
+        setRemovedExistingIDs((current) => [...new Set([...current, ...removedIDs])]);
+        setSelectedFailedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
+        setSelectedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
+      }
+
+      if (failedCount > 0) {
+        const firstFailure = settled.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected',
+        );
+        setRemovalError(
+          `${t('routes.claudeBatchTest.removeFailedExistingError', { count: failedCount })}: ${
+            firstFailure?.reason instanceof Error
+              ? firstFailure.reason.message
+              : String(firstFailure?.reason ?? '')
+          }`,
+        );
+      }
+    } finally {
+      setIsRemovingFailedExisting(false);
     }
   };
 
@@ -596,10 +616,10 @@ export function ClaudeProviderBatchTestDialog({
                   type="button"
                   variant="destructive"
                   size="sm"
-                  disabled={selectedFailedExistingResults.length === 0 || deleteProvider.isPending}
+                  disabled={selectedFailedExistingResults.length === 0 || isRemovingFailedExisting}
                   onClick={handleRemoveSelectedFailedExisting}
                 >
-                  {deleteProvider.isPending ? (
+                  {isRemovingFailedExisting ? (
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   ) : (
                     <Trash2 className="h-4 w-4 mr-2" />
@@ -686,7 +706,7 @@ export function ClaudeProviderBatchTestDialog({
               ) : (
                 <div className="divide-y divide-border">
                   {previewItems.map((item) => {
-                    const result = resultMap.get(resultKeyForItem(item));
+                    const result = resultMap.get(previewResultMatchKeyMap.get(item.key) ?? '');
                     return (
                       <div
                         key={item.key}

--- a/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
+++ b/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { FlaskConical, Loader2, Play, ShieldCheck, Trash2 } from 'lucide-react';
@@ -30,6 +30,14 @@ import {
   toCreateProviderData,
   type BulkCustomProviderCommand,
 } from '@/pages/providers/utils/bulk-custom-provider-import';
+import {
+  collectSuccessfulRemovedExistingIDs,
+  filterRemovedExistingResults,
+  getClaudeBatchCandidateResultKey,
+  getClaudeBatchExistingResultKey,
+  getClaudeBatchResultKey,
+  summarizeClaudeBatchDisplayResults,
+} from '@/pages/client-routes/utils/claude-provider-batch-test';
 
 interface ClaudeProviderBatchTestDialogProps {
   providers: Provider[];
@@ -118,8 +126,15 @@ function resultLabel(status: string | undefined, t: TFunction) {
   }
 }
 
-function resultByIndex(results: ClaudeProviderBatchProviderResult[] | undefined) {
-  return new Map((results ?? []).map((result) => [result.index, result]));
+function resultKeyForItem(item: PreviewItem) {
+  if (item.source === 'existing' && item.providerID) {
+    return getClaudeBatchExistingResultKey(item.providerID);
+  }
+  return getClaudeBatchCandidateResultKey(item.name, item.baseURL);
+}
+
+function resultByPreviewKey(results: ClaudeProviderBatchProviderResult[] | undefined) {
+  return new Map((results ?? []).map((result) => [getClaudeBatchResultKey(result), result]));
 }
 
 export function ClaudeProviderBatchTestDialog({
@@ -140,18 +155,31 @@ export function ClaudeProviderBatchTestDialog({
   const [createRoutes, setCreateRoutes] = useState(true);
   const [overwriteExisting, setOverwriteExisting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const failedExistingSectionRef = useRef<HTMLElement | null>(null);
   const batchTest = useClaudeProviderBatchTest();
   const deleteProvider = useDeleteProvider();
 
+  const removedExistingIDSet = useMemo(() => new Set(removedExistingIDs), [removedExistingIDs]);
+
+  const activeProviders = useMemo(
+    () => providers.filter((provider) => !removedExistingIDSet.has(provider.id)),
+    [providers, removedExistingIDSet],
+  );
+
+  const activeRoutes = useMemo(
+    () => routes.filter((route) => !removedExistingIDSet.has(route.providerID)),
+    [routes, removedExistingIDSet],
+  );
+
   const claudeProviders = useMemo(
     () =>
-      providers.filter(
+      activeProviders.filter(
         (provider) =>
           provider.type === 'custom' &&
           (provider.supportedClientTypes?.length === 0 ||
             provider.supportedClientTypes?.includes('claude')),
       ),
-    [providers],
+    [activeProviders],
   );
 
   const claudeProviderIDs = useMemo(
@@ -171,42 +199,42 @@ export function ClaudeProviderBatchTestDialog({
 
   const existingByName = useMemo(() => {
     const map = new Map<string, Provider>();
-    for (const provider of providers) map.set(provider.name.trim().toLowerCase(), provider);
+    for (const provider of activeProviders) map.set(provider.name.trim().toLowerCase(), provider);
     return map;
-  }, [providers]);
+  }, [activeProviders]);
 
   const existingByBaseURL = useMemo(() => {
     const map = new Map<string, Provider>();
-    for (const provider of providers) {
+    for (const provider of activeProviders) {
       const baseURL = providerBaseURL(provider);
       if (baseURL) map.set(baseURL, provider);
     }
     return map;
-  }, [providers]);
+  }, [activeProviders]);
 
   const providerByID = useMemo(() => {
     const map = new Map<number, Provider>();
-    for (const provider of providers) map.set(Number(provider.id), provider);
+    for (const provider of activeProviders) map.set(Number(provider.id), provider);
     return map;
-  }, [providers]);
+  }, [activeProviders]);
 
   const existingRouteProviderIDs = useMemo(
     () =>
       new Set(
-        routes
+        activeRoutes
           .filter((route) => route.clientType === 'claude' && route.projectID === projectID)
           .map((route) => route.providerID),
       ),
-    [routes, projectID],
+    [activeRoutes, projectID],
   );
 
   const routeCountByProviderID = useMemo(() => {
     const map = new Map<number, number>();
-    for (const route of routes) {
+    for (const route of activeRoutes) {
       map.set(route.providerID, (map.get(route.providerID) ?? 0) + 1);
     }
     return map;
-  }, [routes]);
+  }, [activeRoutes]);
 
   const previewItems = useMemo<PreviewItem[]>(() => {
     const selectedExisting = claudeProviders
@@ -269,18 +297,18 @@ export function ClaudeProviderBatchTestDialog({
     [previewItems],
   );
 
-  const resultMap = resultByIndex(batchTest.data?.results);
-  const removedExistingIDSet = useMemo(() => new Set(removedExistingIDs), [removedExistingIDs]);
+  const displayResults = useMemo(
+    () => filterRemovedExistingResults(batchTest.data?.results, removedExistingIDSet),
+    [batchTest.data?.results, removedExistingIDSet],
+  );
+  const resultMap = resultByPreviewKey(displayResults);
+  const displaySummary = summarizeClaudeBatchDisplayResults(displayResults);
   const failedExistingResults = useMemo(
     () =>
-      (batchTest.data?.results ?? []).filter(
-        (result) =>
-          result.source === 'existing' &&
-          result.existingID &&
-          !result.ok &&
-          !removedExistingIDSet.has(result.existingID),
+      displayResults.filter(
+        (result) => result.source === 'existing' && result.existingID && !result.ok,
       ),
-    [batchTest.data?.results, removedExistingIDSet],
+    [displayResults],
   );
   const selectedFailedExistingResults = useMemo(
     () =>
@@ -295,6 +323,11 @@ export function ClaudeProviderBatchTestDialog({
   );
   const canRun =
     previewItems.some((item) => item.selected && !item.error) && parsePreview.errors.length === 0;
+
+  useEffect(() => {
+    if (failedExistingResults.length === 0) return;
+    failedExistingSectionRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [failedExistingResults.length]);
 
   const handleToggleExisting = (providerID: number, checked: boolean) => {
     setSelectedExistingIDs((current) =>
@@ -354,16 +387,29 @@ export function ClaudeProviderBatchTestDialog({
     if (!confirmed) return;
 
     setRemovalError(null);
-    try {
-      for (const result of targets) {
-        await deleteProvider.mutateAsync(result.existingID!);
-      }
-      const removedIDs = targets.map((result) => result.existingID!);
+    const settled = await Promise.allSettled(
+      targets.map((result) => deleteProvider.mutateAsync(result.existingID!)),
+    );
+    const removedIDs = collectSuccessfulRemovedExistingIDs(targets, settled);
+    const failedCount = settled.filter((result) => result.status === 'rejected').length;
+
+    if (removedIDs.length > 0) {
       setRemovedExistingIDs((current) => [...new Set([...current, ...removedIDs])]);
       setSelectedFailedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
       setSelectedExistingIDs((current) => current.filter((id) => !removedIDs.includes(id)));
-    } catch (error) {
-      setRemovalError(error instanceof Error ? error.message : String(error));
+    }
+
+    if (failedCount > 0) {
+      const firstFailure = settled.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      setRemovalError(
+        `${t('routes.claudeBatchTest.removeFailedExistingError', { count: failedCount })}: ${
+          firstFailure?.reason instanceof Error
+            ? firstFailure.reason.message
+            : String(firstFailure?.reason ?? '')
+        }`,
+      );
     }
   };
 
@@ -532,6 +578,82 @@ export function ClaudeProviderBatchTestDialog({
             </label>
           </section>
 
+          {failedExistingResults.length > 0 && (
+            <section
+              ref={failedExistingSectionRef}
+              className="min-w-0 space-y-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                    {t('routes.claudeBatchTest.failedExistingTitle')}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {t('routes.claudeBatchTest.failedExistingDescription')}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={selectedFailedExistingResults.length === 0 || deleteProvider.isPending}
+                  onClick={handleRemoveSelectedFailedExisting}
+                >
+                  {deleteProvider.isPending ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4 mr-2" />
+                  )}
+                  {t('routes.claudeBatchTest.removeSelectedFailedExisting', {
+                    count: selectedFailedExistingResults.length,
+                  })}
+                </Button>
+              </div>
+              <div className="divide-y divide-amber-500/20 rounded-md border border-amber-500/20 bg-background/60">
+                {failedExistingResults.map((result) => {
+                  const providerID = result.existingID ?? 0;
+                  const provider = providerByID.get(providerID);
+                  const routeCount = routeCountByProviderID.get(providerID) ?? 0;
+                  return (
+                    <label key={providerID || result.index} className="flex gap-3 p-3 text-sm">
+                      <input
+                        type="checkbox"
+                        className="mt-1"
+                        checked={selectedFailedExistingIDs.includes(providerID)}
+                        onChange={(event) =>
+                          handleToggleFailedExisting(providerID, event.target.checked)
+                        }
+                      />
+                      <span className="min-w-0 flex-1 space-y-1">
+                        <span className="flex min-w-0 flex-wrap items-center gap-2">
+                          <span className="truncate font-medium">{result.name}</span>
+                          <Badge variant={resultBadgeVariant(result.status)}>
+                            {resultLabel(result.status, t)}
+                          </Badge>
+                          <Badge variant="outline">
+                            {t('routes.claudeBatchTest.routeReferenceCount', { count: routeCount })}
+                          </Badge>
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {maskURL(providerBaseURL(provider) || result.baseURL || '')}
+                        </span>
+                        {(result.error || result.message) && (
+                          <span
+                            className="block truncate text-xs text-red-500"
+                            title={result.error || result.message}
+                          >
+                            {result.error || result.message}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              {removalError && <p className="text-xs text-red-500">{removalError}</p>}
+            </section>
+          )}
+
           <section className="min-w-0 space-y-2">
             <div className="flex items-center justify-between gap-2">
               <p className="text-sm font-medium">{t('routes.claudeBatchTest.previewTitle')}</p>
@@ -541,17 +663,17 @@ export function ClaudeProviderBatchTestDialog({
                 </span>
                 <span>
                   {t('routes.claudeBatchTest.countUsable', {
-                    count: batchTest.data?.usableCount ?? 0,
+                    count: displaySummary.usableCount,
                   })}
                 </span>
                 <span>
                   {t('routes.claudeBatchTest.countSaved', {
-                    count: batchTest.data?.persistedCount ?? 0,
+                    count: displaySummary.persistedCount,
                   })}
                 </span>
                 <span>
                   {t('routes.claudeBatchTest.countRoutesCreated', {
-                    count: batchTest.data?.routesCreated ?? 0,
+                    count: displaySummary.routesCreated,
                   })}
                 </span>
               </div>
@@ -563,8 +685,8 @@ export function ClaudeProviderBatchTestDialog({
                 </div>
               ) : (
                 <div className="divide-y divide-border">
-                  {previewItems.map((item, visibleIndex) => {
-                    const result = resultMap.get(visibleIndex);
+                  {previewItems.map((item) => {
+                    const result = resultMap.get(resultKeyForItem(item));
                     return (
                       <div
                         key={item.key}
@@ -636,79 +758,6 @@ export function ClaudeProviderBatchTestDialog({
               )}
             </div>
           </section>
-
-          {failedExistingResults.length > 0 && (
-            <section className="min-w-0 space-y-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
-                    {t('routes.claudeBatchTest.failedExistingTitle')}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {t('routes.claudeBatchTest.failedExistingDescription')}
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  disabled={selectedFailedExistingResults.length === 0 || deleteProvider.isPending}
-                  onClick={handleRemoveSelectedFailedExisting}
-                >
-                  {deleteProvider.isPending ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : (
-                    <Trash2 className="h-4 w-4 mr-2" />
-                  )}
-                  {t('routes.claudeBatchTest.removeSelectedFailedExisting', {
-                    count: selectedFailedExistingResults.length,
-                  })}
-                </Button>
-              </div>
-              <div className="divide-y divide-amber-500/20 rounded-md border border-amber-500/20 bg-background/60">
-                {failedExistingResults.map((result) => {
-                  const providerID = result.existingID ?? 0;
-                  const provider = providerByID.get(providerID);
-                  const routeCount = routeCountByProviderID.get(providerID) ?? 0;
-                  return (
-                    <label key={providerID || result.index} className="flex gap-3 p-3 text-sm">
-                      <input
-                        type="checkbox"
-                        className="mt-1"
-                        checked={selectedFailedExistingIDs.includes(providerID)}
-                        onChange={(event) =>
-                          handleToggleFailedExisting(providerID, event.target.checked)
-                        }
-                      />
-                      <span className="min-w-0 flex-1 space-y-1">
-                        <span className="flex min-w-0 flex-wrap items-center gap-2">
-                          <span className="truncate font-medium">{result.name}</span>
-                          <Badge variant={resultBadgeVariant(result.status)}>
-                            {resultLabel(result.status, t)}
-                          </Badge>
-                          <Badge variant="outline">
-                            {t('routes.claudeBatchTest.routeReferenceCount', { count: routeCount })}
-                          </Badge>
-                        </span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {maskURL(providerBaseURL(provider) || result.baseURL || '')}
-                        </span>
-                        {(result.error || result.message) && (
-                          <span
-                            className="block truncate text-xs text-red-500"
-                            title={result.error || result.message}
-                          >
-                            {result.error || result.message}
-                          </span>
-                        )}
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
-              {removalError && <p className="text-xs text-red-500">{removalError}</p>}
-            </section>
-          )}
         </div>
 
         <DialogFooter className="shrink-0 border-t border-border px-6 py-4">

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -6,7 +6,9 @@ import {
   filterRemovedExistingResults,
   getClaudeBatchCandidateResultKey,
   getClaudeBatchExistingResultKey,
+  getClaudeBatchOccurrenceMatchKeys,
   getClaudeBatchResultKey,
+  getFailedExistingResultSignature,
   summarizeClaudeBatchDisplayResults,
 } from './claude-provider-batch-test';
 
@@ -88,5 +90,24 @@ describe('Claude provider batch test helpers', () => {
     ];
 
     expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);
+  });
+
+  it('adds occurrence suffixes so duplicate candidate keys do not overwrite each other', () => {
+    const candidateKey = getClaudeBatchCandidateResultKey('Same Provider', 'https://api.test/');
+
+    expect(getClaudeBatchOccurrenceMatchKeys([candidateKey, candidateKey, 'existing-7'])).toEqual([
+      `${candidateKey}#0`,
+      `${candidateKey}#1`,
+      'existing-7#0',
+    ]);
+  });
+
+  it('builds a failed existing signature from the result identity and failure details', () => {
+    expect(
+      getFailedExistingResultSignature([
+        result({ existingID: 1, status: 'request_failed', error: 'timeout', message: 'slow' }),
+        result({ existingID: 2, status: 'upstream_5xx', error: '500', message: 'bad gateway' }),
+      ]),
+    ).toBe('1:request_failed:timeout:slow|2:upstream_5xx:500:bad gateway');
   });
 });

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ClaudeProviderBatchProviderResult } from '@/lib/transport';
+import {
+  collectSuccessfulRemovedExistingIDs,
+  filterRemovedExistingResults,
+  getClaudeBatchCandidateResultKey,
+  getClaudeBatchExistingResultKey,
+  getClaudeBatchResultKey,
+  summarizeClaudeBatchDisplayResults,
+} from './claude-provider-batch-test';
+
+function result(
+  overrides: Partial<ClaudeProviderBatchProviderResult>,
+): ClaudeProviderBatchProviderResult {
+  return {
+    index: 0,
+    source: 'existing',
+    existingID: 1,
+    name: 'Provider A',
+    type: 'custom',
+    baseURL: 'https://example.com',
+    requestedModel: 'claude-sonnet-4',
+    mappedModel: 'claude-sonnet-4',
+    action: 'test',
+    status: 'usable',
+    ok: true,
+    persisted: false,
+    routeCreated: false,
+    routeUpdated: false,
+    routeEnabled: false,
+    durationMs: 1,
+    ...overrides,
+  };
+}
+
+describe('Claude provider batch test helpers', () => {
+  it('keys existing results by provider id and candidates by normalized name/base URL', () => {
+    expect(getClaudeBatchExistingResultKey(42)).toBe('existing-42');
+    expect(getClaudeBatchCandidateResultKey('  Provider X ', 'https://example.com///')).toBe(
+      'candidate-provider x-https://example.com',
+    );
+    expect(getClaudeBatchResultKey(result({ source: 'existing', existingID: 7 }))).toBe(
+      'existing-7',
+    );
+    expect(
+      getClaudeBatchResultKey(
+        result({
+          source: 'candidate',
+          existingID: undefined,
+          name: 'New One',
+          baseURL: 'https://api.test/',
+        }),
+      ),
+    ).toBe('candidate-new one-https://api.test');
+  });
+
+  it('removes deleted existing providers from display results and recomputes summaries', () => {
+    const results = [
+      result({ existingID: 1, ok: false, persisted: false, routeCreated: false }),
+      result({ existingID: 2, ok: true, persisted: true, routeCreated: true }),
+      result({
+        source: 'candidate',
+        existingID: undefined,
+        name: 'Candidate',
+        ok: true,
+        persisted: true,
+        routeCreated: false,
+      }),
+    ];
+
+    const displayResults = filterRemovedExistingResults(results, new Set([1]));
+
+    expect(displayResults.map((item) => item.existingID ?? item.name)).toEqual([2, 'Candidate']);
+    expect(summarizeClaudeBatchDisplayResults(displayResults)).toEqual({
+      usableCount: 2,
+      persistedCount: 2,
+      routesCreated: 1,
+    });
+  });
+
+  it('keeps failed removals selected by only collecting fulfilled delete targets', () => {
+    const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
+    const settled: PromiseSettledResult<unknown>[] = [
+      { status: 'fulfilled', value: undefined },
+      { status: 'rejected', reason: new Error('delete failed') },
+      { status: 'fulfilled', value: undefined },
+    ];
+
+    expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);
+  });
+});

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -1,0 +1,47 @@
+import type { ClaudeProviderBatchProviderResult } from '@/lib/transport';
+
+export function getClaudeBatchExistingResultKey(providerID: number) {
+  return `existing-${providerID}`;
+}
+
+export function getClaudeBatchCandidateResultKey(name: string, baseURL: string) {
+  return `candidate-${name.trim().toLowerCase()}-${baseURL.replace(/\/+$/, '')}`;
+}
+
+export function getClaudeBatchResultKey(
+  result: Pick<ClaudeProviderBatchProviderResult, 'source' | 'existingID' | 'name' | 'baseURL'>,
+) {
+  if (result.source === 'existing' && result.existingID) {
+    return getClaudeBatchExistingResultKey(result.existingID);
+  }
+  return getClaudeBatchCandidateResultKey(result.name, result.baseURL ?? '');
+}
+
+export function filterRemovedExistingResults(
+  results: ClaudeProviderBatchProviderResult[] | undefined,
+  removedExistingIDs: Set<number>,
+) {
+  return (results ?? []).filter(
+    (result) =>
+      result.source !== 'existing' ||
+      !result.existingID ||
+      !removedExistingIDs.has(result.existingID),
+  );
+}
+
+export function summarizeClaudeBatchDisplayResults(results: ClaudeProviderBatchProviderResult[]) {
+  return {
+    usableCount: results.filter((result) => result.ok).length,
+    persistedCount: results.filter((result) => result.persisted).length,
+    routesCreated: results.filter((result) => result.routeCreated).length,
+  };
+}
+
+export function collectSuccessfulRemovedExistingIDs<T extends { existingID?: number }>(
+  targets: T[],
+  settled: PromiseSettledResult<unknown>[],
+) {
+  return targets
+    .filter((target, index) => Boolean(target.existingID) && settled[index]?.status === 'fulfilled')
+    .map((target) => target.existingID!);
+}

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -17,6 +17,19 @@ export function getClaudeBatchResultKey(
   return getClaudeBatchCandidateResultKey(result.name, result.baseURL ?? '');
 }
 
+export function getClaudeBatchResultMatchKey(baseKey: string, occurrence: number) {
+  return `${baseKey}#${occurrence}`;
+}
+
+export function getClaudeBatchOccurrenceMatchKeys(baseKeys: string[]) {
+  const occurrenceByBaseKey = new Map<string, number>();
+  return baseKeys.map((baseKey) => {
+    const occurrence = occurrenceByBaseKey.get(baseKey) ?? 0;
+    occurrenceByBaseKey.set(baseKey, occurrence + 1);
+    return getClaudeBatchResultMatchKey(baseKey, occurrence);
+  });
+}
+
 export function filterRemovedExistingResults(
   results: ClaudeProviderBatchProviderResult[] | undefined,
   removedExistingIDs: Set<number>,
@@ -44,4 +57,15 @@ export function collectSuccessfulRemovedExistingIDs<T extends { existingID?: num
   return targets
     .filter((target, index) => Boolean(target.existingID) && settled[index]?.status === 'fulfilled')
     .map((target) => target.existingID!);
+}
+
+export function getFailedExistingResultSignature(
+  results: Pick<ClaudeProviderBatchProviderResult, 'existingID' | 'status' | 'error' | 'message'>[],
+) {
+  return results
+    .map(
+      (result) =>
+        `${result.existingID ?? 0}:${result.status ?? ''}:${result.error ?? ''}:${result.message ?? ''}`,
+    )
+    .join('|');
 }


### PR DESCRIPTION
## Summary
- move failed existing Claude provider removal confirmation above the preview/results list and auto-scroll it into view after failed tests
- remove successfully deleted existing providers from local provider/route/preview/result state immediately
- key batch test results by stable provider/candidate identity instead of result index, and add focused regression helpers/tests

## Validation
- `pnpm --dir web test -- src/pages/client-routes/utils/claude-provider-batch-test.test.ts`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`
- `go test ./internal/handler ./internal/service ./tests/e2e`
- Playwright UI smoke against isolated local data dir on `127.0.0.1:9896`: confirmed failed existing provider section is visible without manual scrolling; after confirm remove, provider, route, preview row, result row, and API records are gone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了 Claude 批量测试对话框的结果展示与统计逻辑，已移除项会自动从预览和汇总中排除。
  * 新增失败移除场景的错误提示文案，并支持数量占位显示。
  * 失败项区域可自动定位，方便快速查看处理结果。

* **测试**
  * 补充了批量测试相关的自动化测试，覆盖结果匹配、过滤与汇总行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->