### PR TITLE
fix(proxy): skip request records without providers

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -7,23 +7,24 @@ import (
 )
 
 var (
-	ErrNotFound            = errors.New("not found")
-	ErrAlreadyExists       = errors.New("already exists")
-	ErrSlugExists          = errors.New("slug already exists")
-	ErrInvalidInput        = errors.New("invalid input")
-	ErrInvalidState        = errors.New("invalid state")
-	ErrNoRoutes            = errors.New("no routes available")
-	ErrAllRoutesFailed     = errors.New("all routes failed")
-	ErrFirstByteTimeout    = errors.New("first byte timeout")
-	ErrStreamIdleTimeout   = errors.New("stream idle timeout")
-	ErrUpstreamError       = errors.New("upstream error")
-	ErrFormatConversion    = errors.New("format conversion error")
-	ErrUnsupportedFormat   = errors.New("unsupported format")
-	ErrInviteCodeRequired  = errors.New("invite code required")
-	ErrInviteCodeInvalid   = errors.New("invite code invalid")
-	ErrInviteCodeExpired   = errors.New("invite code expired")
-	ErrInviteCodeExhausted = errors.New("invite code exhausted")
-	ErrInviteCodeDisabled  = errors.New("invite code disabled")
+	ErrNotFound             = errors.New("not found")
+	ErrAlreadyExists        = errors.New("already exists")
+	ErrSlugExists           = errors.New("slug already exists")
+	ErrInvalidInput         = errors.New("invalid input")
+	ErrInvalidState         = errors.New("invalid state")
+	ErrNoRoutes             = errors.New("no routes available")
+	ErrNoAvailableProviders = errors.New("no available providers")
+	ErrAllRoutesFailed      = errors.New("all routes failed")
+	ErrFirstByteTimeout     = errors.New("first byte timeout")
+	ErrStreamIdleTimeout    = errors.New("stream idle timeout")
+	ErrUpstreamError        = errors.New("upstream error")
+	ErrFormatConversion     = errors.New("format conversion error")
+	ErrUnsupportedFormat    = errors.New("unsupported format")
+	ErrInviteCodeRequired   = errors.New("invite code required")
+	ErrInviteCodeInvalid    = errors.New("invite code invalid")
+	ErrInviteCodeExpired    = errors.New("invite code expired")
+	ErrInviteCodeExhausted  = errors.New("invite code exhausted")
+	ErrInviteCodeDisabled   = errors.New("invite code disabled")
 )
 
 // ErrorScope defines what resource is broken, determining cooldown granularity
@@ -55,6 +56,7 @@ const (
 type ProxyError struct {
 	Err     error
 	Message string
+	Code    string
 
 	// Classification
 	Scope          ErrorScope     // What resource is broken (determines cooldown granularity)
@@ -62,8 +64,8 @@ type ProxyError struct {
 	HTTPStatusCode int            // Original HTTP status code
 
 	// Cooldown hints
-	RetryAfter         time.Duration // Suggested retry delay
-	CooldownUntil      *time.Time    // Absolute cooldown end time
+	RetryAfter         time.Duration  // Suggested retry delay
+	CooldownUntil      *time.Time     // Absolute cooldown end time
 	CooldownUpdateChan chan time.Time // Channel for async cooldown updates (optional)
 
 	// Retry

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -29,7 +30,14 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		SessionID:    state.sessionID,
 	})
 	if err != nil {
-		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, fmt.Sprintf("route match failed: %v", err))
+		message := fmt.Sprintf("route match failed: %v", err)
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
+		if errors.Is(err, domain.ErrNoAvailableProviders) {
+			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
+			proxyErr.Code = "no_available_provider"
+		} else if errors.Is(err, domain.ErrNoRoutes) {
+			proxyErr.Code = "no_routes_available"
+		}
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
 		state.lastErr = proxyErr
@@ -39,8 +47,9 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	}
 
 	if len(result.Routes) == 0 {
-		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, "no routes configured")
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
 		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "no_available_provider"
 		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
 		state.lastErr = proxyErr
 		c.Err = proxyErr

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -403,12 +403,16 @@ func writeProxyError(w http.ResponseWriter, err *domain.ProxyError) {
 		statusCode = err.HTTPStatusCode
 	}
 	w.WriteHeader(statusCode)
+	payload := map[string]interface{}{
+		"message":   err.Error(),
+		"type":      "upstream_error",
+		"retryable": err.Retryable,
+	}
+	if err.Code != "" {
+		payload["code"] = err.Code
+	}
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"error": map[string]interface{}{
-			"message":   err.Error(),
-			"type":      "upstream_error",
-			"retryable": err.Retryable,
-		},
+		"error": payload,
 	})
 }
 
@@ -458,13 +462,17 @@ func writeStreamError(w http.ResponseWriter, err *domain.ProxyError) {
 	}
 	w.WriteHeader(statusCode)
 
+	payload := map[string]interface{}{
+		"message":   err.Error(),
+		"type":      "upstream_error",
+		"retryable": err.Retryable,
+	}
+	if err.Code != "" {
+		payload["code"] = err.Code
+	}
 	errorEvent := map[string]interface{}{
-		"type": "error",
-		"error": map[string]interface{}{
-			"message":   err.Error(),
-			"type":      "upstream_error",
-			"retryable": err.Retryable,
-		},
+		"type":  "error",
+		"error": payload,
 	}
 	data, _ := json.Marshal(errorEvent)
 	w.Write([]byte("data: "))

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -290,7 +290,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	r.mu.RUnlock()
 
 	if len(matched) == 0 {
-		return nil, domain.ErrNoRoutes
+		return nil, domain.ErrNoAvailableProviders
 	}
 
 	// Sticky / session-affinity layer. Only meaningful when:

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1111,14 +1111,101 @@ func TestProxyRouteWithoutConfiguredProviderDoesNotRecordRequest(t *testing.T) {
 
 	var payload map[string]map[string]any
 	DecodeJSON(t, resp, &payload)
+	if got := payload["error"]["code"]; got != "no_available_provider" {
+		t.Fatalf("error.code = %v, want no_available_provider", got)
+	}
 	msg, _ := payload["error"]["message"].(string)
-	if !strings.Contains(msg, "route match failed") || !strings.Contains(msg, "no routes available") {
-		t.Fatalf("error.message = %q, want to contain route match failed and no routes available", msg)
+	if !strings.Contains(msg, "no available provider") {
+		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
 	assertNoProxyRequestsRecorded(t, env)
 }
 
+func TestProxyMatchedRouteWithUnsupportedProviderModelDoesNotRecordRequest(t *testing.T) {
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-openai-model-filter", "http://127.0.0.1:1", []string{"openai"})
+
+	providerResp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", providerID), map[string]any{
+		"name":                 "mock-openai-model-filter",
+		"type":                 "custom",
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        []string{"only-this-model"},
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "http://127.0.0.1:1",
+				"apiKey":  "sk-mock-test-key",
+			},
+		},
+	})
+	AssertStatus(t, providerResp, http.StatusOK)
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusServiceUnavailable)
+
+	var payload map[string]map[string]any
+	DecodeJSON(t, resp, &payload)
+	if got := payload["error"]["code"]; got != "no_available_provider" {
+		t.Fatalf("error.code = %v, want no_available_provider", got)
+	}
+	msg, _ := payload["error"]["message"].(string)
+	if !strings.Contains(msg, "no available provider") {
+		t.Fatalf("error.message = %q, want to contain no available provider", msg)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func TestProxyMatchedRouteWithCooldownProviderDoesNotRecordAdditionalRequest(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "Rate limit exceeded",
+				"type":    "rate_limit_error",
+			},
+		})
+	}))
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-cooldown-provider", mock.URL, []string{"openai"})
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusTooManyRequests)
+	if got := len(getProxyRequests(t, env)); got != 1 {
+		t.Fatalf("expected first upstream failure to be recorded, got %d requests", got)
+	}
+
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusServiceUnavailable)
+
+	var payload map[string]map[string]any
+	DecodeJSON(t, resp, &payload)
+	if got := payload["error"]["code"]; got != "no_available_provider" {
+		t.Fatalf("error.code = %v, want no_available_provider", got)
+	}
+	msg, _ := payload["error"]["message"].(string)
+	if !strings.Contains(msg, "no available provider") {
+		t.Fatalf("error.message = %q, want to contain no available provider", msg)
+	}
+	if got := len(getProxyRequests(t, env)); got != 1 {
+		t.Fatalf("expected cooldown route-match rejection to stay out of requests tab, got %d requests", got)
+	}
+}
+
 func assertNoProxyRequestsRecorded(t *testing.T, env *ProxyTestEnv) {
+	t.Helper()
+
+	requests := getProxyRequests(t, env)
+	if len(requests) != 0 {
+		t.Fatalf("expected route-match rejection to stay out of requests tab, got %d requests: %#v", len(requests), requests)
+	}
+}
+
+func getProxyRequests(t *testing.T, env *ProxyTestEnv) []map[string]any {
 	t.Helper()
 
 	requestsResp := env.doRequest(http.MethodGet, "/api/admin/requests?limit=20", nil, env.Token)
@@ -1127,9 +1214,7 @@ func assertNoProxyRequestsRecorded(t *testing.T, env *ProxyTestEnv) {
 		Items []map[string]any `json:"items"`
 	}
 	DecodeJSON(t, requestsResp, &requests)
-	if len(requests.Items) != 0 {
-		t.Fatalf("expected route-match rejection to stay out of requests tab, got %d requests: %#v", len(requests.Items), requests.Items)
-	}
+	return requests.Items
 }
 
 func TestProxyCodexToGeminiStreamingSSE(t *testing.T) {


### PR DESCRIPTION
## Summary
- Skip request-record creation when a matched route cannot resolve any usable provider.
- Preserve `no_routes_available` behavior for requests with no configured route.
- Keep successful provider-backed requests recorded in Requests.

## Validation
- `go test ./tests/e2e -run 'TestProxy(NoMatchingRoute|RouteWithoutConfiguredProviderDoesNotRecordRequest|MatchedRouteWithUnsupportedProviderModelDoesNotRecordRequest|MatchedRouteWithCooldownProviderDoesNotRecordAdditionalRequest|UpstreamError)$' -count=1 -v`
- `pnpm build`
- `go test ./... -count=1`
- Manual local service check with Maxx + Vite UI + mock OpenAI upstream: three rejected requests left Requests at 0; after adding an available provider, a successful 200 response recorded exactly one request.

## Changed files
- `internal/domain/errors.go`
- `internal/router/router.go`
- `internal/executor/middleware_route_match.go`
- `internal/handler/proxy.go`
- `tests/e2e/proxy_integration_test.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 新增“没有可用提供方”的错误提示与错误码，前端/客户端可据此区分不同不可用原因。
  * 错误响应中可返回更明确的错误编码，便于展示和排查。

* **Bug Fixes**
  * 路由匹配失败时，按实际原因返回更准确的错误信息。
  * 当可用提供方不存在或处于冷却中时，不再继续记录请求。

* **Tests**
  * 增加了相关端到端测试，覆盖不可用提供方、冷却状态和请求记录行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->