### PR TITLE
fix(executor): retry disabled-cooldown HTTP errors

### DIFF
--- a/internal/adapter/provider/antigravity/adapter.go
+++ b/internal/adapter/provider/antigravity/adapter.go
@@ -345,7 +345,11 @@ func (a *AntigravityAdapter) Execute(c *flow.Ctx, provider *domain.Provider) err
 
 					// Set status code and classify error scope/reason
 					proxyErr.HTTPStatusCode = resp.StatusCode
-					if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+					if resp.StatusCode == http.StatusPaymentRequired {
+						proxyErr.Scope = domain.ScopeKey
+						proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+						proxyErr.Retryable = false
+					} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 						proxyErr.Scope = domain.ScopeKey
 						proxyErr.Reason = domain.CooldownReasonAuthFailure
 						proxyErr.Retryable = false
@@ -1129,8 +1133,8 @@ func (a *AntigravityAdapter) handleCollectedStreamResponse(c *flow.Ctx, resp *ht
 				domain.ClientTypeGemini, domain.ClientTypeOpenAI, geminiResponse)
 			if convErr != nil {
 				proxyErr := domain.NewProxyErrorWithMessage(domain.ErrFormatConversion, false, "failed to transform response")
-			proxyErr.Scope = domain.ScopeRequest
-			return proxyErr
+				proxyErr.Scope = domain.ScopeRequest
+				return proxyErr
 			}
 		default:
 			responseBody = geminiResponse

--- a/internal/adapter/provider/antigravity/adapter.go
+++ b/internal/adapter/provider/antigravity/adapter.go
@@ -345,21 +345,7 @@ func (a *AntigravityAdapter) Execute(c *flow.Ctx, provider *domain.Provider) err
 
 					// Set status code and classify error scope/reason
 					proxyErr.HTTPStatusCode = resp.StatusCode
-					if resp.StatusCode == http.StatusPaymentRequired {
-						proxyErr.Scope = domain.ScopeKey
-						proxyErr.Reason = domain.CooldownReasonQuotaExhausted
-						proxyErr.Retryable = false
-					} else if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-						proxyErr.Scope = domain.ScopeKey
-						proxyErr.Reason = domain.CooldownReasonAuthFailure
-						proxyErr.Retryable = false
-					} else if resp.StatusCode >= 500 && resp.StatusCode < 600 {
-						proxyErr.Scope = domain.ScopeProvider
-						proxyErr.Reason = domain.CooldownReasonServerError
-					} else if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-						proxyErr.Scope = domain.ScopeRequest
-						proxyErr.Retryable = false
-					}
+					classifyAntigravityHTTPError(proxyErr, resp.StatusCode)
 
 					// Set retry info on error for upstream handling
 					if retryAfter > 0 {
@@ -974,6 +960,29 @@ func (a *AntigravityAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Respon
 			sendFinalEvents()
 			return nil
 		}
+	}
+}
+
+// classifyAntigravityHTTPError maps upstream HTTP status into failover/cooldown scope.
+func classifyAntigravityHTTPError(proxyErr *domain.ProxyError, statusCode int) {
+	if proxyErr == nil {
+		return
+	}
+
+	if statusCode == http.StatusPaymentRequired {
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+	} else if statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonAuthFailure
+		proxyErr.Retryable = false
+	} else if statusCode >= 500 && statusCode < 600 {
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+	} else if statusCode >= 400 && statusCode < 500 {
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Retryable = false
 	}
 }
 

--- a/internal/adapter/provider/antigravity/request_test.go
+++ b/internal/adapter/provider/antigravity/request_test.go
@@ -1,8 +1,10 @@
 package antigravity
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/tidwall/gjson"
 )
 
@@ -40,5 +42,26 @@ func TestApplyAntigravityRequestTuning(t *testing.T) {
 	}
 	if !gjson.GetBytes(out, "request.tools.0.functionDeclarations.0.parameters").Exists() {
 		t.Fatalf("expected parameters to exist after rename")
+	}
+}
+
+func TestClassifyAntigravityHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	proxyErr := domain.NewProxyErrorWithMessage(
+		domain.ErrUpstreamError,
+		true,
+		"upstream returned status 402",
+	)
+	proxyErr.HTTPStatusCode = http.StatusPaymentRequired
+
+	classifyAntigravityHTTPError(proxyErr, http.StatusPaymentRequired)
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
 	}
 }

--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -650,6 +650,11 @@ func classifyBedrockHTTPError(statusCode int, body []byte, headers http.Header, 
 			proxyErr.Model = model
 		}
 
+	case statusCode == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
 	case statusCode == 403:
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure

--- a/internal/adapter/provider/bedrock/classify_test.go
+++ b/internal/adapter/provider/bedrock/classify_test.go
@@ -1,6 +1,11 @@
 package bedrock
 
-import "testing"
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
 
 func TestIsBedrockModelUnavailable(t *testing.T) {
 	tests := []struct {
@@ -52,5 +57,24 @@ func TestIsBedrockModelUnavailable(t *testing.T) {
 				t.Errorf("isBedrockModelUnavailable(%q) = %v, want %v", tt.body, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassifyBedrockHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	proxyErr := classifyBedrockHTTPError(
+		http.StatusPaymentRequired,
+		[]byte(`{"message":"Insufficient balance"}`),
+		make(http.Header),
+		"anthropic.claude",
+	)
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
 	}
 }

--- a/internal/adapter/provider/claude/adapter.go
+++ b/internal/adapter/provider/claude/adapter.go
@@ -699,6 +699,11 @@ func classifyClaudeHTTPError(statusCode int, body []byte, headers http.Header, m
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
 		proxyErr.Retryable = false
 
+	case statusCode == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
 	case statusCode == 403:
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
@@ -779,7 +784,6 @@ func extractModelFromResponse(body []byte) string {
 	}
 	return ""
 }
-
 
 var claudeFilteredHeaders = map[string]bool{
 	// Hop-by-hop headers

--- a/internal/adapter/provider/claude/adapter_test.go
+++ b/internal/adapter/provider/claude/adapter_test.go
@@ -3,6 +3,8 @@ package claude
 import (
 	"net/http"
 	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
 )
 
 func TestApplyClaudeHeadersPreservesProvidedUA(t *testing.T) {
@@ -42,5 +44,24 @@ func TestApplyClaudeHeadersUsesDefaultUAWhenMissing(t *testing.T) {
 	a.applyClaudeHeaders(upstreamReq2, nil, "sk-ant-oat-123", true, nil)
 	if got := upstreamReq2.Header.Get("User-Agent"); got != ClaudeUserAgent {
 		t.Fatalf("expected default Claude User-Agent when client request is nil, got %q", got)
+	}
+}
+
+func TestClassifyClaudeHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	proxyErr := classifyClaudeHTTPError(
+		http.StatusPaymentRequired,
+		[]byte(`{"error":{"message":"Insufficient balance","type":"bad_response_status_code"}}`),
+		make(http.Header),
+		"claude-sonnet-4",
+	)
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
 	}
 }

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -932,6 +932,11 @@ func classifyCodexHTTPError(statusCode int, body []byte, headers http.Header, mo
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
 		proxyErr.Retryable = false
 
+	case statusCode == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
 	case statusCode == 403:
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -632,3 +632,22 @@ func TestSendFinalStreamEventsEmitsCacheOnlyMetrics(t *testing.T) {
 
 	}
 }
+
+func TestClassifyCodexHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	proxyErr := classifyCodexHTTPError(
+		http.StatusPaymentRequired,
+		[]byte(`{"error":{"message":"Insufficient balance","type":"bad_response_status_code"}}`),
+		make(http.Header),
+		"gpt-5",
+	)
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
+	}
+}

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -1191,6 +1191,14 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
 		proxyErr.Retryable = false
 
+	// 402 — account/key has no remaining balance. Treat it as key-level
+	// quota exhaustion so routing can fail over to another provider instead of
+	// aborting the whole request as a client/request error.
+	case statusCode == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
 	// 403 — check if model-specific or account-level
 	case statusCode == 403:
 		if containsAny(bodyLower, "model", "access denied for model", "permission denied for model") {

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -39,6 +39,23 @@ func TestClassifyHTTPError429QuotaExhausted(t *testing.T) {
 	}
 }
 
+func TestClassifyHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	headers := make(http.Header)
+	body := []byte(`{"error":{"message":"Insufficient balance","type":"bad_response_status_code","code":"bad_response_status_code"}}`)
+
+	proxyErr := classifyHTTPError(http.StatusPaymentRequired, body, headers, domain.ClientTypeOpenAI, "gpt-4")
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
+	}
+}
+
 func TestClassifyHTTPError401AuthFailure(t *testing.T) {
 	headers := make(http.Header)
 	proxyErr := classifyHTTPError(401, []byte(`{"error":{"message":"invalid api key"}}`), headers, domain.ClientTypeOpenAI, "gpt-4")

--- a/internal/adapter/provider/kiro/adapter.go
+++ b/internal/adapter/provider/kiro/adapter.go
@@ -739,6 +739,11 @@ func classifyKiroHTTPError(statusCode int, body []byte, headers http.Header, mod
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
 		proxyErr.Retryable = false
 
+	case statusCode == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
 	case statusCode == 403:
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure

--- a/internal/adapter/provider/kiro/adapter_test.go
+++ b/internal/adapter/provider/kiro/adapter_test.go
@@ -1,0 +1,27 @@
+package kiro
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestClassifyKiroHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
+	proxyErr := classifyKiroHTTPError(
+		http.StatusPaymentRequired,
+		[]byte(`{"error":{"message":"Insufficient balance","type":"bad_response_status_code"}}`),
+		make(http.Header),
+		"kiro-model",
+	)
+
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %v, want ScopeKey", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("Reason = %v, want CooldownReasonQuotaExhausted", proxyErr.Reason)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("402 insufficient balance should not retry the same provider")
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -292,6 +292,22 @@ func shouldSkipErrorCooldown(provider *domain.Provider) bool {
 	return provider != nil && provider.Config != nil && provider.Config.DisableErrorCooldown
 }
 
+func applyDisabledErrorCooldownRetryPolicy(provider *domain.Provider, proxyErr *domain.ProxyError) {
+	if !shouldSkipErrorCooldown(provider) || proxyErr == nil {
+		return
+	}
+	if proxyErr.HTTPStatusCode < 400 || proxyErr.HTTPStatusCode >= 600 {
+		return
+	}
+
+	// disableErrorCooldown means upstream HTTP errors should not poison the
+	// provider with cooldown state. Keep that same switch from turning 4xx
+	// classifications into request-level early exits: when the provider opts out
+	// of error cooldowns, every upstream HTTP error follows the route retry
+	// policy first, then normal failover.
+	proxyErr.Retryable = true
+}
+
 // handleAsyncCooldownUpdate listens for async cooldown updates from providers
 func (e *Executor) handleAsyncCooldownUpdate(updateChan chan time.Time, provider *domain.Provider, clientType string, model string) {
 	defer func() { <-e.cooldownSem }()

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -370,6 +370,10 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				return
 			}
 
+			if ok {
+				applyDisabledErrorCooldownRetryPolicy(matchedRoute.Provider, proxyErr)
+			}
+
 			if ok && proxyErr.Scope == domain.ScopeRequest && !proxyErr.Retryable {
 				log.Printf("[Executor] Request-scoped non-retryable error; not failing over after provider %d: %v", matchedRoute.Provider.ID, err)
 				proxyReq.Status = "FAILED"

--- a/tests/e2e/disable_error_cooldown_retry_test.go
+++ b/tests/e2e/disable_error_cooldown_retry_test.go
@@ -1,0 +1,177 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestDisableErrorCooldownRetriesAllHTTPErrorStatuses verifies the provider
+// switch contract: when disableErrorCooldown is enabled, upstream HTTP error
+// responses must not become request-level early exits. Every HTTP 4xx/5xx error
+// should follow the route retry policy first, then fail over to the next route.
+func TestDisableErrorCooldownRetriesAllHTTPErrorStatuses(t *testing.T) {
+	cases := []struct {
+		status int
+		name   string
+	}{
+		{status: http.StatusBadRequest, name: "400_request_error"},
+		{status: http.StatusUnauthorized, name: "401_auth_error"},
+		{status: http.StatusForbidden, name: "403_auth_error"},
+		{status: http.StatusNotFound, name: "404_not_found"},
+		{status: http.StatusPaymentRequired, name: "402_quota_error"},
+		{status: http.StatusTeapot, name: "418_other_client_error"},
+		{status: http.StatusUnprocessableEntity, name: "422_request_error"},
+		{status: http.StatusTooManyRequests, name: "429_rate_limit"},
+		{status: http.StatusInternalServerError, name: "500_server_error"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			env := NewProxyTestEnv(t)
+
+			var failingHits atomic.Int64
+			failing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				failingHits.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"error":{"message":"Insufficient balance","type":"bad_response_status_code","code":"bad_response_status_code"}}`))
+			}))
+			defer failing.Close()
+
+			var fallbackHits atomic.Int64
+			fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fallbackHits.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id":      "chatcmpl-fallback",
+					"object":  "chat.completion",
+					"model":   "gpt-4o",
+					"created": 1700000000,
+					"choices": []map[string]any{{
+						"index":         0,
+						"message":       map[string]any{"role": "assistant", "content": "fallback-ok"},
+						"finish_reason": "stop",
+					}},
+					"usage": map[string]any{"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+				})
+			}))
+			defer fallback.Close()
+
+			failingID := createDisableErrorCooldownProvider(t, env, "failing-disable-cooldown", failing.URL, true)
+			fallbackID := createDisableErrorCooldownProvider(t, env, "fallback", fallback.URL, false)
+			retryID := createFastRetryConfig(t, env, "retry-all-http-errors")
+
+			createRouteWithOptionalRetryConfig(t, env, "openai", failingID, 1, retryID)
+			createRouteWithOptionalRetryConfig(t, env, "openai", fallbackID, 2, 0)
+
+			resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("final status=%d body=%s, want 200 from fallback", resp.StatusCode, body)
+			}
+			if failingHits.Load() != 3 {
+				t.Fatalf("status %d failing hits=%d, want 3 (initial + 2 retries)", tt.status, failingHits.Load())
+			}
+			if fallbackHits.Load() != 1 {
+				t.Fatalf("status %d fallback hits=%d, want 1", tt.status, fallbackHits.Load())
+			}
+			assertNoCooldownForProvider(t, env, failingID)
+		})
+	}
+}
+
+func createDisableErrorCooldownProvider(t *testing.T, env *ProxyTestEnv, name, baseURL string, disable bool) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": name,
+		"type": "custom",
+		"config": map[string]any{
+			"disableErrorCooldown": disable,
+			"custom": map[string]any{
+				"baseURL": baseURL,
+				"apiKey":  "sk-test-key",
+			},
+		},
+		"supportedClientTypes": []string{"openai"},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create provider %s: status=%d body=%s", name, resp.StatusCode, body)
+	}
+	var result struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &result)
+	return result.ID
+}
+
+func createFastRetryConfig(t *testing.T, env *ProxyTestEnv, name string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/retry-configs", map[string]any{
+		"name":            name,
+		"maxRetries":      2,
+		"initialInterval": 1,
+		"backoffRate":     1.0,
+		"maxInterval":     1,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create retry config: status=%d body=%s", resp.StatusCode, body)
+	}
+	var result struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &result)
+	return result.ID
+}
+
+func createRouteWithOptionalRetryConfig(t *testing.T, env *ProxyTestEnv, clientType string, providerID uint64, position int, retryConfigID uint64) {
+	t.Helper()
+	body := map[string]any{
+		"isEnabled":  true,
+		"clientType": clientType,
+		"providerID": providerID,
+		"position":   position,
+		"weight":     1,
+	}
+	if retryConfigID != 0 {
+		body["retryConfigID"] = retryConfigID
+	}
+	resp := env.AdminPost("/api/admin/routes", body)
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create route provider=%d: status=%d body=%s", providerID, resp.StatusCode, b)
+	}
+	resp.Body.Close()
+}
+
+func assertNoCooldownForProvider(t *testing.T, env *ProxyTestEnv, providerID uint64) {
+	t.Helper()
+	resp := env.AdminGet("/api/admin/cooldowns")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list cooldowns: status=%d body=%s", resp.StatusCode, body)
+	}
+	var cooldowns []map[string]any
+	DecodeJSON(t, resp, &cooldowns)
+	for _, cd := range cooldowns {
+		got, ok := cd["providerID"].(float64)
+		if ok && uint64(got) == providerID {
+			t.Fatalf("expected no cooldown for provider %d, found %#v", providerID, cd)
+		}
+		got, ok = cd["providerId"].(float64)
+		if ok && uint64(got) == providerID {
+			t.Fatalf("expected no cooldown for provider %d, found %#v", providerID, cd)
+		}
+		got, ok = cd["provider_id"].(float64)
+		if ok && uint64(got) == providerID {
+			t.Fatalf("expected no cooldown for provider %d, found %#v", providerID, cd)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- classify upstream `402 Payment Required` / insufficient-balance responses as key-level quota exhaustion so a single exhausted provider does not abort route failover
- make `disableErrorCooldown=true` apply to upstream HTTP error control flow: any HTTP 4xx/5xx from that provider follows the route retry policy first, then normal failover, without writing error cooldown state
- add e2e coverage for 400/401/402/403/404/418/422/429/500 under `disableErrorCooldown=true`, verifying initial attempt + configured retries, fallback success, and no cooldown for the failing provider

## Validation
- `git diff --check`
- `go test ./tests/e2e -run TestDisableErrorCooldownRetriesAllHTTPErrorStatuses -v`
- `go test ./internal/executor ./internal/adapter/provider/custom ./internal/adapter/provider/claude ./internal/adapter/provider/codex ./internal/adapter/provider/kiro ./internal/adapter/provider/bedrock ./internal/adapter/provider/antigravity -count=1`

## Notes
This fixes the post-#643 behavior where upstream balance errors could still surface directly instead of failing over, and tightens the `disableErrorCooldown` contract so the switch disables error-cooldown poisoning without bypassing retry/failover policy.