### PR TITLE
fix(providers): bulk delete failed Claude providers

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -343,6 +343,20 @@ type Provider struct {
 	ExcludeFromExport bool `json:"excludeFromExport,omitempty"`
 }
 
+// ProviderBulkDeleteRequest deletes providers and all provider-scoped references in one request.
+type ProviderBulkDeleteRequest struct {
+	IDs []uint64 `json:"ids"`
+}
+
+// ProviderBulkDeleteResult reports the affected providers and cleaned references.
+type ProviderBulkDeleteResult struct {
+	DeletedCount             int      `json:"deletedCount"`
+	DeletedIDs               []uint64 `json:"deletedIDs"`
+	NotFoundIDs              []uint64 `json:"notFoundIDs"`
+	RouteDeletedCount        int      `json:"routeDeletedCount"`
+	ModelMappingDeletedCount int      `json:"modelMappingDeletedCount"`
+}
+
 type Project struct {
 	ID        uint64    `json:"id"`
 	CreatedAt time.Time `json:"createdAt"`

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -82,7 +82,11 @@ func (h *AdminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "restart":
 		h.handleRestart(w, r)
 	case "providers":
-		h.handleProviders(w, r, id)
+		if len(parts) == 3 && parts[2] == "bulk-delete" {
+			h.handleBulkDeleteProviders(w, r)
+		} else {
+			h.handleProviders(w, r, id)
+		}
 	case "routes":
 		if len(parts) > 2 && parts[2] == "batch-positions" {
 			h.handleBatchUpdateRoutePositions(w, r)
@@ -244,6 +248,28 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+func (h *AdminHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req domain.ProviderBulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	result, err := h.svc.BulkDeleteProviders(tenantID, req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 // handleBedrockDiscoveredModels surfaces the runtime discovery catalog

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -250,6 +250,13 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 	}
 }
 
+func bulkDeleteErrorStatus(err error) int {
+	if errors.Is(err, service.ErrIDsRequired) || errors.Is(err, service.ErrInvalidRouteClientType) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
+}
+
 func (h *AdminHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
@@ -265,7 +272,7 @@ func (h *AdminHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.
 	tenantID := maxxctx.GetTenantID(r.Context())
 	result, err := h.svc.BulkDeleteProviders(tenantID, req)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, bulkDeleteErrorStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -536,7 +543,7 @@ func (h *AdminHandler) handleBulkDeleteRoutes(w http.ResponseWriter, r *http.Req
 	tenantID := maxxctx.GetTenantID(r.Context())
 	result, err := h.svc.BulkDeleteRoutes(tenantID, req)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, bulkDeleteErrorStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -65,6 +65,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case len(parts) == 2:
 			h.handleProviders(w, r, 0)
+		case len(parts) == 3 && parts[2] == "bulk-delete":
+			h.handleBulkDeleteProviders(w, r)
 		case len(parts) == 3 && parts[2] == "export":
 			h.handleProvidersExport(w, r)
 		case len(parts) == 3 && parts[2] == "import":
@@ -469,6 +471,31 @@ func (h *SelfServiceHandler) handleProjectBySlug(w http.ResponseWriter, r *http.
 		return
 	}
 	writeJSON(w, http.StatusOK, project)
+}
+
+func (h *SelfServiceHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	var req domain.ProviderBulkDeleteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	result, err := h.svc.BulkDeleteProviders(tenantID, req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (h *SelfServiceHandler) handleRoutes(w http.ResponseWriter, r *http.Request, id uint64) {

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -491,7 +491,7 @@ func (h *SelfServiceHandler) handleBulkDeleteProviders(w http.ResponseWriter, r 
 	tenantID := maxxctx.GetTenantID(r.Context())
 	result, err := h.svc.BulkDeleteProviders(tenantID, req)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, bulkDeleteErrorStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -665,7 +665,7 @@ func (h *SelfServiceHandler) handleBulkDeleteRoutes(w http.ResponseWriter, r *ht
 	tenantID := maxxctx.GetTenantID(r.Context())
 	result, err := h.svc.BulkDeleteRoutes(tenantID, req)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeJSON(w, bulkDeleteErrorStatus(err), map[string]string{"error": err.Error()})
 		return
 	}
 

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -2165,3 +2165,34 @@ func TestSelfServiceHandler_ListEndpoints_EmptySlicesSerializeAsJSONArray(t *tes
 		})
 	}
 }
+
+func TestSelfServiceHandler_BulkDeleteProvidersErrorStatusCodes(t *testing.T) {
+	baseRepo := &selfServiceProviderRepo{providers: []*domain.Provider{{ID: 10, TenantID: domain.DefaultTenantID, Name: "delete-me", Type: "custom"}}}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo:     baseRepo,
+		routeRepo:        &selfServiceRouteRepo{},
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: &selfServiceModelMappingRepo{},
+	})
+
+	badRequestRec := httptest.NewRecorder()
+	handler.ServeHTTP(badRequestRec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/providers/bulk-delete", `{"ids":[]}`))
+	if badRequestRec.Code != http.StatusBadRequest {
+		t.Fatalf("empty ids status = %d, want %d, body = %s", badRequestRec.Code, http.StatusBadRequest, badRequestRec.Body.String())
+	}
+
+	internalErrorHandler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo: &selfServiceProviderRepoWithListError{
+			selfServiceProviderRepo: baseRepo,
+			listErr:                 errors.New("repository unavailable"),
+		},
+		routeRepo:        &selfServiceRouteRepo{},
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: &selfServiceModelMappingRepo{},
+	})
+	internalErrorRec := httptest.NewRecorder()
+	internalErrorHandler.ServeHTTP(internalErrorRec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/providers/bulk-delete", `{"ids":[10]}`))
+	if internalErrorRec.Code != http.StatusInternalServerError {
+		t.Fatalf("repository error status = %d, want %d, body = %s", internalErrorRec.Code, http.StatusInternalServerError, internalErrorRec.Body.String())
+	}
+}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -1695,6 +1695,84 @@ func TestSelfServiceHandler_DeleteProviderRemovesRouteReferences(t *testing.T) {
 	}
 }
 
+func TestSelfServiceHandler_BulkDeleteProvidersRequiresAdminAndCleansReferences(t *testing.T) {
+	providerRepo := &selfServiceProviderRepo{providers: []*domain.Provider{
+		{ID: 10, TenantID: domain.DefaultTenantID, Name: "delete-a", Type: "custom"},
+		{ID: 11, TenantID: domain.DefaultTenantID, Name: "delete-b", Type: "custom"},
+		{ID: 12, TenantID: domain.DefaultTenantID, Name: "keep", Type: "custom"},
+	}}
+	routeRepo := &selfServiceRouteRepo{routes: []*domain.Route{
+		{ID: 1, TenantID: domain.DefaultTenantID, ProviderID: 10, ProjectID: 0, ClientType: domain.ClientTypeClaude, Position: 1, Weight: 1, IsEnabled: true},
+		{ID: 2, TenantID: domain.DefaultTenantID, ProviderID: 11, ProjectID: 42, ClientType: domain.ClientTypeOpenAI, Position: 1, Weight: 1, IsEnabled: true},
+		{ID: 3, TenantID: domain.DefaultTenantID, ProviderID: 12, ProjectID: 0, ClientType: domain.ClientTypeClaude, Position: 2, Weight: 1, IsEnabled: true},
+	}}
+	modelMappingRepo := &selfServiceModelMappingRepo{mappings: []*domain.ModelMapping{
+		{ID: 1, TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: 10, Pattern: "a-*", Target: "a"},
+		{ID: 2, TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: 11, Pattern: "b-*", Target: "b"},
+		{ID: 3, TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: 12, Pattern: "keep-*", Target: "keep"},
+		{ID: 4, TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeGlobal, Pattern: "global-*", Target: "global"},
+	}}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		providerRepo:     providerRepo,
+		routeRepo:        routeRepo,
+		projectRepo:      &selfServiceProjectRepo{},
+		modelMappingRepo: modelMappingRepo,
+	})
+
+	memberRec := httptest.NewRecorder()
+	handler.ServeHTTP(memberRec, newSelfServiceRequestWithBody(http.MethodPost, "/providers/bulk-delete", `{"ids":[10]}`))
+	if memberRec.Code != http.StatusForbidden {
+		t.Fatalf("member status = %d, want %d, body = %s", memberRec.Code, http.StatusForbidden, memberRec.Body.String())
+	}
+
+	adminRec := httptest.NewRecorder()
+	handler.ServeHTTP(adminRec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/providers/bulk-delete", `{"ids":[10,11,10,999999]}`))
+	if adminRec.Code != http.StatusOK {
+		t.Fatalf("admin status = %d, want %d, body = %s", adminRec.Code, http.StatusOK, adminRec.Body.String())
+	}
+
+	var result domain.ProviderBulkDeleteResult
+	if err := json.Unmarshal(adminRec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result.DeletedCount != 2 || result.RouteDeletedCount != 2 || result.ModelMappingDeletedCount != 2 {
+		t.Fatalf("result = %+v, want counts for providers/routes/mappings", result)
+	}
+	if !containsUint64(result.DeletedIDs, 10) || !containsUint64(result.DeletedIDs, 11) || !containsUint64(result.NotFoundIDs, 999999) {
+		t.Fatalf("result IDs = %+v", result)
+	}
+	if len(providerRepo.providers) != 1 || providerRepo.providers[0].ID != 12 {
+		t.Fatalf("providers = %+v, want only unrelated provider", providerRepo.providers)
+	}
+	if len(routeRepo.routes) != 1 || routeRepo.routes[0].ID != 3 {
+		t.Fatalf("routes = %+v, want only unrelated route", routeRepo.routes)
+	}
+	if containsSelfServiceModelMappingID(modelMappingRepo.mappings, 1) || containsSelfServiceModelMappingID(modelMappingRepo.mappings, 2) {
+		t.Fatalf("deleted provider mappings still visible: %+v", modelMappingRepo.mappings)
+	}
+	if !containsSelfServiceModelMappingID(modelMappingRepo.mappings, 3) || !containsSelfServiceModelMappingID(modelMappingRepo.mappings, 4) {
+		t.Fatalf("unrelated mappings were deleted: %+v", modelMappingRepo.mappings)
+	}
+}
+
+func containsUint64(ids []uint64, want uint64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSelfServiceModelMappingID(mappings []*domain.ModelMapping, want uint64) bool {
+	for _, mapping := range mappings {
+		if mapping.ID == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestSelfServiceHandler_SyncRoutesFromProject_OverwriteDefaultToProject(t *testing.T) {
 	routeRepo := &selfServiceRouteRepo{
 		routes: []*domain.Route{

--- a/internal/repository/cached/model_mapping.go
+++ b/internal/repository/cached/model_mapping.go
@@ -70,6 +70,14 @@ func (r *ModelMappingRepository) sortCache() {
 	})
 }
 
+func (r *ModelMappingRepository) Reload() error {
+	if err := r.Load(); err != nil {
+		return err
+	}
+	r.bc.publish(OpReload, 0)
+	return nil
+}
+
 func (r *ModelMappingRepository) Create(mapping *domain.ModelMapping) error {
 	if err := r.repo.Create(mapping); err != nil {
 		return err

--- a/internal/repository/cached/provider.go
+++ b/internal/repository/cached/provider.go
@@ -1,6 +1,7 @@
 package cached
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/awsl-project/maxx/internal/coordinator"
@@ -74,6 +75,22 @@ func (r *ProviderRepository) Delete(tenantID uint64, id uint64) error {
 	delete(r.cache, id)
 	r.mu.Unlock()
 	r.bc.publish(OpDelete, id)
+	return nil
+}
+
+func (r *ProviderRepository) BulkDeleteWithReferences(tenantID uint64, ids []uint64) (*domain.ProviderBulkDeleteResult, error) {
+	deleter, ok := r.repo.(repository.ProviderBulkDeleteRepository)
+	if !ok {
+		return nil, fmt.Errorf("provider bulk delete with references is not supported")
+	}
+	return deleter.BulkDeleteWithReferences(tenantID, ids)
+}
+
+func (r *ProviderRepository) Reload() error {
+	if err := r.Load(); err != nil {
+		return err
+	}
+	r.bc.publish(OpReload, 0)
 	return nil
 }
 

--- a/internal/repository/cached/route.go
+++ b/internal/repository/cached/route.go
@@ -37,6 +37,14 @@ func (r *RouteRepository) Load() error {
 	return nil
 }
 
+func (r *RouteRepository) Reload() error {
+	if err := r.Load(); err != nil {
+		return err
+	}
+	r.bc.publish(OpReload, 0)
+	return nil
+}
+
 func (r *RouteRepository) Create(route *domain.Route) error {
 	if err := r.repo.Create(route); err != nil {
 		return err

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -55,6 +55,13 @@ type ProviderRepository interface {
 	List(tenantID uint64) ([]*domain.Provider, error)
 }
 
+// ProviderBulkDeleteRepository is implemented by repositories that can delete
+// providers and their provider-scoped references atomically. Services should
+// prefer this optional capability over composing Delete calls themselves.
+type ProviderBulkDeleteRepository interface {
+	BulkDeleteWithReferences(tenantID uint64, ids []uint64) (*domain.ProviderBulkDeleteResult, error)
+}
+
 type RouteRepository interface {
 	Create(route *domain.Route) error
 	Update(route *domain.Route) error

--- a/internal/repository/sqlite/provider.go
+++ b/internal/repository/sqlite/provider.go
@@ -112,11 +112,6 @@ func (r *ProviderRepository) BulkDeleteWithReferences(tenantID uint64, rawIDs []
 	return result, nil
 }
 
-type providerRouteScope struct {
-	projectID  uint64
-	clientType string
-}
-
 func bulkSoftDeleteProviderRoutesTx(tx *gorm.DB, tenantID uint64, providerIDs map[uint64]struct{}) (int, error) {
 	if len(providerIDs) == 0 {
 		return 0, nil
@@ -126,34 +121,17 @@ func bulkSoftDeleteProviderRoutesTx(tx *gorm.DB, tenantID uint64, providerIDs ma
 		ids = append(ids, id)
 	}
 
-	var routes []Route
-	if err := tenantScope(tx, tenantID).
-		Where("provider_id IN ? AND deleted_at = 0", ids).
-		Find(&routes).Error; err != nil {
-		return 0, err
-	}
-
-	routeIDsByScope := make(map[providerRouteScope][]uint64)
-	for _, route := range routes {
-		scope := providerRouteScope{projectID: route.ProjectID, clientType: route.ClientType}
-		routeIDsByScope[scope] = append(routeIDsByScope[scope], route.ID)
-	}
-
-	deleted := 0
 	now := time.Now().UnixMilli()
-	for scope, routeIDs := range routeIDsByScope {
-		res := tenantScope(tx.Model(&Route{}), tenantID).
-			Where("id IN ? AND project_id = ? AND client_type = ? AND deleted_at = 0", routeIDs, scope.projectID, scope.clientType).
-			Updates(map[string]any{
-				"deleted_at": now,
-				"updated_at": now,
-			})
-		if res.Error != nil {
-			return 0, res.Error
-		}
-		deleted += int(res.RowsAffected)
+	res := tenantScope(tx.Model(&Route{}), tenantID).
+		Where("provider_id IN ? AND deleted_at = 0", ids).
+		Updates(map[string]any{
+			"deleted_at": now,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return 0, res.Error
 	}
-	return deleted, nil
+	return int(res.RowsAffected), nil
 }
 
 func bulkSoftDeleteProviderModelMappingsTx(tx *gorm.DB, tenantID uint64, providerIDs []uint64) (int, error) {

--- a/internal/repository/sqlite/provider.go
+++ b/internal/repository/sqlite/provider.go
@@ -45,6 +45,150 @@ func (r *ProviderRepository) Delete(tenantID uint64, id uint64) error {
 		}).Error
 }
 
+func (r *ProviderRepository) BulkDeleteWithReferences(tenantID uint64, rawIDs []uint64) (*domain.ProviderBulkDeleteResult, error) {
+	result := &domain.ProviderBulkDeleteResult{}
+	ids := uniqueNonZeroIDs(rawIDs)
+	if len(ids) == 0 {
+		return result, nil
+	}
+
+	err := r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		var models []Provider
+		if err := tenantScope(tx, tenantID).
+			Where("id IN ? AND deleted_at = 0", ids).
+			Find(&models).Error; err != nil {
+			return err
+		}
+
+		found := make(map[uint64]struct{}, len(models))
+		deleteSet := make(map[uint64]struct{}, len(models))
+		for _, model := range models {
+			found[model.ID] = struct{}{}
+			deleteSet[model.ID] = struct{}{}
+		}
+
+		deleteIDs := make([]uint64, 0, len(models))
+		for _, id := range ids {
+			if _, ok := found[id]; ok {
+				deleteIDs = append(deleteIDs, id)
+				result.DeletedIDs = append(result.DeletedIDs, id)
+			} else {
+				result.NotFoundIDs = append(result.NotFoundIDs, id)
+			}
+		}
+		if len(deleteIDs) == 0 {
+			return nil
+		}
+
+		if count, err := bulkSoftDeleteProviderRoutesTx(tx, tenantID, deleteSet); err != nil {
+			return err
+		} else {
+			result.RouteDeletedCount = count
+		}
+
+		if count, err := bulkSoftDeleteProviderModelMappingsTx(tx, tenantID, deleteIDs); err != nil {
+			return err
+		} else {
+			result.ModelMappingDeletedCount = count
+		}
+
+		now := time.Now().UnixMilli()
+		res := tenantScope(tx.Model(&Provider{}), tenantID).
+			Where("id IN ? AND deleted_at = 0", deleteIDs).
+			Updates(map[string]any{
+				"deleted_at": now,
+				"updated_at": now,
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		result.DeletedCount = int(res.RowsAffected)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+type providerRouteScope struct {
+	projectID  uint64
+	clientType string
+}
+
+func bulkSoftDeleteProviderRoutesTx(tx *gorm.DB, tenantID uint64, providerIDs map[uint64]struct{}) (int, error) {
+	if len(providerIDs) == 0 {
+		return 0, nil
+	}
+	ids := make([]uint64, 0, len(providerIDs))
+	for id := range providerIDs {
+		ids = append(ids, id)
+	}
+
+	var routes []Route
+	if err := tenantScope(tx, tenantID).
+		Where("provider_id IN ? AND deleted_at = 0", ids).
+		Find(&routes).Error; err != nil {
+		return 0, err
+	}
+
+	routeIDsByScope := make(map[providerRouteScope][]uint64)
+	for _, route := range routes {
+		scope := providerRouteScope{projectID: route.ProjectID, clientType: route.ClientType}
+		routeIDsByScope[scope] = append(routeIDsByScope[scope], route.ID)
+	}
+
+	deleted := 0
+	now := time.Now().UnixMilli()
+	for scope, routeIDs := range routeIDsByScope {
+		res := tenantScope(tx.Model(&Route{}), tenantID).
+			Where("id IN ? AND project_id = ? AND client_type = ? AND deleted_at = 0", routeIDs, scope.projectID, scope.clientType).
+			Updates(map[string]any{
+				"deleted_at": now,
+				"updated_at": now,
+			})
+		if res.Error != nil {
+			return 0, res.Error
+		}
+		deleted += int(res.RowsAffected)
+	}
+	return deleted, nil
+}
+
+func bulkSoftDeleteProviderModelMappingsTx(tx *gorm.DB, tenantID uint64, providerIDs []uint64) (int, error) {
+	if len(providerIDs) == 0 {
+		return 0, nil
+	}
+	now := time.Now().UnixMilli()
+	res := tenantScope(tx.Model(&ModelMapping{}), tenantID).
+		Where("scope = ? AND provider_id IN ? AND deleted_at = 0", string(domain.ModelMappingScopeProvider), providerIDs).
+		Updates(map[string]any{
+			"deleted_at": now,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return int(res.RowsAffected), nil
+}
+
+func uniqueNonZeroIDs(rawIDs []uint64) []uint64 {
+	seen := make(map[uint64]struct{}, len(rawIDs))
+	ids := make([]uint64, 0, len(rawIDs))
+	for _, id := range rawIDs {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 func (r *ProviderRepository) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
 	var model Provider
 	if err := tenantScope(r.db.gorm, tenantID).First(&model, id).Error; err != nil {

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -193,6 +193,128 @@ func (s *AdminService) DeleteProvider(tenantID uint64, id uint64) error {
 	return s.providerRepo.Delete(tenantID, id)
 }
 
+type providerBulkDeleteRouteScope struct {
+	projectID  uint64
+	clientType domain.ClientType
+}
+
+func (s *AdminService) BulkDeleteProviders(tenantID uint64, req domain.ProviderBulkDeleteRequest) (*domain.ProviderBulkDeleteResult, error) {
+	ids := uniqueNonZeroIDs(req.IDs)
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("ids required")
+	}
+
+	result := &domain.ProviderBulkDeleteResult{}
+
+	providers, err := s.providerRepo.List(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	providerByID := make(map[uint64]*domain.Provider, len(providers))
+	for _, provider := range providers {
+		providerByID[provider.ID] = provider
+	}
+
+	deleteSet := make(map[uint64]struct{}, len(ids))
+	for _, id := range ids {
+		if _, ok := providerByID[id]; ok {
+			deleteSet[id] = struct{}{}
+			result.DeletedIDs = append(result.DeletedIDs, id)
+		} else {
+			result.NotFoundIDs = append(result.NotFoundIDs, id)
+		}
+	}
+	if len(deleteSet) == 0 {
+		return result, nil
+	}
+
+	if err := s.bulkDeleteProviderRoutes(tenantID, deleteSet, result); err != nil {
+		return nil, err
+	}
+	if err := s.bulkDeleteProviderModelMappings(tenantID, deleteSet, result); err != nil {
+		return nil, err
+	}
+
+	for _, id := range result.DeletedIDs {
+		if s.adapterRefresher != nil {
+			s.adapterRefresher.RemoveAdapter(id)
+		}
+		if err := s.providerRepo.Delete(tenantID, id); err != nil {
+			return nil, err
+		}
+		result.DeletedCount++
+	}
+
+	return result, nil
+}
+
+func (s *AdminService) bulkDeleteProviderRoutes(tenantID uint64, providerIDs map[uint64]struct{}, result *domain.ProviderBulkDeleteResult) error {
+	routes, err := s.routeRepo.List(tenantID)
+	if err != nil {
+		return err
+	}
+
+	routeIDsByScope := make(map[providerBulkDeleteRouteScope][]uint64)
+	for _, route := range routes {
+		if _, ok := providerIDs[route.ProviderID]; !ok {
+			continue
+		}
+		scope := providerBulkDeleteRouteScope{projectID: route.ProjectID, clientType: route.ClientType}
+		routeIDsByScope[scope] = append(routeIDsByScope[scope], route.ID)
+	}
+
+	for scope, routeIDs := range routeIDsByScope {
+		deleteResult, err := s.routeRepo.BulkDelete(tenantID, domain.RouteBulkDeleteRequest{
+			IDs:        routeIDs,
+			ClientType: scope.clientType,
+			ProjectID:  scope.projectID,
+		})
+		if err != nil {
+			return err
+		}
+		if deleteResult != nil {
+			result.RouteDeletedCount += deleteResult.DeletedCount
+		}
+	}
+	return nil
+}
+
+func (s *AdminService) bulkDeleteProviderModelMappings(tenantID uint64, providerIDs map[uint64]struct{}, result *domain.ProviderBulkDeleteResult) error {
+	mappings, err := s.modelMappingRepo.List(tenantID)
+	if err != nil {
+		return err
+	}
+	for _, mapping := range mappings {
+		if mapping.Scope != domain.ModelMappingScopeProvider {
+			continue
+		}
+		if _, ok := providerIDs[mapping.ProviderID]; !ok {
+			continue
+		}
+		if err := s.modelMappingRepo.Delete(tenantID, mapping.ID); err != nil {
+			return err
+		}
+		result.ModelMappingDeletedCount++
+	}
+	return nil
+}
+
+func uniqueNonZeroIDs(rawIDs []uint64) []uint64 {
+	seen := make(map[uint64]struct{}, len(rawIDs))
+	ids := make([]uint64, 0, len(rawIDs))
+	for _, id := range rawIDs {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 func preserveExcludedProviderWriteOnlyMode(existing, incoming *domain.Provider) {
 	if existing == nil || incoming == nil || !existing.ExcludeFromExport {
 		return

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base32"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -32,6 +33,12 @@ type ProviderAdapterRefresher interface {
 	// by admin endpoints that reach into adapter-specific runtime state.
 	GetAdapter(providerID uint64) (provider.ProviderAdapter, bool)
 }
+
+// ErrIDsRequired marks bulk-delete requests missing a non-empty ID list.
+var ErrIDsRequired = errors.New("ids required")
+
+// ErrInvalidRouteClientType marks bulk route-delete requests with an unsupported client type.
+var ErrInvalidRouteClientType = errors.New("invalid clientType")
 
 // GetProviderAdapter exposes the cached adapter for a provider so HTTP
 // handlers can call adapter-specific methods (e.g. Bedrock discovery).
@@ -201,7 +208,7 @@ type providerBulkDeleteRouteScope struct {
 func (s *AdminService) BulkDeleteProviders(tenantID uint64, req domain.ProviderBulkDeleteRequest) (*domain.ProviderBulkDeleteResult, error) {
 	ids := uniqueNonZeroIDs(req.IDs)
 	if len(ids) == 0 {
-		return nil, fmt.Errorf("ids required")
+		return nil, ErrIDsRequired
 	}
 
 	if deleter, ok := s.providerRepo.(repository.ProviderBulkDeleteRepository); ok {
@@ -584,17 +591,17 @@ func (s *AdminService) DeleteRoute(tenantID uint64, id uint64) error {
 
 func (s *AdminService) BulkDeleteRoutes(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
 	if len(req.IDs) == 0 {
-		return nil, fmt.Errorf("ids required")
+		return nil, ErrIDsRequired
 	}
 	if !isValidRouteClientType(req.ClientType) {
-		return nil, fmt.Errorf("invalid clientType")
+		return nil, ErrInvalidRouteClientType
 	}
 	return s.routeRepo.BulkDelete(tenantID, req)
 }
 
 func (s *AdminService) SyncRoutesFromProject(tenantID uint64, req domain.RouteSyncRequest) (*domain.RouteSyncResult, error) {
 	if !isValidRouteClientType(req.ClientType) {
-		return nil, fmt.Errorf("invalid clientType")
+		return nil, ErrInvalidRouteClientType
 	}
 	if req.Mode == "" {
 		req.Mode = domain.RouteSyncModeOverwrite

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -216,15 +216,9 @@ func (s *AdminService) BulkDeleteProviders(tenantID uint64, req domain.ProviderB
 		if err != nil {
 			return nil, err
 		}
-		if err := reloadRepositoryCache(s.providerRepo); err != nil {
-			return nil, err
-		}
-		if err := reloadRepositoryCache(s.routeRepo); err != nil {
-			return nil, err
-		}
-		if err := reloadRepositoryCache(s.modelMappingRepo); err != nil {
-			return nil, err
-		}
+		reloadRepositoryCacheBestEffort("provider", s.providerRepo)
+		reloadRepositoryCacheBestEffort("route", s.routeRepo)
+		reloadRepositoryCacheBestEffort("model mapping", s.modelMappingRepo)
 		if s.adapterRefresher != nil && result != nil {
 			for _, id := range result.DeletedIDs {
 				s.adapterRefresher.RemoveAdapter(id)
@@ -269,11 +263,11 @@ func (s *AdminService) bulkDeleteProvidersWithoutTransaction(tenantID uint64, id
 	}
 
 	for _, id := range result.DeletedIDs {
-		if s.adapterRefresher != nil {
-			s.adapterRefresher.RemoveAdapter(id)
-		}
 		if err := s.providerRepo.Delete(tenantID, id); err != nil {
 			return nil, err
+		}
+		if s.adapterRefresher != nil {
+			s.adapterRefresher.RemoveAdapter(id)
 		}
 		result.DeletedCount++
 	}
@@ -290,6 +284,12 @@ func reloadRepositoryCache(repo any) error {
 		return reloader.Reload()
 	}
 	return nil
+}
+
+func reloadRepositoryCacheBestEffort(name string, repo any) {
+	if err := reloadRepositoryCache(repo); err != nil {
+		log.Printf("[Admin] provider bulk delete succeeded but %s cache reload failed: %v", name, err)
+	}
 }
 
 func (s *AdminService) bulkDeleteProviderRoutes(tenantID uint64, providerIDs map[uint64]struct{}, result *domain.ProviderBulkDeleteResult) error {

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -204,6 +204,32 @@ func (s *AdminService) BulkDeleteProviders(tenantID uint64, req domain.ProviderB
 		return nil, fmt.Errorf("ids required")
 	}
 
+	if deleter, ok := s.providerRepo.(repository.ProviderBulkDeleteRepository); ok {
+		result, err := deleter.BulkDeleteWithReferences(tenantID, ids)
+		if err != nil {
+			return nil, err
+		}
+		if err := reloadRepositoryCache(s.providerRepo); err != nil {
+			return nil, err
+		}
+		if err := reloadRepositoryCache(s.routeRepo); err != nil {
+			return nil, err
+		}
+		if err := reloadRepositoryCache(s.modelMappingRepo); err != nil {
+			return nil, err
+		}
+		if s.adapterRefresher != nil && result != nil {
+			for _, id := range result.DeletedIDs {
+				s.adapterRefresher.RemoveAdapter(id)
+			}
+		}
+		return result, nil
+	}
+
+	return s.bulkDeleteProvidersWithoutTransaction(tenantID, ids)
+}
+
+func (s *AdminService) bulkDeleteProvidersWithoutTransaction(tenantID uint64, ids []uint64) (*domain.ProviderBulkDeleteResult, error) {
 	result := &domain.ProviderBulkDeleteResult{}
 
 	providers, err := s.providerRepo.List(tenantID)
@@ -246,6 +272,17 @@ func (s *AdminService) BulkDeleteProviders(tenantID uint64, req domain.ProviderB
 	}
 
 	return result, nil
+}
+
+type repositoryCacheReloader interface {
+	Reload() error
+}
+
+func reloadRepositoryCache(repo any) error {
+	if reloader, ok := repo.(repositoryCacheReloader); ok {
+		return reloader.Reload()
+	}
+	return nil
 }
 
 func (s *AdminService) bulkDeleteProviderRoutes(tenantID uint64, providerIDs map[uint64]struct{}, result *domain.ProviderBulkDeleteResult) error {

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -108,3 +108,116 @@ func containsModelMappingID(mappings []*domain.ModelMapping, id uint64) bool {
 	}
 	return false
 }
+
+func TestAdminServiceBulkDeleteProvidersCleansReferencesInOnePass(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	providerRepo := sqlite.NewProviderRepository(db)
+	routeRepo := sqlite.NewRouteRepository(db)
+	modelMappingRepo := sqlite.NewModelMappingRepository(db)
+
+	providers := []*domain.Provider{
+		newTestCustomProvider("bulk-delete-a"),
+		newTestCustomProvider("bulk-delete-b"),
+		newTestCustomProvider("bulk-keep"),
+	}
+	for _, provider := range providers {
+		if err := providerRepo.Create(provider); err != nil {
+			t.Fatalf("Create(provider %s) error = %v", provider.Name, err)
+		}
+	}
+
+	routes := []*domain.Route{
+		{TenantID: domain.DefaultTenantID, ProviderID: providers[0].ID, ClientType: domain.ClientTypeClaude, ProjectID: 0, Position: 1, Weight: 1, IsEnabled: true},
+		{TenantID: domain.DefaultTenantID, ProviderID: providers[0].ID, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, Position: 2, Weight: 1, IsEnabled: true},
+		{TenantID: domain.DefaultTenantID, ProviderID: providers[1].ID, ClientType: domain.ClientTypeClaude, ProjectID: 7, Position: 3, Weight: 1, IsEnabled: true},
+		{TenantID: domain.DefaultTenantID, ProviderID: providers[2].ID, ClientType: domain.ClientTypeClaude, ProjectID: 0, Position: 4, Weight: 1, IsEnabled: true},
+	}
+	for _, route := range routes {
+		if err := routeRepo.Create(route); err != nil {
+			t.Fatalf("Create(route) error = %v", err)
+		}
+	}
+
+	mappings := []*domain.ModelMapping{
+		{TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: providers[0].ID, Pattern: "a-*", Target: "upstream-a"},
+		{TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: providers[1].ID, Pattern: "b-*", Target: "upstream-b"},
+		{TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: providers[2].ID, Pattern: "keep-*", Target: "keep-upstream"},
+		{TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeGlobal, Pattern: "global-*", Target: "global-upstream"},
+	}
+	for _, mapping := range mappings {
+		if err := modelMappingRepo.Create(mapping); err != nil {
+			t.Fatalf("Create(mapping) error = %v", err)
+		}
+	}
+
+	svc := NewAdminService(providerRepo, routeRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, modelMappingRepo, nil, nil, nil, "", nil, nil, nil)
+	result, err := svc.BulkDeleteProviders(domain.DefaultTenantID, domain.ProviderBulkDeleteRequest{
+		IDs: []uint64{providers[0].ID, providers[1].ID, providers[0].ID, 999999, 0},
+	})
+	if err != nil {
+		t.Fatalf("BulkDeleteProviders() error = %v", err)
+	}
+
+	if result.DeletedCount != 2 || result.RouteDeletedCount != 3 || result.ModelMappingDeletedCount != 2 {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	assertServiceContainsID(t, result.DeletedIDs, providers[0].ID)
+	assertServiceContainsID(t, result.DeletedIDs, providers[1].ID)
+	assertServiceContainsID(t, result.NotFoundIDs, 999999)
+
+	remainingProviders, err := providerRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(providers) error = %v", err)
+	}
+	if len(remainingProviders) != 1 || remainingProviders[0].ID != providers[2].ID {
+		t.Fatalf("providers after bulk delete = %+v, want only keep provider", remainingProviders)
+	}
+
+	remainingRoutes, err := routeRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(routes) error = %v", err)
+	}
+	if len(remainingRoutes) != 1 || remainingRoutes[0].ID != routes[3].ID {
+		t.Fatalf("routes after bulk delete = %+v, want only keep route", remainingRoutes)
+	}
+
+	remainingMappings, err := modelMappingRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(mappings) error = %v", err)
+	}
+	if containsModelMappingID(remainingMappings, mappings[0].ID) || containsModelMappingID(remainingMappings, mappings[1].ID) {
+		t.Fatalf("deleted provider mappings still visible: %+v", remainingMappings)
+	}
+	if !containsModelMappingID(remainingMappings, mappings[2].ID) || !containsModelMappingID(remainingMappings, mappings[3].ID) {
+		t.Fatalf("unrelated mappings were deleted: %+v", remainingMappings)
+	}
+}
+
+func newTestCustomProvider(name string) *domain.Provider {
+	return &domain.Provider{
+		TenantID: domain.DefaultTenantID,
+		Name:     name,
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://api.example.com/" + name,
+			APIKey:  "sk-test",
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeOpenAI},
+		SupportModels:        []string{"*"},
+	}
+}
+
+func assertServiceContainsID(t *testing.T, ids []uint64, want uint64) {
+	t.Helper()
+	for _, id := range ids {
+		if id == want {
+			return
+		}
+	}
+	t.Fatalf("ids %v does not contain %d", ids, want)
+}

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
 )
@@ -265,6 +267,117 @@ func TestAdminServiceBulkDeleteProvidersRollsBackReferencesWhenProviderDeleteFai
 	if !containsModelMappingID(mappings, mapping.ID) {
 		t.Fatalf("provider mapping was deleted despite transaction rollback: %+v", mappings)
 	}
+}
+
+func TestAdminServiceBulkDeleteProvidersReturnsResultWhenPostCommitReloadFails(t *testing.T) {
+	repo := &bulkDeleteReloadFailingProviderRepo{
+		result: &domain.ProviderBulkDeleteResult{
+			DeletedIDs:        []uint64{42},
+			DeletedCount:      1,
+			NotFoundIDs:       []uint64{99},
+			RouteDeletedCount: 2,
+		},
+		reloadErr: errors.New("reload failed after commit"),
+	}
+	adapter := &recordingProviderAdapterRefresher{}
+	svc := NewAdminService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", adapter, nil, nil)
+
+	result, err := svc.BulkDeleteProviders(domain.DefaultTenantID, domain.ProviderBulkDeleteRequest{IDs: []uint64{42, 99}})
+	if err != nil {
+		t.Fatalf("BulkDeleteProviders() error = %v, want nil because delete already committed", err)
+	}
+	if result != repo.result {
+		t.Fatalf("BulkDeleteProviders() result = %#v, want original committed result %#v", result, repo.result)
+	}
+	if len(adapter.removed) != 1 || adapter.removed[0] != 42 {
+		t.Fatalf("removed adapters = %v, want [42]", adapter.removed)
+	}
+}
+
+func TestAdminServiceBulkDeleteProvidersFallbackDoesNotRemoveAdapterWhenDeleteFails(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	baseProviderRepo := sqlite.NewProviderRepository(db)
+	provider := newTestCustomProvider("delete-fails")
+	if err := baseProviderRepo.Create(provider); err != nil {
+		t.Fatalf("Create(provider) error = %v", err)
+	}
+
+	providerRepo := &deleteFailingProviderRepo{base: baseProviderRepo, deleteErr: errors.New("delete blocked")}
+	routeRepo := sqlite.NewRouteRepository(db)
+	modelMappingRepo := sqlite.NewModelMappingRepository(db)
+	adapter := &recordingProviderAdapterRefresher{}
+	svc := NewAdminService(providerRepo, routeRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, modelMappingRepo, nil, nil, nil, "", adapter, nil, nil)
+
+	_, err = svc.BulkDeleteProviders(domain.DefaultTenantID, domain.ProviderBulkDeleteRequest{IDs: []uint64{provider.ID}})
+	if err == nil {
+		t.Fatal("BulkDeleteProviders() error = nil, want delete failure")
+	}
+	if len(adapter.removed) != 0 {
+		t.Fatalf("removed adapters = %v, want none when provider delete fails", adapter.removed)
+	}
+}
+
+type bulkDeleteReloadFailingProviderRepo struct {
+	result    *domain.ProviderBulkDeleteResult
+	reloadErr error
+}
+
+func (r *bulkDeleteReloadFailingProviderRepo) Create(provider *domain.Provider) error  { return nil }
+func (r *bulkDeleteReloadFailingProviderRepo) Update(provider *domain.Provider) error  { return nil }
+func (r *bulkDeleteReloadFailingProviderRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *bulkDeleteReloadFailingProviderRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
+	return nil, nil
+}
+func (r *bulkDeleteReloadFailingProviderRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	return nil, nil
+}
+func (r *bulkDeleteReloadFailingProviderRepo) BulkDeleteWithReferences(tenantID uint64, ids []uint64) (*domain.ProviderBulkDeleteResult, error) {
+	return r.result, nil
+}
+func (r *bulkDeleteReloadFailingProviderRepo) Reload() error { return r.reloadErr }
+
+type deleteFailingProviderRepo struct {
+	base      providerRepositoryMethods
+	deleteErr error
+}
+
+type providerRepositoryMethods interface {
+	Create(provider *domain.Provider) error
+	Update(provider *domain.Provider) error
+	Delete(tenantID uint64, id uint64) error
+	GetByID(tenantID uint64, id uint64) (*domain.Provider, error)
+	List(tenantID uint64) ([]*domain.Provider, error)
+}
+
+func (r *deleteFailingProviderRepo) Create(provider *domain.Provider) error {
+	return r.base.Create(provider)
+}
+func (r *deleteFailingProviderRepo) Update(provider *domain.Provider) error {
+	return r.base.Update(provider)
+}
+func (r *deleteFailingProviderRepo) Delete(tenantID uint64, id uint64) error { return r.deleteErr }
+func (r *deleteFailingProviderRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
+	return r.base.GetByID(tenantID, id)
+}
+func (r *deleteFailingProviderRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	return r.base.List(tenantID)
+}
+
+type recordingProviderAdapterRefresher struct {
+	removed []uint64
+}
+
+func (r *recordingProviderAdapterRefresher) RefreshAdapter(p *domain.Provider) error { return nil }
+func (r *recordingProviderAdapterRefresher) RemoveAdapter(providerID uint64) {
+	r.removed = append(r.removed, providerID)
+}
+func (r *recordingProviderAdapterRefresher) GetAdapter(providerID uint64) (provideradapter.ProviderAdapter, bool) {
+	return nil, false
 }
 
 func containsProviderID(providers []*domain.Provider, id uint64) bool {

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -286,6 +286,9 @@ func TestAdminServiceBulkDeleteProvidersReturnsResultWhenPostCommitReloadFails(t
 	if err != nil {
 		t.Fatalf("BulkDeleteProviders() error = %v, want nil because delete already committed", err)
 	}
+	if repo.reloadCalls != 1 {
+		t.Fatalf("Reload() calls = %d, want 1", repo.reloadCalls)
+	}
 	if result != repo.result {
 		t.Fatalf("BulkDeleteProviders() result = %#v, want original committed result %#v", result, repo.result)
 	}
@@ -323,8 +326,9 @@ func TestAdminServiceBulkDeleteProvidersFallbackDoesNotRemoveAdapterWhenDeleteFa
 }
 
 type bulkDeleteReloadFailingProviderRepo struct {
-	result    *domain.ProviderBulkDeleteResult
-	reloadErr error
+	result      *domain.ProviderBulkDeleteResult
+	reloadErr   error
+	reloadCalls int
 }
 
 func (r *bulkDeleteReloadFailingProviderRepo) Create(provider *domain.Provider) error  { return nil }
@@ -339,7 +343,10 @@ func (r *bulkDeleteReloadFailingProviderRepo) List(tenantID uint64) ([]*domain.P
 func (r *bulkDeleteReloadFailingProviderRepo) BulkDeleteWithReferences(tenantID uint64, ids []uint64) (*domain.ProviderBulkDeleteResult, error) {
 	return r.result, nil
 }
-func (r *bulkDeleteReloadFailingProviderRepo) Reload() error { return r.reloadErr }
+func (r *bulkDeleteReloadFailingProviderRepo) Reload() error {
+	r.reloadCalls++
+	return r.reloadErr
+}
 
 type deleteFailingProviderRepo struct {
 	base      providerRepositoryMethods

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -196,6 +197,83 @@ func TestAdminServiceBulkDeleteProvidersCleansReferencesInOnePass(t *testing.T) 
 	if !containsModelMappingID(remainingMappings, mappings[2].ID) || !containsModelMappingID(remainingMappings, mappings[3].ID) {
 		t.Fatalf("unrelated mappings were deleted: %+v", remainingMappings)
 	}
+}
+
+func TestAdminServiceBulkDeleteProvidersRollsBackReferencesWhenProviderDeleteFails(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	providerRepo := sqlite.NewProviderRepository(db)
+	routeRepo := sqlite.NewRouteRepository(db)
+	modelMappingRepo := sqlite.NewModelMappingRepository(db)
+
+	provider := newTestCustomProvider("rollback-provider")
+	if err := providerRepo.Create(provider); err != nil {
+		t.Fatalf("Create(provider) error = %v", err)
+	}
+
+	route := &domain.Route{TenantID: domain.DefaultTenantID, ProviderID: provider.ID, ClientType: domain.ClientTypeClaude, ProjectID: 0, Position: 1, Weight: 1, IsEnabled: true}
+	if err := routeRepo.Create(route); err != nil {
+		t.Fatalf("Create(route) error = %v", err)
+	}
+
+	mapping := &domain.ModelMapping{TenantID: domain.DefaultTenantID, Scope: domain.ModelMappingScopeProvider, ProviderID: provider.ID, Pattern: "rollback-*", Target: "upstream"}
+	if err := modelMappingRepo.Create(mapping); err != nil {
+		t.Fatalf("Create(mapping) error = %v", err)
+	}
+
+	triggerSQL := fmt.Sprintf(`
+		CREATE TRIGGER fail_provider_soft_delete
+		BEFORE UPDATE OF deleted_at ON providers
+		WHEN OLD.id = %d AND NEW.deleted_at != 0
+		BEGIN
+			SELECT RAISE(ABORT, 'provider delete blocked');
+		END;
+	`, provider.ID)
+	if err := db.GormDB().Exec(triggerSQL).Error; err != nil {
+		t.Fatalf("create trigger error = %v", err)
+	}
+
+	svc := NewAdminService(providerRepo, routeRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, modelMappingRepo, nil, nil, nil, "", nil, nil, nil)
+	if _, err := svc.BulkDeleteProviders(domain.DefaultTenantID, domain.ProviderBulkDeleteRequest{IDs: []uint64{provider.ID}}); err == nil {
+		t.Fatal("BulkDeleteProviders() error = nil, want provider delete failure")
+	}
+
+	providers, err := providerRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(providers) error = %v", err)
+	}
+	if !containsProviderID(providers, provider.ID) {
+		t.Fatalf("provider was deleted despite transaction rollback: %+v", providers)
+	}
+
+	routes, err := routeRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(routes) error = %v", err)
+	}
+	if len(routes) != 1 || routes[0].ID != route.ID {
+		t.Fatalf("routes after failed bulk delete = %+v, want original route", routes)
+	}
+
+	mappings, err := modelMappingRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(mappings) error = %v", err)
+	}
+	if !containsModelMappingID(mappings, mapping.ID) {
+		t.Fatalf("provider mapping was deleted despite transaction rollback: %+v", mappings)
+	}
+}
+
+func containsProviderID(providers []*domain.Provider, id uint64) bool {
+	for _, provider := range providers {
+		if provider.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func newTestCustomProvider(name string) *domain.Provider {

--- a/tests/e2e/playwright/claude-provider-batch-test-bulk-remove.spec.ts
+++ b/tests/e2e/playwright/claude-provider-batch-test-bulk-remove.spec.ts
@@ -1,0 +1,252 @@
+import { expect, test, type Page } from "playwright/test";
+
+const providers = [
+  {
+    id: 101,
+    createdAt: "2026-06-27T00:00:00Z",
+    updatedAt: "2026-06-27T00:00:00Z",
+    type: "custom",
+    name: "Claude Expired A",
+    config: {
+      custom: { baseURL: "https://expired-a.example.com", apiKey: "sk-a" },
+    },
+    supportedClientTypes: ["claude"],
+    supportModels: ["claude-*"],
+  },
+  {
+    id: 102,
+    createdAt: "2026-06-27T00:00:00Z",
+    updatedAt: "2026-06-27T00:00:00Z",
+    type: "custom",
+    name: "Claude Expired B",
+    config: {
+      custom: { baseURL: "https://expired-b.example.com", apiKey: "sk-b" },
+    },
+    supportedClientTypes: ["claude"],
+    supportModels: ["claude-*"],
+  },
+];
+
+const routes = [
+  {
+    id: 201,
+    createdAt: "2026-06-27T00:00:00Z",
+    updatedAt: "2026-06-27T00:00:00Z",
+    isEnabled: true,
+    isNative: true,
+    projectID: 0,
+    clientType: "claude",
+    providerID: 101,
+    position: 1,
+    weight: 1,
+  },
+  {
+    id: 202,
+    createdAt: "2026-06-27T00:00:00Z",
+    updatedAt: "2026-06-27T00:00:00Z",
+    isEnabled: true,
+    isNative: true,
+    projectID: 0,
+    clientType: "claude",
+    providerID: 102,
+    position: 2,
+    weight: 1,
+  },
+];
+
+async function mockRouteApis(page: Page, bulkDeleteBodies: unknown[]) {
+  await page.route("**/api/**", async (route) => {
+    const url = new URL(route.request().url());
+    const { pathname } = url;
+    const method = route.request().method();
+
+    const json = (body: unknown, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (pathname === "/api/admin/auth/status") {
+      return json({ authEnabled: false });
+    }
+
+    if (pathname === "/api/settings" || pathname === "/api/admin/settings") {
+      return json({ ui_multitenant_enabled: "false" });
+    }
+
+    if (pathname === "/api/providers" || pathname === "/api/admin/providers") {
+      return json(providers);
+    }
+
+    if (pathname === "/api/routes" || pathname === "/api/admin/routes") {
+      return json(routes);
+    }
+
+    if (
+      pathname === "/api/routes/claude-provider-batch-test" &&
+      method === "POST"
+    ) {
+      return json({
+        clientType: "claude",
+        projectID: 0,
+        testModel: "claude-sonnet-4",
+        persistMode: "passed",
+        createRoutes: true,
+        concurrency: 2,
+        testedCount: 2,
+        usableCount: 0,
+        persistedCount: 0,
+        routesCreated: 0,
+        routesUpdated: 0,
+        routesDisabled: 0,
+        routesSkipped: 0,
+        results: providers.map((provider, index) => ({
+          index,
+          source: "existing",
+          existingID: provider.id,
+          providerID: provider.id,
+          name: provider.name,
+          type: provider.type,
+          baseURL: provider.config.custom.baseURL,
+          requestedModel: "claude-sonnet-4",
+          mappedModel: "claude-sonnet-4",
+          action: "test_existing_route",
+          status: "auth_failed",
+          httpStatus: 401,
+          ok: false,
+          persisted: false,
+          routeCreated: false,
+          routeUpdated: false,
+          routeEnabled: true,
+          message: "expired token",
+          error: "expired token",
+          durationMs: 42,
+        })),
+      });
+    }
+
+    if (pathname === "/api/providers/bulk-delete" && method === "POST") {
+      const payload = route.request().postDataJSON();
+      bulkDeleteBodies.push(payload);
+      return json({
+        deletedCount: 2,
+        deletedIDs: [101, 102],
+        notFoundIDs: [],
+        routeDeletedCount: 2,
+        modelMappingDeletedCount: 2,
+      });
+    }
+
+    if (
+      pathname === "/api/projects" ||
+      pathname === "/api/admin/projects" ||
+      pathname === "/api/admin/routing-strategies" ||
+      pathname === "/api/requests/active" ||
+      pathname === "/api/admin/requests/active"
+    ) {
+      return json([]);
+    }
+
+    if (
+      pathname === "/api/provider-stats" ||
+      pathname === "/api/admin/provider-stats"
+    ) {
+      return json({});
+    }
+
+    if (
+      pathname === "/api/model-mappings" ||
+      pathname === "/api/admin/model-mappings"
+    ) {
+      return json([]);
+    }
+
+    return route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Unmocked endpoint", pathname, method }),
+    });
+  });
+}
+
+test("claude batch test removes failed existing providers with one bulk request", async ({
+  page,
+}, testInfo) => {
+  const bulkDeleteBodies: unknown[] = [];
+  await mockRouteApis(page, bulkDeleteBodies);
+
+  page.on("dialog", (dialog) => dialog.accept());
+
+  await page.goto("/routes/claude");
+
+  await expect(
+    page.getByRole("heading", { name: /Claude Routes|Claude 路由/ }),
+  ).toBeVisible({
+    timeout: 10000,
+  });
+  await page
+    .getByRole("button", { name: /Batch test providers|批量测试提供商/ })
+    .click();
+  await expect(
+    page.getByRole("heading", {
+      name: /Claude provider batch test|Claude 提供商批量测试/,
+    }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /Select all|全选|选择全部/ }).click();
+  await page
+    .getByRole("button", { name: /Start concurrent test|开始并发测试/ })
+    .click();
+
+  const dialog = page.getByRole("dialog", {
+    name: /Claude provider batch test|Claude 提供商批量测试/,
+  });
+  await expect(
+    dialog.getByText(
+      /Existing providers pending removal confirmation|待确认移除的已有提供商/,
+    ),
+  ).toBeVisible();
+  await expect(dialog.getByText("Claude Expired A").first()).toBeVisible();
+  await expect(dialog.getByText("Claude Expired B").first()).toBeVisible();
+
+  const beforeScreenshotPath = testInfo.outputPath(
+    "claude-batch-test-failed-existing-before-bulk-remove.png",
+  );
+  await page.screenshot({ path: beforeScreenshotPath, fullPage: true });
+  await testInfo.attach("failed existing providers before bulk remove", {
+    path: beforeScreenshotPath,
+    contentType: "image/png",
+  });
+
+  await page
+    .getByRole("button", { name: /Select all failed items|选择全部失败项/ })
+    .click();
+  await page
+    .getByRole("button", {
+      name: /Remove selected failed items \(2\)|移除所选失败项（2）/,
+    })
+    .click();
+
+  await expect.poll(() => bulkDeleteBodies.length).toBe(1);
+  expect(bulkDeleteBodies[0]).toEqual({ ids: [101, 102] });
+  await expect(
+    dialog.getByText(
+      /Existing providers pending removal confirmation|待确认移除的已有提供商/,
+    ),
+  ).toHaveCount(0);
+  await expect(
+    dialog.getByRole("button", {
+      name: /Remove selected failed items|移除所选失败项/,
+    }),
+  ).toHaveCount(0);
+
+  const afterScreenshotPath = testInfo.outputPath(
+    "claude-batch-test-after-bulk-remove.png",
+  );
+  await page.screenshot({ path: afterScreenshotPath, fullPage: true });
+  await testInfo.attach("failed existing providers after bulk remove", {
+    path: afterScreenshotPath,
+    contentType: "image/png",
+  });
+});

--- a/tests/e2e/providers_test.go
+++ b/tests/e2e/providers_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
 )
 
 func TestListProviders_Empty(t *testing.T) {
@@ -239,6 +242,94 @@ func TestCreateProvider_EmptyBody(t *testing.T) {
 	}
 }
 
+func TestBulkDeleteProvidersEndToEndCleansReferencesAndPreservesScope(t *testing.T) {
+	env := NewTestEnv(t)
+
+	projectID := createE2EProject(t, env, "bulk-delete-project", "bulk-delete-project")
+	deleteAID := createE2EProvider(t, env, "bulk-delete-a")
+	deleteBID := createE2EProvider(t, env, "bulk-delete-b")
+	keepID := createE2EProvider(t, env, "bulk-delete-keep")
+
+	createE2ERoute(t, env, deleteAID, 0, "claude")
+	createE2ERoute(t, env, deleteAID, projectID, "claude")
+	createE2ERoute(t, env, deleteBID, projectID, "openai")
+	keepRouteID := createE2ERoute(t, env, keepID, projectID, "claude")
+
+	createE2EProviderModelMapping(t, env, deleteAID, "delete-a-*", "target-a")
+	createE2EProviderModelMapping(t, env, deleteBID, "delete-b-*", "target-b")
+	keepMappingID := createE2EProviderModelMapping(t, env, keepID, "keep-*", "target-keep")
+	globalMappingID := createE2EGlobalModelMapping(t, env, "global-*", "target-global")
+
+	otherTenantID, otherProviderID := seedOtherTenantProviderReferences(t, env)
+
+	resp := env.AdminPost("/api/admin/providers/bulk-delete", map[string]any{
+		"ids": []uint64{deleteAID, deleteBID, 999999},
+	})
+	AssertStatus(t, resp, http.StatusOK)
+
+	var result domain.ProviderBulkDeleteResult
+	DecodeJSON(t, resp, &result)
+	assertUintSet(t, "deletedIDs", result.DeletedIDs, []uint64{deleteAID, deleteBID})
+	assertUintSet(t, "notFoundIDs", result.NotFoundIDs, []uint64{999999})
+	if result.DeletedCount != 2 {
+		t.Fatalf("expected 2 deleted providers, got %d", result.DeletedCount)
+	}
+	if result.RouteDeletedCount != 3 {
+		t.Fatalf("expected 3 deleted routes, got %d", result.RouteDeletedCount)
+	}
+	if result.ModelMappingDeletedCount != 2 {
+		t.Fatalf("expected 2 deleted provider mappings, got %d", result.ModelMappingDeletedCount)
+	}
+
+	resp = env.AdminGet("/api/admin/providers")
+	AssertStatus(t, resp, http.StatusOK)
+	var providers []map[string]any
+	DecodeJSON(t, resp, &providers)
+	assertListedIDs(t, "providers after bulk delete", providers, []uint64{keepID})
+
+	resp = env.AdminGet("/api/admin/routes")
+	AssertStatus(t, resp, http.StatusOK)
+	var routes []map[string]any
+	DecodeJSON(t, resp, &routes)
+	assertListedIDs(t, "routes after bulk delete", routes, []uint64{keepRouteID})
+	if gotProviderID := uint64(routes[0]["providerID"].(float64)); gotProviderID != keepID {
+		t.Fatalf("expected remaining route to belong to provider %d, got %d", keepID, gotProviderID)
+	}
+
+	resp = env.AdminGet("/api/admin/model-mappings")
+	AssertStatus(t, resp, http.StatusOK)
+	var mappings []map[string]any
+	DecodeJSON(t, resp, &mappings)
+	assertListedIDs(t, "model mappings after bulk delete", mappings, []uint64{keepMappingID, globalMappingID})
+	for _, mapping := range mappings {
+		if providerID, ok := mapping["providerID"].(float64); ok && uint64(providerID) != 0 && uint64(providerID) != keepID {
+			t.Fatalf("unexpected provider-scoped mapping remained after bulk delete: %#v", mapping)
+		}
+	}
+
+	otherProviders, err := sqlite.NewProviderRepository(env.DB).List(otherTenantID)
+	if err != nil {
+		t.Fatalf("list other tenant providers: %v", err)
+	}
+	assertDomainProviderIDs(t, "other tenant providers", otherProviders, []uint64{otherProviderID})
+
+	otherRoutes, err := sqlite.NewRouteRepository(env.DB).List(otherTenantID)
+	if err != nil {
+		t.Fatalf("list other tenant routes: %v", err)
+	}
+	if len(otherRoutes) != 1 || otherRoutes[0].ProviderID != otherProviderID {
+		t.Fatalf("expected other tenant route to remain for provider %d, got %#v", otherProviderID, otherRoutes)
+	}
+
+	otherMappings, err := sqlite.NewModelMappingRepository(env.DB).List(otherTenantID)
+	if err != nil {
+		t.Fatalf("list other tenant mappings: %v", err)
+	}
+	if len(otherMappings) != 1 || otherMappings[0].ProviderID != otherProviderID {
+		t.Fatalf("expected other tenant provider mapping to remain for provider %d, got %#v", otherProviderID, otherMappings)
+	}
+}
+
 func TestProviders_Unauthorized(t *testing.T) {
 	env := NewTestEnv(t)
 
@@ -370,4 +461,170 @@ func TestCreateProvider_SQLInjection(t *testing.T) {
 	resp = env.AdminGet(fmt.Sprintf("/api/admin/providers/%d", id))
 	AssertStatus(t, resp, http.StatusOK)
 	resp.Body.Close()
+}
+
+func createE2EProvider(t *testing.T, env *TestEnv, name string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": name,
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "https://api.example.com/" + name,
+				"apiKey":  "sk-test-key",
+			},
+		},
+		"supportedClientTypes": []string{"claude", "openai"},
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	return uint64(created["id"].(float64))
+}
+
+func createE2EProject(t *testing.T, env *TestEnv, name, slug string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/projects", map[string]any{
+		"name":                name,
+		"slug":                slug,
+		"enabledCustomRoutes": []string{"claude", "openai"},
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	return uint64(created["id"].(float64))
+}
+
+func createE2ERoute(t *testing.T, env *TestEnv, providerID, projectID uint64, clientType string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   true,
+		"projectID":  projectID,
+		"clientType": clientType,
+		"providerID": providerID,
+		"position":   1,
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	return uint64(created["id"].(float64))
+}
+
+func createE2EProviderModelMapping(t *testing.T, env *TestEnv, providerID uint64, pattern, target string) uint64 {
+	t.Helper()
+	return createE2EModelMapping(t, env, map[string]any{
+		"scope":      "provider",
+		"providerID": providerID,
+		"pattern":    pattern,
+		"target":     target,
+		"priority":   10,
+	})
+}
+
+func createE2EGlobalModelMapping(t *testing.T, env *TestEnv, pattern, target string) uint64 {
+	t.Helper()
+	return createE2EModelMapping(t, env, map[string]any{
+		"scope":    "global",
+		"pattern":  pattern,
+		"target":   target,
+		"priority": 20,
+	})
+}
+
+func createE2EModelMapping(t *testing.T, env *TestEnv, body map[string]any) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/model-mappings", body)
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	return uint64(created["id"].(float64))
+}
+
+func seedOtherTenantProviderReferences(t *testing.T, env *TestEnv) (uint64, uint64) {
+	t.Helper()
+	tenantRepo := sqlite.NewTenantRepository(env.DB)
+	otherTenant := &domain.Tenant{Name: "Other Tenant", Slug: "other-tenant"}
+	if err := tenantRepo.Create(otherTenant); err != nil {
+		t.Fatalf("create other tenant: %v", err)
+	}
+
+	providerRepo := sqlite.NewProviderRepository(env.DB)
+	otherProvider := &domain.Provider{
+		TenantID: otherTenant.ID,
+		Name:     "other-tenant-provider",
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://api.example.com/other",
+			APIKey:  "sk-other",
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+	if err := providerRepo.Create(otherProvider); err != nil {
+		t.Fatalf("create other tenant provider: %v", err)
+	}
+
+	routeRepo := sqlite.NewRouteRepository(env.DB)
+	if err := routeRepo.Create(&domain.Route{
+		TenantID:   otherTenant.ID,
+		IsEnabled:  true,
+		IsNative:   true,
+		ProjectID:  0,
+		ClientType: domain.ClientTypeClaude,
+		ProviderID: otherProvider.ID,
+		Position:   1,
+	}); err != nil {
+		t.Fatalf("create other tenant route: %v", err)
+	}
+
+	mappingRepo := sqlite.NewModelMappingRepository(env.DB)
+	if err := mappingRepo.Create(&domain.ModelMapping{
+		TenantID:   otherTenant.ID,
+		Scope:      domain.ModelMappingScopeProvider,
+		ProviderID: otherProvider.ID,
+		Pattern:    "other-*",
+		Target:     "other-target",
+		Priority:   1,
+	}); err != nil {
+		t.Fatalf("create other tenant mapping: %v", err)
+	}
+
+	return otherTenant.ID, otherProvider.ID
+}
+
+func assertListedIDs(t *testing.T, label string, items []map[string]any, want []uint64) {
+	t.Helper()
+	got := make([]uint64, 0, len(items))
+	for _, item := range items {
+		got = append(got, uint64(item["id"].(float64)))
+	}
+	assertUintSet(t, label, got, want)
+}
+
+func assertDomainProviderIDs(t *testing.T, label string, items []*domain.Provider, want []uint64) {
+	t.Helper()
+	got := make([]uint64, 0, len(items))
+	for _, item := range items {
+		got = append(got, item.ID)
+	}
+	assertUintSet(t, label, got, want)
+}
+
+func assertUintSet(t *testing.T, label string, got []uint64, want []uint64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s: expected ids %v, got %v", label, want, got)
+	}
+	counts := make(map[uint64]int, len(want))
+	for _, id := range want {
+		counts[id]++
+	}
+	for _, id := range got {
+		counts[id]--
+	}
+	for id, count := range counts {
+		if count != 0 {
+			t.Fatalf("%s: expected ids %v, got %v; id %d count delta %d", label, want, got, id, count)
+		}
+	}
 }

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -10,6 +10,7 @@ export {
   useCreateProvider,
   useUpdateProvider,
   useDeleteProvider,
+  useBulkDeleteProviders,
   useProviderStats,
   useAllProviderStats,
   useAntigravityQuota,

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -82,6 +82,20 @@ export function useDeleteProvider() {
   });
 }
 
+// 批量删除 Provider
+export function useBulkDeleteProviders() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (ids: number[]) => getTransport().bulkDeleteProviders({ ids }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: providerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: routeKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: ['model-mappings'] });
+    },
+  });
+}
+
 // 获取 Provider 统计信息
 export function useProviderStats(clientType?: string, projectId?: number) {
   return useQuery({

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -8,6 +8,8 @@ import type { Transport, TransportConfig } from './interface';
 import type {
   Provider,
   CreateProviderData,
+  ProviderBulkDeleteRequest,
+  ProviderBulkDeleteResult,
   Project,
   CreateProjectData,
   Session,
@@ -253,6 +255,14 @@ export class HttpTransport implements Transport {
 
   async deleteProvider(id: number): Promise<void> {
     await this.client.delete(`/providers/${id}`);
+  }
+
+  async bulkDeleteProviders(data: ProviderBulkDeleteRequest): Promise<ProviderBulkDeleteResult> {
+    const { data: result } = await this.client.post<ProviderBulkDeleteResult>(
+      '/providers/bulk-delete',
+      data,
+    );
+    return result;
   }
 
   async exportProviders(): Promise<Provider[]> {

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -14,6 +14,8 @@ export type {
   DisguiseType,
   ProviderConfigAntigravity,
   CreateProviderData,
+  ProviderBulkDeleteRequest,
+  ProviderBulkDeleteResult,
   Project,
   CreateProjectData,
   Session,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -6,6 +6,8 @@
 import type {
   Provider,
   CreateProviderData,
+  ProviderBulkDeleteRequest,
+  ProviderBulkDeleteResult,
   Project,
   CreateProjectData,
   Session,
@@ -95,6 +97,7 @@ export interface Transport {
   createProvider(data: CreateProviderData): Promise<Provider>;
   updateProvider(id: number, data: Partial<Provider>): Promise<Provider>;
   deleteProvider(id: number): Promise<void>;
+  bulkDeleteProviders(data: ProviderBulkDeleteRequest): Promise<ProviderBulkDeleteResult>;
   exportProviders(): Promise<Provider[]>;
   importProviders(providers: Provider[]): Promise<ImportResult>;
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -212,6 +212,18 @@ export interface Route {
   modelMapping?: Record<string, string>;
 }
 
+export interface ProviderBulkDeleteRequest {
+  ids: number[];
+}
+
+export interface ProviderBulkDeleteResult {
+  deletedCount: number;
+  deletedIDs: number[];
+  notFoundIDs: number[];
+  routeDeletedCount: number;
+  modelMappingDeletedCount: number;
+}
+
 export type CreateRouteData = Omit<Route, 'id' | 'createdAt' | 'updatedAt'>;
 
 export interface RoutePositionUpdate {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -331,7 +331,8 @@
       "itemDetails": "Routes: {{routes}} · Provider mappings: {{mappings}}",
       "confirm": "Delete providers",
       "deleting": "Deleting...",
-      "completed": "Deleted {{count}} provider(s)."
+      "completed": "Deleted {{count}} provider(s).",
+      "notDeleted": "Provider was not deleted"
     },
     "refreshQuotas": "Refresh quotas for all Antigravity providers",
     "refreshCodex": "Refresh subscription info for all Codex providers",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -328,7 +328,8 @@
       "itemDetails": "路由：{{routes}} · Provider 映射：{{mappings}}",
       "confirm": "删除提供商",
       "deleting": "删除中...",
-      "completed": "已删除 {{count}} 个提供商。"
+      "completed": "已删除 {{count}} 个提供商。",
+      "notDeleted": "提供商未被删除"
     },
     "refreshQuotas": "刷新所有 Antigravity 的额度",
     "refreshCodex": "刷新所有 Codex 的订阅信息",

--- a/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
+++ b/web/src/pages/client-routes/components/claude-provider-batch-test-dialog.tsx
@@ -23,7 +23,7 @@ import type {
   Provider,
   Route,
 } from '@/lib/transport';
-import { useClaudeProviderBatchTest, useDeleteProvider } from '@/hooks/queries';
+import { useBulkDeleteProviders, useClaudeProviderBatchTest } from '@/hooks/queries';
 import { cn } from '@/lib/utils';
 import {
   parseBulkCustomProviderCommands,
@@ -40,7 +40,7 @@ import {
   getFailedExistingResultSignature,
   isClaudeBatchTestExcludedProvider,
   isClaudeBatchTestSelectableProvider,
-  settleProviderRemovalsSequentially,
+  settleProviderRemovalsInBulk,
   summarizeClaudeBatchDisplayResults,
 } from '@/pages/client-routes/utils/claude-provider-batch-test';
 
@@ -170,7 +170,7 @@ export function ClaudeProviderBatchTestDialog({
   const abortRef = useRef<AbortController | null>(null);
   const failedExistingSectionRef = useRef<HTMLElement | null>(null);
   const batchTest = useClaudeProviderBatchTest();
-  const deleteProvider = useDeleteProvider();
+  const bulkDeleteProviders = useBulkDeleteProviders();
 
   const removedExistingIDSet = useMemo(() => new Set(removedExistingIDs), [removedExistingIDs]);
 
@@ -441,8 +441,8 @@ export function ClaudeProviderBatchTestDialog({
     setRemovalError(null);
     setIsRemovingFailedExisting(true);
     try {
-      const settled = await settleProviderRemovalsSequentially(targets, (providerID) =>
-        deleteProvider.mutateAsync(providerID),
+      const settled = await settleProviderRemovalsInBulk(targets, (providerIDs) =>
+        bulkDeleteProviders.mutateAsync(providerIDs),
       );
       const removedIDs = collectSuccessfulRemovedExistingIDs(targets, settled);
       const failedCount = settled.filter((result) => result.status === 'rejected').length;

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -157,12 +157,26 @@ describe('Claude provider batch test helpers', () => {
     expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([]);
   });
 
-  it('keeps providers selected when the bulk delete response does not delete them', async () => {
+  it('treats not-found providers as removed because the cleanup target is already gone', async () => {
     const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
     const settled = await settleProviderRemovalsInBulk(targets, async () => ({
       deletedCount: 2,
       deletedIDs: [1, 3],
       notFoundIDs: [2],
+      routeDeletedCount: 2,
+      modelMappingDeletedCount: 1,
+    }));
+
+    expect(settled.map((item) => item.status)).toEqual(['fulfilled', 'fulfilled', 'fulfilled']);
+    expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps providers selected when the bulk delete response neither deletes nor reports them missing', async () => {
+    const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
+    const settled = await settleProviderRemovalsInBulk(targets, async () => ({
+      deletedCount: 2,
+      deletedIDs: [1, 3],
+      notFoundIDs: [],
       routeDeletedCount: 2,
       modelMappingDeletedCount: 1,
     }));

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.test.ts
@@ -11,7 +11,7 @@ import {
   getFailedExistingResultSignature,
   isClaudeBatchTestExcludedProvider,
   isClaudeBatchTestSelectableProvider,
-  settleProviderRemovalsSequentially,
+  settleProviderRemovalsInBulk,
   summarizeClaudeBatchDisplayResults,
 } from './claude-provider-batch-test';
 
@@ -126,32 +126,46 @@ describe('Claude provider batch test helpers', () => {
     expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);
   });
 
-  it('removes selected failed providers sequentially instead of firing a concurrent delete burst', async () => {
-    const calls: number[] = [];
-    let inFlight = 0;
-    let maxInFlight = 0;
+  it('removes selected failed providers with one bulk delete request', async () => {
+    const calls: number[][] = [];
 
-    const settled = await settleProviderRemovalsSequentially(
+    const settled = await settleProviderRemovalsInBulk(
       [{ existingID: 10 }, { existingID: 20 }, { existingID: 30 }],
-      async (providerID) => {
-        inFlight += 1;
-        maxInFlight = Math.max(maxInFlight, inFlight);
-        calls.push(providerID);
-        await Promise.resolve();
-        inFlight -= 1;
+      async (providerIDs) => {
+        calls.push(providerIDs);
+        return {
+          deletedCount: 3,
+          deletedIDs: [10, 20, 30],
+          notFoundIDs: [],
+          routeDeletedCount: 4,
+          modelMappingDeletedCount: 2,
+        };
       },
     );
 
-    expect(calls).toEqual([10, 20, 30]);
-    expect(maxInFlight).toBe(1);
+    expect(calls).toEqual([[10, 20, 30]]);
     expect(settled.map((item) => item.status)).toEqual(['fulfilled', 'fulfilled', 'fulfilled']);
   });
 
-  it('keeps successful sequential removals ordered when one provider delete fails', async () => {
-    const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
-    const settled = await settleProviderRemovalsSequentially(targets, async (providerID) => {
-      if (providerID === 2) throw new Error('delete failed');
+  it('marks every requested provider as failed when the bulk delete request fails', async () => {
+    const targets = [{ existingID: 1 }, { existingID: 2 }];
+    const settled = await settleProviderRemovalsInBulk(targets, async () => {
+      throw new Error('bulk delete failed');
     });
+
+    expect(settled.map((item) => item.status)).toEqual(['rejected', 'rejected']);
+    expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([]);
+  });
+
+  it('keeps providers selected when the bulk delete response does not delete them', async () => {
+    const targets = [{ existingID: 1 }, { existingID: 2 }, { existingID: 3 }];
+    const settled = await settleProviderRemovalsInBulk(targets, async () => ({
+      deletedCount: 2,
+      deletedIDs: [1, 3],
+      notFoundIDs: [2],
+      routeDeletedCount: 2,
+      modelMappingDeletedCount: 1,
+    }));
 
     expect(settled.map((item) => item.status)).toEqual(['fulfilled', 'rejected', 'fulfilled']);
     expect(collectSuccessfulRemovedExistingIDs(targets, settled)).toEqual([1, 3]);

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -1,4 +1,8 @@
-import type { ClaudeProviderBatchProviderResult, Provider } from '@/lib/transport';
+import type {
+  ClaudeProviderBatchProviderResult,
+  Provider,
+  ProviderBulkDeleteResult,
+} from '@/lib/transport';
 
 type ClaudeBatchProviderSelectionFields = Pick<
   Provider,
@@ -80,23 +84,42 @@ export function collectSuccessfulRemovedExistingIDs<T extends { existingID?: num
     .map((target) => target.existingID!);
 }
 
-export async function settleProviderRemovalsSequentially<T extends { existingID?: number }>(
+export async function settleProviderRemovalsInBulk<T extends { existingID?: number }>(
   targets: T[],
-  removeProvider: (providerID: number) => Promise<unknown>,
+  removeProviders: (providerIDs: number[]) => Promise<ProviderBulkDeleteResult>,
 ): Promise<PromiseSettledResult<unknown>[]> {
-  const settled: PromiseSettledResult<unknown>[] = [];
-  for (const target of targets) {
-    if (!target.existingID) {
-      settled.push({ status: 'rejected', reason: new Error('missing existing provider id') });
-      continue;
-    }
-    try {
-      settled.push({ status: 'fulfilled', value: await removeProvider(target.existingID) });
-    } catch (reason) {
-      settled.push({ status: 'rejected', reason });
-    }
+  const providerIDs = targets.map((target) => target.existingID).filter((id): id is number => !!id);
+  if (providerIDs.length === 0) {
+    return targets.map(() => ({
+      status: 'rejected',
+      reason: new Error('missing existing provider id'),
+    }));
   }
-  return settled;
+
+  let result: ProviderBulkDeleteResult;
+  try {
+    result = await removeProviders(providerIDs);
+  } catch (reason) {
+    return targets.map((target) => ({
+      status: 'rejected',
+      reason: target.existingID ? reason : new Error('missing existing provider id'),
+    }));
+  }
+  const deletedIDs = new Set(result.deletedIDs);
+  const notFoundIDs = new Set(result.notFoundIDs);
+
+  return targets.map((target) => {
+    if (!target.existingID) {
+      return { status: 'rejected', reason: new Error('missing existing provider id') };
+    }
+    if (deletedIDs.has(target.existingID)) {
+      return { status: 'fulfilled', value: result };
+    }
+    const reason = notFoundIDs.has(target.existingID)
+      ? new Error(`provider ${target.existingID} not found`)
+      : new Error(`provider ${target.existingID} was not deleted`);
+    return { status: 'rejected', reason };
+  });
 }
 
 export function getFailedExistingResultSignature(

--- a/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
+++ b/web/src/pages/client-routes/utils/claude-provider-batch-test.ts
@@ -112,13 +112,13 @@ export async function settleProviderRemovalsInBulk<T extends { existingID?: numb
     if (!target.existingID) {
       return { status: 'rejected', reason: new Error('missing existing provider id') };
     }
-    if (deletedIDs.has(target.existingID)) {
+    if (deletedIDs.has(target.existingID) || notFoundIDs.has(target.existingID)) {
       return { status: 'fulfilled', value: result };
     }
-    const reason = notFoundIDs.has(target.existingID)
-      ? new Error(`provider ${target.existingID} not found`)
-      : new Error(`provider ${target.existingID} was not deleted`);
-    return { status: 'rejected', reason };
+    return {
+      status: 'rejected',
+      reason: new Error(`provider ${target.existingID} was not deleted`),
+    };
   });
 }
 

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -71,6 +71,10 @@ import {
   type BulkCustomProviderParseError,
 } from './utils/bulk-custom-provider-import';
 import { invertVisibleProviderSelection } from './utils/selection';
+import {
+  buildProviderBulkDeleteStatus,
+  type ProviderBulkDeleteStatus,
+} from './utils/provider-bulk-delete';
 
 type ManageProvidersButtonProps = Omit<ComponentProps<typeof Button>, 'disabled'> & {
   canManage: boolean;
@@ -128,11 +132,6 @@ type ProviderBulkDeletePreviewItem = {
   streamingCount: number;
 };
 
-type ProviderBulkDeleteStatus = {
-  deleted: number;
-  failed: Array<{ id: number; name: string; message: string }>;
-} | null;
-
 export function ProvidersPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -143,7 +142,7 @@ export function ProvidersPage() {
   const { data: providerStats = {} } = useAllProviderStats();
   const { countsByProvider } = useStreamingRequests();
   const [importStatus, setImportStatus] = useState<ImportResult | null>(null);
-  const [bulkDeleteStatus, setBulkDeleteStatus] = useState<ProviderBulkDeleteStatus>(null);
+  const [bulkDeleteStatus, setBulkDeleteStatus] = useState<ProviderBulkDeleteStatus | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedProviderIds, setSelectedProviderIds] = useState<Set<number>>(new Set());
   const [isBulkDeleteOpen, setIsBulkDeleteOpen] = useState(false);
@@ -417,25 +416,20 @@ export function ProvidersPage() {
       const result = await bulkDeleteProviders.mutateAsync(
         selectedProviders.map((provider) => provider.id),
       );
-      const deletedIDs = new Set(result.deletedIDs);
-      const failed = selectedProviders
-        .filter((provider) => !deletedIDs.has(provider.id))
-        .map((provider) => ({
-          id: provider.id,
-          name: provider.name,
-          message: result.notFoundIDs.includes(provider.id)
-            ? t('providers.notFound')
-            : t('providers.bulkDelete.notDeleted'),
-        }));
+      const status = buildProviderBulkDeleteStatus(
+        selectedProviders,
+        result,
+        t('providers.bulkDelete.notDeleted'),
+      );
 
-      setBulkDeleteStatus({ deleted: result.deletedCount, failed });
+      setBulkDeleteStatus(status);
 
-      if (failed.length === 0) {
+      if (status.failed.length === 0) {
         setSelectedProviderIds(new Set());
         setIsBulkDeleteOpen(false);
         setTimeout(() => setBulkDeleteStatus(null), 5000);
       } else {
-        setSelectedProviderIds(new Set(failed.map((item) => item.id)));
+        setSelectedProviderIds(new Set(status.failed.map((item) => item.id)));
       }
     } catch (error) {
       setBulkDeleteStatus({

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -21,7 +21,7 @@ import {
   useProxyRequestUpdates,
   useCreateProvider,
   useCreateModelMapping,
-  useDeleteProvider,
+  useBulkDeleteProviders,
   useRoutes,
   useModelMappings,
 } from '@/hooks/queries';
@@ -160,10 +160,10 @@ export function ProvidersPage() {
   const queryClient = useQueryClient();
   const createProvider = useCreateProvider();
   const createModelMapping = useCreateModelMapping();
-  const deleteProvider = useDeleteProvider();
+  const bulkDeleteProviders = useBulkDeleteProviders();
   const canManageProviderSettings = user?.role === 'admin';
   const providerReadOnlyHint = t('providers.readOnlyHint');
-  const isBulkDeleting = deleteProvider.isPending;
+  const isBulkDeleting = bulkDeleteProviders.isPending;
 
   // 订阅请求更新事件，确保 providerStats 实时刷新
   useProxyRequestUpdates();
@@ -413,33 +413,39 @@ export function ProvidersPage() {
   const handleBulkDeleteProviders = async () => {
     if (!canManageProviderSettings || selectedProviders.length === 0 || isBulkDeleting) return;
 
-    const failed: Array<{ id: number; name: string; message: string }> = [];
-    let deleted = 0;
+    try {
+      const result = await bulkDeleteProviders.mutateAsync(
+        selectedProviders.map((provider) => provider.id),
+      );
+      const deletedIDs = new Set(result.deletedIDs);
+      const failed = selectedProviders
+        .filter((provider) => !deletedIDs.has(provider.id))
+        .map((provider) => ({
+          id: provider.id,
+          name: provider.name,
+          message: result.notFoundIDs.includes(provider.id)
+            ? t('providers.notFound')
+            : t('providers.bulkDelete.notDeleted'),
+        }));
 
-    for (const provider of selectedProviders) {
-      try {
-        await deleteProvider.mutateAsync(provider.id);
-        deleted += 1;
-      } catch (error) {
-        failed.push({
+      setBulkDeleteStatus({ deleted: result.deletedCount, failed });
+
+      if (failed.length === 0) {
+        setSelectedProviderIds(new Set());
+        setIsBulkDeleteOpen(false);
+        setTimeout(() => setBulkDeleteStatus(null), 5000);
+      } else {
+        setSelectedProviderIds(new Set(failed.map((item) => item.id)));
+      }
+    } catch (error) {
+      setBulkDeleteStatus({
+        deleted: 0,
+        failed: selectedProviders.map((provider) => ({
           id: provider.id,
           name: provider.name,
           message: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    queryClient.invalidateQueries({ queryKey: ['providers'] });
-    queryClient.invalidateQueries({ queryKey: ['routes'] });
-    queryClient.invalidateQueries({ queryKey: ['model-mappings'] });
-    setBulkDeleteStatus({ deleted, failed });
-
-    if (failed.length === 0) {
-      setSelectedProviderIds(new Set());
-      setIsBulkDeleteOpen(false);
-      setTimeout(() => setBulkDeleteStatus(null), 5000);
-    } else {
-      setSelectedProviderIds(new Set(failed.map((item) => item.id)));
+        })),
+      });
     }
   };
 

--- a/web/src/pages/providers/utils/provider-bulk-delete.test.ts
+++ b/web/src/pages/providers/utils/provider-bulk-delete.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildProviderBulkDeleteStatus } from './provider-bulk-delete';
+import type { Provider } from '@/lib/transport';
+
+function provider(id: number, name: string): Provider {
+  return {
+    id,
+    tenantID: 1,
+    type: 'custom',
+    name,
+    logo: '',
+    config: {},
+    supportedClientTypes: [],
+    supportModels: [],
+    excludeFromExport: false,
+    createdAt: '2026-06-27T00:00:00Z',
+    updatedAt: '2026-06-27T00:00:00Z',
+  };
+}
+
+describe('provider bulk delete result helpers', () => {
+  it('treats not-found providers as resolved instead of failed', () => {
+    const status = buildProviderBulkDeleteStatus(
+      [provider(101, 'expired-a'), provider(102, 'expired-b')],
+      {
+        deletedCount: 1,
+        deletedIDs: [101],
+        notFoundIDs: [102],
+        routeDeletedCount: 2,
+        modelMappingDeletedCount: 1,
+      },
+      'Provider was not deleted',
+    );
+
+    expect(status).toEqual({ deleted: 2, failed: [] });
+  });
+
+  it('keeps selected providers failed when the backend neither deleted nor reported them missing', () => {
+    const status = buildProviderBulkDeleteStatus(
+      [provider(101, 'expired-a'), provider(103, 'still-present')],
+      {
+        deletedCount: 1,
+        deletedIDs: [101],
+        notFoundIDs: [],
+        routeDeletedCount: 1,
+        modelMappingDeletedCount: 0,
+      },
+      'Provider was not deleted',
+    );
+
+    expect(status).toEqual({
+      deleted: 1,
+      failed: [{ id: 103, name: 'still-present', message: 'Provider was not deleted' }],
+    });
+  });
+});

--- a/web/src/pages/providers/utils/provider-bulk-delete.ts
+++ b/web/src/pages/providers/utils/provider-bulk-delete.ts
@@ -1,0 +1,30 @@
+import type { Provider, ProviderBulkDeleteResult } from '@/lib/transport';
+
+export type ProviderBulkDeleteStatus = {
+  deleted: number;
+  failed: Array<{ id: number; name: string; message: string }>;
+};
+
+export function buildProviderBulkDeleteStatus(
+  selectedProviders: Provider[],
+  result: ProviderBulkDeleteResult,
+  notDeletedMessage: string,
+): ProviderBulkDeleteStatus {
+  const selectedProviderIDs = new Set(selectedProviders.map((provider) => provider.id));
+  const deletedIDs = new Set(result.deletedIDs);
+  const resolvedMissingIDs = new Set(
+    result.notFoundIDs.filter((id) => selectedProviderIDs.has(id) && !deletedIDs.has(id)),
+  );
+  const resolvedIDs = new Set([...deletedIDs, ...resolvedMissingIDs]);
+
+  return {
+    deleted: result.deletedCount + resolvedMissingIDs.size,
+    failed: selectedProviders
+      .filter((provider) => !resolvedIDs.has(provider.id))
+      .map((provider) => ({
+        id: provider.id,
+        name: provider.name,
+        message: notDeletedMessage,
+      })),
+  };
+}


### PR DESCRIPTION
## Summary
- add a provider bulk-delete API that deletes selected providers and cleans provider route/model-mapping references in one request
- switch Claude provider batch-test failed-existing removal to the bulk mutation instead of sequential provider deletes
- reuse the same bulk delete mutation from the Providers page bulk-delete flow
- add service, handler, frontend utility, and Playwright coverage for the bulk removal path

## Validation
- `go test ./internal/service ./internal/repository/sqlite`
- `go test ./internal/handler`
- `pnpm -C web test -- src/pages/client-routes/utils/claude-provider-batch-test.test.ts`
- `pnpm -C web typecheck`
- `pnpm -C web lint`
- `pnpm -C web build`
- `cd web && pnpm exec playwright test -c ../tests/e2e/playwright/playwright.config.ts ../tests/e2e/playwright/claude-provider-batch-test-bulk-remove.spec.ts --project=e2e-chromium`

## Notes
- The Playwright run emitted a Vite dev-server WebSocket proxy `ECONNREFUSED` warning while the mocked UI/API scenario was running; the test itself passed and asserted a single `POST /api/providers/bulk-delete` with `{ ids: [101, 102] }`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增提供商批量删除：支持一次请求删除多个提供商，并返回已删除/未找到/未删除的详细结果统计；同时清理关联路由与模型映射的删除计数。
  * 页面与接口打通：在“移除失败项”流程中改为一次性批量删除（而非逐个删除）。
* **改进**
  * 统一错误响应：空/非法请求返回 400；缺少权限返回 403；其余服务错误返回 500。
  * 结果文案区分“已删除”和“未被删除”。
* **测试**
  * 新增接口、服务与前端 E2E/单测覆盖批量删除与引用清理行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->