### PR TITLE
fix(proxy): normalize OpenAI route URLs

### DIFF
--- a/internal/adapter/client/adapter.go
+++ b/internal/adapter/client/adapter.go
@@ -45,9 +45,9 @@ func (a *Adapter) Match(req *http.Request) (domain.ClientType, bool) {
 		return domain.ClientTypeCodex, true
 	case strings.HasPrefix(path, "/v1/responses"):
 		return domain.ClientTypeCodex, true
-	case strings.HasPrefix(path, "/v1/chat/completions"):
+	case isOpenAIChatCompletionsPath(path):
 		return domain.ClientTypeOpenAI, true
-	case strings.HasPrefix(path, "/v1/images/"):
+	case isOpenAIImagesPath(path):
 		// OpenAI Images API (generations/edits). Body carries no messages/input,
 		// so body-detection can't classify it — key off the path.
 		return domain.ClientTypeOpenAI, true
@@ -220,9 +220,9 @@ func (a *Adapter) DetectClientType(req *http.Request, body []byte) domain.Client
 		return domain.ClientTypeCodex
 	case strings.HasPrefix(path, "/responses"):
 		return domain.ClientTypeCodex
-	case strings.HasPrefix(path, "/v1/chat/completions"):
+	case isOpenAIChatCompletionsPath(path):
 		return domain.ClientTypeOpenAI
-	case strings.HasPrefix(path, "/v1/images/"):
+	case isOpenAIImagesPath(path):
 		// OpenAI Images API (generations/edits). Body carries no messages/input,
 		// so body-detection can't classify it — key off the path.
 		return domain.ClientTypeOpenAI
@@ -273,6 +273,14 @@ func (a *Adapter) detectFromBodyBytes(body []byte) domain.ClientType {
 	}
 
 	return ""
+}
+
+func isOpenAIChatCompletionsPath(path string) bool {
+	return strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/chat/completions")
+}
+
+func isOpenAIImagesPath(path string) bool {
+	return strings.HasPrefix(path, "/v1/images/") || strings.HasPrefix(path, "/images/")
 }
 
 func isClaudeUserAgent(userAgent string) bool {

--- a/internal/adapter/client/adapter_test.go
+++ b/internal/adapter/client/adapter_test.go
@@ -38,17 +38,28 @@ func TestDetectClientTypeRecognizesImagesPath(t *testing.T) {
 	// Images generation body has neither messages/input/contents — only path can classify it.
 	body := []byte(`{"model":"gpt-image-2","prompt":"a cat","n":1,"size":"1024x1024"}`)
 
-	req := httptest.NewRequest("POST", "/v1/images/generations", strings.NewReader(string(body)))
-	if got := adapter.DetectClientType(req, body); got != domain.ClientTypeOpenAI {
-		t.Fatalf("DetectClientType = %s, want %s", got, domain.ClientTypeOpenAI)
-	}
-	if got, ok := adapter.Match(req); !ok || got != domain.ClientTypeOpenAI {
-		t.Fatalf("Match = (%s, %v), want (%s, true)", got, ok, domain.ClientTypeOpenAI)
+	for _, path := range []string{"/v1/images/generations", "/images/generations"} {
+		req := httptest.NewRequest("POST", path, strings.NewReader(string(body)))
+		if got := adapter.DetectClientType(req, body); got != domain.ClientTypeOpenAI {
+			t.Fatalf("DetectClientType(%s) = %s, want %s", path, got, domain.ClientTypeOpenAI)
+		}
+		if got, ok := adapter.Match(req); !ok || got != domain.ClientTypeOpenAI {
+			t.Fatalf("Match(%s) = (%s, %v), want (%s, true)", path, got, ok, domain.ClientTypeOpenAI)
+		}
+
+		// Model must be extractable from the body for routing/pricing.
+		if got := adapter.ExtractModel(req, body, domain.ClientTypeOpenAI); got != "gpt-image-2" {
+			t.Fatalf("ExtractModel(%s) = %q, want %q", path, got, "gpt-image-2")
+		}
 	}
 
-	// Model must be extractable from the body for routing/pricing.
-	if got := adapter.ExtractModel(req, body, domain.ClientTypeOpenAI); got != "gpt-image-2" {
-		t.Fatalf("ExtractModel = %q, want %q", got, "gpt-image-2")
+	chatBody := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	chatReq := httptest.NewRequest("POST", "/chat/completions", strings.NewReader(string(chatBody)))
+	if got := adapter.DetectClientType(chatReq, chatBody); got != domain.ClientTypeOpenAI {
+		t.Fatalf("DetectClientType(/chat/completions) = %s, want %s", got, domain.ClientTypeOpenAI)
+	}
+	if got, ok := adapter.Match(chatReq); !ok || got != domain.ClientTypeOpenAI {
+		t.Fatalf("Match(/chat/completions) = (%s, %v), want (%s, true)", got, ok, domain.ClientTypeOpenAI)
 	}
 }
 

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -890,7 +890,31 @@ func updateModelInMultipartForm(body []byte, req *http.Request, model string) ([
 }
 
 func buildUpstreamURL(baseURL string, requestPath string) string {
-	return strings.TrimSuffix(baseURL, "/") + requestPath
+	baseURL = strings.TrimSuffix(strings.TrimSpace(baseURL), "/")
+	requestPath = normalizeOpenAIUpstreamRequestPath(requestPath)
+
+	// OpenAI-compatible configs are commonly entered either as the API origin
+	// (https://api.openai.com) or as the versioned API root
+	// (https://api.openai.com/v1). The request URI is already versioned for the
+	// canonical proxy routes, so avoid forwarding /v1/v1/... upstream.
+	if strings.HasSuffix(baseURL, "/v1") && strings.HasPrefix(requestPath, "/v1/") {
+		requestPath = strings.TrimPrefix(requestPath, "/v1")
+	}
+
+	return baseURL + requestPath
+}
+
+func normalizeOpenAIUpstreamRequestPath(requestPath string) string {
+	switch {
+	case strings.HasPrefix(requestPath, "/chat/completions"):
+		return "/v1" + requestPath
+	case strings.HasPrefix(requestPath, "/images/"):
+		return "/v1" + requestPath
+	case requestPath == "/models" || strings.HasPrefix(requestPath, "/models?"):
+		return "/v1" + requestPath
+	default:
+		return requestPath
+	}
 }
 
 // isMultipartForm reports whether the request body is multipart/form-data

--- a/internal/adapter/provider/custom/adapter_url_test.go
+++ b/internal/adapter/provider/custom/adapter_url_test.go
@@ -1,0 +1,57 @@
+package custom
+
+import "testing"
+
+func TestBuildUpstreamURLNormalizesOpenAIBaseRoots(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseURL     string
+		requestPath string
+		want        string
+	}{
+		{
+			name:        "origin plus canonical v1 path",
+			baseURL:     "https://api.openai.com",
+			requestPath: "/v1/chat/completions",
+			want:        "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:        "versioned root plus canonical v1 path",
+			baseURL:     "https://api.openai.com/v1",
+			requestPath: "/v1/chat/completions",
+			want:        "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:        "versioned root plus root-style chat path",
+			baseURL:     "https://api.openai.com/v1",
+			requestPath: "/chat/completions",
+			want:        "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:        "compat prefix plus canonical v1 path",
+			baseURL:     "https://relay.example.com/compatible",
+			requestPath: "/v1/chat/completions",
+			want:        "https://relay.example.com/compatible/v1/chat/completions",
+		},
+		{
+			name:        "compat versioned prefix plus canonical v1 path",
+			baseURL:     "https://relay.example.com/compatible/v1",
+			requestPath: "/v1/chat/completions",
+			want:        "https://relay.example.com/compatible/v1/chat/completions",
+		},
+		{
+			name:        "root-style images path gains v1",
+			baseURL:     "https://api.openai.com",
+			requestPath: "/images/generations",
+			want:        "https://api.openai.com/v1/images/generations",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildUpstreamURL(tt.baseURL, tt.requestPath); got != tt.want {
+				t.Fatalf("buildUpstreamURL(%q, %q) = %q, want %q", tt.baseURL, tt.requestPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -22,9 +22,12 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 		mux.Handle("/v1/messages/", handlers.ProxyHandler)
 		// OpenAI API
 		mux.Handle("/v1/chat/completions", handlers.ProxyHandler)
+		mux.Handle("/chat/completions", handlers.ProxyHandler)
 		// OpenAI Images API (gpt-image-* generation + edits)
 		mux.Handle("/v1/images/generations", handlers.ProxyHandler)
 		mux.Handle("/v1/images/edits", handlers.ProxyHandler)
+		mux.Handle("/images/generations", handlers.ProxyHandler)
+		mux.Handle("/images/edits", handlers.ProxyHandler)
 		// Codex API
 		mux.Handle("/responses", handlers.ProxyHandler)
 		mux.Handle("/responses/", handlers.ProxyHandler)
@@ -36,6 +39,7 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 
 	if handlers.ModelsHandler != nil {
 		mux.Handle("/v1/models", handlers.ModelsHandler)
+		mux.Handle("/models", handlers.ModelsHandler)
 		mux.Handle("/v1beta/models", handlers.ModelsHandler)
 	}
 

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -165,7 +165,7 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 	}
 
 	// Normalize OpenAI Responses payloads sent to chat/completions
-	if strings.HasPrefix(r.URL.Path, "/v1/chat/completions") {
+	if isOpenAIChatCompletionsPath(r.URL.Path) {
 		if normalized, ok := normalizeOpenAIChatCompletionsPayload(body); ok {
 			body = normalized
 		}
@@ -482,4 +482,8 @@ func writeStreamError(w http.ResponseWriter, err *domain.ProxyError) {
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+func isOpenAIChatCompletionsPath(path string) bool {
+	return strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/chat/completions")
 }

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -541,6 +541,54 @@ func TestProxyOpenAIPassthrough(t *testing.T) {
 	}
 }
 
+func TestProxyOpenAIRootAliasPassthrough(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockOpenAIUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-openai-root-alias", mock.URL, []string{"openai"})
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.ProxyPost("/chat/completions", openaiRequest("gpt-4o"), nil)
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusOK)
+
+	_, path, _, _ := captured.Get()
+	if path != "/v1/chat/completions" {
+		t.Errorf("Expected upstream path /v1/chat/completions, got %s", path)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if gjson.GetBytes(respBody, "object").String() != "chat.completion" {
+		t.Errorf("Response should have object=chat.completion, got: %s", string(respBody))
+	}
+}
+
+func TestProxyOpenAIProviderBaseURLWithV1DoesNotDoublePrefix(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockOpenAIUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-openai-versioned-root", mock.URL+"/v1", []string{"openai"})
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusOK)
+
+	_, path, _, _ := captured.Get()
+	if path != "/v1/chat/completions" {
+		t.Errorf("Expected upstream path /v1/chat/completions, got %s", path)
+	}
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if gjson.GetBytes(respBody, "object").String() != "chat.completion" {
+		t.Errorf("Response should have object=chat.completion, got: %s", string(respBody))
+	}
+}
+
 func TestProxyCodexPassthrough(t *testing.T) {
 	captured := &capturedRequest{}
 	mock := newMockCodexUpstream(t, captured)


### PR DESCRIPTION
## Summary
- Add OpenAI root-style public aliases (`/chat/completions`, `/images/*`, `/models`) while preserving the canonical `/v1/...` routes.
- Normalize custom-provider upstream URL construction so provider base URLs ending in `/v1` no longer produce `/v1/v1/...`.
- Normalize root-style OpenAI upstream request paths to `/v1/...` and cover the behavior with unit/e2e regressions.

## Root cause
`custom.buildUpstreamURL` appended the incoming request URI directly to the configured provider base URL. OpenAI client requests use `/v1/chat/completions`, so a provider configured with an OpenAI API root like `https://api.openai.com/v1` was forwarded as `https://api.openai.com/v1/v1/chat/completions`.

The public proxy routes also only registered `/v1/chat/completions`, so OpenAI-compatible clients configured with a base URL that did not include `/v1` could hit `/chat/completions` and fail before dispatch.

## Validation
- `go test ./internal/adapter/provider/custom ./internal/adapter/client ./tests/e2e -run 'TestBuildUpstreamURLNormalizesOpenAIBaseRoots|TestDetectClientTypeRecognizesImagesPath|TestProxyOpenAIPassthrough|TestProxyOpenAIRootAliasPassthrough|TestProxyOpenAIProviderBaseURLWithV1DoesNotDoublePrefix' -count=1`
- `go test ./internal/core ./internal/handler ./internal/executor ./tests/e2e -count=1`
- `git diff --check`
- `go list -e -f '{{if ne .ImportPath "github.com/awsl-project/maxx"}}{{.ImportPath}}{{end}}' ./... | grep -v '^$' | xargs go test`

Note: plain `go test ./...` still fails at the root package in this checkout because `main.go` embeds `web/dist`, which is not present before building the frontend: `pattern all:web/dist: no matching files found`. All non-root Go packages pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持更多 OpenAI 兼容路径，包括无版本前缀的聊天、图片和模型接口。
  * 代理转发时会自动规范上游路径，避免重复添加版本前缀。

* **Bug Fixes**
  * 修复自定义 OpenAI 上游地址已包含版本路径时，出现重复 `/v1/v1/...` 的问题。
  * 提升对聊天补全与图片生成请求的识别一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->