### PR TITLE
fix(routes): stabilize unmatched route handling and batch tests

### DIFF
--- a/internal/executor/middleware_ingress.go
+++ b/internal/executor/middleware_ingress.go
@@ -86,52 +86,6 @@ func (e *Executor) ingress(c *flow.Ctx) {
 		}
 	}
 
-	proxyReq := &domain.ProxyRequest{
-		TenantID:     state.tenantID,
-		InstanceID:   e.instanceID,
-		RequestID:    generateRequestID(),
-		SessionID:    state.sessionID,
-		ClientType:   state.clientType,
-		ProjectID:    state.projectID,
-		RequestModel: state.requestModel,
-		StartTime:    time.Now(),
-		IsStream:     state.isStream,
-		Status:       "PENDING",
-		APITokenID:   state.apiTokenID,
-		DevMode:      state.apiTokenDevMode,
-	}
-
-	clearDetail := e.shouldClearRequestDetailFor(state)
-	if !clearDetail {
-		requestURI := state.requestURI
-		requestHeaders := state.requestHeaders
-		requestBody := state.requestBody
-		headers := flattenHeaders(requestHeaders)
-		if c.Request != nil {
-			if c.Request.Host != "" {
-				if headers == nil {
-					headers = make(map[string]string)
-				}
-				headers["Host"] = c.Request.Host
-			}
-			proxyReq.RequestInfo = &domain.RequestInfo{
-				Method:  c.Request.Method,
-				URL:     requestURI,
-				Headers: headers,
-				Body:    domain.RequestBodySnapshot(requestBody, requestHeaders.Get("Content-Type"), state.apiTokenDevMode),
-			}
-		}
-	}
-
-	if err := e.proxyRequestRepo.Create(proxyReq); err != nil {
-		log.Printf("[Executor] Failed to create proxy request: %v", err)
-	}
-
-	if e.broadcaster != nil {
-		e.broadcaster.BroadcastProxyRequest(proxyReq)
-	}
-
-	state.proxyReq = proxyReq
 	state.ctx = ctx
 
 	if state.projectID == 0 && e.projectWaiter != nil {
@@ -158,15 +112,12 @@ func (e *Executor) ingress(c *flow.Ctx) {
 				}
 			}
 
+			proxyReq := e.newProxyRequest(c, state, status)
 			proxyReq.Status = status
 			proxyReq.Error = errorMsg
 			proxyReq.EndTime = time.Now()
 			proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-			_ = e.proxyRequestRepo.Update(proxyReq)
-
-			if e.broadcaster != nil {
-				e.broadcaster.BroadcastProxyRequest(proxyReq)
-			}
+			e.createProxyRequest(proxyReq)
 
 			proxyErr := domain.NewProxyErrorWithMessage(err, false, "project binding required: "+err.Error())
 			proxyErr.Scope = domain.ScopeRequest
@@ -177,9 +128,61 @@ func (e *Executor) ingress(c *flow.Ctx) {
 		}
 
 		state.projectID = session.ProjectID
-		proxyReq.ProjectID = state.projectID
 		state.ctx = ctx
 	}
 
 	c.Next()
+}
+
+func (e *Executor) newProxyRequest(c *flow.Ctx, state *execState, status string) *domain.ProxyRequest {
+	proxyReq := &domain.ProxyRequest{
+		TenantID:     state.tenantID,
+		InstanceID:   e.instanceID,
+		RequestID:    generateRequestID(),
+		SessionID:    state.sessionID,
+		ClientType:   state.clientType,
+		ProjectID:    state.projectID,
+		RequestModel: state.requestModel,
+		StartTime:    time.Now(),
+		IsStream:     state.isStream,
+		Status:       status,
+		APITokenID:   state.apiTokenID,
+		DevMode:      state.apiTokenDevMode,
+	}
+
+	clearDetail := e.shouldClearRequestDetailFor(state)
+	if !clearDetail {
+		requestURI := state.requestURI
+		requestHeaders := state.requestHeaders
+		requestBody := state.requestBody
+		headers := flattenHeaders(requestHeaders)
+		if c.Request != nil {
+			if c.Request.Host != "" {
+				if headers == nil {
+					headers = make(map[string]string)
+				}
+				headers["Host"] = c.Request.Host
+			}
+			proxyReq.RequestInfo = &domain.RequestInfo{
+				Method:  c.Request.Method,
+				URL:     requestURI,
+				Headers: headers,
+				Body:    domain.RequestBodySnapshot(requestBody, requestHeaders.Get("Content-Type"), state.apiTokenDevMode),
+			}
+		}
+	}
+
+	return proxyReq
+}
+
+func (e *Executor) createProxyRequest(proxyReq *domain.ProxyRequest) {
+	if proxyReq == nil {
+		return
+	}
+	if err := e.proxyRequestRepo.Create(proxyReq); err != nil {
+		log.Printf("[Executor] Failed to create proxy request: %v", err)
+	}
+	if e.broadcaster != nil {
+		e.broadcaster.BroadcastProxyRequest(proxyReq)
+	}
 }

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -2,8 +2,7 @@ package executor
 
 import (
 	"fmt"
-	"log"
-	"time"
+	"net/http"
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -20,7 +19,6 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		return
 	}
 
-	proxyReq := state.proxyReq
 	result, err := e.router.Match(&router.MatchContext{
 		Ctx:          state.ctx,
 		TenantID:     state.tenantID,
@@ -31,18 +29,9 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		SessionID:    state.sessionID,
 	})
 	if err != nil {
-		proxyReq.Status = "FAILED"
-		proxyReq.Error = "no routes available"
-		proxyReq.EndTime = time.Now()
-		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-		if err := e.proxyRequestRepo.Update(proxyReq); err != nil {
-			log.Printf("[Executor] failed to update proxy request: %v", err)
-		}
-		if e.broadcaster != nil {
-			e.broadcaster.BroadcastProxyRequest(proxyReq)
-		}
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, fmt.Sprintf("route match failed: %v", err))
 		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
 		state.lastErr = proxyErr
 		c.Err = proxyErr
 		c.Abort()
@@ -50,31 +39,18 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	}
 
 	if len(result.Routes) == 0 {
-		proxyReq.Status = "FAILED"
-		proxyReq.Error = "no routes configured"
-		proxyReq.EndTime = time.Now()
-		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-		if err := e.proxyRequestRepo.Update(proxyReq); err != nil {
-			log.Printf("[Executor] failed to update proxy request: %v", err)
-		}
-		if e.broadcaster != nil {
-			e.broadcaster.BroadcastProxyRequest(proxyReq)
-		}
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, "no routes configured")
 		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
 		state.lastErr = proxyErr
 		c.Err = proxyErr
 		c.Abort()
 		return
 	}
 
-	proxyReq.Status = "IN_PROGRESS"
-	if err := e.proxyRequestRepo.Update(proxyReq); err != nil {
-		log.Printf("[Executor] failed to update proxy request: %v", err)
-	}
-	if e.broadcaster != nil {
-		e.broadcaster.BroadcastProxyRequest(proxyReq)
-	}
+	proxyReq := e.newProxyRequest(c, state, "IN_PROGRESS")
+	e.createProxyRequest(proxyReq)
+	state.proxyReq = proxyReq
 	state.routes = result.Routes
 	state.stickyWrite = result.Sticky
 

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1076,7 +1076,7 @@ func TestProxyNoMatchingRoute(t *testing.T) {
 	env := NewProxyTestEnv(t)
 
 	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
-	AssertStatus(t, resp, http.StatusBadGateway)
+	AssertStatus(t, resp, http.StatusServiceUnavailable)
 
 	var payload map[string]map[string]any
 	DecodeJSON(t, resp, &payload)
@@ -1089,6 +1089,46 @@ func TestProxyNoMatchingRoute(t *testing.T) {
 	}
 	if got := payload["error"]["retryable"]; got != false {
 		t.Fatalf("error.retryable = %v, want false", got)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func TestProxyRouteWithoutConfiguredProviderDoesNotRecordRequest(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	routeResp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   false,
+		"clientType": "openai",
+		"providerID": 999999,
+		"projectID":  0,
+		"position":   1,
+	})
+	AssertStatus(t, routeResp, http.StatusCreated)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusServiceUnavailable)
+
+	var payload map[string]map[string]any
+	DecodeJSON(t, resp, &payload)
+	msg, _ := payload["error"]["message"].(string)
+	if !strings.Contains(msg, "route match failed") || !strings.Contains(msg, "no routes available") {
+		t.Fatalf("error.message = %q, want to contain route match failed and no routes available", msg)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func assertNoProxyRequestsRecorded(t *testing.T, env *ProxyTestEnv) {
+	t.Helper()
+
+	requestsResp := env.doRequest(http.MethodGet, "/api/admin/requests?limit=20", nil, env.Token)
+	AssertStatus(t, requestsResp, http.StatusOK)
+	var requests struct {
+		Items []map[string]any `json:"items"`
+	}
+	DecodeJSON(t, requestsResp, &requests)
+	if len(requests.Items) != 0 {
+		t.Fatalf("expected route-match rejection to stay out of requests tab, got %d requests: %#v", len(requests.Items), requests.Items)
 	}
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -765,6 +765,7 @@
       "parseErrorLine": "Line {{line}}: {{message}}",
       "existingTitle": "Existing Claude providers",
       "existingSelectedCount": "Selected {{selected}} / {{total}}",
+      "excludedExistingCount": "Hidden {{count}} export-excluded providers",
       "selectAllExisting": "Select all",
       "clearExistingSelection": "Clear selection",
       "noExistingProviders": "No custom Claude providers are available.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -762,6 +762,7 @@
       "parseErrorLine": "第 {{line}} 行：{{message}}",
       "existingTitle": "已存在 Claude provider",
       "existingSelectedCount": "已选 {{selected}} / {{total}}",
+      "excludedExistingCount": "已隐藏 {{count}} 个不导出的 provider",
       "selectAllExisting": "全选",
       "clearExistingSelection": "取消全选",
       "noExistingProviders": "没有可选的 custom Claude provider。",

--- a/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
+++ b/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
@@ -38,6 +38,8 @@ import {
   getClaudeBatchOccurrenceMatchKeys,
   getClaudeBatchResultKey,
   getFailedExistingResultSignature,
+  isClaudeBatchTestExcludedProvider,
+  isClaudeBatchTestSelectableProvider,
   summarizeClaudeBatchDisplayResults,
 } from '@/pages/client-routes/utils/claude-provider-batch-test';
 
@@ -182,20 +184,19 @@ export function ClaudeProviderBatchTestDialog({
   );
 
   const claudeProviders = useMemo(
-    () =>
-      activeProviders.filter(
-        (provider) =>
-          provider.type === 'custom' &&
-          (provider.supportedClientTypes?.length === 0 ||
-            provider.supportedClientTypes?.includes('claude')),
-      ),
+    () => activeProviders.filter(isClaudeBatchTestSelectableProvider),
     [activeProviders],
   );
+
+  const excludedExistingProviderCount = activeProviders.filter(
+    isClaudeBatchTestExcludedProvider,
+  ).length;
 
   const claudeProviderIDs = useMemo(
     () => claudeProviders.map((provider) => provider.id),
     [claudeProviders],
   );
+  const claudeProviderIDSet = useMemo(() => new Set(claudeProviderIDs), [claudeProviderIDs]);
 
   const selectedExistingCount = useMemo(
     () => selectedExistingIDs.filter((id) => claudeProviderIDs.includes(id)).length,
@@ -204,6 +205,13 @@ export function ClaudeProviderBatchTestDialog({
 
   const allExistingSelected =
     claudeProviderIDs.length > 0 && selectedExistingCount === claudeProviderIDs.length;
+
+  useEffect(() => {
+    setSelectedExistingIDs((current) => {
+      if (current.every((id) => claudeProviderIDSet.has(id))) return current;
+      return current.filter((id) => claudeProviderIDSet.has(id));
+    });
+  }, [claudeProviderIDSet]);
 
   const parsePreview = useMemo(() => parseBulkCustomProviderCommands(commandsText), [commandsText]);
 
@@ -370,7 +378,7 @@ export function ClaudeProviderBatchTestDialog({
     await batchTest.mutateAsync({
       signal: controller.signal,
       data: {
-        existingProviderIDs: selectedExistingIDs,
+        existingProviderIDs: selectedExistingIDs.filter((id) => claudeProviderIDSet.has(id)),
         candidates: selectedCandidateData,
         projectID,
         testModel: testModel.trim() || DEFAULT_TEST_MODEL,
@@ -502,6 +510,13 @@ export function ClaudeProviderBatchTestDialog({
                       total: claudeProviderIDs.length,
                     })}
                   </p>
+                  {excludedExistingProviderCount > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      {t('routes.claudeBatchTest.excludedExistingCount', {
+                        count: excludedExistingProviderCount,
+                      })}
+                    </p>
+                  )}
                 </div>
                 <Button
                   type="button"

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -9,6 +9,8 @@ import {
   getClaudeBatchOccurrenceMatchKeys,
   getClaudeBatchResultKey,
   getFailedExistingResultSignature,
+  isClaudeBatchTestExcludedProvider,
+  isClaudeBatchTestSelectableProvider,
   summarizeClaudeBatchDisplayResults,
 } from './claude-provider-batch-test';
 
@@ -37,6 +39,37 @@ function result(
 }
 
 describe('Claude provider batch test helpers', () => {
+  it('excludes export-hidden providers from the Claude batch-test selectable list', () => {
+    expect(
+      isClaudeBatchTestSelectableProvider({
+        type: 'custom',
+        supportedClientTypes: ['claude'],
+        excludeFromExport: false,
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeBatchTestSelectableProvider({
+        type: 'custom',
+        supportedClientTypes: [],
+        excludeFromExport: false,
+      }),
+    ).toBe(true);
+    const exportHiddenClaudeProvider = {
+      type: 'custom' as const,
+      supportedClientTypes: ['claude'],
+      excludeFromExport: true,
+    };
+    expect(isClaudeBatchTestSelectableProvider(exportHiddenClaudeProvider)).toBe(false);
+    expect(isClaudeBatchTestExcludedProvider(exportHiddenClaudeProvider)).toBe(true);
+    const openAIOnlyProvider = {
+      type: 'custom' as const,
+      supportedClientTypes: ['openai'],
+      excludeFromExport: false,
+    };
+    expect(isClaudeBatchTestSelectableProvider(openAIOnlyProvider)).toBe(false);
+    expect(isClaudeBatchTestExcludedProvider(openAIOnlyProvider)).toBe(false);
+  });
+
   it('keys existing results by provider id and candidates by normalized name/base URL', () => {
     expect(getClaudeBatchExistingResultKey(42)).toBe('existing-42');
     expect(getClaudeBatchCandidateResultKey('  Provider X ', 'https://example.com///')).toBe(

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -1,4 +1,25 @@
-import type { ClaudeProviderBatchProviderResult } from '@/lib/transport';
+import type { ClaudeProviderBatchProviderResult, Provider } from '@/lib/transport';
+
+type ClaudeBatchProviderSelectionFields = Pick<
+  Provider,
+  'type' | 'supportedClientTypes' | 'excludeFromExport'
+>;
+
+function supportsClaudeBatchTest(provider: ClaudeBatchProviderSelectionFields) {
+  return (
+    provider.type === 'custom' &&
+    (provider.supportedClientTypes?.length === 0 ||
+      provider.supportedClientTypes?.includes('claude'))
+  );
+}
+
+export function isClaudeBatchTestSelectableProvider(provider: ClaudeBatchProviderSelectionFields) {
+  return supportsClaudeBatchTest(provider) && !provider.excludeFromExport;
+}
+
+export function isClaudeBatchTestExcludedProvider(provider: ClaudeBatchProviderSelectionFields) {
+  return supportsClaudeBatchTest(provider) && !!provider.excludeFromExport;
+}
 
 export function getClaudeBatchExistingResultKey(providerID: number) {
   return `existing-${providerID}`;


### PR DESCRIPTION
## Summary
- return `503 Service Unavailable` for unmatched routes / routes pointing at missing providers without creating red request-tab records
- create proxy request records only after route match succeeds, while preserving real rejected project-binding failures
- hide `excludeFromExport` custom Claude providers from the Claude provider batch-test selection list
- prune hidden providers from selected IDs and re-filter before submitting a batch test

## Validation
- `go test ./tests/e2e -run 'TestProxyNoMatchingRoute|TestProxyRouteWithoutConfiguredProviderDoesNotRecordRequest|TestProviderScopedProxyRoute' -count=1`
- `go test ./internal/executor ./tests/e2e -count=1`
- `go test ./...`
- `pnpm test -- src/pages/client-routes/utils/claude-provider-batch-test.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (passes; existing Vite large chunk warning only)
- browser screenshot assertion: normal Claude providers remain visible in the batch-test dialog, `excludeFromExport=true` provider is hidden, hidden-count hint is shown
