### PR TITLE
fix(desktop): stop tray loop on quit

### DIFF
--- a/internal/desktop/launcher.go
+++ b/internal/desktop/launcher.go
@@ -125,6 +125,12 @@ type LauncherApp struct {
 	serverError error
 	serverReady bool
 	starting    bool
+
+	lifecycleMu  sync.Mutex
+	shutdownOnce sync.Once
+	quitOnce     sync.Once
+	trayQuitMu   sync.RWMutex
+	trayQuit     func()
 }
 
 // NewLauncherApp 创建启动器应用
@@ -172,6 +178,9 @@ func (a *LauncherApp) Startup(ctx context.Context) {
 
 // startServerAsync 异步启动服务器
 func (a *LauncherApp) startServerAsync() {
+	a.lifecycleMu.Lock()
+	defer a.lifecycleMu.Unlock()
+
 	a.mu.Lock()
 	a.starting = true
 	a.serverError = nil
@@ -365,22 +374,69 @@ func (a *LauncherApp) RestartServer() error {
 	return nil
 }
 
+// SetTrayQuitFunc registers a platform tray shutdown hook.
+// Windows systray runs its own event loop; every Quit path must stop it or the
+// desktop process can remain alive after Wails has been asked to exit.
+func (a *LauncherApp) SetTrayQuitFunc(fn func()) {
+	a.trayQuitMu.Lock()
+	defer a.trayQuitMu.Unlock()
+	a.trayQuit = fn
+}
+
+func (a *LauncherApp) quitTray() {
+	a.trayQuitMu.RLock()
+	fn := a.trayQuit
+	a.trayQuitMu.RUnlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+func (a *LauncherApp) shutdownResources(ctx context.Context) {
+	a.shutdownOnce.Do(func() {
+		a.lifecycleMu.Lock()
+		defer a.lifecycleMu.Unlock()
+
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		// Stop the managed HTTP server first so no new handlers can race with
+		// coordinator/database teardown.
+		if a.server != nil {
+			if err := a.server.Stop(ctx); err != nil {
+				log.Printf("[Launcher] Failed to stop server: %v", err)
+			}
+			a.server = nil
+		}
+
+		if a.components != nil && a.components.CoordinatorCleanup != nil {
+			a.components.CoordinatorCleanup()
+		}
+		a.components = nil
+
+		if a.dbRepos != nil {
+			if err := core.CloseDatabase(a.dbRepos); err != nil {
+				log.Printf("[Launcher] Failed to close database: %v", err)
+			}
+			a.dbRepos = nil
+		}
+	})
+}
+
 // Quit 退出应用（暴露给前端）
 func (a *LauncherApp) Quit() {
-	log.Println("[Launcher] Quitting application...")
+	a.quitOnce.Do(func() {
+		log.Println("[Launcher] Quitting application...")
 
-	// 停止服务器
-	if a.server != nil {
-		a.server.Stop(a.ctx)
-	}
+		a.shutdownResources(a.ctx)
+		// Stop the tray event loop on platforms that provide one before asking Wails
+		// to quit; otherwise the process may stay resident after user-visible quit.
+		a.quitTray()
 
-	// 关闭数据库
-	if a.dbRepos != nil {
-		core.CloseDatabase(a.dbRepos)
-	}
-
-	// 退出应用
-	runtime.Quit(a.ctx)
+		// 退出应用
+		runtime.Quit(a.ctx)
+	})
 }
 
 // ShowWindow 显示窗口（供托盘调用）
@@ -467,23 +523,7 @@ func (a *LauncherApp) HideWindow() {
 // Shutdown Wails 关闭回调
 func (a *LauncherApp) Shutdown(ctx context.Context) {
 	log.Println("[Launcher] ========== Application Shutdown ==========")
-
-	if a.server != nil {
-		if err := a.server.Stop(ctx); err != nil {
-			log.Printf("[Launcher] Failed to stop server: %v", err)
-		}
-	}
-
-	if a.components != nil && a.components.CoordinatorCleanup != nil {
-		a.components.CoordinatorCleanup()
-	}
-
-	if a.dbRepos != nil {
-		if err := core.CloseDatabase(a.dbRepos); err != nil {
-			log.Printf("[Launcher] Failed to close database: %v", err)
-		}
-	}
-
+	a.shutdownResources(ctx)
 	log.Println("[Launcher] ========== Application Shutdown Complete ==========")
 }
 

--- a/internal/desktop/launcher.go
+++ b/internal/desktop/launcher.go
@@ -126,7 +126,8 @@ type LauncherApp struct {
 	serverReady bool
 	starting    bool
 
-	lifecycleMu  sync.Mutex
+	lifecycleMu  sync.Mutex // protects startup/shutdown ordering
+	shuttingDown bool
 	shutdownOnce sync.Once
 	quitOnce     sync.Once
 	trayQuitMu   sync.RWMutex
@@ -180,6 +181,15 @@ func (a *LauncherApp) Startup(ctx context.Context) {
 func (a *LauncherApp) startServerAsync() {
 	a.lifecycleMu.Lock()
 	defer a.lifecycleMu.Unlock()
+
+	if a.shuttingDown {
+		log.Println("[Launcher] Skip server startup: application is shutting down")
+		a.mu.Lock()
+		a.starting = false
+		a.serverReady = false
+		a.mu.Unlock()
+		return
+	}
 
 	a.mu.Lock()
 	a.starting = true
@@ -396,6 +406,8 @@ func (a *LauncherApp) shutdownResources(ctx context.Context) {
 	a.shutdownOnce.Do(func() {
 		a.lifecycleMu.Lock()
 		defer a.lifecycleMu.Unlock()
+
+		a.shuttingDown = true
 
 		if ctx == nil {
 			ctx = context.Background()

--- a/internal/desktop/launcher_shutdown_test.go
+++ b/internal/desktop/launcher_shutdown_test.go
@@ -37,3 +37,29 @@ func TestTrayQuitFuncCanBeRegisteredAndInvoked(t *testing.T) {
 		t.Fatalf("tray quit calls = %d, want 1", calls)
 	}
 }
+
+func TestStartServerAsyncSkipsAfterShutdownBegins(t *testing.T) {
+	app := &LauncherApp{}
+
+	app.shutdownResources(context.Background())
+	app.startServerAsync()
+
+	if app.server != nil {
+		t.Fatalf("server = %#v, want nil after startup is skipped", app.server)
+	}
+	if app.dbRepos != nil {
+		t.Fatalf("dbRepos = %#v, want nil after startup is skipped", app.dbRepos)
+	}
+	if app.components != nil {
+		t.Fatalf("components = %#v, want nil after startup is skipped", app.components)
+	}
+
+	app.mu.RLock()
+	defer app.mu.RUnlock()
+	if app.starting {
+		t.Fatal("starting = true, want false after startup is skipped")
+	}
+	if app.serverReady {
+		t.Fatal("serverReady = true, want false after startup is skipped")
+	}
+}

--- a/internal/desktop/launcher_shutdown_test.go
+++ b/internal/desktop/launcher_shutdown_test.go
@@ -1,0 +1,39 @@
+package desktop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/core"
+)
+
+func TestShutdownResourcesIsIdempotent(t *testing.T) {
+	cleanupCalls := 0
+	app := &LauncherApp{
+		components: &core.ServerComponents{
+			CoordinatorCleanup: func() { cleanupCalls++ },
+		},
+	}
+
+	app.shutdownResources(context.Background())
+	app.shutdownResources(context.Background())
+
+	if cleanupCalls != 1 {
+		t.Fatalf("CoordinatorCleanup calls = %d, want 1", cleanupCalls)
+	}
+	if app.components != nil {
+		t.Fatalf("components = %#v, want nil after shutdown", app.components)
+	}
+}
+
+func TestTrayQuitFuncCanBeRegisteredAndInvoked(t *testing.T) {
+	app := &LauncherApp{}
+	calls := 0
+	app.SetTrayQuitFunc(func() { calls++ })
+
+	app.quitTray()
+
+	if calls != 1 {
+		t.Fatalf("tray quit calls = %d, want 1", calls)
+	}
+}

--- a/internal/desktop/tray_windows.go
+++ b/internal/desktop/tray_windows.go
@@ -30,10 +30,14 @@ type TrayManager struct {
 
 // NewTrayManager 创建托盘管理器
 func NewTrayManager(ctx context.Context, app *LauncherApp) *TrayManager {
-	return &TrayManager{
+	manager := &TrayManager{
 		ctx: ctx,
 		app: app,
 	}
+	if app != nil {
+		app.SetTrayQuitFunc(systray.Quit)
+	}
+	return manager
 }
 
 // Start 启动托盘
@@ -160,6 +164,7 @@ func (t *TrayManager) quit() {
 	log.Println("[Tray] Quitting application...")
 	if t.app != nil {
 		t.app.Quit()
+		return
 	}
 	systray.Quit()
 }

--- a/internal/desktop/tray_windows_test.go
+++ b/internal/desktop/tray_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package desktop
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewTrayManagerRegistersTrayQuitFunc(t *testing.T) {
+	app := &LauncherApp{}
+	manager := NewTrayManager(context.Background(), app)
+
+	if manager.app != app {
+		t.Fatalf("manager app = %#v, want original app", manager.app)
+	}
+
+	app.trayQuitMu.RLock()
+	fn := app.trayQuit
+	app.trayQuitMu.RUnlock()
+	if fn == nil {
+		t.Fatal("tray quit hook was not registered")
+	}
+}


### PR DESCRIPTION
## Summary
- route every user-visible desktop Quit path through one centralized shutdown path
- register the Windows systray quit hook on `LauncherApp` so page/menu Quit also stops the tray event loop
- make resource shutdown and Quit idempotent to avoid duplicate server/database/tray cleanup
- serialize server startup vs shutdown to avoid startup/quit races

## Evidence / validation
- `go test ./internal/desktop`
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/desktop -o /tmp/maxx-quit-evidence/desktop.test.exe`

Evidence snapshots were generated locally under `/tmp/maxx-quit-evidence/`:
- `01-diff-snapshot.txt`
- `02-go-test-internal-desktop.txt`
- `03-go-test-all.txt`
- `04-windows-desktop-compile.txt`
- `desktop.test.exe`

## Notes
This fixes the code path where `LauncherApp.Quit()` stopped the managed server and database but did not stop the Windows systray event loop, allowing the process to remain resident after a real Quit action.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 托盘退出现已支持更稳定的退出回调，退出应用时会更一致地处理托盘与程序关闭流程。

* **Bug 修复**
  * 优化桌面启动器的关闭与清理流程，减少重复关闭、竞态和资源释放不完整的问题。
  * 提升退出时对后台服务和相关资源的处理可靠性，避免异常关闭后残留状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->