### PR TITLE
fix(conversion): fail closed on route format errors

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/adapter/provider/custom/error_fixer"
+	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -520,6 +521,12 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 	copyResponseHeaders(c.Writer.Header(), resp.Header)
 	c.Writer.WriteHeader(resp.StatusCode)
 	if _, err := c.Writer.Write(body); err != nil {
+		if converter.IsResponseConversionError(err) {
+			proxyErr := domain.NewProxyErrorWithMessage(err, true, "response format conversion failed")
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonServerError
+			return proxyErr
+		}
 		proxyErr := domain.NewProxyErrorWithMessage(err, false, "client disconnected")
 		proxyErr.Scope = domain.ScopeRequest
 		return proxyErr
@@ -748,8 +755,14 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 				if len(processedLine) > 0 {
 					_, writeErr := c.Writer.Write([]byte(processedLine))
 					if writeErr != nil {
-						// Client disconnected
 						sendFinalEvents()
+						if converter.IsResponseConversionError(writeErr) {
+							proxyErr := domain.NewProxyErrorWithMessage(writeErr, true, "response format conversion failed")
+							proxyErr.Scope = domain.ScopeProvider
+							proxyErr.Reason = domain.CooldownReasonServerError
+							return proxyErr
+						}
+						// Client disconnected
 						proxyErr := domain.NewProxyErrorWithMessage(writeErr, false, "client disconnected")
 						proxyErr.Scope = domain.ScopeRequest
 						return proxyErr

--- a/internal/converter/conversion_error.go
+++ b/internal/converter/conversion_error.go
@@ -1,0 +1,38 @@
+package converter
+
+import "errors"
+
+var ErrNilConvertedResponse = errors.New("converted response is nil")
+
+// ResponseConversionError marks failures while converting an upstream response
+// back into the client protocol. Callers should fail closed instead of passing
+// the upstream protocol through to a client that cannot understand it.
+type ResponseConversionError struct {
+	Err error
+}
+
+func (e *ResponseConversionError) Error() string {
+	if e == nil || e.Err == nil {
+		return "response format conversion failed"
+	}
+	return "response format conversion failed: " + e.Err.Error()
+}
+
+func (e *ResponseConversionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func NewResponseConversionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ResponseConversionError{Err: err}
+}
+
+func IsResponseConversionError(err error) bool {
+	var target *ResponseConversionError
+	return errors.As(err, &target)
+}

--- a/internal/executor/converting_writer.go
+++ b/internal/executor/converting_writer.go
@@ -200,8 +200,7 @@ func (c *ConvertingResponseWriter) writeStream(b []byte) (int, error) {
 	// Convert the chunk
 	converted, err := c.converter.TransformStreamChunk(c.targetType, c.originalType, b, c.streamState)
 	if err != nil {
-		// On conversion error, pass through original data
-		return c.underlying.Write(b)
+		return 0, converter.NewResponseConversionError(err)
 	}
 
 	if len(converted) > 0 {
@@ -232,9 +231,11 @@ func (c *ConvertingResponseWriter) Finalize() error {
 
 	// Convert the response
 	converted, err := c.converter.TransformResponseWithState(c.targetType, c.originalType, body, c.streamState)
-	if err != nil || converted == nil {
-		// On conversion error or nil result, use original body
-		converted = body
+	if err != nil {
+		return converter.NewResponseConversionError(err)
+	}
+	if converted == nil {
+		return converter.NewResponseConversionError(converter.ErrNilConvertedResponse)
 	}
 
 	// Update Content-Type header based on original client type

--- a/internal/executor/format_conversion_dispatch_test.go
+++ b/internal/executor/format_conversion_dispatch_test.go
@@ -1,0 +1,216 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type openAIOnlyConversionAdapter struct {
+	calls            int
+	seenClientType   domain.ClientType
+	seenRequestURI   string
+	seenRequestBody  []byte
+	responseBody     string
+	responseStatus   int
+	responseStreamed bool
+}
+
+func (a *openAIOnlyConversionAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *openAIOnlyConversionAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	a.seenClientType = flow.GetClientType(c)
+	a.seenRequestURI = flow.GetRequestURI(c)
+	a.seenRequestBody = append([]byte(nil), flow.GetRequestBody(c)...)
+
+	status := a.responseStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(status)
+	_, err := c.Writer.Write([]byte(a.responseBody))
+	return err
+}
+
+func TestDispatchConvertsClaudeRouteThroughOpenAIProvider(t *testing.T) {
+	adapter := &openAIOnlyConversionAdapter{responseBody: `{
+		"id":"chatcmpl-claude-route",
+		"object":"chat.completion",
+		"created":1700000000,
+		"model":"gpt-4o-mini",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"converted back to claude"},"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}
+	}`}
+	c, proxyRepo, attemptRepo := newClaudeOpenAIConversionDispatchCtx(t, `{
+		"model":"claude-3-5-sonnet",
+		"max_tokens":64,
+		"messages":[{"role":"user","content":"hello"}],
+		"stream":false
+	}`, adapter)
+	e := newClaudeOpenAIConversionTestExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if adapter.seenClientType != domain.ClientTypeOpenAI {
+		t.Fatalf("adapter client type = %s, want openai", adapter.seenClientType)
+	}
+	if adapter.seenRequestURI != "/v1/chat/completions" {
+		t.Fatalf("request URI = %q, want /v1/chat/completions", adapter.seenRequestURI)
+	}
+
+	var openaiReq map[string]any
+	if err := json.Unmarshal(adapter.seenRequestBody, &openaiReq); err != nil {
+		t.Fatalf("adapter received invalid OpenAI body: %v\n%s", err, adapter.seenRequestBody)
+	}
+	if got := openaiReq["model"]; got != "claude-3-5-sonnet" {
+		t.Fatalf("converted model = %v, want claude-3-5-sonnet", got)
+	}
+	if got, ok := openaiReq["stream"]; ok && got != false {
+		t.Fatalf("converted stream = %v, want absent or false", got)
+	}
+	messages, ok := openaiReq["messages"].([]any)
+	if !ok || len(messages) != 1 {
+		t.Fatalf("converted messages = %#v, want one OpenAI message", openaiReq["messages"])
+	}
+	first, _ := messages[0].(map[string]any)
+	if first["role"] != "user" {
+		t.Fatalf("converted role = %v, want user", first["role"])
+	}
+
+	body := c.Writer.(*httptest.ResponseRecorder).Body.String()
+	if !strings.Contains(body, `"type":"message"`) || !strings.Contains(body, `"text":"converted back to claude"`) {
+		t.Fatalf("client body was not converted back to Claude format: %s", body)
+	}
+	if len(attemptRepo.updated) == 0 || attemptRepo.updated[len(attemptRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed attempt, got %#v", attemptRepo.updated)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchFailsClosedWhenClaudeToOpenAIRequestConversionFails(t *testing.T) {
+	adapter := &openAIOnlyConversionAdapter{responseBody: `{}`}
+	c, proxyRepo, attemptRepo := newClaudeOpenAIConversionDispatchCtx(t, `{not-json`, adapter)
+	e := newClaudeOpenAIConversionTestExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected request conversion failure")
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want 0 so malformed Claude body is not sent as OpenAI", adapter.calls)
+	}
+	if len(attemptRepo.created) != 0 {
+		t.Fatalf("created attempts = %d, want 0 before upstream dispatch", len(attemptRepo.created))
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "" {
+		t.Fatalf("client body = %q, want empty fail-closed body", got)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchFailsClosedWhenOpenAIToClaudeResponseConversionFails(t *testing.T) {
+	adapter := &openAIOnlyConversionAdapter{responseBody: `{not-openai-json`}
+	c, proxyRepo, attemptRepo := newClaudeOpenAIConversionDispatchCtx(t, `{
+		"model":"claude-3-5-sonnet",
+		"max_tokens":64,
+		"messages":[{"role":"user","content":"hello"}],
+		"stream":false
+	}`, adapter)
+	e := newClaudeOpenAIConversionTestExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected response conversion failure")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "" {
+		t.Fatalf("client body = %q, want empty body instead of raw OpenAI payload", got)
+	}
+	if len(attemptRepo.updated) == 0 || attemptRepo.updated[len(attemptRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed attempt, got %#v", attemptRepo.updated)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func newClaudeOpenAIConversionTestExecutor(proxyRepo *codexGuardProxyRequestRepo, attemptRepo *recordingAttemptRepo) *Executor {
+	return &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &codexGuardModelMappingRepo{},
+		settingsRepo:     &codexGuardSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+}
+
+func newClaudeOpenAIConversionDispatchCtx(t *testing.T, requestBody string, adapter *openAIOnlyConversionAdapter) (*flow.Ctx, *codexGuardProxyRequestRepo, *recordingAttemptRepo) {
+	t.Helper()
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(requestBody)).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         200,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeClaude,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:                 context.Background(),
+		proxyReq:            proxyReq,
+		tenantID:            domain.DefaultTenantID,
+		clientType:          domain.ClientTypeClaude,
+		requestModel:        "claude-3-5-sonnet",
+		isStream:            false,
+		requestBody:         []byte(requestBody),
+		originalRequestBody: []byte(requestBody),
+		requestHeaders:      http.Header{"Content-Type": []string{"application/json"}},
+		requestURI:          "/v1/messages",
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 30, TenantID: domain.DefaultTenantID, ProviderID: 40, ClientType: domain.ClientTypeClaude},
+				Provider: &domain.Provider{
+					ID:                   40,
+					TenantID:             domain.DefaultTenantID,
+					Type:                 "custom",
+					Name:                 "openai-only-custom",
+					SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+				},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c, proxyRepo, attemptRepo
+}

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -92,18 +92,21 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				convertedBody, convErr = e.converter.TransformRequest(
 					clientType, currentClientType, requestBody, mappedModel, state.isStream)
 				if convErr != nil {
-					log.Printf("[Executor] Request conversion failed: %v, proceeding with original format", convErr)
-					needsConversion = false
-					currentClientType = clientType
-				} else {
-					requestBody = convertedBody
+					log.Printf("[Executor] Request conversion failed: %v; refusing to send original %s payload to %s provider %s",
+						convErr, clientType, currentClientType, matchedRoute.Provider.Name)
+					proxyErr := domain.NewProxyErrorWithMessage(convErr, true, "request format conversion failed")
+					proxyErr.Scope = domain.ScopeRequest
+					state.lastErr = proxyErr
+					continue
+				}
 
-					originalURI := requestURI
-					convertedURI := ConvertRequestURI(requestURI, clientType, currentClientType, mappedModel, state.isStream)
-					if convertedURI != originalURI {
-						requestURI = convertedURI
-						log.Printf("[Executor] URI converted: %s -> %s", originalURI, convertedURI)
-					}
+				requestBody = convertedBody
+
+				originalURI := requestURI
+				convertedURI := ConvertRequestURI(requestURI, clientType, currentClientType, mappedModel, state.isStream)
+				if convertedURI != originalURI {
+					requestURI = convertedURI
+					log.Printf("[Executor] URI converted: %s -> %s", originalURI, convertedURI)
 				}
 			}
 		}
@@ -186,6 +189,10 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			if needsConversion && convertingWriter != nil && !state.isStream {
 				if finalizeErr := convertingWriter.Finalize(); finalizeErr != nil {
 					log.Printf("[Executor] Response conversion finalize failed: %v", finalizeErr)
+					proxyErr := domain.NewProxyErrorWithMessage(finalizeErr, true, "response format conversion failed")
+					proxyErr.Scope = domain.ScopeProvider
+					proxyErr.Reason = domain.CooldownReasonServerError
+					err = proxyErr
 				}
 			}
 			if err == nil && modifierWriter != nil {


### PR DESCRIPTION
## Summary
- fail closed when route-level request format conversion fails instead of forwarding the original client protocol to an incompatible provider
- fail closed when upstream response conversion fails instead of passing raw upstream protocol data back to the client
- preserve retry/failover behavior for provider response conversion failures and classify conversion write errors in the custom adapter
- add executor regression coverage for Claude routes using an OpenAI-only provider via request/URI/body conversion and OpenAI response conversion back to Claude

## Tests
- `go test ./internal/executor -run 'TestDispatchConvertsClaudeRouteThroughOpenAIProvider|TestDispatchFailsClosedWhenClaudeToOpenAIRequestConversionFails|TestDispatchFailsClosedWhenOpenAIToClaudeResponseConversionFails' -count=1`
- `go test ./internal/executor ./internal/converter ./internal/adapter/provider/custom -count=1`
- `go test ./internal/... -count=1`
- `go vet ./internal/...`
- `go test ./tests/e2e -count=1`
- `git diff --cached --check`

## Notes
- This implements方案 B from the discussion: harden the existing conversion path and add regression tests, without introducing a product-level route target protocol switch.
- Did not check or invoke CodeRabbit.
- This PR does not merge or release anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 改进了请求与响应格式转换失败时的处理，系统会更准确地区分不同失败场景并采取相应重试/降级策略。
* **Bug 修复**
  * 转换失败时不再误回退为原始内容，减少返回不符合预期格式的情况。
  * 流式与非流式响应在转换异常时会更一致地失败并上报。
* **测试**
  * 新增覆盖格式转换成功、失败封闭及错误回传的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->