### PR TITLE
fix(routes): stabilize Claude failed-provider bulk removal

### DIFF
--- a/internal/adapter/provider/custom/claude_test_request.go
+++ b/internal/adapter/provider/custom/claude_test_request.go
@@ -1,0 +1,69 @@
+package custom
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// NewClaudeMessagesTestRequest builds the same upstream Claude messages request shape
+// used by CustomAdapter for a non-stream Claude request. It is intentionally small:
+// callers provide the already model-mapped Claude payload and the resolved Claude
+// base URL, while this helper owns the custom-provider body/header compatibility
+// contract (disguise mode, Claude Code headers, Bedrock compatibility, auth style,
+// beta extraction, and OAuth tool prefixing).
+func NewClaudeMessagesTestRequest(ctx context.Context, provider *domain.Provider, baseURL string, payload []byte) (*http.Request, error) {
+	endpoint := addClaudeQueryParams(buildUpstreamURL(strings.TrimRight(strings.TrimSpace(baseURL), "/"), "/v1/messages"))
+	upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	customCfg := provider.Config.Custom
+	apiKey := customCfg.APIKey
+	clientReq := newClaudeBatchSyntheticClientRequest()
+	clientUA := clientReq.Header.Get("User-Agent")
+	requestBody, extraBetas := processClaudeRequestBody(payload, clientUA, customCfg)
+	useAPIKey := shouldUseClaudeAPIKey(apiKey, clientReq)
+	if isClaudeOAuthToken(apiKey) {
+		requestBody = applyClaudeToolPrefix(requestBody, claudeToolPrefix)
+	}
+
+	effectiveDisguise := customCfg.ResolveDisguise()
+	disguiseType := ""
+	if effectiveDisguise != nil {
+		disguiseType = strings.ToLower(strings.TrimSpace(effectiveDisguise.Type))
+	}
+	switch disguiseType {
+	case domain.DisguiseTypeBedrock:
+		applyBedrockCompatHeaders(upstreamReq, clientReq, apiKey, false)
+	case domain.DisguiseTypeNone:
+		upstreamReq.Header = make(http.Header)
+		copyHeadersFiltered(upstreamReq.Header, clientReq.Header)
+		if len(extraBetas) > 0 {
+			upstreamReq.Header.Set(
+				"Anthropic-Beta",
+				mergeBetaList(upstreamReq.Header.Get("Anthropic-Beta"), extraBetas),
+			)
+		}
+		setClaudeAuthForURL(upstreamReq, apiKey, useAPIKey)
+	default:
+		applyClaudeHeaders(upstreamReq, clientReq, apiKey, useAPIKey, extraBetas, false)
+	}
+
+	upstreamReq.Body = io.NopCloser(bytes.NewReader(requestBody))
+	upstreamReq.ContentLength = int64(len(requestBody))
+	return upstreamReq, nil
+}
+
+func newClaudeBatchSyntheticClientRequest() *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", defaultClaudeUserAgent)
+	req.Header.Set("Anthropic-Version", defaultAnthropicVersion)
+	return req
+}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -1482,6 +1482,188 @@ func TestSelfServiceHandler_ClaudeProviderBatchTest_ExistingProvidersAreTestOnly
 	}
 }
 
+func TestSelfServiceHandler_ClaudeProviderBatchTest_UsesClaudeClientBaseURL(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/claude/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"wrong base URL"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_mock","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"mock"}`))
+	}))
+	defer upstream.Close()
+
+	providerRepo := &selfServiceProviderRepo{providers: []*domain.Provider{{
+		ID:       10,
+		TenantID: domain.DefaultTenantID,
+		Name:     "existing-client-base-url",
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: upstream.URL + "/generic",
+			ClientBaseURL: map[domain.ClientType]string{
+				domain.ClientTypeClaude: upstream.URL + "/claude",
+			},
+			APIKey: "sk-existing",
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}}}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo:     providerRepo,
+		routeRepo:        &selfServiceRouteRepo{},
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: &selfServiceModelMappingRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/routes/claude-provider-batch-test", `{
+		"projectID":0,
+		"testModel":"claude-sonnet-4",
+		"maxTokens":8,
+		"concurrency":1,
+		"persistMode":"passed",
+		"existingProviderIDs":[10]
+	}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result service.ClaudeProviderBatchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Results) != 1 || result.Results[0].Status != service.ClaudeProviderBatchStatusUsable {
+		t.Fatalf("results = %+v, want client-specific Claude base URL to be tested successfully", result.Results)
+	}
+	if !strings.Contains(result.Results[0].BaseURL, "/claude") || strings.Contains(result.Results[0].BaseURL, "/generic") {
+		t.Fatalf("BaseURL = %q, want masked Claude client-specific base URL", result.Results[0].BaseURL)
+	}
+}
+
+func TestSelfServiceHandler_ClaudeProviderBatchTest_UsesWildcardProviderModelMapping(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if payload.Model != "mock-sonnet" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"type":"not_found_error","message":"model not found"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_mock","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"mock-sonnet"}`))
+	}))
+	defer upstream.Close()
+
+	providerRepo := &selfServiceProviderRepo{providers: []*domain.Provider{{
+		ID:       10,
+		TenantID: domain.DefaultTenantID,
+		Name:     "existing-wildcard-mapping",
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: upstream.URL,
+			APIKey:  "sk-existing",
+			ModelMapping: map[string]string{
+				"claude-*": "mock-sonnet",
+			},
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}}}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo:     providerRepo,
+		routeRepo:        &selfServiceRouteRepo{},
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: &selfServiceModelMappingRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/routes/claude-provider-batch-test", `{
+		"projectID":0,
+		"testModel":"claude-sonnet-4",
+		"maxTokens":8,
+		"concurrency":1,
+		"persistMode":"passed",
+		"existingProviderIDs":[10]
+	}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result service.ClaudeProviderBatchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Results) != 1 || result.Results[0].Status != service.ClaudeProviderBatchStatusUsable || result.Results[0].MappedModel != "mock-sonnet" {
+		t.Fatalf("results = %+v, want wildcard provider model mapping to be applied before testing", result.Results)
+	}
+}
+
+func TestSelfServiceHandler_ClaudeProviderBatchTest_HonorsBedrockDisguiseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, header := range []string{"Anthropic-Beta", "Anthropic-Version", "X-App", "X-Stainless-Runtime"} {
+			if value := strings.TrimSpace(r.Header.Get(header)); value != "" {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"unexpected Claude identity header"}}`))
+				return
+			}
+		}
+		if userAgent := r.Header.Get("User-Agent"); !strings.Contains(userAgent, "aws-sdk-go-v2") {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unexpected user agent"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_mock","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"mock"}`))
+	}))
+	defer upstream.Close()
+
+	providerRepo := &selfServiceProviderRepo{providers: []*domain.Provider{{
+		ID:       10,
+		TenantID: domain.DefaultTenantID,
+		Name:     "existing-bedrock-disguise",
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: upstream.URL,
+			APIKey:  "sk-existing",
+			Disguise: &domain.ProviderConfigCustomDisguise{
+				Type: domain.DisguiseTypeBedrock,
+			},
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}}}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo:     providerRepo,
+		routeRepo:        &selfServiceRouteRepo{},
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: &selfServiceModelMappingRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/routes/claude-provider-batch-test", `{
+		"projectID":0,
+		"testModel":"claude-sonnet-4",
+		"maxTokens":2048,
+		"concurrency":1,
+		"persistMode":"passed",
+		"existingProviderIDs":[10]
+	}`))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var result service.ClaudeProviderBatchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Results) != 1 || result.Results[0].Status != service.ClaudeProviderBatchStatusUsable {
+		t.Fatalf("results = %+v, want bedrock disguise request headers to match custom adapter behavior", result.Results)
+	}
+}
+
 func TestSelfServiceHandler_DeleteProviderRemovesRouteReferences(t *testing.T) {
 	providerRepo := &selfServiceProviderRepo{providers: []*domain.Provider{
 		{ID: 10, TenantID: domain.DefaultTenantID, Name: "delete-me", Type: "custom"},

--- a/internal/service/claude_provider_batch.go
+++ b/internal/service/claude_provider_batch.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	customadapter "github.com/awsl-project/maxx/internal/adapter/provider/custom"
 	"github.com/awsl-project/maxx/internal/domain"
 )
 
@@ -270,6 +271,7 @@ func baseClaudeBatchResult(index int, source string, existingID uint64, provider
 		if provider.Config != nil && provider.Config.Custom != nil {
 			result.ModelMapping = cloneStringMap(provider.Config.Custom.ModelMapping)
 			result.MappedModel = mapClaudeBatchModel(requestedModel, provider.Config.Custom.ModelMapping)
+			result.BaseURL = maskURL(normalizedProviderClientBaseURL(provider, domain.ClientTypeClaude))
 		}
 	}
 	if result.MappedModel == "" {
@@ -298,24 +300,15 @@ func testClaudeBatchProvider(ctx context.Context, item *claudeBatchPreparedProvi
 		}},
 	}
 	payload, _ := json.Marshal(body)
-	endpoint := strings.TrimRight(custom.BaseURL, "/") + "/v1/messages"
-	if !strings.Contains(endpoint, "?") {
-		endpoint += "?beta=true"
-	}
-
 	testCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	started := time.Now()
-	httpReq, err := http.NewRequestWithContext(testCtx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	httpReq, err := customadapter.NewClaudeMessagesTestRequest(testCtx, item.provider, normalizedProviderClientBaseURL(item.provider, domain.ClientTypeClaude), payload)
 	if err != nil {
 		result.Status = ClaudeProviderBatchStatusValidationFailed
 		result.Error = "invalid base URL"
 		return result
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Anthropic-Version", "2023-06-01")
-	httpReq.Header.Set("User-Agent", "maxx-claude-provider-batch-test")
-	setClaudeBatchAuthHeader(httpReq, custom.APIKey)
 
 	resp, err := (&http.Client{Timeout: 22 * time.Second}).Do(httpReq)
 	result.DurationMS = time.Since(started).Milliseconds()
@@ -352,7 +345,7 @@ func validateClaudeBatchProvider(provider *domain.Provider) error {
 	if provider.Config == nil || provider.Config.Custom == nil {
 		return fmt.Errorf("custom provider config is required")
 	}
-	if strings.TrimSpace(provider.Config.Custom.BaseURL) == "" {
+	if normalizedProviderClientBaseURL(provider, domain.ClientTypeClaude) == "" {
 		return fmt.Errorf("base URL is required")
 	}
 	if strings.TrimSpace(provider.Config.Custom.APIKey) == "" && strings.TrimSpace(provider.Config.Custom.Backend) != "ollama" {
@@ -581,6 +574,17 @@ func normalizedProviderBaseURL(provider *domain.Provider) string {
 	return strings.TrimRight(strings.TrimSpace(provider.Config.Custom.BaseURL), "/")
 }
 
+func normalizedProviderClientBaseURL(provider *domain.Provider, clientType domain.ClientType) string {
+	if provider == nil || provider.Config == nil || provider.Config.Custom == nil {
+		return ""
+	}
+	custom := provider.Config.Custom
+	if clientBaseURL := strings.TrimSpace(custom.ClientBaseURL[clientType]); clientBaseURL != "" {
+		return strings.TrimRight(clientBaseURL, "/")
+	}
+	return normalizedProviderBaseURL(provider)
+}
+
 func mapClaudeBatchModel(requested string, mapping map[string]string) string {
 	requested = strings.TrimSpace(requested)
 	if requested == "" {
@@ -589,21 +593,13 @@ func mapClaudeBatchModel(requested string, mapping map[string]string) string {
 	if mapped := strings.TrimSpace(mapping[requested]); mapped != "" {
 		return mapped
 	}
-	if mapped := strings.TrimSpace(mapping["*"]); mapped != "" {
-		return mapped
+	for pattern, mapped := range mapping {
+		mapped = strings.TrimSpace(mapped)
+		if mapped != "" && domain.MatchWildcard(pattern, requested) {
+			return mapped
+		}
 	}
 	return requested
-}
-
-func setClaudeBatchAuthHeader(req *http.Request, apiKey string) {
-	if strings.TrimSpace(apiKey) == "" {
-		return
-	}
-	if req.URL != nil && strings.EqualFold(req.URL.Scheme, "https") && strings.EqualFold(req.URL.Host, "api.anthropic.com") {
-		req.Header.Set("x-api-key", apiKey)
-		return
-	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
 }
 
 func sanitizeClaudeBatchError(message string) string {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -815,6 +815,8 @@
       "autoSavePassedHint": "Fixed rule: new configs are added only after passing; existing providers are tested only and are never silently deleted.",
       "failedExistingTitle": "Existing providers pending removal confirmation",
       "failedExistingDescription": "These existing Claude providers failed the test. Select and confirm removal to delete them globally from the Providers tab and clean up routes/project references that use them.",
+      "selectAllFailedExisting": "Select all failed items",
+      "clearFailedExistingSelection": "Clear failed selection",
       "removeSelectedFailedExisting": "Remove selected failed items ({{count}})",
       "confirmRemoveFailedExisting": "Remove {{count}} existing provider(s)? This deletes them globally from the Providers tab and cleans up {{routeCount}} route/project reference(s). This cannot be undone.",
       "removeFailedExistingError": "Failed to remove {{count}} provider(s)",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -812,6 +812,8 @@
       "autoSavePassedHint": "规则固定：待测试配置仅通过后自动添加；已存在 provider 只测试，不会静默删除。",
       "failedExistingTitle": "待确认移除的已存在 provider",
       "failedExistingDescription": "这些已存在 Claude provider 未通过测试。勾选后确认移除，会从 Providers tab 全局删除，并清理引用它们的 route/project 配置。",
+      "selectAllFailedExisting": "全选失败项",
+      "clearFailedExistingSelection": "取消全选失败项",
       "removeSelectedFailedExisting": "移除选中失败项（{{count}}）",
       "confirmRemoveFailedExisting": "确认移除 {{count}} 个已存在 provider？这会从 Providers tab 全局删除，并清理 {{routeCount}} 条引用 route/project 配置。此操作不可撤销。",
       "removeFailedExistingError": "{{count}} 个 provider 移除失败",

--- a/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
+++ b/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
@@ -40,6 +40,7 @@ import {
   getFailedExistingResultSignature,
   isClaudeBatchTestExcludedProvider,
   isClaudeBatchTestSelectableProvider,
+  settleProviderRemovalsSequentially,
   summarizeClaudeBatchDisplayResults,
 } from '@/pages/client-routes/utils/claude-provider-batch-test';
 
@@ -343,6 +344,17 @@ export function ClaudeProviderBatchTestDialog({
     (count, result) => count + (routeCountByProviderID.get(result.existingID ?? 0) ?? 0),
     0,
   );
+  const failedExistingIDs = useMemo(
+    () =>
+      failedExistingResults.map((result) => result.existingID).filter((id): id is number => !!id),
+    [failedExistingResults],
+  );
+  const failedExistingIDSet = useMemo(() => new Set(failedExistingIDs), [failedExistingIDs]);
+  const selectedFailedExistingCount = selectedFailedExistingIDs.filter((id) =>
+    failedExistingIDSet.has(id),
+  ).length;
+  const allFailedExistingSelected =
+    failedExistingIDs.length > 0 && selectedFailedExistingCount === failedExistingIDs.length;
   const failedExistingResultSignature = getFailedExistingResultSignature(failedExistingResults);
   const canRun =
     previewItems.some((item) => item.selected && !item.error) && parsePreview.errors.length === 0;
@@ -351,6 +363,13 @@ export function ClaudeProviderBatchTestDialog({
     if (failedExistingResults.length === 0) return;
     failedExistingSectionRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }, [failedExistingResults.length, failedExistingResultSignature]);
+
+  useEffect(() => {
+    setSelectedFailedExistingIDs((current) => {
+      if (current.every((id) => failedExistingIDSet.has(id))) return current;
+      return current.filter((id) => failedExistingIDSet.has(id));
+    });
+  }, [failedExistingIDSet]);
 
   const handleToggleExisting = (providerID: number, checked: boolean) => {
     setSelectedExistingIDs((current) =>
@@ -398,6 +417,16 @@ export function ClaudeProviderBatchTestDialog({
     );
   };
 
+  const handleToggleAllFailedExisting = () => {
+    setSelectedFailedExistingIDs((current) => {
+      if (allFailedExistingSelected) {
+        const idsToClear = new Set(failedExistingIDs);
+        return current.filter((id) => !idsToClear.has(id));
+      }
+      return [...new Set([...current, ...failedExistingIDs])];
+    });
+  };
+
   const handleRemoveSelectedFailedExisting = async () => {
     const targets = selectedFailedExistingResults.filter((result) => result.existingID);
     if (targets.length === 0 || isRemovingFailedExisting) return;
@@ -412,8 +441,8 @@ export function ClaudeProviderBatchTestDialog({
     setRemovalError(null);
     setIsRemovingFailedExisting(true);
     try {
-      const settled = await Promise.allSettled(
-        targets.map((result) => deleteProvider.mutateAsync(result.existingID!)),
+      const settled = await settleProviderRemovalsSequentially(targets, (providerID) =>
+        deleteProvider.mutateAsync(providerID),
       );
       const removedIDs = collectSuccessfulRemovedExistingIDs(targets, settled);
       const failedCount = settled.filter((result) => result.status === 'rejected').length;
@@ -627,22 +656,37 @@ export function ClaudeProviderBatchTestDialog({
                     {t('routes.claudeBatchTest.failedExistingDescription')}
                   </p>
                 </div>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="sm"
-                  disabled={selectedFailedExistingResults.length === 0 || isRemovingFailedExisting}
-                  onClick={handleRemoveSelectedFailedExisting}
-                >
-                  {isRemovingFailedExisting ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : (
-                    <Trash2 className="h-4 w-4 mr-2" />
-                  )}
-                  {t('routes.claudeBatchTest.removeSelectedFailedExisting', {
-                    count: selectedFailedExistingResults.length,
-                  })}
-                </Button>
+                <div className="flex shrink-0 flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={failedExistingIDs.length === 0 || isRemovingFailedExisting}
+                    onClick={handleToggleAllFailedExisting}
+                  >
+                    {allFailedExistingSelected
+                      ? t('routes.claudeBatchTest.clearFailedExistingSelection')
+                      : t('routes.claudeBatchTest.selectAllFailedExisting')}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    disabled={
+                      selectedFailedExistingResults.length === 0 || isRemovingFailedExisting
+                    }
+                    onClick={handleRemoveSelectedFailedExisting}
+                  >
+                    {isRemovingFailedExisting ? (
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4 mr-2" />
+                    )}
+                    {t('routes.claudeBatchTest.removeSelectedFailedExisting', {
+                      count: selectedFailedExistingResults.length,
+                    })}
+                  </Button>
+                </div>
               </div>
               <div className="divide-y divide-amber-500/20 rounded-md border border-amber-500/20 bg-background/60">
                 {failedExistingResults.map((result) => {

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -11,6 +11,7 @@ import {
   getFailedExistingResultSignature,
   isClaudeBatchTestExcludedProvider,
   isClaudeBatchTestSelectableProvider,
+  settleProviderRemovalsSequentially,
   summarizeClaudeBatchDisplayResults,
 } from './claude-provider-batch-test';
 
@@ -122,6 +123,37 @@ describe('Claude provider batch test helpers', () => {
       { status: 'fulfilled', value: undefined },
     ];
 
+    expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);
+  });
+
+  it('removes selected failed providers sequentially instead of firing a concurrent delete burst', async () => {
+    const calls: number[] = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const settled = await settleProviderRemovalsSequentially(
+      [{ existingID: 10 }, { existingID: 20 }, { existingID: 30 }],
+      async (providerID) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        calls.push(providerID);
+        await Promise.resolve();
+        inFlight -= 1;
+      },
+    );
+
+    expect(calls).toEqual([10, 20, 30]);
+    expect(maxInFlight).toBe(1);
+    expect(settled.map((item) => item.status)).toEqual(['fulfilled', 'fulfilled', 'fulfilled']);
+  });
+
+  it('keeps successful sequential removals ordered when one provider delete fails', async () => {
+    const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
+    const settled = await settleProviderRemovalsSequentially(targets, async (providerID) => {
+      if (providerID === 2) throw new Error('delete failed');
+    });
+
+    expect(settled.map((item) => item.status)).toEqual(['fulfilled', 'rejected', 'fulfilled']);
     expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);
   });
 

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -80,6 +80,25 @@ export function collectSuccessfulRemovedExistingIDs<T extends { existingID?: num
     .map((target) => target.existingID!);
 }
 
+export async function settleProviderRemovalsSequentially<T extends { existingID?: number }>(
+  targets: T[],
+  removeProvider: (providerID: number) => Promise<unknown>,
+): Promise<PromiseSettledResult<unknown>[]> {
+  const settled: PromiseSettledResult<unknown>[] = [];
+  for (const target of targets) {
+    if (!target.existingID) {
+      settled.push({ status: 'rejected', reason: new Error('missing existing provider id') });
+      continue;
+    }
+    try {
+      settled.push({ status: 'fulfilled', value: await removeProvider(target.existingID) });
+    } catch (reason) {
+      settled.push({ status: 'rejected', reason });
+    }
+  }
+  return settled;
+}
+
 export function getFailedExistingResultSignature(
   results: Pick<ClaudeProviderBatchProviderResult, 'existingID' | 'status' | 'error' | 'message'>[],
 ) {


### PR DESCRIPTION
## Summary
- add select-all / clear-selection controls to the failed existing Claude provider removal section
- remove selected failed existing providers sequentially instead of firing concurrent DELETE requests
- prune stale failed-provider selections when the failed result list changes after removal/refresh
- align Claude batch provider test requests with the custom provider adapter request path, including Claude-specific `clientBaseURL`, wildcard provider `modelMapping`, and disguise/header handling for relays such as Bedrock-compatible upstreams
- add regression coverage for sequential deletion, partial delete failure handling, Claude client base URL precedence, wildcard model mapping, and Bedrock disguise header behavior

## Validation
- `go test ./internal/handler -run 'TestSelfServiceHandler_ClaudeProviderBatchTest'`
- `go test ./internal/adapter/provider/custom ./internal/service ./internal/handler -run 'ClaudeProviderBatch|ClaudeMessagesTestRequest|CustomAdapter|ClaudeHeaders|ClaudeBody|AdminServiceDeleteProvider'`
- `go test ./internal/...`
- `pnpm test -- src/pages/client-routes/utils/claude-provider-batch-test.test.ts` (Vitest ran related frontend unit suites: 9 files, 48 tests passed)
- `pnpm typecheck`
- `pnpm build`
- Manual UI verification against a temporary local Maxx backend/frontend: seeded 20 custom Claude providers, selected all, batch-tested to failed state, selected all failed items, removed selected, then confirmed `GET /api/providers` returned 0 providers.

## Screenshots / Evidence
- Local screenshots captured during verification and posted to the WeChat thread.