### PR TITLE
fix(executor): retry disabled-cooldown stream read errors

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -1,0 +1,141 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type disabledCooldownStreamRetryAdapter struct {
+	calls int
+}
+
+func (a *disabledCooldownStreamRetryAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *disabledCooldownStreamRetryAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	if a.calls == 1 {
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = c.Writer.Write([]byte("data: partial\n\n"))
+		proxyErr := domain.NewProxyErrorWithMessage(
+			errors.New("stream error: stream ID 1; INTERNAL_ERROR; received from peer"),
+			false,
+			"upstream stream read error after response started",
+		)
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonNetworkError
+		return proxyErr
+	}
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	_, _ = c.Writer.Write([]byte("data: fallback\n\ndata: [DONE]\n\n"))
+	return nil
+}
+
+func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
+	c, adapter, attemptRepo, proxyRepo := newDisabledCooldownStreamDispatchCtx(true)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	}
+	if got := attemptRepo.updated[0].Status; got != "FAILED" {
+		t.Fatalf("first attempt status = %q, want FAILED", got)
+	}
+	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "COMPLETED" {
+		t.Fatalf("final attempt status = %q, want COMPLETED", got)
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
+		t.Fatalf("client body = %q", got)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
+	c, adapter, _, proxyRepo := newDisabledCooldownStreamDispatchCtx(false)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected committed stream read error")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\n" {
+		t.Fatalf("client body = %q", got)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func newDisabledCooldownStreamTestExecutor(proxyRepo *codexGuardProxyRequestRepo, attemptRepo *recordingAttemptRepo) *Executor {
+	return &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &codexGuardModelMappingRepo{},
+		settingsRepo:     &codexGuardSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+}
+
+func newDisabledCooldownStreamDispatchCtx(disableErrorCooldown bool) (*flow.Ctx, *disabledCooldownStreamRetryAdapter, *recordingAttemptRepo, *codexGuardProxyRequestRepo) {
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	adapter := &disabledCooldownStreamRetryAdapter{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         100,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeOpenAI,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-4o",
+		isStream:     true,
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeOpenAI},
+				Provider: &domain.Provider{
+					ID:       20,
+					TenantID: domain.DefaultTenantID,
+					Type:     "custom",
+					Name:     "custom-disabled-cooldown",
+					Config:   &domain.ProviderConfig{DisableErrorCooldown: disableErrorCooldown},
+				},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c, adapter, attemptRepo, proxyRepo
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/converter"
@@ -296,16 +297,37 @@ func applyDisabledErrorCooldownRetryPolicy(provider *domain.Provider, proxyErr *
 	if !shouldSkipErrorCooldown(provider) || proxyErr == nil {
 		return
 	}
-	if proxyErr.HTTPStatusCode < 400 || proxyErr.HTTPStatusCode >= 600 {
+	if !isDisabledErrorCooldownRetryableError(proxyErr) {
 		return
 	}
 
-	// disableErrorCooldown means upstream HTTP errors should not poison the
-	// provider with cooldown state. Keep that same switch from turning 4xx
-	// classifications into request-level early exits: when the provider opts out
-	// of error cooldowns, every upstream HTTP error follows the route retry
+	// disableErrorCooldown means upstream failures should not poison the provider
+	// with cooldown state. Keep that same switch from turning provider failures
+	// into early exits: when the provider opts out of error cooldowns, upstream
+	// HTTP errors and transport/stream read failures follow the route retry
 	// policy first, then normal failover.
 	proxyErr.Retryable = true
+}
+
+func isDisabledErrorCooldownRetryableError(proxyErr *domain.ProxyError) bool {
+	if proxyErr == nil {
+		return false
+	}
+	if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+		return true
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		return false
+	}
+	if proxyErr.Reason == domain.CooldownReasonNetworkError {
+		return true
+	}
+	msg := strings.ToLower(proxyErr.Message)
+	return strings.Contains(msg, "stream read error") || strings.Contains(msg, "upstream stream")
+}
+
+func shouldRetryCommittedResponseError(provider *domain.Provider, proxyErr *domain.ProxyError) bool {
+	return shouldSkipErrorCooldown(provider) && proxyErr != nil && proxyErr.Retryable && isDisabledErrorCooldownRetryableError(proxyErr)
 }
 
 // handleAsyncCooldownUpdate listens for async cooldown updates from providers

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -326,7 +326,10 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			}
 
 			proxyErr, ok := err.(*domain.ProxyError)
-			if responseCapture.WroteToClient() {
+			if ok {
+				applyDisabledErrorCooldownRetryPolicy(matchedRoute.Provider, proxyErr)
+			}
+			if responseCapture.WroteToClient() && !shouldRetryCommittedResponseError(matchedRoute.Provider, proxyErr) {
 				log.Printf("[Executor] Response already committed; not failing over after provider %d error: %v", matchedRoute.Provider.ID, err)
 				proxyReq.Status = "FAILED"
 				proxyReq.EndTime = time.Now()
@@ -368,10 +371,6 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				state.lastErr = ctx.Err()
 				c.Err = state.lastErr
 				return
-			}
-
-			if ok {
-				applyDisabledErrorCooldownRetryPolicy(matchedRoute.Provider, proxyErr)
 			}
 
 			if ok && proxyErr.Scope == domain.ScopeRequest && !proxyErr.Retryable {

--- a/internal/executor/response_capture.go
+++ b/internal/executor/response_capture.go
@@ -81,9 +81,11 @@ func (rc *ResponseCapture) Write(b []byte) (int, error) {
 }
 
 // WroteToClient reports whether any response header or body byte has already
-// been forwarded to the downstream client. Once true, the executor must not
-// transparently fail over to another provider: doing so could splice two
-// upstream responses into one client-visible stream.
+// been forwarded to the downstream client. Once true, the executor normally
+// must not transparently fail over to another provider: doing so could splice
+// two upstream responses into one client-visible stream. The only current
+// exception is the explicit disable-error-cooldown policy for provider-level
+// stream read failures, where failover is intentionally allowed by dispatch.
 func (rc *ResponseCapture) WroteToClient() bool {
 	return rc.wrote
 }


### PR DESCRIPTION
## Summary
- extend disabled-error-cooldown retry policy beyond HTTP 4xx/5xx to provider-level transport/stream read failures
- apply the disabled-error-cooldown policy before the committed-response guard so eligible stream read errors can enter the route retry budget
- add executor regression coverage for `upstream stream read error after response started: stream error: stream ID 1; INTERNAL_ERROR; received from peer`, plus a negative case proving normal committed-response protection remains when error cooldown is enabled

## Tests
- `go test ./internal/executor`
- `go test ./internal/adapter/provider/custom`
- `go test ./tests/e2e -run TestDisableErrorCooldownRetriesAllHTTPErrorStatuses -count=1`
- `git diff --check`

## Notes
- Did not check or invoke CodeRabbit; this PR was created from the explicit stream-read retry requirement only.
- This does not merge or release anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了流式请求在已开始返回后遇到读取失败时的重试处理。
  * 在关闭错误冷却时，符合条件的已提交响应现在可继续重试并返回完整结果；开启冷却时仍保持失败并停止重试。
  * 修正了相关状态更新，确保客户端结果、重试次数和最终请求状态保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->