### PR TITLE
fix(models): enforce token auth on model list

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -517,8 +517,8 @@ func main() {
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
-	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
 	// Setup routes
 	mux := http.NewServeMux()

--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -516,6 +516,7 @@ func main() {
 
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
@@ -541,7 +542,7 @@ func main() {
 	// Proxy routes - catch all AI API endpoints
 	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
 		ProxyHandler:         proxyHandler,
-		ModelsHandler:        modelsHandler,
+		ModelsHandler:        protectedModelsHandler,
 		ProviderProxyHandler: providerProxyHandler,
 	})
 

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -473,7 +473,7 @@ func InitializeServerComponents(
 	claudeHandler := handler.NewClaudeHandler(adminService, wailsBroadcaster)
 	claudeOAuthServer := NewClaudeOAuthServer(claudeHandler)
 	claudeHandler.SetOAuthServer(claudeOAuthServer)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, repos.CachedProjectRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProjectRepo)
 
 	log.Printf("[Core] Creating request tracker for graceful shutdown")
 	requestTracker := NewRequestTracker()
@@ -498,7 +498,7 @@ func InitializeServerComponents(
 		ClaudeHandler:          claudeHandler,
 		ClaudeOAuthServer:      claudeOAuthServer,
 		ProjectProxyHandler:    projectProxyHandler,
-		ProviderProxyHandler:   handler.NewProviderProxyHandler(proxyHandler, modelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
+		ProviderProxyHandler:   handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
 		RequestTracker:         requestTracker,
 		PprofManager:           pprofMgr,
 		AuthMiddleware:         authMiddleware,

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
 	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"  // Register claude adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude" // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/codex"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"
 	"github.com/awsl-project/maxx/internal/converter"
@@ -77,29 +78,30 @@ type DatabaseRepos struct {
 
 // ServerComponents 包含服务器运行所需的所有组件
 type ServerComponents struct {
-	Router               *router.Router
-	WebSocketHub         *handler.WebSocketHub
-	WailsBroadcaster     *event.WailsBroadcaster
-	Executor             *executor.Executor
-	ClientAdapter        *client.Adapter
-	AdminService         *service.AdminService
-	ProxyHandler         *handler.ProxyHandler
-	ModelsHandler        *handler.ModelsHandler
-	AdminHandler         *handler.AdminHandler
-	SelfServiceHandler   *handler.SelfServiceHandler
-	AntigravityHandler   *handler.AntigravityHandler
-	KiroHandler          *handler.KiroHandler
-	CodexHandler         *handler.CodexHandler
-	CodexOAuthServer     *CodexOAuthServer
-	ClaudeHandler        *handler.ClaudeHandler
-	ClaudeOAuthServer    *ClaudeOAuthServer
-	ProjectProxyHandler  *handler.ProjectProxyHandler
-	ProviderProxyHandler *handler.ProviderProxyHandler
-	RequestTracker       *RequestTracker
-	PprofManager         *PprofManager
-	AuthMiddleware       *handler.AuthMiddleware
-	AuthHandler          *handler.AuthHandler
-	BackupService        *service.BackupService
+	Router                 *router.Router
+	WebSocketHub           *handler.WebSocketHub
+	WailsBroadcaster       *event.WailsBroadcaster
+	Executor               *executor.Executor
+	ClientAdapter          *client.Adapter
+	AdminService           *service.AdminService
+	ProxyHandler           *handler.ProxyHandler
+	ModelsHandler          *handler.ModelsHandler
+	ProtectedModelsHandler http.Handler
+	AdminHandler           *handler.AdminHandler
+	SelfServiceHandler     *handler.SelfServiceHandler
+	AntigravityHandler     *handler.AntigravityHandler
+	KiroHandler            *handler.KiroHandler
+	CodexHandler           *handler.CodexHandler
+	CodexOAuthServer       *CodexOAuthServer
+	ClaudeHandler          *handler.ClaudeHandler
+	ClaudeOAuthServer      *ClaudeOAuthServer
+	ProjectProxyHandler    *handler.ProjectProxyHandler
+	ProviderProxyHandler   *handler.ProviderProxyHandler
+	RequestTracker         *RequestTracker
+	PprofManager           *PprofManager
+	AuthMiddleware         *handler.AuthMiddleware
+	AuthHandler            *handler.AuthHandler
+	BackupService          *service.BackupService
 
 	// Coordinator wiring (desktop launcher 与 cmd/maxx 共用此字段)
 	Coordinator        coordinator.Coordinator
@@ -458,6 +460,7 @@ func InitializeServerComponents(
 		repos.CachedProviderRepo,
 		repos.CachedModelMappingRepo,
 	)
+	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService)
 	adminHandler.SetUserRepo(repos.UserRepo)
@@ -477,31 +480,32 @@ func InitializeServerComponents(
 	proxyHandler.SetRequestTracker(requestTracker)
 
 	components := &ServerComponents{
-		Router:               r,
-		WebSocketHub:         wsHub,
-		WailsBroadcaster:     wailsBroadcaster,
-		Executor:             exec,
-		ClientAdapter:        clientAdapter,
-		AdminService:         adminService,
-		ProxyHandler:         proxyHandler,
-		ModelsHandler:        modelsHandler,
-		AdminHandler:         adminHandler,
-		SelfServiceHandler:   selfServiceHandler,
-		AntigravityHandler:   antigravityHandler,
-		KiroHandler:          kiroHandler,
-		CodexHandler:         codexHandler,
-		CodexOAuthServer:     codexOAuthServer,
-		ClaudeHandler:        claudeHandler,
-		ClaudeOAuthServer:    claudeOAuthServer,
-		ProjectProxyHandler:  projectProxyHandler,
-		ProviderProxyHandler: handler.NewProviderProxyHandler(proxyHandler, modelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
-		RequestTracker:       requestTracker,
-		PprofManager:         pprofMgr,
-		AuthMiddleware:       authMiddleware,
-		AuthHandler:          authHandler,
-		BackupService:        backupService,
-		Coordinator:          coordComp.Coordinator,
-		CoordinatorCleanup:   coordComp.Cleanup,
+		Router:                 r,
+		WebSocketHub:           wsHub,
+		WailsBroadcaster:       wailsBroadcaster,
+		Executor:               exec,
+		ClientAdapter:          clientAdapter,
+		AdminService:           adminService,
+		ProxyHandler:           proxyHandler,
+		ModelsHandler:          modelsHandler,
+		ProtectedModelsHandler: protectedModelsHandler,
+		AdminHandler:           adminHandler,
+		SelfServiceHandler:     selfServiceHandler,
+		AntigravityHandler:     antigravityHandler,
+		KiroHandler:            kiroHandler,
+		CodexHandler:           codexHandler,
+		CodexOAuthServer:       codexOAuthServer,
+		ClaudeHandler:          claudeHandler,
+		ClaudeOAuthServer:      claudeOAuthServer,
+		ProjectProxyHandler:    projectProxyHandler,
+		ProviderProxyHandler:   handler.NewProviderProxyHandler(proxyHandler, modelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
+		RequestTracker:         requestTracker,
+		PprofManager:           pprofMgr,
+		AuthMiddleware:         authMiddleware,
+		AuthHandler:            authHandler,
+		BackupService:          backupService,
+		Coordinator:            coordComp.Coordinator,
+		CoordinatorCleanup:     coordComp.Cleanup,
 	}
 
 	log.Printf("[Core] Server components initialized successfully")

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -98,9 +98,14 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 	mux.Handle("/api/codex/", http.StripPrefix("/api", components.CodexHandler))
 	mux.Handle("/api/claude/", http.StripPrefix("/api", components.ClaudeHandler))
 
+	modelsHandler := http.Handler(components.ModelsHandler)
+	if components.ProtectedModelsHandler != nil {
+		modelsHandler = components.ProtectedModelsHandler
+	}
+
 	RegisterProxyRoutes(mux, ProxyRouteHandlers{
 		ProxyHandler:         components.ProxyHandler,
-		ModelsHandler:        components.ModelsHandler,
+		ModelsHandler:        modelsHandler,
 		ProviderProxyHandler: components.ProviderProxyHandler,
 	})
 

--- a/internal/handler/project_proxy.go
+++ b/internal/handler/project_proxy.go
@@ -13,14 +13,14 @@ import (
 // like /{slug}/v1/messages, /{slug}/v1/chat/completions, etc.
 type ProjectProxyHandler struct {
 	proxyHandler  *ProxyHandler
-	modelsHandler *ModelsHandler
+	modelsHandler http.Handler
 	projectRepo   repository.ProjectRepository
 }
 
 // NewProjectProxyHandler creates a new project proxy handler
 func NewProjectProxyHandler(
 	proxyHandler *ProxyHandler,
-	modelsHandler *ModelsHandler,
+	modelsHandler http.Handler,
 	projectRepo repository.ProjectRepository,
 ) *ProjectProxyHandler {
 	return &ProjectProxyHandler{

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -21,7 +21,7 @@ import (
 // requested provider without going through the generic route selection / retry chain.
 type ProviderProxyHandler struct {
 	proxyHandler     *ProxyHandler
-	modelsHandler    *ModelsHandler
+	modelsHandler    http.Handler
 	providerRepo     repository.ProviderRepository
 	routeRepo        repository.RouteRepository
 	proxyRequestRepo repository.ProxyRequestRepository
@@ -30,7 +30,7 @@ type ProviderProxyHandler struct {
 // NewProviderProxyHandler creates a new provider proxy handler.
 func NewProviderProxyHandler(
 	proxyHandler *ProxyHandler,
-	modelsHandler *ModelsHandler,
+	modelsHandler http.Handler,
 	providerRepo repository.ProviderRepository,
 	routeRepo repository.RouteRepository,
 	proxyRequestRepo repository.ProxyRequestRepository,

--- a/internal/handler/token_auth.go
+++ b/internal/handler/token_auth.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/repository/cached"
@@ -189,6 +190,44 @@ func (m *TokenAuthMiddleware) ValidateRequest(req *http.Request, clientType doma
 	}(apiToken.TenantID, apiToken.ID, clientIP, lastSeenAt)
 
 	return apiToken, nil
+}
+
+// WrapModelList protects GET model-list endpoints with the same API-token gate
+// as proxy requests when token auth is enabled. Keeping this as a small wrapper
+// avoids routing GET /v1/models through ProxyHandler's POST-only request pipeline.
+func (m *TokenAuthMiddleware) WrapModelList(next http.Handler) http.Handler {
+	if next == nil {
+		return nil
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiToken, err := m.ValidateRequest(r, modelListClientType(r))
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, err.Error())
+			return
+		}
+
+		tenantID := domain.DefaultTenantID
+		if apiToken != nil && apiToken.TenantID > 0 {
+			tenantID = apiToken.TenantID
+		}
+		ctx := maxxctx.WithTenantID(r.Context(), tenantID)
+		if apiToken != nil {
+			ctx = maxxctx.WithAPITokenID(ctx, apiToken.ID)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func modelListClientType(r *http.Request) domain.ClientType {
+	if r != nil {
+		if r.URL != nil && r.URL.Path == "/v1beta/models" {
+			return domain.ClientTypeGemini
+		}
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(r.Header.Get("User-Agent"))), "claude-cli") {
+			return domain.ClientTypeClaude
+		}
+	}
+	return domain.ClientTypeOpenAI
 }
 
 func (m *TokenAuthMiddleware) GetConcurrentLimit() int {

--- a/internal/handler/token_auth_test.go
+++ b/internal/handler/token_auth_test.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository/cached"
 )
@@ -153,6 +155,85 @@ func TestTokenAuthValidateRequestUpdatesLastSeenWithClientIP(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for UpdateLastSeen call")
+	}
+}
+
+func TestTokenAuthWrapModelListRequiresTokenWhenEnabled(t *testing.T) {
+	repo := newTokenAuthTestRepo()
+	cachedRepo := cached.NewAPITokenRepository(repo)
+	apiToken := &domain.APIToken{
+		TenantID:    7,
+		Token:       "maxx_models_token_123",
+		TokenPrefix: "maxx_models...",
+		Name:        "models-token",
+		IsEnabled:   true,
+	}
+	if err := cachedRepo.Create(apiToken); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	middleware := NewTokenAuthMiddleware(cachedRepo, tokenAuthTestSettingRepo{})
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := maxxctx.GetTenantID(r.Context()); got != 7 {
+			t.Fatalf("tenant id = %d, want 7", got)
+		}
+		if got := maxxctx.GetAPITokenID(r.Context()); got != apiToken.ID {
+			t.Fatalf("api token id = %d, want %d", got, apiToken.ID)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	})
+	handler := middleware.WrapModelList(next)
+
+	missingReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	missingRec := httptest.NewRecorder()
+	handler.ServeHTTP(missingRec, missingReq)
+	if missingRec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing-token status = %d, want 401", missingRec.Code)
+	}
+
+	badReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	badReq.Header.Set("Authorization", "Bearer maxx_wrong")
+	badRec := httptest.NewRecorder()
+	handler.ServeHTTP(badRec, badReq)
+	if badRec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad-token status = %d, want 401", badRec.Code)
+	}
+
+	validReq := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	validReq.Header.Set("Authorization", "Bearer "+apiToken.Token)
+	validRec := httptest.NewRecorder()
+	handler.ServeHTTP(validRec, validReq)
+	if validRec.Code != http.StatusOK {
+		t.Fatalf("valid-token status = %d, want 200", validRec.Code)
+	}
+}
+
+func TestTokenAuthWrapModelListAcceptsGeminiKeyHeader(t *testing.T) {
+	repo := newTokenAuthTestRepo()
+	cachedRepo := cached.NewAPITokenRepository(repo)
+	apiToken := &domain.APIToken{
+		TenantID:    domain.DefaultTenantID,
+		Token:       "maxx_models_gemini_token",
+		TokenPrefix: "maxx_models...",
+		Name:        "gemini-models-token",
+		IsEnabled:   true,
+	}
+	if err := cachedRepo.Create(apiToken); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	middleware := NewTokenAuthMiddleware(cachedRepo, tokenAuthTestSettingRepo{})
+	handler := middleware.WrapModelList(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	req.Header.Set("x-goog-api-key", apiToken.Token)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Gemini key header status = %d, want 200", rec.Code)
 	}
 }
 

--- a/tests/e2e/models_test.go
+++ b/tests/e2e/models_test.go
@@ -85,3 +85,99 @@ func TestGetModels_ResponseFormat(t *testing.T) {
 		t.Fatalf("Expected model entry 'object' to be 'model', got %v", model["object"])
 	}
 }
+
+func TestGetModels_APITokenAuthAndModelSources(t *testing.T) {
+	env := NewTestEnv(t)
+
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "models-source-provider",
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "https://models-source.example.test",
+				"apiKey":  "sk-models-source",
+			},
+		},
+		"supportedClientTypes": []string{"openai"},
+		"supportModels": []string{
+			"gpt-models-e2e-provider",
+			"gpt-models-e2e-duplicate",
+		},
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = env.AdminPost("/api/admin/model-mappings", map[string]any{
+		"scope":    "global",
+		"pattern":  "gpt-models-e2e-pattern",
+		"target":   "gpt-models-e2e-duplicate",
+		"priority": 10,
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	resp = env.UnauthGet("/v1/models")
+	AssertStatus(t, resp, http.StatusUnauthorized)
+	resp.Body.Close()
+
+	resp = env.RequestWithToken(http.MethodGet, "/v1/models", nil, "maxx_wrong")
+	AssertStatus(t, resp, http.StatusUnauthorized)
+	resp.Body.Close()
+
+	resp = env.AdminPost("/api/admin/api-tokens", map[string]any{
+		"name":        "models-list-token",
+		"description": "Token for /v1/models e2e coverage",
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	tokenStr, ok := created["token"].(string)
+	if !ok || tokenStr == "" {
+		t.Fatalf("Expected token string, got %v", created["token"])
+	}
+
+	resp = env.RequestWithToken(http.MethodGet, "/v1/models", nil, tokenStr)
+	AssertStatus(t, resp, http.StatusOK)
+	var result map[string]any
+	DecodeJSON(t, resp, &result)
+
+	if result["object"] != "list" {
+		t.Fatalf("Expected object 'list', got %v", result["object"])
+	}
+	data, ok := result["data"].([]any)
+	if !ok {
+		t.Fatal("Expected 'data' to be an array")
+	}
+
+	ids := make(map[string]int)
+	for i, item := range data {
+		model, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("Expected model entry %d to be an object", i)
+		}
+		id, ok := model["id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("Expected model entry %d to have non-empty string id", i)
+		}
+		ids[id]++
+		if model["object"] != "model" {
+			t.Fatalf("Expected model entry %d object to be 'model', got %v", i, model["object"])
+		}
+		if _, exists := model["created"]; !exists {
+			t.Fatalf("Expected model entry %d to contain created", i)
+		}
+		if model["owned_by"] != "maxx" {
+			t.Fatalf("Expected model entry %d owned_by to be maxx, got %v", i, model["owned_by"])
+		}
+	}
+
+	for _, want := range []string{"gpt-models-e2e-provider", "gpt-models-e2e-pattern", "gpt-models-e2e-duplicate"} {
+		if ids[want] != 1 {
+			t.Fatalf("model %q occurrence count = %d, want 1", want, ids[want])
+		}
+	}
+}

--- a/tests/e2e/models_test.go
+++ b/tests/e2e/models_test.go
@@ -181,3 +181,74 @@ func TestGetModels_APITokenAuthAndModelSources(t *testing.T) {
 		}
 	}
 }
+
+func TestGetModels_ProjectAndProviderScopedRoutesRequireAPIToken(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	projectResp := env.AdminPost("/api/admin/projects", map[string]any{
+		"name":                "models scoped project",
+		"slug":                "models-scoped-project",
+		"enabledCustomRoutes": []string{},
+	})
+	AssertStatus(t, projectResp, http.StatusCreated)
+	projectResp.Body.Close()
+
+	providerResp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "models scoped provider",
+		"type": "custom",
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "https://models-scoped-provider.example.test",
+				"apiKey":  "sk-models-scoped-provider",
+			},
+		},
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        []string{"gpt-models-scoped-provider"},
+	})
+	AssertStatus(t, providerResp, http.StatusCreated)
+	var provider map[string]any
+	DecodeJSON(t, providerResp, &provider)
+	providerID := int(provider["id"].(float64))
+
+	resp := env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	resp = env.AdminPost("/api/admin/api-tokens", map[string]any{
+		"name":        "scoped-models-list-token",
+		"description": "Token for project/provider scoped model-list e2e coverage",
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var created map[string]any
+	DecodeJSON(t, resp, &created)
+	tokenStr, ok := created["token"].(string)
+	if !ok || tokenStr == "" {
+		t.Fatalf("Expected token string, got %v", created["token"])
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "project scoped", path: "/project/models-scoped-project/v1/models"},
+		{name: "provider scoped", path: "/provider/" + itoa(uint64(providerID)) + "/v1/models"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := env.doRequest(http.MethodGet, tc.path, nil, "")
+			AssertStatus(t, resp, http.StatusUnauthorized)
+			resp.Body.Close()
+
+			resp = env.doRequest(http.MethodGet, tc.path, nil, "maxx_wrong")
+			AssertStatus(t, resp, http.StatusUnauthorized)
+			resp.Body.Close()
+
+			resp = env.doRequest(http.MethodGet, tc.path, nil, tokenStr)
+			AssertStatus(t, resp, http.StatusOK)
+			var result map[string]any
+			DecodeJSON(t, resp, &result)
+			if result["object"] != "list" {
+				t.Fatalf("Expected object 'list', got %v", result["object"])
+			}
+		})
+	}
+}

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -194,8 +194,8 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
-	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
 	// Setup routes (mirroring main.go)
 	mux := http.NewServeMux()

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -193,6 +193,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, modelsHandler, cachedProjectRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, modelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
 
@@ -207,7 +208,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 
 	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
 		ProxyHandler:         proxyHandler,
-		ModelsHandler:        modelsHandler,
+		ModelsHandler:        protectedModelsHandler,
 		ProviderProxyHandler: providerProxyHandler,
 	})
 	mux.Handle("/project/", projectProxyHandler)

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -210,7 +210,7 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 	// end-to-end. The project proxy safely 404s on non-project paths, so a nil
 	// proxy handler is fine for the routes these tests exercise.
 	if opts.mountRoot {
-		projectProxyHandler := handler.NewProjectProxyHandler(nil, modelsHandler, cachedProjectRepo)
+		projectProxyHandler := handler.NewProjectProxyHandler(nil, protectedModelsHandler, cachedProjectRepo)
 		if opts.serveStatic {
 			staticHandler := handler.NewStaticHandler()
 			mux.Handle("/", handler.NewCombinedHandler(projectProxyHandler, staticHandler))

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -180,6 +180,8 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	tokenAuthMiddleware := handler.NewTokenAuthMiddleware(cachedAPITokenRepo, settingRepo)
+	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 
 	// Setup routes (mirroring main.go)
 	mux := http.NewServeMux()
@@ -191,9 +193,9 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService)
 	handler.RegisterSelfServiceRoutes(mux, authMiddleware.Wrap, adminHandler, selfServiceHandler)
 
-	// Models endpoint (public)
+	// Models endpoint (public unless API-token auth is enabled)
 	core.RegisterProxyRoutes(mux, core.ProxyRouteHandlers{
-		ModelsHandler: modelsHandler,
+		ModelsHandler: protectedModelsHandler,
 	})
 
 	// Health check


### PR DESCRIPTION
## Summary
- Protect model-list endpoints with API-token auth when `api_token_auth_enabled=true`.
- Keep `/v1/models` public when token auth is disabled for backward compatibility.
- Preserve OpenAI-compatible model-list response format while injecting token tenant context for model source lookup.
- Add regression coverage for missing/wrong token responses, valid token access, provider support models, model mapping entries, dedupe, and Gemini key header handling.

## Validation
- `go test ./internal/handler -run 'TestTokenAuthWrapModelList|TestModelsHandler|TestCollectModelNames|TestShouldIncludePricingModel' -count=1`
- `go test ./tests/e2e -run 'TestGetModels' -count=1`
- `go test ./internal/core ./internal/handler ./tests/e2e -count=1`
- `go test ./...`

## Notes
- This is local/e2e validation against the repository test server, not a live prod/staging curl run. No real external base URL/token/environment was provided, so the PR does not claim live environment evidence.
