### PR TITLE
[codex] add Codex reasoning guard retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,15 +378,15 @@ Configurable via Admin UI:
 | `timezone` | Timezone setting | `Asia/Shanghai` |
 | `quota_refresh_interval` | Antigravity quota refresh (minutes) | `0` (disabled) |
 | `auto_sort_antigravity` | Auto-sort Antigravity routes | `false` |
-| `codex_reasoning_guard` | Codex non-stream reasoning token guard retry config | see below |
+| `codex_reasoning_guard` | Codex non-stream reasoning token guard retry config | disabled by default |
 | `enable_pprof` | Enable pprof profiling | `false` |
 | `pprof_port` | Pprof server port | `6060` |
 | `pprof_password` | Pprof access password | (empty) |
 
-Codex reasoning guard retries the same route/provider before writing a non-stream
-Codex response to the client when `reasoning_tokens` matches a configured value.
-The default blocked values are `516`, `1034`, and `1552`; `max_attempts` counts
-the first upstream request.
+Codex reasoning guard is disabled by default. When enabled, it retries the same
+route/provider before writing a non-stream Codex response to the client when
+`reasoning_tokens` matches a configured value. The default blocked values are
+`516`, `1034`, and `1552`; `max_attempts` counts the first upstream request.
 
 ```bash
 maxx-cli settings set codex_reasoning_guard '{"enabled":true,"blocked_reasoning_tokens":[516,1034,1552],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}'

--- a/README.md
+++ b/README.md
@@ -378,9 +378,19 @@ Configurable via Admin UI:
 | `timezone` | Timezone setting | `Asia/Shanghai` |
 | `quota_refresh_interval` | Antigravity quota refresh (minutes) | `0` (disabled) |
 | `auto_sort_antigravity` | Auto-sort Antigravity routes | `false` |
+| `codex_reasoning_guard` | Codex non-stream reasoning token guard retry config | see below |
 | `enable_pprof` | Enable pprof profiling | `false` |
 | `pprof_port` | Pprof server port | `6060` |
 | `pprof_password` | Pprof access password | (empty) |
+
+Codex reasoning guard retries the same route/provider before writing a non-stream
+Codex response to the client when `reasoning_tokens` matches a configured value.
+The default blocked values are `516`, `1034`, and `1552`; `max_attempts` counts
+the first upstream request.
+
+```bash
+maxx-cli settings set codex_reasoning_guard '{"enabled":true,"blocked_reasoning_tokens":[516,1034,1552],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}'
+```
 
 ### Database Configuration
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -364,9 +364,18 @@ MAXX_CORS_ALLOW_ORIGINS=https://ui.example.com,http://localhost:3000 maxx
 | `timezone` | 时区设置 | `Asia/Shanghai` |
 | `quota_refresh_interval` | Antigravity 配额刷新间隔（分钟） | `0`（禁用） |
 | `auto_sort_antigravity` | 自动排序 Antigravity 路由 | `false` |
+| `codex_reasoning_guard` | Codex 非流式 reasoning token guard retry 配置 | 见下方示例 |
 | `enable_pprof` | 启用 pprof 性能分析 | `false` |
 | `pprof_port` | pprof 服务端口 | `6060` |
 | `pprof_password` | pprof 访问密码 | （空） |
+
+Codex reasoning guard 会在非流式 Codex 响应写回客户端之前检查
+`reasoning_tokens`。命中配置值时，maxx 会对同一路由/供应商重新发起一次上游请求。
+默认拦截值为 `516`、`1034`、`1552`；`max_attempts` 包含首次上游请求。
+
+```bash
+maxx-cli settings set codex_reasoning_guard '{"enabled":true,"blocked_reasoning_tokens":[516,1034,1552],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}'
+```
 
 ### 数据库配置
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -364,12 +364,12 @@ MAXX_CORS_ALLOW_ORIGINS=https://ui.example.com,http://localhost:3000 maxx
 | `timezone` | 时区设置 | `Asia/Shanghai` |
 | `quota_refresh_interval` | Antigravity 配额刷新间隔（分钟） | `0`（禁用） |
 | `auto_sort_antigravity` | 自动排序 Antigravity 路由 | `false` |
-| `codex_reasoning_guard` | Codex 非流式 reasoning token guard retry 配置 | 见下方示例 |
+| `codex_reasoning_guard` | Codex 非流式 reasoning token guard retry 配置 | 默认关闭 |
 | `enable_pprof` | 启用 pprof 性能分析 | `false` |
 | `pprof_port` | pprof 服务端口 | `6060` |
 | `pprof_password` | pprof 访问密码 | （空） |
 
-Codex reasoning guard 会在非流式 Codex 响应写回客户端之前检查
+Codex reasoning guard 默认关闭。启用后，它会在非流式 Codex 响应写回客户端之前检查
 `reasoning_tokens`。命中配置值时，maxx 会对同一路由/供应商重新发起一次上游请求。
 默认拦截值为 `516`、`1034`、`1552`；`max_attempts` 包含首次上游请求。
 

--- a/internal/adapter/provider/cliproxyapi_codex/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/awsl-project/CLIProxyAPI/v7/sdk/exec"
 	"github.com/awsl-project/CLIProxyAPI/v7/sdk/translator"
 	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/payloadoverride"
@@ -335,10 +336,42 @@ func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseW
 		}
 	}
 
+	if proxyErr := codexReasoningGuardProxyError(c, resp.Payload); proxyErr != nil {
+		return proxyErr
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(resp.Payload)
 
+	return nil
+}
+
+func codexReasoningGuardProxyError(c *flow.Ctx, body []byte) *domain.ProxyError {
+	v, ok := c.Get(flow.KeyCodexReasoningGuard)
+	if !ok {
+		return nil
+	}
+	cfg, ok := v.(codexguard.Config)
+	if !ok || !cfg.Enabled || cfg.Mode != codexguard.ModeNonStream {
+		return nil
+	}
+
+	tokens, err := codexguard.ExtractReasoningTokensFromJSON(body)
+	if err != nil {
+		log.Printf("[CLIProxyAPI-Codex] reasoning guard skipped invalid JSON response: %v", err)
+		return nil
+	}
+	for _, token := range tokens {
+		if codexguard.IsBlockedToken(token, cfg.BlockedReasoningTokens) {
+			guardErr := codexguard.NewReasoningGuardError(token, cfg)
+			proxyErr := domain.NewProxyErrorWithMessage(guardErr, false, "codex reasoning guard triggered")
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.HTTPStatusCode = guardErr.StatusCode
+			proxyErr.Code = guardErr.ErrorCode
+			return proxyErr
+		}
+	}
 	return nil
 }
 

--- a/internal/adapter/provider/cliproxyapi_codex/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter.go
@@ -313,6 +313,10 @@ func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseW
 		return proxyErr
 	}
 
+	if proxyErr := codexReasoningGuardProxyError(c, resp.Payload); proxyErr != nil {
+		return proxyErr
+	}
+
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
 		// Send response info
 		eventChan.SendResponseInfo(&domain.ResponseInfo{
@@ -334,10 +338,6 @@ func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseW
 		if model := extractModelFromResponse(resp.Payload); model != "" {
 			eventChan.SendResponseModel(model)
 		}
-	}
-
-	if proxyErr := codexReasoningGuardProxyError(c, resp.Payload); proxyErr != nil {
-		return proxyErr
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
@@ -40,7 +40,9 @@ func TestCodexReasoningGuardProxyError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
-	ctx.Set(flow.KeyCodexReasoningGuard, codexguard.DefaultConfig())
+	cfg := codexguard.DefaultConfig()
+	cfg.Enabled = true
+	ctx.Set(flow.KeyCodexReasoningGuard, cfg)
 
 	err := codexReasoningGuardProxyError(ctx, []byte(`{"usage":{"output_tokens_details":{"reasoning_tokens":516}}}`))
 	if err == nil {

--- a/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
@@ -1,9 +1,13 @@
 package cliproxyapi_codex
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
 )
 
 func TestNewAdapterSetsBaseURLAttribute(t *testing.T) {
@@ -29,5 +33,39 @@ func TestNewAdapterSetsBaseURLAttribute(t *testing.T) {
 
 	if got := adapter.authObj.Attributes["base_url"]; got != "https://mock.example.test/codex" {
 		t.Fatalf("expected base_url attribute to be trimmed provider base URL, got %q", got)
+	}
+}
+
+func TestCodexReasoningGuardProxyError(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyCodexReasoningGuard, codexguard.DefaultConfig())
+
+	err := codexReasoningGuardProxyError(ctx, []byte(`{"usage":{"output_tokens_details":{"reasoning_tokens":516}}}`))
+	if err == nil {
+		t.Fatalf("expected reasoning guard proxy error")
+	}
+	if !codexguard.IsReasoningGuardError(err) {
+		t.Fatalf("expected reasoning guard error, got %v", err)
+	}
+	if err.HTTPStatusCode != http.StatusBadGateway {
+		t.Fatalf("HTTPStatusCode = %d, want %d", err.HTTPStatusCode, http.StatusBadGateway)
+	}
+	if err.Code != codexguard.DefaultErrorCode {
+		t.Fatalf("Code = %q, want %q", err.Code, codexguard.DefaultErrorCode)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("expected helper not to write client body, got %q", rec.Body.String())
+	}
+}
+
+func TestCodexReasoningGuardProxyErrorNoMatch(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	ctx := flow.NewCtx(httptest.NewRecorder(), req)
+	ctx.Set(flow.KeyCodexReasoningGuard, codexguard.DefaultConfig())
+
+	if err := codexReasoningGuardProxyError(ctx, []byte(`{"usage":{"output_tokens_details":{"reasoning_tokens":128}}}`)); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
 	cliproxyapi "github.com/awsl-project/maxx/internal/adapter/provider/cliproxyapi_codex"
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/codexutil"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -547,11 +548,43 @@ func (a *CodexAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response)
 		}
 	}
 
+	if proxyErr := codexReasoningGuardProxyError(c, body); proxyErr != nil {
+		return proxyErr
+	}
+
 	// Copy response headers
 	copyResponseHeaders(c.Writer.Header(), resp.Header)
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
 	_, _ = c.Writer.Write(body)
+	return nil
+}
+
+func codexReasoningGuardProxyError(c *flow.Ctx, body []byte) *domain.ProxyError {
+	v, ok := c.Get(flow.KeyCodexReasoningGuard)
+	if !ok {
+		return nil
+	}
+	cfg, ok := v.(codexguard.Config)
+	if !ok || !cfg.Enabled || cfg.Mode != codexguard.ModeNonStream {
+		return nil
+	}
+
+	tokens, err := codexguard.ExtractReasoningTokensFromJSON(body)
+	if err != nil {
+		log.Printf("[Codex] reasoning guard skipped invalid JSON response: %v", err)
+		return nil
+	}
+	for _, token := range tokens {
+		if codexguard.IsBlockedToken(token, cfg.BlockedReasoningTokens) {
+			guardErr := codexguard.NewReasoningGuardError(token, cfg)
+			proxyErr := domain.NewProxyErrorWithMessage(guardErr, false, "codex reasoning guard triggered")
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.HTTPStatusCode = guardErr.StatusCode
+			proxyErr.Code = guardErr.ErrorCode
+			return proxyErr
+		}
+	}
 	return nil
 }
 

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -526,6 +526,10 @@ func (a *CodexAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response)
 		return proxyErr
 	}
 
+	if proxyErr := codexReasoningGuardProxyError(c, body); proxyErr != nil {
+		return proxyErr
+	}
+
 	// Send events via EventChannel
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
 		eventChan.SendResponseInfo(&domain.ResponseInfo{
@@ -546,10 +550,6 @@ func (a *CodexAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response)
 		if model := extractModelFromResponse(body); model != "" {
 			eventChan.SendResponseModel(model)
 		}
-	}
-
-	if proxyErr := codexReasoningGuardProxyError(c, body); proxyErr != nil {
-		return proxyErr
 	}
 
 	// Copy response headers

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -533,6 +534,32 @@ func TestHandleNonStreamResponseForwardsCacheReadCount(t *testing.T) {
 	}
 	if metrics.CacheReadCount != 80 {
 		t.Fatalf("expected CacheReadCount=80, got %d", metrics.CacheReadCount)
+	}
+}
+
+func TestHandleNonStreamResponseReturnsReasoningGuardBeforeWritingClient(t *testing.T) {
+	a := &CodexAdapter{}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyCodexReasoningGuard, codexguard.DefaultConfig())
+
+	body := `{"id":"resp_1","object":"response","model":"gpt-5","usage":{"output_tokens_details":{"reasoning_tokens":516}}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+
+	err := a.handleNonStreamResponse(ctx, resp)
+	if err == nil {
+		t.Fatalf("expected reasoning guard error")
+	}
+	if !codexguard.IsReasoningGuardError(err) {
+		t.Fatalf("expected reasoning guard error, got %v", err)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("expected no client body before guard retry, got %q", rec.Body.String())
 	}
 }
 

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -542,7 +542,9 @@ func TestHandleNonStreamResponseReturnsReasoningGuardBeforeWritingClient(t *test
 	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
-	ctx.Set(flow.KeyCodexReasoningGuard, codexguard.DefaultConfig())
+	cfg := codexguard.DefaultConfig()
+	cfg.Enabled = true
+	ctx.Set(flow.KeyCodexReasoningGuard, cfg)
 
 	body := `{"id":"resp_1","object":"response","model":"gpt-5","usage":{"output_tokens_details":{"reasoning_tokens":516}}}`
 	resp := &http.Response{

--- a/internal/codexguard/codexguard.go
+++ b/internal/codexguard/codexguard.go
@@ -37,7 +37,7 @@ func DefaultConfig() Config {
 	blocked := append([]int(nil), defaultBlockedReasoningTokens...)
 
 	return Config{
-		Enabled:                true,
+		Enabled:                false,
 		BlockedReasoningTokens: blocked,
 		MaxAttempts:            2,
 		StatusCode:             DefaultStatusCode,

--- a/internal/codexguard/codexguard.go
+++ b/internal/codexguard/codexguard.go
@@ -112,7 +112,12 @@ func ExtractReasoningTokensFromJSON(data []byte) ([]int, error) {
 	if err := dec.Decode(&payload); err != nil {
 		return nil, fmt.Errorf("parse reasoning token JSON: %w", err)
 	}
-	if dec.More() {
+
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("parse reasoning token JSON: %w", err)
+		}
 		return nil, errors.New("parse reasoning token JSON: trailing data")
 	}
 

--- a/internal/codexguard/codexguard.go
+++ b/internal/codexguard/codexguard.go
@@ -1,0 +1,327 @@
+package codexguard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	ModeNonStream = "non_stream"
+
+	DefaultStatusCode = 502
+	DefaultErrorCode  = "reasoning_guard_triggered"
+)
+
+var (
+	defaultBlockedReasoningTokens = []int{516, 1034, 1552}
+
+	ErrReasoningGuardTriggered = errors.New("reasoning guard triggered")
+)
+
+type Config struct {
+	Enabled                bool   `json:"enabled"`
+	BlockedReasoningTokens []int  `json:"blocked_reasoning_tokens"`
+	MaxAttempts            int    `json:"max_attempts"`
+	StatusCode             int    `json:"status_code"`
+	ErrorCode              string `json:"error_code"`
+	Mode                   string `json:"mode"`
+}
+
+func DefaultConfig() Config {
+	blocked := append([]int(nil), defaultBlockedReasoningTokens...)
+
+	return Config{
+		Enabled:                true,
+		BlockedReasoningTokens: blocked,
+		MaxAttempts:            2,
+		StatusCode:             DefaultStatusCode,
+		ErrorCode:              DefaultErrorCode,
+		Mode:                   ModeNonStream,
+	}
+}
+
+func ParseConfigJSON(data []byte) (Config, error) {
+	cfg := DefaultConfig()
+	if len(bytes.TrimSpace(data)) == 0 {
+		return cfg, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, fmt.Errorf("parse codexguard config: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return Config{}, fmt.Errorf("parse codexguard config: %w", err)
+		}
+		return Config{}, errors.New("parse codexguard config: trailing JSON value")
+	}
+	if err := ValidateConfig(cfg); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func ValidateConfig(cfg Config) error {
+	if cfg.MaxAttempts < 1 {
+		return fmt.Errorf("invalid max_attempts %d: must be >= 1", cfg.MaxAttempts)
+	}
+	if cfg.StatusCode < 400 || cfg.StatusCode > 599 {
+		return fmt.Errorf("invalid status_code %d: must be in [400, 599]", cfg.StatusCode)
+	}
+	if strings.TrimSpace(cfg.ErrorCode) == "" {
+		return errors.New("invalid error_code: must not be empty")
+	}
+	if cfg.Mode != ModeNonStream {
+		return fmt.Errorf("invalid mode %q: must be %q", cfg.Mode, ModeNonStream)
+	}
+	if cfg.MaxAttempts > 10 {
+		return fmt.Errorf("invalid max_attempts %d: must be <= 10", cfg.MaxAttempts)
+	}
+	if cfg.Enabled && len(cfg.BlockedReasoningTokens) == 0 {
+		return errors.New("invalid blocked_reasoning_tokens: must not be empty when enabled")
+	}
+	seen := make(map[int]struct{}, len(cfg.BlockedReasoningTokens))
+	for _, token := range cfg.BlockedReasoningTokens {
+		if token < 0 {
+			return fmt.Errorf("invalid blocked_reasoning_tokens entry %d: must be >= 0", token)
+		}
+		if _, ok := seen[token]; ok {
+			return fmt.Errorf("invalid blocked_reasoning_tokens entry %d: duplicate value", token)
+		}
+		seen[token] = struct{}{}
+	}
+
+	return nil
+}
+
+func ExtractReasoningTokensFromJSON(data []byte) ([]int, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	var payload any
+	if err := dec.Decode(&payload); err != nil {
+		return nil, fmt.Errorf("parse reasoning token JSON: %w", err)
+	}
+	if dec.More() {
+		return nil, errors.New("parse reasoning token JSON: trailing data")
+	}
+
+	var tokens []int
+	if err := collectReasoningTokens(payload, &tokens); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}
+
+func collectReasoningTokens(value any, tokens *[]int) error {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			if key == "reasoning_tokens" {
+				if err := appendReasoningTokenValue(nested, tokens); err != nil {
+					return err
+				}
+			}
+			if err := collectReasoningTokens(nested, tokens); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, nested := range typed {
+			if err := collectReasoningTokens(nested, tokens); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func appendReasoningTokenValue(value any, tokens *[]int) error {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case json.Number:
+		token, err := parseReasoningTokenNumber(typed.String())
+		if err != nil {
+			return err
+		}
+		*tokens = append(*tokens, token)
+	case string:
+		token, err := parseReasoningTokenNumber(strings.TrimSpace(typed))
+		if err != nil {
+			return err
+		}
+		*tokens = append(*tokens, token)
+	case []any:
+		for _, nested := range typed {
+			if err := appendReasoningTokenValue(nested, tokens); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		return collectReasoningTokens(typed, tokens)
+	default:
+		return fmt.Errorf("invalid reasoning_tokens value %T: want integer number or integer string", value)
+	}
+
+	return nil
+}
+
+func parseReasoningTokenNumber(raw string) (int, error) {
+	if raw == "" {
+		return 0, errors.New("invalid reasoning_tokens value: empty string")
+	}
+
+	parsed, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid reasoning_tokens value %q: %w", raw, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("invalid reasoning_tokens value %d: must be >= 0", parsed)
+	}
+	if parsed > int64(math.MaxInt) {
+		return 0, fmt.Errorf("invalid reasoning_tokens value %d: overflows int", parsed)
+	}
+
+	return int(parsed), nil
+}
+
+func IsBlockedToken(token int, blocked []int) bool {
+	for _, candidate := range blocked {
+		if token == candidate {
+			return true
+		}
+	}
+
+	return false
+}
+
+type ReasoningGuardError struct {
+	Token      int
+	StatusCode int
+	ErrorCode  string
+}
+
+func NewReasoningGuardError(token int, cfg Config) ReasoningGuardError {
+	return ReasoningGuardError{
+		Token:      token,
+		StatusCode: cfg.StatusCode,
+		ErrorCode:  cfg.ErrorCode,
+	}
+}
+
+func (e ReasoningGuardError) Error() string {
+	return fmt.Sprintf("%s: reasoning_tokens %d is blocked", e.ErrorCode, e.Token)
+}
+
+func (e ReasoningGuardError) Unwrap() error {
+	return ErrReasoningGuardTriggered
+}
+
+func IsReasoningGuardError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrReasoningGuardTriggered) {
+		return true
+	}
+
+	var guardErr ReasoningGuardError
+	return errors.As(err, &guardErr)
+}
+
+type SSEInspector struct {
+	cfg Config
+	buf string
+}
+
+func NewSSEInspector(cfg Config) (*SSEInspector, error) {
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	return &SSEInspector{cfg: cfg}, nil
+}
+
+func (i *SSEInspector) Inspect(chunk []byte) error {
+	if i == nil {
+		return errors.New("nil SSEInspector")
+	}
+	if !i.cfg.Enabled {
+		return nil
+	}
+
+	i.buf += string(chunk)
+	for {
+		idx := strings.IndexByte(i.buf, '\n')
+		if idx < 0 {
+			return nil
+		}
+
+		line := i.buf[:idx]
+		i.buf = i.buf[idx+1:]
+		if err := i.InspectLine(line); err != nil {
+			return err
+		}
+	}
+}
+
+func (i *SSEInspector) Flush() error {
+	if i == nil {
+		return errors.New("nil SSEInspector")
+	}
+	if !i.cfg.Enabled {
+		i.buf = ""
+		return nil
+	}
+	if i.buf == "" {
+		return nil
+	}
+
+	line := i.buf
+	i.buf = ""
+	return i.InspectLine(line)
+}
+
+func (i *SSEInspector) InspectLine(line string) error {
+	if i == nil {
+		return errors.New("nil SSEInspector")
+	}
+	if !i.cfg.Enabled {
+		return nil
+	}
+
+	line = strings.TrimRight(line, "\r")
+	if !strings.HasPrefix(line, "data:") {
+		return nil
+	}
+
+	data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+	if data == "" || data == "[DONE]" {
+		return nil
+	}
+
+	tokens, err := ExtractReasoningTokensFromJSON([]byte(data))
+	if err != nil {
+		return fmt.Errorf("inspect SSE data: %w", err)
+	}
+	for _, token := range tokens {
+		if IsBlockedToken(token, i.cfg.BlockedReasoningTokens) {
+			return NewReasoningGuardError(token, i.cfg)
+		}
+	}
+
+	return nil
+}

--- a/internal/codexguard/codexguard_test.go
+++ b/internal/codexguard/codexguard_test.go
@@ -1,0 +1,297 @@
+package codexguard
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if !cfg.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if !reflect.DeepEqual(cfg.BlockedReasoningTokens, []int{516, 1034, 1552}) {
+		t.Fatalf("BlockedReasoningTokens = %#v, want %#v", cfg.BlockedReasoningTokens, []int{516, 1034, 1552})
+	}
+	if cfg.MaxAttempts != 2 {
+		t.Fatalf("MaxAttempts = %d, want 2", cfg.MaxAttempts)
+	}
+	if cfg.StatusCode != 502 {
+		t.Fatalf("StatusCode = %d, want 502", cfg.StatusCode)
+	}
+	if cfg.ErrorCode != "reasoning_guard_triggered" {
+		t.Fatalf("ErrorCode = %q, want reasoning_guard_triggered", cfg.ErrorCode)
+	}
+	if cfg.Mode != "non_stream" {
+		t.Fatalf("Mode = %q, want non_stream", cfg.Mode)
+	}
+
+	cfg.BlockedReasoningTokens[0] = 999
+	next := DefaultConfig()
+	if next.BlockedReasoningTokens[0] != 516 {
+		t.Fatalf("DefaultConfig returned shared blocked token slice")
+	}
+}
+
+func TestParseConfigJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Config
+		wantErr bool
+	}{
+		{
+			name:  "empty uses defaults",
+			input: "",
+			want:  DefaultConfig(),
+		},
+		{
+			name: "partial override",
+			input: `{
+				"enabled": false,
+				"blocked_reasoning_tokens": [1, 2],
+				"max_attempts": 3,
+				"status_code": 503,
+				"error_code": "custom_guard",
+				"mode": "non_stream"
+			}`,
+			want: Config{
+				Enabled:                false,
+				BlockedReasoningTokens: []int{1, 2},
+				MaxAttempts:            3,
+				StatusCode:             503,
+				ErrorCode:              "custom_guard",
+				Mode:                   ModeNonStream,
+			},
+		},
+		{
+			name:    "invalid json",
+			input:   `{`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid config",
+			input:   `{"max_attempts":0}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseConfigJSON([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseConfigJSON returned nil error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseConfigJSON returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ParseConfigJSON = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	valid := DefaultConfig()
+	if err := ValidateConfig(valid); err != nil {
+		t.Fatalf("ValidateConfig(valid) returned error: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{
+			name: "max attempts",
+			mutate: func(cfg *Config) {
+				cfg.MaxAttempts = 0
+			},
+		},
+		{
+			name: "status code",
+			mutate: func(cfg *Config) {
+				cfg.StatusCode = 200
+			},
+		},
+		{
+			name: "error code",
+			mutate: func(cfg *Config) {
+				cfg.ErrorCode = " "
+			},
+		},
+		{
+			name: "mode",
+			mutate: func(cfg *Config) {
+				cfg.Mode = "batch"
+			},
+		},
+		{
+			name: "blocked token",
+			mutate: func(cfg *Config) {
+				cfg.BlockedReasoningTokens = []int{-1}
+			},
+		},
+		{
+			name: "empty blocked token",
+			mutate: func(cfg *Config) {
+				cfg.BlockedReasoningTokens = nil
+			},
+		},
+		{
+			name: "duplicate blocked token",
+			mutate: func(cfg *Config) {
+				cfg.BlockedReasoningTokens = []int{516, 516}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			tt.mutate(&cfg)
+			if err := ValidateConfig(cfg); err == nil {
+				t.Fatal("ValidateConfig returned nil error")
+			}
+		})
+	}
+}
+
+func TestExtractReasoningTokensFromJSON(t *testing.T) {
+	payload := []byte(`{
+		"id": "resp_123",
+		"usage": {
+			"output_tokens_details": {
+				"reasoning_tokens": 516
+			}
+		},
+		"choices": [
+			{
+				"message": {
+					"usage": {
+						"completion_tokens_details": {
+							"reasoning_tokens": "1034"
+						}
+					}
+				}
+			}
+		],
+		"nested": {
+			"reasoning_tokens": [1552, "7", null]
+		}
+	}`)
+
+	got, err := ExtractReasoningTokensFromJSON(payload)
+	if err != nil {
+		t.Fatalf("ExtractReasoningTokensFromJSON returned error: %v", err)
+	}
+	want := []int{516, 1034, 1552, 7}
+	slices.Sort(got)
+	slices.Sort(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExtractReasoningTokensFromJSON = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtractReasoningTokensFromJSONNoMatch(t *testing.T) {
+	got, err := ExtractReasoningTokensFromJSON([]byte(`{"usage":{"output_tokens":5}}`))
+	if err != nil {
+		t.Fatalf("ExtractReasoningTokensFromJSON returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ExtractReasoningTokensFromJSON = %#v, want empty slice", got)
+	}
+}
+
+func TestExtractReasoningTokensFromJSONInvalidReasoningToken(t *testing.T) {
+	if _, err := ExtractReasoningTokensFromJSON([]byte(`{"reasoning_tokens":"1.5"}`)); err == nil {
+		t.Fatal("ExtractReasoningTokensFromJSON returned nil error")
+	}
+}
+
+func TestIsBlockedToken(t *testing.T) {
+	blocked := []int{516, 1034, 1552}
+
+	if !IsBlockedToken(1034, blocked) {
+		t.Fatal("IsBlockedToken(1034) = false, want true")
+	}
+	if IsBlockedToken(42, blocked) {
+		t.Fatal("IsBlockedToken(42) = true, want false")
+	}
+}
+
+func TestSSEInspectorMultipleData(t *testing.T) {
+	inspector, err := NewSSEInspector(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSSEInspector returned error: %v", err)
+	}
+
+	stream := "" +
+		"event: response.output_text.delta\n" +
+		"data: {\"usage\":{\"output_tokens_details\":{\"reasoning_tokens\":42}}}\n\n" +
+		"data: [DONE]\n" +
+		"data: {\"choices\":[{\"usage\":{\"completion_tokens_details\":{\"reasoning_tokens\":\"1034\"}}}]}\n"
+
+	err = inspector.Inspect([]byte(stream))
+	if err == nil {
+		t.Fatal("Inspect returned nil error")
+	}
+	if !IsReasoningGuardError(err) {
+		t.Fatalf("Inspect error = %v, want reasoning guard error", err)
+	}
+
+	var guardErr ReasoningGuardError
+	if !errors.As(err, &guardErr) {
+		t.Fatalf("errors.As failed for %T", err)
+	}
+	if guardErr.Token != 1034 {
+		t.Fatalf("guardErr.Token = %d, want 1034", guardErr.Token)
+	}
+}
+
+func TestSSEInspectorNoHitAndFlush(t *testing.T) {
+	inspector, err := NewSSEInspector(DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewSSEInspector returned error: %v", err)
+	}
+
+	if err := inspector.Inspect([]byte("data: {\"reasoning_tokens\":42}")); err != nil {
+		t.Fatalf("Inspect returned error before complete line: %v", err)
+	}
+	if err := inspector.Flush(); err != nil {
+		t.Fatalf("Flush returned error: %v", err)
+	}
+}
+
+func TestSSEInspectorDisabled(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Enabled = false
+
+	inspector, err := NewSSEInspector(cfg)
+	if err != nil {
+		t.Fatalf("NewSSEInspector returned error: %v", err)
+	}
+	if err := inspector.Inspect([]byte("data: {\"reasoning_tokens\":516}\n")); err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+}
+
+func TestReasoningGuardErrorSentinel(t *testing.T) {
+	err := NewReasoningGuardError(516, DefaultConfig())
+
+	if !IsReasoningGuardError(err) {
+		t.Fatal("IsReasoningGuardError returned false")
+	}
+	if !errors.Is(err, ErrReasoningGuardTriggered) {
+		t.Fatal("errors.Is(err, ErrReasoningGuardTriggered) returned false")
+	}
+	if IsReasoningGuardError(errors.New("other")) {
+		t.Fatal("IsReasoningGuardError(other) returned true")
+	}
+}

--- a/internal/codexguard/codexguard_test.go
+++ b/internal/codexguard/codexguard_test.go
@@ -215,6 +215,21 @@ func TestExtractReasoningTokensFromJSONInvalidReasoningToken(t *testing.T) {
 	}
 }
 
+func TestExtractReasoningTokensFromJSONRejectsTrailingData(t *testing.T) {
+	tests := []string{
+		`{"reasoning_tokens":516} {"reasoning_tokens":1034}`,
+		`{"reasoning_tokens":516}]`,
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, err := ExtractReasoningTokensFromJSON([]byte(input)); err == nil {
+				t.Fatal("ExtractReasoningTokensFromJSON returned nil error")
+			}
+		})
+	}
+}
+
 func TestIsBlockedToken(t *testing.T) {
 	blocked := []int{516, 1034, 1552}
 

--- a/internal/codexguard/codexguard_test.go
+++ b/internal/codexguard/codexguard_test.go
@@ -10,8 +10,8 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
 
-	if !cfg.Enabled {
-		t.Fatal("Enabled = false, want true")
+	if cfg.Enabled {
+		t.Fatal("Enabled = true, want false")
 	}
 	if !reflect.DeepEqual(cfg.BlockedReasoningTokens, []int{516, 1034, 1552}) {
 		t.Fatalf("BlockedReasoningTokens = %#v, want %#v", cfg.BlockedReasoningTokens, []int{516, 1034, 1552})
@@ -139,8 +139,9 @@ func TestValidateConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "empty blocked token",
+			name: "empty blocked token when enabled",
 			mutate: func(cfg *Config) {
+				cfg.Enabled = true
 				cfg.BlockedReasoningTokens = nil
 			},
 		},
@@ -242,7 +243,9 @@ func TestIsBlockedToken(t *testing.T) {
 }
 
 func TestSSEInspectorMultipleData(t *testing.T) {
-	inspector, err := NewSSEInspector(DefaultConfig())
+	cfg := DefaultConfig()
+	cfg.Enabled = true
+	inspector, err := NewSSEInspector(cfg)
 	if err != nil {
 		t.Fatalf("NewSSEInspector returned error: %v", err)
 	}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -778,6 +778,7 @@ const (
 	SettingKeyAutoSortAntigravity                  = "auto_sort_antigravity"                    // 是否自动排序 Antigravity 路由，"true" 或 "false"
 	SettingKeyAutoSortCodex                        = "auto_sort_codex"                          // 是否自动排序 Codex 路由，"true" 或 "false"
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"
+	SettingKeyCodexReasoningGuard                  = "codex_reasoning_guard"                    // Codex reasoning guard 配置（JSON 对象）
 	SettingKeyPayloadOverrideRules                 = "payload_override_rules"                   // 请求 payload 覆盖规则（JSON 数组）
 	SettingKeyEnablePprof                          = "enable_pprof"                             // 是否启用 pprof 性能分析，"true" 或 "false"，默认 "false"
 	SettingKeyPprofPort                            = "pprof_port"                               // pprof 服务端口，默认 6060

--- a/internal/executor/codex_guard.go
+++ b/internal/executor/codex_guard.go
@@ -1,0 +1,36 @@
+package executor
+
+import (
+	"log"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/codexguard"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func (e *Executor) getCodexGuardConfig() codexguard.Config {
+	cfg := codexguard.DefaultConfig()
+	if e == nil || e.settingsRepo == nil {
+		return cfg
+	}
+
+	raw, err := e.settingsRepo.Get(domain.SettingKeyCodexReasoningGuard)
+	if err != nil {
+		log.Printf("[Executor] failed to load %s setting, using defaults: %v", domain.SettingKeyCodexReasoningGuard, err)
+		return cfg
+	}
+	if strings.TrimSpace(raw) == "" {
+		return cfg
+	}
+
+	parsed, err := codexguard.ParseConfigJSON([]byte(raw))
+	if err != nil {
+		log.Printf("[Executor] invalid %s setting, using defaults: %v", domain.SettingKeyCodexReasoningGuard, err)
+		return cfg
+	}
+	return parsed
+}
+
+func shouldRetryCodexGuard(err error, cfg codexguard.Config, guardFailures int) bool {
+	return cfg.Enabled && codexguard.IsReasoningGuardError(err) && guardFailures < cfg.MaxAttempts
+}

--- a/internal/executor/codex_guard.go
+++ b/internal/executor/codex_guard.go
@@ -16,8 +16,8 @@ func (e *Executor) getCodexGuardConfig() codexguard.Config {
 
 	raw, err := e.settingsRepo.Get(domain.SettingKeyCodexReasoningGuard)
 	if err != nil {
-		log.Printf("[Executor] failed to load %s setting, using defaults: %v", domain.SettingKeyCodexReasoningGuard, err)
-		return cfg
+		log.Printf("[Executor] failed to load %s setting, disabling guard: %v", domain.SettingKeyCodexReasoningGuard, err)
+		return disabledCodexGuardConfig()
 	}
 	if strings.TrimSpace(raw) == "" {
 		return cfg
@@ -25,10 +25,16 @@ func (e *Executor) getCodexGuardConfig() codexguard.Config {
 
 	parsed, err := codexguard.ParseConfigJSON([]byte(raw))
 	if err != nil {
-		log.Printf("[Executor] invalid %s setting, using defaults: %v", domain.SettingKeyCodexReasoningGuard, err)
-		return cfg
+		log.Printf("[Executor] invalid %s setting, disabling guard: %v", domain.SettingKeyCodexReasoningGuard, err)
+		return disabledCodexGuardConfig()
 	}
 	return parsed
+}
+
+func disabledCodexGuardConfig() codexguard.Config {
+	cfg := codexguard.DefaultConfig()
+	cfg.Enabled = false
+	return cfg
 }
 
 func shouldRetryCodexGuard(err error, cfg codexguard.Config, guardFailures int) bool {

--- a/internal/executor/codex_guard_test.go
+++ b/internal/executor/codex_guard_test.go
@@ -174,8 +174,8 @@ func TestGetCodexGuardConfig(t *testing.T) {
 
 		got := e.getCodexGuardConfig()
 
-		if !got.Enabled {
-			t.Fatal("Enabled = false, want true")
+		if got.Enabled {
+			t.Fatal("Enabled = true, want false")
 		}
 		if got.MaxAttempts != codexguard.DefaultConfig().MaxAttempts {
 			t.Fatalf("MaxAttempts = %d, want default", got.MaxAttempts)
@@ -210,7 +210,7 @@ func TestDispatchRetriesCodexReasoningGuardWithoutOrdinaryRetryBudget(t *testing
 	proxyRepo := &codexGuardProxyRequestRepo{}
 	attemptRepo := &recordingAttemptRepo{}
 	adapter := &codexGuardSequenceAdapter{errors: []error{guardErr}}
-	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, nil)
+	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, enabledCodexGuardSettings())
 
 	c := newCodexGuardDispatchCtx(adapter)
 	e.dispatch(c)
@@ -243,7 +243,7 @@ func TestDispatchStopsAfterCodexReasoningGuardAttemptsExhausted(t *testing.T) {
 	proxyRepo := &codexGuardProxyRequestRepo{}
 	attemptRepo := &recordingAttemptRepo{}
 	adapter := &codexGuardSequenceAdapter{errors: []error{guardErr, guardErr}}
-	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, nil)
+	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, enabledCodexGuardSettings())
 
 	c := newCodexGuardDispatchCtx(adapter)
 	e.dispatch(c)
@@ -272,6 +272,12 @@ func TestDispatchStopsAfterCodexReasoningGuardAttemptsExhausted(t *testing.T) {
 	}
 	if last.StatusCode != 502 {
 		t.Fatalf("final proxy request status code = %d, want 502", last.StatusCode)
+	}
+}
+
+func enabledCodexGuardSettings() map[string]string {
+	return map[string]string{
+		domain.SettingKeyCodexReasoningGuard: `{"enabled":true,"blocked_reasoning_tokens":[516,1034,1552],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`,
 	}
 }
 

--- a/internal/executor/codex_guard_test.go
+++ b/internal/executor/codex_guard_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -97,9 +98,13 @@ func (r *codexGuardProxyRequestRepo) ClearDetailOlderThan(time.Time, []string) (
 
 type codexGuardSettingsRepo struct {
 	values map[string]string
+	getErr error
 }
 
 func (r *codexGuardSettingsRepo) Get(key string) (string, error) {
+	if r.getErr != nil {
+		return "", r.getErr
+	}
 	if r.values == nil {
 		return "", nil
 	}
@@ -161,6 +166,43 @@ func (a *codexGuardSequenceAdapter) Execute(c *flow.Ctx, _ *domain.Provider) err
 	c.Writer.WriteHeader(http.StatusOK)
 	_, _ = c.Writer.Write([]byte(`{"ok":true}`))
 	return nil
+}
+
+func TestGetCodexGuardConfig(t *testing.T) {
+	t.Run("unset uses defaults", func(t *testing.T) {
+		e := &Executor{settingsRepo: &codexGuardSettingsRepo{}}
+
+		got := e.getCodexGuardConfig()
+
+		if !got.Enabled {
+			t.Fatal("Enabled = false, want true")
+		}
+		if got.MaxAttempts != codexguard.DefaultConfig().MaxAttempts {
+			t.Fatalf("MaxAttempts = %d, want default", got.MaxAttempts)
+		}
+	})
+
+	t.Run("settings read error disables guard", func(t *testing.T) {
+		e := &Executor{settingsRepo: &codexGuardSettingsRepo{getErr: errors.New("read failed")}}
+
+		got := e.getCodexGuardConfig()
+
+		if got.Enabled {
+			t.Fatal("Enabled = true, want false")
+		}
+	})
+
+	t.Run("invalid stored config disables guard", func(t *testing.T) {
+		e := &Executor{settingsRepo: &codexGuardSettingsRepo{values: map[string]string{
+			domain.SettingKeyCodexReasoningGuard: `{"max_attempts":0}`,
+		}}}
+
+		got := e.getCodexGuardConfig()
+
+		if got.Enabled {
+			t.Fatal("Enabled = true, want false")
+		}
+	})
 }
 
 func TestDispatchRetriesCodexReasoningGuardWithoutOrdinaryRetryBudget(t *testing.T) {

--- a/internal/executor/codex_guard_test.go
+++ b/internal/executor/codex_guard_test.go
@@ -1,0 +1,288 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/codexguard"
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type codexGuardProxyRequestRepo struct {
+	updated []*domain.ProxyRequest
+}
+
+func (r *codexGuardProxyRequestRepo) Create(req *domain.ProxyRequest) error { return nil }
+
+func (r *codexGuardProxyRequestRepo) Update(req *domain.ProxyRequest) error {
+	snap := *req
+	r.updated = append(r.updated, &snap)
+	return nil
+}
+
+func (r *codexGuardProxyRequestRepo) GetByID(uint64, uint64) (*domain.ProxyRequest, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) List(uint64, int, int) ([]*domain.ProxyRequest, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) ListCursor(uint64, int, uint64, uint64, *repository.ProxyRequestFilter) ([]*domain.ProxyRequest, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) ListActive(uint64) ([]*domain.ProxyRequest, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) Count(uint64) (int64, error) { return 0, nil }
+
+func (r *codexGuardProxyRequestRepo) CountWithFilter(uint64, *repository.ProxyRequestFilter) (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) GetErrorStats(uint64, *repository.ProxyRequestFilter) (*repository.ProxyRequestErrorStats, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) UpdateProjectIDBySessionID(uint64, string, uint64) (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) MarkStaleAsFailed([]string) (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) FixFailedRequestsWithoutEndTime() (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) DeleteOlderThan(time.Time) (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) HasRecentRequests(time.Time) (bool, error) {
+	return false, nil
+}
+
+func (r *codexGuardProxyRequestRepo) GetProjectUsageSummaries(uint64, time.Time, ...uint64) (map[uint64]domain.ProjectUsageSummary, error) {
+	return nil, nil
+}
+
+func (r *codexGuardProxyRequestRepo) UpdateCost(uint64, uint64) error { return nil }
+
+func (r *codexGuardProxyRequestRepo) UpdateCostAtomically(uint64, uint64, map[uint64]domain.AttemptCostUpdate) error {
+	return nil
+}
+
+func (r *codexGuardProxyRequestRepo) RecalculateCostsFromAttempts() (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) RecalculateCostsFromAttemptsWithProgress(chan<- domain.Progress) (int64, error) {
+	return 0, nil
+}
+
+func (r *codexGuardProxyRequestRepo) ClearDetailOlderThan(time.Time, []string) (int64, error) {
+	return 0, nil
+}
+
+type codexGuardSettingsRepo struct {
+	values map[string]string
+}
+
+func (r *codexGuardSettingsRepo) Get(key string) (string, error) {
+	if r.values == nil {
+		return "", nil
+	}
+	return r.values[key], nil
+}
+
+func (r *codexGuardSettingsRepo) Set(key, value string) error {
+	if r.values == nil {
+		r.values = map[string]string{}
+	}
+	r.values[key] = value
+	return nil
+}
+
+func (r *codexGuardSettingsRepo) GetAll() ([]*domain.SystemSetting, error) { return nil, nil }
+
+func (r *codexGuardSettingsRepo) Delete(key string) error { return nil }
+
+type codexGuardModelMappingRepo struct{}
+
+func (r *codexGuardModelMappingRepo) Create(*domain.ModelMapping) error { return nil }
+func (r *codexGuardModelMappingRepo) Update(*domain.ModelMapping) error { return nil }
+func (r *codexGuardModelMappingRepo) Delete(uint64, uint64) error       { return nil }
+func (r *codexGuardModelMappingRepo) GetByID(uint64, uint64) (*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *codexGuardModelMappingRepo) List(uint64) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *codexGuardModelMappingRepo) ListEnabled(uint64) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *codexGuardModelMappingRepo) ListByClientType(uint64, domain.ClientType) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *codexGuardModelMappingRepo) ListByQuery(uint64, *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *codexGuardModelMappingRepo) Count(uint64) (int, error) { return 0, nil }
+func (r *codexGuardModelMappingRepo) DeleteAll(uint64) error    { return nil }
+func (r *codexGuardModelMappingRepo) ClearAll(uint64) error     { return nil }
+func (r *codexGuardModelMappingRepo) SeedDefaults(uint64) error { return nil }
+
+type codexGuardSequenceAdapter struct {
+	errors []error
+	calls  int
+}
+
+func (a *codexGuardSequenceAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeCodex}
+}
+
+func (a *codexGuardSequenceAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	if a.calls <= len(a.errors) && a.errors[a.calls-1] != nil {
+		return a.errors[a.calls-1]
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(`{"ok":true}`))
+	return nil
+}
+
+func TestDispatchRetriesCodexReasoningGuardWithoutOrdinaryRetryBudget(t *testing.T) {
+	guardErr := newTestCodexGuardProxyError()
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	adapter := &codexGuardSequenceAdapter{errors: []error{guardErr}}
+	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, nil)
+
+	c := newCodexGuardDispatchCtx(adapter)
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	}
+	if got := attemptRepo.updated[0].Status; got != "FAILED" {
+		t.Fatalf("first attempt status = %q, want FAILED", got)
+	}
+	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "COMPLETED" {
+		t.Fatalf("final attempt status = %q, want COMPLETED", got)
+	}
+	if body := c.Writer.(*httptest.ResponseRecorder).Body.String(); body != `{"ok":true}` {
+		t.Fatalf("client body = %q, want success body", body)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchStopsAfterCodexReasoningGuardAttemptsExhausted(t *testing.T) {
+	guardErr := newTestCodexGuardProxyError()
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	adapter := &codexGuardSequenceAdapter{errors: []error{guardErr, guardErr}}
+	e := newCodexGuardTestExecutor(proxyRepo, attemptRepo, nil)
+
+	c := newCodexGuardDispatchCtx(adapter)
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatalf("expected dispatch error")
+	}
+	if !codexguard.IsReasoningGuardError(c.Err) {
+		t.Fatalf("expected reasoning guard error, got %v", c.Err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "" {
+		t.Fatalf("expected no client body to be written by dispatch, got %q", got)
+	}
+	if len(proxyRepo.updated) == 0 {
+		t.Fatalf("expected proxy request updates")
+	}
+	last := proxyRepo.updated[len(proxyRepo.updated)-1]
+	if last.Status != "FAILED" {
+		t.Fatalf("final proxy request status = %q, want FAILED", last.Status)
+	}
+	if last.StatusCode != 502 {
+		t.Fatalf("final proxy request status code = %d, want 502", last.StatusCode)
+	}
+}
+
+func newCodexGuardTestExecutor(
+	proxyRepo *codexGuardProxyRequestRepo,
+	attemptRepo *recordingAttemptRepo,
+	settings map[string]string,
+) *Executor {
+	return &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &codexGuardModelMappingRepo{},
+		settingsRepo:     &codexGuardSettingsRepo{values: settings},
+		converter:        converter.GetGlobalRegistry(),
+	}
+}
+
+func newCodexGuardDispatchCtx(adapter *codexGuardSequenceAdapter) *flow.Ctx {
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil).WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{
+		ID:         100,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeCodex,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeCodex,
+		requestModel: "gpt-5",
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeCodex},
+				Provider:        &domain.Provider{ID: 20, TenantID: domain.DefaultTenantID, Type: "codex", Name: "codex"},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c
+}
+
+func newTestCodexGuardProxyError() *domain.ProxyError {
+	cfg := codexguard.DefaultConfig()
+	guardErr := codexguard.NewReasoningGuardError(516, cfg)
+	proxyErr := domain.NewProxyErrorWithMessage(guardErr, false, "codex reasoning guard triggered")
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.HTTPStatusCode = cfg.StatusCode
+	proxyErr.Code = cfg.ErrorCode
+	return proxyErr
+}

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/domain"
@@ -29,6 +30,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 	proxyReq := state.proxyReq
 	ctx := state.ctx
 	clearDetail := e.shouldClearRequestDetailFor(state)
+	codexGuardConfig := e.getCodexGuardConfig()
 
 	// Pre-warm tokens for all matched routes in parallel.
 	// This avoids serial token refresh delays when failing over between providers.
@@ -108,7 +110,8 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 
 		retryConfig := e.getRetryConfig(state.tenantID, matchedRoute.RetryConfig)
 
-		for attempt := 0; attempt <= retryConfig.MaxRetries; attempt++ {
+		guardFailures := 0
+		for attempt := 0; attempt <= retryConfig.MaxRetries; {
 			if ctx.Err() != nil {
 				state.lastErr = ctx.Err()
 				c.Err = state.lastErr
@@ -153,6 +156,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			c.Set(flow.KeyUpstreamAttempt, attemptRecord)
 			c.Set(flow.KeyEventChan, eventChan)
 			c.Set(flow.KeyBroadcaster, e.broadcaster)
+			c.Set(flow.KeyCodexReasoningGuard, codexGuardConfig)
 			eventDone := make(chan struct{})
 			go e.processAdapterEventsRealtime(eventChan, attemptRecord, eventDone, clearDetail)
 
@@ -312,6 +316,15 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				e.broadcaster.BroadcastProxyRequest(proxyReq)
 			}
 
+			if codexguardErr := codexguard.IsReasoningGuardError(err); codexguardErr && !responseCapture.WroteToClient() {
+				guardFailures++
+				if shouldRetryCodexGuard(err, codexGuardConfig, guardFailures) {
+					log.Printf("[Executor] Codex reasoning guard triggered for provider %d, retrying guarded attempt %d/%d",
+						matchedRoute.Provider.ID, guardFailures+1, codexGuardConfig.MaxAttempts)
+					continue
+				}
+			}
+
 			proxyErr, ok := err.(*domain.ProxyError)
 			if responseCapture.WroteToClient() {
 				log.Printf("[Executor] Response already committed; not failing over after provider %d error: %v", matchedRoute.Provider.ID, err)
@@ -425,6 +438,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				case <-time.After(waitTime):
 				}
 			}
+			attempt++
 		}
 	}
 

--- a/internal/flow/keys.go
+++ b/internal/flow/keys.go
@@ -28,4 +28,5 @@ const (
 	KeyUpstreamAttempt     = "upstream_attempt"
 	KeyEventChan           = "event_chan"
 	KeyBroadcaster         = "broadcaster"
+	KeyCodexReasoningGuard = "codex_reasoning_guard"
 )

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -1,6 +1,10 @@
 package service
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/payloadoverride"
 )
@@ -9,7 +13,19 @@ func validateSystemSettingValue(key, value string) error {
 	switch key {
 	case domain.SettingKeyPayloadOverrideRules:
 		return payloadoverride.ValidateRulesJSON(value)
+	case domain.SettingKeyCodexReasoningGuard:
+		return validateCodexReasoningGuardSetting(value)
 	default:
 		return nil
 	}
+}
+
+func validateCodexReasoningGuardSetting(value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%w: %s cannot be empty", domain.ErrInvalidInput, domain.SettingKeyCodexReasoningGuard)
+	}
+	if _, err := codexguard.ParseConfigJSON([]byte(value)); err != nil {
+		return fmt.Errorf("%w: invalid %s: %v", domain.ErrInvalidInput, domain.SettingKeyCodexReasoningGuard, err)
+	}
+	return nil
 }

--- a/internal/service/system_setting_validation_test.go
+++ b/internal/service/system_setting_validation_test.go
@@ -35,6 +35,8 @@ func (r *stubSystemSettingRepo) Delete(key string) error {
 	return nil
 }
 
+const validCodexReasoningGuardSetting = `{"enabled":true,"blocked_reasoning_tokens":[516,1034,1552],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`
+
 func TestAdminServiceUpdateSettingRejectsInvalidPayloadOverrideRules(t *testing.T) {
 	repo := &stubSystemSettingRepo{}
 	svc := &AdminService{settingRepo: repo}
@@ -45,6 +47,96 @@ func TestAdminServiceUpdateSettingRejectsInvalidPayloadOverrideRules(t *testing.
 	}
 	if len(repo.values) != 0 {
 		t.Fatalf("expected invalid setting not to be persisted")
+	}
+}
+
+func TestAdminServiceUpdateSettingValidatesCodexReasoningGuard(t *testing.T) {
+	t.Run("accepts valid config", func(t *testing.T) {
+		repo := &stubSystemSettingRepo{}
+		svc := &AdminService{settingRepo: repo}
+
+		if err := svc.UpdateSetting(domain.SettingKeyCodexReasoningGuard, validCodexReasoningGuardSetting); err != nil {
+			t.Fatalf("expected valid setting, got %v", err)
+		}
+		if got := repo.values[domain.SettingKeyCodexReasoningGuard]; got != validCodexReasoningGuardSetting {
+			t.Fatalf("expected setting to be persisted, got %q", got)
+		}
+	})
+
+	t.Run("rejects invalid config", func(t *testing.T) {
+		repo := &stubSystemSettingRepo{}
+		svc := &AdminService{settingRepo: repo}
+
+		err := svc.UpdateSetting(domain.SettingKeyCodexReasoningGuard, `{"enabled":true,"blocked_reasoning_tokens":[],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`)
+		if !errors.Is(err, domain.ErrInvalidInput) {
+			t.Fatalf("expected invalid input error, got %v", err)
+		}
+		if len(repo.values) != 0 {
+			t.Fatalf("expected invalid setting not to be persisted")
+		}
+	})
+}
+
+func TestValidateSystemSettingValueCodexReasoningGuard(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:  "valid config",
+			value: validCodexReasoningGuardSetting,
+		},
+		{
+			name:    "invalid json",
+			value:   `{"enabled":true`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown field",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":[516],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream","unexpected":true}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty blocked token",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":[],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid max attempts",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":[516],"max_attempts":0,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid status code",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":[516],"max_attempts":2,"status_code":200,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty mode",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":[516],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":" "}`,
+			wantErr: true,
+		},
+		{
+			name:    "non integer blocked token",
+			value:   `{"enabled":true,"blocked_reasoning_tokens":["516"],"max_attempts":2,"status_code":502,"error_code":"reasoning_guard_triggered","mode":"non_stream"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSystemSettingValue(domain.SettingKeyCodexReasoningGuard, tt.value)
+			if tt.wantErr {
+				if !errors.Is(err, domain.ErrInvalidInput) {
+					t.Fatalf("expected invalid input error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
 	}
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1295,6 +1295,22 @@
         "loadUnsupportedProtocol": "The saved override rules contain an unsupported protocol. This UI currently supports codex only."
       }
     },
+    "codexReasoningGuard": {
+      "title": "Codex Reasoning Guard",
+      "desc": "Retry the same route before writing to the client when a response hits configured reasoning token rules.",
+      "hint": "Phase 1 only applies to non-stream responses. max_attempts is the total upstream attempt count including the first request.",
+      "errors": {
+        "required": "Configuration cannot be empty.",
+        "invalidJson": "Configuration must be valid JSON.",
+        "objectRequired": "Top-level configuration must be an object.",
+        "enabledRequired": "enabled must be a boolean.",
+        "tokensRequired": "blocked_reasoning_tokens must be a non-empty array of integers.",
+        "maxAttempts": "max_attempts must be an integer from 1 to 10.",
+        "statusCode": "status_code must be an integer from 400 to 599.",
+        "errorCode": "error_code cannot be empty.",
+        "mode": "mode must currently be non_stream."
+      }
+    },
     "themeDefault": "Default",
     "themeLuxury": "Luxury"
   },

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1299,6 +1299,7 @@
       "title": "Codex Reasoning Guard",
       "desc": "Retry the same route before writing to the client when a response hits configured reasoning token rules.",
       "hint": "Phase 1 only applies to non-stream responses. max_attempts is the total upstream attempt count including the first request.",
+      "editorLabel": "Codex reasoning guard JSON configuration",
       "errors": {
         "required": "Configuration cannot be empty.",
         "invalidJson": "Configuration must be valid JSON.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1296,6 +1296,7 @@
       "title": "Codex reasoning guard",
       "desc": "命中 reasoning token 规则时在写回客户端前重试同一路由。",
       "hint": "第一阶段仅支持非流式响应。max_attempts 表示包含首次请求在内的上游尝试总数。",
+      "editorLabel": "Codex reasoning guard JSON 配置",
       "errors": {
         "required": "配置不能为空。",
         "invalidJson": "配置必须是合法 JSON。",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1292,6 +1292,22 @@
         "loadUnsupportedProtocol": "当前已保存的覆盖规则包含暂不支持的 protocol。当前界面仅支持 codex。"
       }
     },
+    "codexReasoningGuard": {
+      "title": "Codex reasoning guard",
+      "desc": "命中 reasoning token 规则时在写回客户端前重试同一路由。",
+      "hint": "第一阶段仅支持非流式响应。max_attempts 表示包含首次请求在内的上游尝试总数。",
+      "errors": {
+        "required": "配置不能为空。",
+        "invalidJson": "配置必须是合法 JSON。",
+        "objectRequired": "配置顶层必须是对象。",
+        "enabledRequired": "enabled 必须是布尔值。",
+        "tokensRequired": "blocked_reasoning_tokens 必须是非空整数数组。",
+        "maxAttempts": "max_attempts 必须是 1 到 10 之间的整数。",
+        "statusCode": "status_code 必须是 400 到 599 之间的整数。",
+        "errorCode": "error_code 不能为空。",
+        "mode": "mode 当前必须是 non_stream。"
+      }
+    },
     "themeDefault": "默认",
     "themeLuxury": "奢华"
   },

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -1252,8 +1252,12 @@ function CodexReasoningGuardSection() {
   const deleteSetting = useDeleteSetting();
   const { t } = useTranslation();
 
-  const rawSetting = settings?.[CODEX_REASONING_GUARD_SETTING_KEY] ?? '';
-  const serverText = rawSetting.trim() || DEFAULT_CODEX_REASONING_GUARD_SETTING;
+  const hasStoredSetting = Boolean(
+    settings && Object.prototype.hasOwnProperty.call(settings, CODEX_REASONING_GUARD_SETTING_KEY),
+  );
+  const rawSetting = hasStoredSetting ? (settings?.[CODEX_REASONING_GUARD_SETTING_KEY] ?? '') : '';
+  const serverText = hasStoredSetting ? rawSetting : DEFAULT_CODEX_REASONING_GUARD_SETTING;
+  const editorLabel = t('settings.codexReasoningGuard.editorLabel');
   const [draft, setDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
@@ -1271,6 +1275,12 @@ function CodexReasoningGuardSection() {
       setDraft(serverText);
     }
   }, [initialized, isDirty, serverText]);
+
+  useEffect(() => {
+    if (initialized && isDirty && draft === serverText) {
+      setIsDirty(false);
+    }
+  }, [initialized, isDirty, draft, serverText]);
 
   const validationError = (() => {
     const trimmed = draft.trim();
@@ -1327,7 +1337,7 @@ function CodexReasoningGuardSection() {
   })();
 
   const isPending = updateSetting.isPending || deleteSetting.isPending;
-  const hasChanges = initialized && isDirty;
+  const hasChanges = initialized && isDirty && draft !== serverText;
 
   const handleSave = async () => {
     if (validationError) {
@@ -1342,7 +1352,7 @@ function CodexReasoningGuardSection() {
   };
 
   const handleReset = async () => {
-    if (rawSetting.trim()) {
+    if (hasStoredSetting) {
       await deleteSetting.mutateAsync(CODEX_REASONING_GUARD_SETTING_KEY);
     }
     setDraft(DEFAULT_CODEX_REASONING_GUARD_SETTING);
@@ -1393,6 +1403,7 @@ function CodexReasoningGuardSection() {
         )}
 
         <Textarea
+          aria-label={editorLabel}
           value={draft}
           onChange={(event) => {
             setDraft(event.target.value);

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -69,6 +69,19 @@ function parseRetentionInteger(value: string): number | null {
 
 const PAYLOAD_OVERRIDE_SETTING_KEY = 'payload_override_rules';
 const PAYLOAD_OVERRIDE_RESERVED_ROOTS = new Set(['model', 'stream']);
+const CODEX_REASONING_GUARD_SETTING_KEY = 'codex_reasoning_guard';
+const DEFAULT_CODEX_REASONING_GUARD_SETTING = JSON.stringify(
+  {
+    enabled: true,
+    blocked_reasoning_tokens: [516, 1034, 1552],
+    max_attempts: 2,
+    status_code: 502,
+    error_code: 'reasoning_guard_triggered',
+    mode: 'non_stream',
+  },
+  null,
+  2,
+);
 
 type PayloadOverrideProtocol = 'codex';
 
@@ -289,6 +302,7 @@ export function SettingsPage() {
               <DataRetentionSection />
               <ForceProjectSection />
               <PayloadOverrideSection />
+              <CodexReasoningGuardSection />
               <APITokenConcurrencySection />
               <AntigravitySection />
               <PprofSection />
@@ -1227,6 +1241,172 @@ function PayloadOverrideSection() {
             {t('settings.payloadOverrides.addRule')}
           </Button>
         </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CodexReasoningGuardSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const deleteSetting = useDeleteSetting();
+  const { t } = useTranslation();
+
+  const rawSetting = settings?.[CODEX_REASONING_GUARD_SETTING_KEY] ?? '';
+  const serverText = rawSetting.trim() || DEFAULT_CODEX_REASONING_GUARD_SETTING;
+  const [draft, setDraft] = useState('');
+  const [initialized, setInitialized] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !initialized) {
+      setDraft(serverText);
+      setInitialized(true);
+      setIsDirty(false);
+    }
+  }, [initialized, isLoading, serverText]);
+
+  useEffect(() => {
+    if (initialized && !isDirty) {
+      setDraft(serverText);
+    }
+  }, [initialized, isDirty, serverText]);
+
+  const validationError = (() => {
+    const trimmed = draft.trim();
+    if (!trimmed) {
+      return t('settings.codexReasoningGuard.errors.required');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return t('settings.codexReasoningGuard.errors.invalidJson');
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return t('settings.codexReasoningGuard.errors.objectRequired');
+    }
+
+    const cfg = parsed as Record<string, unknown>;
+    if (typeof cfg.enabled !== 'boolean') {
+      return t('settings.codexReasoningGuard.errors.enabledRequired');
+    }
+    if (
+      !Array.isArray(cfg.blocked_reasoning_tokens) ||
+      cfg.blocked_reasoning_tokens.length === 0 ||
+      cfg.blocked_reasoning_tokens.some(
+        (token) => !Number.isInteger(token) || (token as number) < 0,
+      )
+    ) {
+      return t('settings.codexReasoningGuard.errors.tokensRequired');
+    }
+    if (
+      !Number.isInteger(cfg.max_attempts) ||
+      (cfg.max_attempts as number) < 1 ||
+      (cfg.max_attempts as number) > 10
+    ) {
+      return t('settings.codexReasoningGuard.errors.maxAttempts');
+    }
+    if (
+      !Number.isInteger(cfg.status_code) ||
+      (cfg.status_code as number) < 400 ||
+      (cfg.status_code as number) > 599
+    ) {
+      return t('settings.codexReasoningGuard.errors.statusCode');
+    }
+    if (typeof cfg.error_code !== 'string' || !cfg.error_code.trim()) {
+      return t('settings.codexReasoningGuard.errors.errorCode');
+    }
+    if (cfg.mode !== 'non_stream') {
+      return t('settings.codexReasoningGuard.errors.mode');
+    }
+
+    return '';
+  })();
+
+  const isPending = updateSetting.isPending || deleteSetting.isPending;
+  const hasChanges = initialized && isDirty;
+
+  const handleSave = async () => {
+    if (validationError) {
+      return;
+    }
+    const parsed = JSON.parse(draft) as Record<string, unknown>;
+    await updateSetting.mutateAsync({
+      key: CODEX_REASONING_GUARD_SETTING_KEY,
+      value: JSON.stringify(parsed),
+    });
+    setIsDirty(false);
+  };
+
+  const handleReset = async () => {
+    if (rawSetting.trim()) {
+      await deleteSetting.mutateAsync(CODEX_REASONING_GUARD_SETTING_KEY);
+    }
+    setDraft(DEFAULT_CODEX_REASONING_GUARD_SETTING);
+    setIsDirty(false);
+  };
+
+  if (isLoading || !initialized) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-base font-medium flex items-center gap-2">
+              <Braces className="h-4 w-4 text-muted-foreground" />
+              {t('settings.codexReasoningGuard.title')}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.codexReasoningGuard.desc')}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleReset}
+              disabled={isPending}
+            >
+              {t('common.reset')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={!hasChanges || !!validationError || isPending}
+              size="sm"
+            >
+              {isPending ? t('common.saving') : t('common.save')}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        {validationError && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {validationError}
+          </div>
+        )}
+
+        <Textarea
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setIsDirty(true);
+          }}
+          rows={10}
+          disabled={isPending}
+          className="font-mono text-xs"
+          spellCheck={false}
+        />
+
+        <p className="text-xs text-muted-foreground">
+          {t('settings.codexReasoningGuard.hint')}
+        </p>
       </CardContent>
     </Card>
   );

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -72,7 +72,7 @@ const PAYLOAD_OVERRIDE_RESERVED_ROOTS = new Set(['model', 'stream']);
 const CODEX_REASONING_GUARD_SETTING_KEY = 'codex_reasoning_guard';
 const DEFAULT_CODEX_REASONING_GUARD_SETTING = JSON.stringify(
   {
-    enabled: true,
+    enabled: false,
     blocked_reasoning_tokens: [516, 1034, 1552],
     max_attempts: 2,
     status_code: 502,


### PR DESCRIPTION
## What changed

- Added `internal/codexguard` for parsing and validating the Codex reasoning guard config, extracting `reasoning_tokens` from JSON/SSE payloads, and identifying guard-triggered errors.
- Added `codex_reasoning_guard` system setting validation plus a Settings page JSON editor and README examples.
- Wired non-stream Official Codex and CLIProxyAPI Codex adapters to detect blocked `reasoning_tokens` before writing response headers/body.
- Extended executor dispatch so guard-triggered attempts retry the same route/provider without consuming ordinary retry budget or triggering cooldown.
- Added unit coverage for config validation, adapter write-before-guard behavior, and executor retry/exhaustion behavior.

## Why

This ports the useful behavior from `codex-retry-gateway` into maxx directly, without running a separate local gateway or rewriting a user's Codex CLI config. The maxx-native implementation keeps retry behavior visible in `ProxyUpstreamAttempt` records and preserves the existing routing, billing, and request audit paths.

## Behavior

Default config blocks `reasoning_tokens` values `516`, `1034`, and `1552` for non-stream Codex responses. `max_attempts` is the total upstream attempt count including the first request. When attempts are exhausted, maxx returns the configured status/code, defaulting to `502` and `reasoning_guard_triggered`.

Streaming strict buffering is intentionally not enabled in this first pass, so existing stream behavior is unchanged.

## Validation

- `go test -count=1 ./internal/codexguard ./internal/service ./internal/executor ./internal/adapter/provider/codex ./internal/adapter/provider/cliproxyapi_codex ./internal/cooldown ./internal/repository/sqlite`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- `git diff --check`

Also ran `go test -count=1 ./...`; it still fails in existing Windows-local CLI config tests unrelated to this change:

- `cmd/maxx-cli/internal/cfg.TestSavePermissionsAre0600`: got mode `0666`, expected `0600`
- `cmd/maxx-cli/internal/cfg.TestLegacyMigration`: migrated config file not found under the test temp dir

All other packages in that run, including `tests/e2e` and `tests/multiinstance`, passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增系统设置项 `codex_reasoning_guard`，可通过 CLI 配置；在设置页新增配置卡片并提供草稿编辑、重置与校验。
* **Bug Fixes**
  * 当 Codex 非流式响应命中受控的 `reasoning_tokens` 时，在下发前中断并返回受控错误；按配置执行有限重试，耗尽后停止（`max_attempts` 计入首次请求）。
* **文档**
  * 更新 README/README_CN：新增配置说明、默认拦截 token 列表与示例命令；调整表格排布。
* **Tests**
  * 补充 Codex 推理守护相关的单元测试与拦截/重试场景覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->