### PR TITLE
fix(ui): keep token nav visible and clarify cooldown copy

### DIFF
--- a/web/src/components/layout/app-sidebar/sidebar-config.test.ts
+++ b/web/src/components/layout/app-sidebar/sidebar-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { sidebarConfig } from './sidebar-config';
+import type { MenuItem } from '@/types/sidebar';
+
+function findItem(key: string): MenuItem | undefined {
+  return sidebarConfig.sections.flatMap((section) => section.items).find((item) => item.key === key);
+}
+
+describe('sidebarConfig', () => {
+  it('keeps API tokens visible when admin auth is disabled', () => {
+    const item = findItem('api-tokens');
+
+    expect(item).toMatchObject({
+      type: 'standard',
+      to: '/api-tokens',
+      adminOnly: true,
+    });
+    expect(item).not.toHaveProperty('authOnly', true);
+  });
+});

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -107,7 +107,6 @@ export const sidebarConfig: SidebarConfig = {
           icon: Key,
           labelKey: 'nav.apiTokens',
           adminOnly: true,
-          authOnly: true,
         },
         {
           type: 'standard',

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1557,7 +1557,7 @@
     "endpointOverride": "Endpoint Override",
     "errorCooldownTitle": "3. Error Cooldown",
     "disableErrorCooldown": "Disable Error Cooldown",
-    "disableErrorCooldownDesc": "When enabled, errors won't trigger automatic cooldown. Manual freezes and explicit cooldown times still apply.",
+    "disableErrorCooldownDesc": "When enabled, upstream errors from this provider won't create new automatic cooldowns. Related request errors will continue according to the current retry policy. Existing cooldowns must expire or be cleared manually.",
     "responsesPassthrough": "Passthrough Responses Path",
     "responsesPassthroughDesc": "For Codex Responses requests, forward the client's original path (e.g. /v1/responses) instead of a hardcoded /responses. Turn off only for upstreams that expect /responses, or when the Base URL already ends with /v1.",
     "excludeFromExport": "Do not export this provider",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1554,7 +1554,7 @@
     "endpointOverride": "端点覆盖",
     "errorCooldownTitle": "3. 错误冷冻",
     "disableErrorCooldown": "禁用错误冷冻",
-    "disableErrorCooldownDesc": "开启后，错误将不再触发自动冷冻；手动冷冻与上游明确冷冻时间仍会生效。",
+    "disableErrorCooldownDesc": "开启后，该提供商的上游错误不会触发新的自动冷冻；遇到相关请求错误时，会按当前重试策略继续尝试。已存在的冷冻仍需过期或手动清除。",
     "responsesPassthrough": "透传 Responses 路径",
     "responsesPassthroughDesc": "Codex Responses 请求按客户端原始路径转发（如 /v1/responses），而不是硬编码 /responses。仅当上游只认 /responses、或 Base URL 已自带 /v1 时才需要关闭。",
     "excludeFromExport": "不导出此提供商配置",


### PR DESCRIPTION
## Summary
- keep the API Tokens sidebar entry visible for admin users even when admin auth is not enabled
- keep the entry guarded as admin-only and cover that contract with a regression test
- clarify the zh/en provider copy for `disableErrorCooldown`, including retry-policy behavior and existing cooldown handling

## Why
Packaged builds include the API Tokens page, but the sidebar entry was marked `authOnly`. In the default unauthenticated admin setup, that hides the entry even though the page is used to enable API token authentication.

The error-cooldown setting copy also needed to match the current behavior more precisely: enabling the switch prevents new automatic cooldowns from upstream errors and related request errors continue according to the configured retry policy, while existing cooldowns still need to expire or be cleared manually.

## Verification
- `pnpm exec prettier --check src/locales/zh.json src/locales/en.json`
- parsed `web/src/locales/zh.json` and `web/src/locales/en.json` as JSON
- GitHub CI and CodeRabbit are rerunning after the latest push
