### PR TITLE
fix(user-panel): complete multitenant follow-ups

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1801,12 +1801,32 @@ func (h *AdminHandler) handleUsageStats(w http.ResponseWriter, r *http.Request) 
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
-	stats, err := h.svc.GetUsageStats(tenantID, filter)
+	var stats []*domain.UsageStats
+	var err error
+	if h.userPanelMemberUsageStatsEnabled(r) {
+		stats, err = getUserPanelUsageStatsForUser(h.svc, tenantID, maxxctx.GetUserID(r.Context()), filter)
+	} else {
+		stats, err = h.svc.GetUsageStats(tenantID, filter)
+	}
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	if stats == nil {
+		stats = []*domain.UsageStats{}
+	}
 	writeJSON(w, http.StatusOK, stats)
+}
+
+func (h *AdminHandler) userPanelMemberUsageStatsEnabled(r *http.Request) bool {
+	if maxxctx.GetUserRole(r.Context()) != string(domain.UserRoleMember) || maxxctx.GetUserID(r.Context()) == 0 {
+		return false
+	}
+	settings, err := h.svc.GetSettings()
+	if err != nil {
+		return false
+	}
+	return settings["ui_multitenant_enabled"] == "true" && settings["ui_multitenant_layout"] == "user_panel"
 }
 
 // handleRecalculateUsageStats handles POST /admin/usage-stats/recalculate

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1127,7 +1127,18 @@ func (h *SelfServiceHandler) handleUsageStats(w http.ResponseWriter, r *http.Req
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
-	stats, err := h.svc.GetUsageStats(tenantID, filter)
+	var stats []*domain.UsageStats
+	var err error
+	if h.userPanelLayoutEnabled() {
+		userID := maxxctx.GetUserID(r.Context())
+		if userID == 0 {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user required"})
+			return
+		}
+		stats, err = getUserPanelUsageStatsForUser(h.svc, tenantID, userID, filter)
+	} else {
+		stats, err = h.svc.GetUsageStats(tenantID, filter)
+	}
 	if err != nil {
 		writeSelfServiceInternalError(w, "GetUsageStats failed", err)
 		return
@@ -1136,6 +1147,32 @@ func (h *SelfServiceHandler) handleUsageStats(w http.ResponseWriter, r *http.Req
 		stats = []*domain.UsageStats{}
 	}
 	writeJSON(w, http.StatusOK, stats)
+}
+
+func getUserPanelUsageStatsForUser(svc *service.AdminService, tenantID uint64, userID uint64, filter repository.UsageStatsFilter) ([]*domain.UsageStats, error) {
+	tokens, err := findUserPanelAPITokensForUser(svc, tenantID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return []*domain.UsageStats{}, nil
+	}
+
+	stats := []*domain.UsageStats{}
+	for _, token := range tokens {
+		if token == nil || token.ID == 0 {
+			continue
+		}
+		tokenFilter := filter
+		tokenID := token.ID
+		tokenFilter.APITokenID = &tokenID
+		tokenStats, err := svc.GetUsageStats(tenantID, tokenFilter)
+		if err != nil {
+			return nil, err
+		}
+		stats = append(stats, tokenStats...)
+	}
+	return stats, nil
 }
 
 func (h *SelfServiceHandler) handleUserPanelAPIToken(w http.ResponseWriter, r *http.Request, regenerate bool) {
@@ -1161,28 +1198,33 @@ func (h *SelfServiceHandler) handleUserPanelAPIToken(w http.ResponseWriter, r *h
 		return
 	}
 
-	existing, err := h.findUserPanelAPITokens(tenantID, userID)
+	existing, err := findUserPanelAPITokensForUser(h.svc, tenantID, userID)
 	if err != nil {
 		writeSelfServiceInternalError(w, "GetUserPanelAPITokens failed", err)
 		return
 	}
 
 	if r.Method == http.MethodGet {
-		writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": sanitizeAPIToken(firstUserPanelAPIToken(existing))})
+		writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": sanitizeAPIToken(firstActiveUserPanelAPIToken(existing))})
 		return
 	}
 
+	activeToken := firstActiveUserPanelAPIToken(existing)
 	if regenerate {
 		for _, token := range existing {
-			if err := h.svc.DeleteAPIToken(tenantID, token.ID); err != nil {
-				writeSelfServiceInternalError(w, "DeleteUserPanelAPIToken failed", err)
+			if token == nil || !token.IsEnabled {
+				continue
+			}
+			token.IsEnabled = false
+			if err := h.svc.UpdateAPIToken(tenantID, token); err != nil {
+				writeSelfServiceInternalError(w, "DisableUserPanelAPIToken failed", err)
 				return
 			}
 		}
-	} else if firstUserPanelAPIToken(existing) != nil {
+	} else if activeToken != nil {
 		writeJSON(w, http.StatusConflict, map[string]any{
 			"error":    "user panel token already exists",
-			"apiToken": sanitizeAPIToken(firstUserPanelAPIToken(existing)),
+			"apiToken": sanitizeAPIToken(activeToken),
 		})
 		return
 	}
@@ -1213,8 +1255,8 @@ func (h *SelfServiceHandler) userPanelLayoutEnabled() bool {
 	return err == nil && layout == "user_panel"
 }
 
-func (h *SelfServiceHandler) findUserPanelAPITokens(tenantID uint64, userID uint64) ([]*domain.APIToken, error) {
-	tokens, err := h.svc.GetAPITokens(tenantID)
+func findUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint64, userID uint64) ([]*domain.APIToken, error) {
+	tokens, err := svc.GetAPITokens(tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -1228,11 +1270,13 @@ func (h *SelfServiceHandler) findUserPanelAPITokens(tenantID uint64, userID uint
 	return matches, nil
 }
 
-func firstUserPanelAPIToken(tokens []*domain.APIToken) *domain.APIToken {
-	if len(tokens) == 0 {
-		return nil
+func firstActiveUserPanelAPIToken(tokens []*domain.APIToken) *domain.APIToken {
+	for _, token := range tokens {
+		if token != nil && token.IsEnabled {
+			return token
+		}
 	}
-	return tokens[0]
+	return nil
 }
 
 func userPanelAPITokenName(userID uint64) string {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -427,9 +427,17 @@ func (r *selfServiceSettingsRepo) Delete(key string) error {
 
 type selfServiceAPITokenRepo struct {
 	tokens []*domain.APIToken
+	nextID uint64
 }
 
 func (r *selfServiceAPITokenRepo) Create(token *domain.APIToken) error {
+	if token.ID == 0 {
+		r.nextID++
+		if r.nextID < 1000 {
+			r.nextID = 1000
+		}
+		token.ID = r.nextID
+	}
 	r.tokens = append(r.tokens, token)
 	return nil
 }
@@ -492,6 +500,8 @@ func (r *selfServiceAPITokenRepo) UpdateLastSeen(_ uint64, _ uint64, _ string, _
 
 type selfServiceUsageStatsRepo struct {
 	providerStats  map[uint64]*domain.ProviderStats
+	stats          []*domain.UsageStats
+	filters        []repository.UsageStatsFilter
 	lastTenantID   uint64
 	lastClientType string
 	lastProjectID  uint64
@@ -499,8 +509,20 @@ type selfServiceUsageStatsRepo struct {
 
 func (r *selfServiceUsageStatsRepo) Upsert(_ *domain.UsageStats) error        { return nil }
 func (r *selfServiceUsageStatsRepo) BatchUpsert(_ []*domain.UsageStats) error { return nil }
-func (r *selfServiceUsageStatsRepo) Query(_ uint64, _ repository.UsageStatsFilter) ([]*domain.UsageStats, error) {
-	return nil, nil
+func (r *selfServiceUsageStatsRepo) Query(tenantID uint64, filter repository.UsageStatsFilter) ([]*domain.UsageStats, error) {
+	r.lastTenantID = tenantID
+	r.filters = append(r.filters, filter)
+	var result []*domain.UsageStats
+	for _, stat := range r.stats {
+		if stat == nil || stat.TenantID != tenantID {
+			continue
+		}
+		if filter.APITokenID != nil && stat.APITokenID != *filter.APITokenID {
+			continue
+		}
+		result = append(result, stat)
+	}
+	return result, nil
 }
 func (r *selfServiceUsageStatsRepo) QueryDashboardData(_ uint64) (*domain.DashboardData, error) {
 	return nil, nil
@@ -2106,6 +2128,95 @@ func TestSelfServiceHandler_GetAPIToken_MemberRedactsPlaintextToken(t *testing.T
 	}
 }
 
+func TestSelfServiceHandler_UserPanelRegenerateDisablesOldTokenAndKeepsHistory(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "User Console Key (user 9)", Description: marker, IsEnabled: true},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodPost, "/user-panel-token/regenerate"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if len(tokenRepo.tokens) != 2 {
+		t.Fatalf("tokens = %d, want old disabled + new active", len(tokenRepo.tokens))
+	}
+	var oldToken, newToken *domain.APIToken
+	for _, token := range tokenRepo.tokens {
+		switch token.ID {
+		case 10:
+			oldToken = token
+		default:
+			newToken = token
+		}
+	}
+	if oldToken == nil || oldToken.IsEnabled {
+		t.Fatalf("old token = %+v, want disabled historical token", oldToken)
+	}
+	if newToken == nil || !newToken.IsEnabled || newToken.Description != marker {
+		t.Fatalf("new token = %+v, want active replacement with same marker", newToken)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelUsageStatsFollowRegeneratedKeyHistory(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	usageRepo := &selfServiceUsageStatsRepo{
+		stats: []*domain.UsageStats{
+			{ID: 1, TenantID: 1, APITokenID: 10, TotalRequests: 96, SuccessfulRequests: 80, FailedRequests: 16, Model: "old-key-model"},
+			{ID: 2, TenantID: 1, APITokenID: 11, TotalRequests: 55, SuccessfulRequests: 40, FailedRequests: 15, Model: "new-key-model"},
+			{ID: 3, TenantID: 1, APITokenID: 99, TotalRequests: 999, SuccessfulRequests: 999, Model: "other-key-model"},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: &selfServiceAPITokenRepo{tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Description: marker, IsEnabled: false},
+			{ID: 11, TenantID: 1, Description: marker, IsEnabled: true},
+			{ID: 99, TenantID: 1, Description: "regular", IsEnabled: true},
+		}},
+		usageStatsRepo: usageRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodGet, "/usage-stats?granularity=hour"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var stats []domain.UsageStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("stats = %+v, want old and new user panel token stats only", stats)
+	}
+	var total uint64
+	for _, stat := range stats {
+		total += stat.TotalRequests
+		if stat.APITokenID == 99 {
+			t.Fatalf("regular token stat leaked into user panel stats: %+v", stat)
+		}
+	}
+	if total != 151 {
+		t.Fatalf("total requests = %d, want 151", total)
+	}
+	if len(usageRepo.filters) != 2 {
+		t.Fatalf("filters = %+v, want one query per historical user panel token", usageRepo.filters)
+	}
+}
+
 func TestSelfServiceHandler_ListResponseModels_MemberAllowed(t *testing.T) {
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
 		providerRepo:      &selfServiceProviderRepo{},
@@ -2194,5 +2305,80 @@ func TestSelfServiceHandler_BulkDeleteProvidersErrorStatusCodes(t *testing.T) {
 	internalErrorHandler.ServeHTTP(internalErrorRec, newSelfServiceAdminRequestWithBody(http.MethodPost, "/providers/bulk-delete", `{"ids":[10]}`))
 	if internalErrorRec.Code != http.StatusInternalServerError {
 		t.Fatalf("repository error status = %d, want %d, body = %s", internalErrorRec.Code, http.StatusInternalServerError, internalErrorRec.Body.String())
+	}
+}
+
+func newAdminHandlerForSelfServiceTestDeps(deps selfServiceTestDeps) *AdminHandler {
+	adminSvc := service.NewAdminService(
+		deps.providerRepo,
+		deps.routeRepo,
+		deps.projectRepo,
+		nil,
+		deps.retryConfigRepo,
+		nil,
+		nil,
+		nil,
+		deps.settingsRepo,
+		deps.apiTokenRepo,
+		nil,
+		nil,
+		deps.modelMappingRepo,
+		deps.usageStatsRepo,
+		deps.responseModelRepo,
+		deps.modelPriceRepo,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+	return NewAdminHandler(adminSvc, nil, "")
+}
+
+func TestAdminHandler_UserPanelMemberUsageStatsFollowRegeneratedKeyHistory(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	usageRepo := &selfServiceUsageStatsRepo{
+		stats: []*domain.UsageStats{
+			{ID: 1, TenantID: 1, APITokenID: 10, TotalRequests: 96, SuccessfulRequests: 80, FailedRequests: 16, Model: "old-key-model"},
+			{ID: 2, TenantID: 1, APITokenID: 11, TotalRequests: 55715, SuccessfulRequests: 12120, FailedRequests: 43595, Model: "new-key-model"},
+			{ID: 3, TenantID: 1, APITokenID: 99, TotalRequests: 999, SuccessfulRequests: 999, Model: "other-key-model"},
+		},
+	}
+	handler := newAdminHandlerForSelfServiceTestDeps(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: &selfServiceAPITokenRepo{tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Description: marker, IsEnabled: false},
+			{ID: 11, TenantID: 1, Description: marker, IsEnabled: true},
+			{ID: 99, TenantID: 1, Description: "regular", IsEnabled: true},
+		}},
+		usageStatsRepo: usageRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, withSelfServiceContext(httptest.NewRequest(http.MethodGet, "/admin/usage-stats?granularity=hour", nil), domain.UserRoleMember))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var stats []domain.UsageStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("stats = %+v, want old and new user panel token stats only", stats)
+	}
+	var total uint64
+	for _, stat := range stats {
+		total += stat.TotalRequests
+		if stat.APITokenID == 99 {
+			t.Fatalf("regular token stat leaked into member user panel stats: %+v", stat)
+		}
+	}
+	if total != 55811 {
+		t.Fatalf("total requests = %d, want 55811", total)
+	}
+	if len(usageRepo.filters) != 2 {
+		t.Fatalf("filters = %+v, want one query per historical user panel token", usageRepo.filters)
 	}
 }

--- a/web/e2e/settings-multitenant-layout-flow.js
+++ b/web/e2e/settings-multitenant-layout-flow.js
@@ -1,0 +1,173 @@
+import { chromium } from '@playwright/test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:4173';
+const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome-stable';
+const OUT_DIR =
+  process.env.OUT_DIR || '/home/moltbot/clawd-wechat/tmp/maxx-settings-multitenant-layout';
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const ADMIN_USER = {
+  id: 1,
+  username: 'admin',
+  tenantID: 1,
+  tenantName: 'Admin Tenant',
+  role: 'admin',
+};
+
+const settings = {
+  api_token_auth_enabled: 'true',
+  force_project_binding: 'false',
+  ui_multitenant_enabled: 'false',
+  ui_multitenant_layout: 'current',
+};
+const calls = [];
+
+function record(method, path, status, note = '') {
+  calls.push({ time: new Date().toISOString(), method, path, status, note });
+}
+
+async function installMock(page) {
+  await page.route('**/api/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+    const json = async (body, status = 200, note = '') => {
+      record(method, path, status, note);
+      await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+    };
+
+    if (path === '/api/admin/auth/status') return json({ authEnabled: true, user: ADMIN_USER });
+    if (path === '/api/settings' || path === '/api/admin/settings') return json(settings);
+    if (path.startsWith('/api/admin/settings/') && method === 'PUT') {
+      const key = decodeURIComponent(path.slice('/api/admin/settings/'.length));
+      const body = request.postDataJSON();
+      // Simulate a slow network write. The layout selector must appear before this resolves.
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      settings[key] = body.value;
+      if (key === 'ui_multitenant_enabled') {
+        await page.evaluate(() => {
+          window.__maxxSettingsSaved = true;
+        });
+      }
+      if (key === 'ui_multitenant_layout') {
+        await page.evaluate(() => {
+          window.__maxxLayoutSaved = true;
+        });
+      }
+      return json({ key, value: body.value }, 200, `updated ${key}`);
+    }
+    if (path === '/api/admin/proxy-status') {
+      return json({ running: true, address: '127.0.0.1', port: 9880, version: 'v0.99.0-test' });
+    }
+    if (
+      path === '/api/admin/projects' ||
+      path === '/api/admin/providers' ||
+      path === '/api/admin/routes'
+    ) {
+      return json([]);
+    }
+    return json({});
+  });
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({ path: `${OUT_DIR}/${name}.png`, fullPage: true });
+}
+
+async function navigateClient(page, path) {
+  await page.goto(`${BASE_URL}/`);
+  await page.evaluate((targetPath) => {
+    window.history.pushState(null, '', targetPath);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+}
+
+async function run() {
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: CHROME,
+    args: ['--no-sandbox'],
+  });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    locale: 'zh-CN',
+  });
+  const page = await context.newPage();
+  await installMock(page);
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+
+  await navigateClient(page, '/settings');
+  await page
+    .getByText('启用多租户界面', { exact: true })
+    .waitFor({ state: 'visible', timeout: 10_000 });
+  await page
+    .getByText('多租户界面式样', { exact: true })
+    .waitFor({ state: 'detached', timeout: 10_000 });
+  await screenshot(page, '01-before-enable-no-layout-select');
+
+  await page.getByRole('switch', { name: '启用多租户界面' }).click();
+  await page
+    .getByText('多租户界面式样', { exact: true })
+    .waitFor({ state: 'visible', timeout: 500 });
+  await screenshot(page, '02-enabled-layout-select-visible-before-save-finishes');
+  await page.waitForFunction(() => window.__maxxSettingsSaved === true, null, { timeout: 10_000 });
+
+  await page.getByRole('combobox').filter({ hasText: '当前式样' }).click();
+  await page.locator('[data-slot="select-item"]').filter({ hasText: '用户控制台' }).click();
+  await page.waitForFunction(() => window.__maxxLayoutSaved === true, null, { timeout: 10_000 });
+  await page
+    .getByRole('combobox')
+    .filter({ hasText: '用户控制台' })
+    .waitFor({ state: 'visible', timeout: 10_000 });
+  await screenshot(page, '03-layout-changed-user-panel');
+
+  assert.equal(settings.ui_multitenant_enabled, 'true');
+  assert.equal(settings.ui_multitenant_layout, 'user_panel');
+  assert(calls.some((call) => call.note === 'updated ui_multitenant_enabled'));
+  assert(calls.some((call) => call.note === 'updated ui_multitenant_layout'));
+
+  const ledger = await context.newPage();
+  await ledger.setContent(`
+    <html lang="zh-CN">
+      <head><meta charset="utf-8"><style>
+        body { font-family: Inter, system-ui, sans-serif; padding: 24px; background: #f8fafc; color: #0f172a; }
+        table { width: 100%; border-collapse: collapse; background: white; }
+        th, td { border: 1px solid #cbd5e1; padding: 8px; font-size: 13px; text-align: left; }
+        th { background: #e2e8f0; }
+        code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      </style></head>
+      <body>
+        <h1>设置页 Mock 交互证据</h1>
+        <p>多租户开关点击后，式样下拉在保存请求返回前已出现。</p>
+        <p>最终设置：<code>${JSON.stringify(settings)}</code></p>
+        <table>
+          <thead><tr><th>时间</th><th>方法</th><th>路径</th><th>状态</th><th>说明</th></tr></thead>
+          <tbody>${calls
+            .map(
+              (call) =>
+                `<tr><td>${call.time}</td><td>${call.method}</td><td><code>${call.path}</code></td><td>${call.status}</td><td>${call.note}</td></tr>`,
+            )
+            .join('')}</tbody>
+        </table>
+      </body>
+    </html>
+  `);
+  await ledger.screenshot({ path: `${OUT_DIR}/04-mock-interaction-ledger.png`, fullPage: true });
+
+  await browser.close();
+  console.log(
+    JSON.stringify({ ok: true, screenshots: fs.readdirSync(OUT_DIR).sort(), calls }, null, 2),
+  );
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/e2e/user-panel-key-flow.js
+++ b/web/e2e/user-panel-key-flow.js
@@ -216,6 +216,16 @@ async function assertVisible(page, text) {
   await page.getByText(text, { exact: true }).waitFor({ state: 'visible', timeout: 10_000 });
 }
 
+async function assertHidden(page, text) {
+  await page.getByText(text, { exact: true }).waitFor({ state: 'detached', timeout: 10_000 });
+}
+
+async function assertUserPanelUsageStatsRemoved(page) {
+  for (const text of ['接口使用统计', '今日调用', '本月调用', '成功率', '常用模型', '预估成本']) {
+    await assertHidden(page, text);
+  }
+}
+
 async function screenshot(page, name) {
   await page.screenshot({ path: `${OUT_DIR}/${name}.png`, fullPage: true });
 }
@@ -244,9 +254,8 @@ async function run() {
   await userPage.goto(`${BASE_URL}/`);
   await assertVisible(userPage, '暂无专用 Key');
   await assertVisible(userPage, '快速示例');
-  await userPage
-    .getByText('当前可用模型', { exact: true })
-    .waitFor({ state: 'detached', timeout: 10_000 });
+  await assertHidden(userPage, '当前可用模型');
+  await assertUserPanelUsageStatsRemoved(userPage);
   const endpoints = [
     { label: 'OpenAI / Codex', url: `${BASE_URL}/v1` },
     { label: 'Claude', url: BASE_URL },
@@ -320,11 +329,12 @@ async function run() {
     .getByText(secondPlain, { exact: true })
     .waitFor({ state: 'visible', timeout: 10_000 });
   assert.equal(state.tokens[0].id, 102, 'new token should be the active admin-visible token');
-  assert(
-    (await userPage.getByText('55,811', { exact: true }).count()) >= 2,
-    'today and month totals should inherit old + regenerated key usage',
+  await assertUserPanelUsageStatsRemoved(userPage);
+  assert.equal(
+    state.calls.filter((call) => call.path.includes('/api/usage-stats')).length,
+    0,
+    'user panel must not request usage stats after the usage block is removed',
   );
-  await userPage.getByText(/失败 43611 次/).waitFor({ state: 'visible', timeout: 10_000 });
   await screenshot(userPage, '05-user-regenerated-one-time-key');
 
   await navigateClient(adminPage, '/api-tokens');
@@ -347,7 +357,8 @@ async function run() {
       <body>
         <h1>Mock 交互证据</h1>
         <p>当前 active Token 数：<strong>${state.tokens.filter((token) => token.isEnabled).length}</strong></p>
-        <p>历史 Token 数：<strong>${state.tokens.length}</strong>；旧 token 禁用保留，统计继承。</p>
+        <p>历史 Token 数：<strong>${state.tokens.length}</strong>；旧 token 禁用保留，新 token active。</p>
+        <p>用户面板接口使用统计 UI 已移除，页面未请求 <code>/api/usage-stats</code>。</p>
         <p>当前 Token：<code>${state.tokens.find((token) => token.isEnabled)?.tokenPrefix}</code>，完整值仅在用户创建/重新生成瞬间出现。</p>
         <ul>${state.tokens.map((token) => `<li><code>${token.id}</code> ${token.isEnabled ? 'active' : 'disabled'} total=${state.usageByTokenId.get(token.id)?.total ?? 0}</li>`).join('')}</ul>
         <table>

--- a/web/e2e/user-panel-key-flow.js
+++ b/web/e2e/user-panel-key-flow.js
@@ -27,10 +27,9 @@ const MEMBER_USER = {
 const state = {
   nextTokenIndex: 1,
   tokens: [],
+  usageByTokenId: new Map(),
   calls: [],
 };
-
-const RESPONSE_MODELS = ['gpt-4o-mini', 'claude-sonnet-4', 'gemini-2.5-pro', 'gpt-5'];
 
 const settings = {
   api_token_auth_enabled: 'true',
@@ -67,21 +66,65 @@ function createUserPanelToken(userId) {
     projectID: 0,
     isEnabled: true,
     devMode: false,
-    useCount: index === 1 ? 0 : 0,
+    useCount: 0,
   };
   state.tokens.unshift(token);
+  if (!state.usageByTokenId.has(token.id)) {
+    state.usageByTokenId.set(token.id, {
+      total: index === 1 ? 96 : 55_715,
+      success: index === 1 ? 80 : 12_120,
+      failed: index === 1 ? 16 : 43_595,
+    });
+  }
   return { token: plain, apiToken: sanitize(token) };
 }
 
-function currentUserPanelToken(userId) {
-  return state.tokens.find((token) => token.description === userPanelMarker(userId)) || null;
+function userPanelTokens(userId) {
+  const marker = userPanelMarker(userId);
+  return state.tokens.filter((token) => token.description === marker);
 }
 
-function removeUserPanelTokens(userId) {
-  const marker = userPanelMarker(userId);
-  const removed = state.tokens.filter((token) => token.description === marker);
-  state.tokens = state.tokens.filter((token) => token.description !== marker);
-  return removed;
+function currentUserPanelToken(userId) {
+  return userPanelTokens(userId).find((token) => token.isEnabled) || null;
+}
+
+function disableUserPanelTokens(userId) {
+  const disabled = [];
+  for (const token of userPanelTokens(userId)) {
+    if (!token.isEnabled) continue;
+    token.isEnabled = false;
+    token.updatedAt = nowIso();
+    disabled.push(token);
+  }
+  return disabled;
+}
+
+function usageStatsForUser(userId) {
+  return userPanelTokens(userId).map((token) => {
+    const usage = state.usageByTokenId.get(token.id) || { total: 0, success: 0, failed: 0 };
+    return {
+      id: token.id,
+      createdAt: nowIso(),
+      timeBucket: nowIso(),
+      granularity: 'hour',
+      routeID: 1,
+      providerID: 1,
+      projectID: 0,
+      apiTokenID: token.id,
+      clientType: 'openai',
+      model: token.isEnabled ? 'new-key-model' : 'old-key-model',
+      totalRequests: usage.total,
+      successfulRequests: usage.success,
+      failedRequests: usage.failed,
+      totalDurationMs: 1200,
+      totalTtftMs: 300,
+      inputTokens: usage.total * 10,
+      outputTokens: usage.total * 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: usage.total * 100,
+    };
+  });
 }
 
 function record(method, path, status, note = '') {
@@ -104,31 +147,8 @@ async function installMock(page, user) {
     if (path === '/api/proxy-status' || path === '/api/admin/proxy-status') {
       return json({ running: true, address: '127.0.0.1', port: 9880, version: 'v0.99.0-test' });
     }
-    if (path === '/api/usage-stats') {
-      return json([
-        {
-          id: 1,
-          createdAt: nowIso(),
-          timeBucket: nowIso(),
-          granularity: 'hour',
-          routeID: 1,
-          providerID: 1,
-          projectID: 0,
-          apiTokenID: currentUserPanelToken(MEMBER_USER.id)?.id || 0,
-          clientType: 'openai',
-          model: 'gpt-test',
-          totalRequests: 25,
-          successfulRequests: 24,
-          failedRequests: 1,
-          totalDurationMs: 1200,
-          totalTtftMs: 300,
-          inputTokens: 1000,
-          outputTokens: 500,
-          cacheRead: 0,
-          cacheWrite: 0,
-          cost: 1200,
-        },
-      ]);
+    if (path === '/api/usage-stats' || path === '/api/admin/usage-stats') {
+      return json(usageStatsForUser(user.id), 200, 'usage follows all user panel key generations');
     }
     if (path === '/api/user-panel-token' && method === 'GET') {
       return json(
@@ -148,17 +168,17 @@ async function installMock(page, user) {
       return json(createUserPanelToken(user.id), 201, 'create dedicated token');
     }
     if (path === '/api/user-panel-token/regenerate' && method === 'POST') {
-      const removed = removeUserPanelTokens(user.id);
+      const disabled = disableUserPanelTokens(user.id);
       const created = createUserPanelToken(user.id);
       return json(
         created,
         201,
-        `regenerated; removed=${removed.map((token) => token.id).join(',')}`,
+        `regenerated; disabled=${disabled.map((token) => token.id).join(',')}; history preserved`,
       );
     }
     if (path === '/api/api-tokens') return json(state.tokens.map(sanitize));
-    if (path === '/api/admin/api-tokens') return json(state.tokens);
-    if (path === '/api/response-models') return json(RESPONSE_MODELS);
+    if (path === '/api/admin/api-tokens')
+      return json(state.tokens.filter((token) => token.isEnabled));
     if (path === '/api/admin/projects' || path === '/api/projects') return json([]);
     if (path === '/api/admin/requests/count') return json(0);
     if (path === '/api/admin/requests')
@@ -171,8 +191,6 @@ async function installMock(page, user) {
         '/api/routes',
         '/api/admin/model-mappings',
         '/api/model-mappings',
-        '/api/admin/response-models',
-        '/api/response-models',
         '/api/admin/sessions',
         '/api/sessions',
       ].includes(path)
@@ -226,21 +244,23 @@ async function run() {
   await userPage.goto(`${BASE_URL}/`);
   await assertVisible(userPage, '暂无专用 Key');
   await assertVisible(userPage, '快速示例');
-  await assertVisible(userPage, '当前可用模型');
-  for (const model of RESPONSE_MODELS) {
-    await assertVisible(userPage, model);
+  await userPage
+    .getByText('当前可用模型', { exact: true })
+    .waitFor({ state: 'detached', timeout: 10_000 });
+  const endpoints = [
+    { label: 'OpenAI / Codex', url: `${BASE_URL}/v1` },
+    { label: 'Claude', url: BASE_URL },
+    { label: 'Gemini', url: `${BASE_URL}/v1beta/models/{model}:generateContent` },
+  ];
+  for (const endpoint of endpoints) {
+    await userPage
+      .getByText(endpoint.url, { exact: true })
+      .waitFor({ state: 'visible', timeout: 10_000 });
+    await userPage.getByRole('button', { name: `复制 ${endpoint.label}` }).click();
+    const copiedEndpoint = await userPage.evaluate(() => navigator.clipboard.readText());
+    assert.equal(copiedEndpoint, endpoint.url, `${endpoint.label} copy should match endpoint URL`);
   }
-  for (const url of [
-    `${BASE_URL}/v1`,
-    BASE_URL,
-    `${BASE_URL}/v1beta/models/{model}:generateContent`,
-  ]) {
-    await userPage.getByText(url, { exact: true }).waitFor({ state: 'visible', timeout: 10_000 });
-  }
-  await userPage.getByRole('button', { name: /复制/ }).first().click();
-  const copiedEndpoint = await userPage.evaluate(() => navigator.clipboard.readText());
-  assert.match(copiedEndpoint, /\/v1$/, 'base URL copy should copy OpenAI/Codex base URL');
-  await userPage.getByRole('button', { name: /复制/ }).nth(1).click();
+  await userPage.getByRole('button', { name: /复制/ }).last().click();
   const copiedExample = await userPage.evaluate(() => navigator.clipboard.readText());
   assert.match(
     copiedExample,
@@ -288,13 +308,23 @@ async function run() {
   userPage.once('dialog', (dialog) => dialog.accept());
   await userPage.getByRole('button', { name: /重新生成/ }).click();
   await assertVisible(userPage, '请立即复制');
-  assert.equal(state.tokens.length, 1, 'regenerate should replace old token with one token');
+  assert.equal(
+    state.tokens.filter((token) => token.isEnabled).length,
+    1,
+    'regenerate should leave exactly one active token',
+  );
+  assert.equal(state.tokens.length, 2, 'regenerate should preserve old token history');
   const secondPlain = state.tokens[0].token;
   assert.notEqual(secondPlain, firstPlain, 'regenerated token should differ from old token');
   await userPage
     .getByText(secondPlain, { exact: true })
     .waitFor({ state: 'visible', timeout: 10_000 });
-  assert.equal(state.tokens[0].id, 102, 'new token should be the only admin-visible token');
+  assert.equal(state.tokens[0].id, 102, 'new token should be the active admin-visible token');
+  assert(
+    (await userPage.getByText('55,811', { exact: true }).count()) >= 2,
+    'today and month totals should inherit old + regenerated key usage',
+  );
+  await userPage.getByText(/失败 43611 次/).waitFor({ state: 'visible', timeout: 10_000 });
   await screenshot(userPage, '05-user-regenerated-one-time-key');
 
   await navigateClient(adminPage, '/api-tokens');
@@ -316,8 +346,10 @@ async function run() {
       </style></head>
       <body>
         <h1>Mock 交互证据</h1>
-        <p>当前 admin 可见 Token 数：<strong>${state.tokens.length}</strong></p>
-        <p>当前 Token：<code>${state.tokens[0].tokenPrefix}</code>，完整值仅在用户创建/重新生成瞬间出现。</p>
+        <p>当前 active Token 数：<strong>${state.tokens.filter((token) => token.isEnabled).length}</strong></p>
+        <p>历史 Token 数：<strong>${state.tokens.length}</strong>；旧 token 禁用保留，统计继承。</p>
+        <p>当前 Token：<code>${state.tokens.find((token) => token.isEnabled)?.tokenPrefix}</code>，完整值仅在用户创建/重新生成瞬间出现。</p>
+        <ul>${state.tokens.map((token) => `<li><code>${token.id}</code> ${token.isEnabled ? 'active' : 'disabled'} total=${state.usageByTokenId.get(token.id)?.total ?? 0}</li>`).join('')}</ul>
         <table>
           <thead><tr><th>时间</th><th>方法</th><th>路径</th><th>状态</th><th>说明</th></tr></thead>
           <tbody>${state.calls

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { apiTokenKeys } from './use-api-tokens';
 import { getTransport } from '@/lib/transport';
 
@@ -6,6 +6,17 @@ export const userPanelTokenKeys = {
   all: ['user-panel-token'] as const,
   detail: () => [...userPanelTokenKeys.all, 'detail'] as const,
 };
+
+async function refreshUserPanelTokenDependents(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: userPanelTokenKeys.all }),
+    queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() }),
+  ]);
+  await queryClient.refetchQueries({
+    predicate: (query) => query.queryKey[0] === 'usageStats',
+    type: 'active',
+  });
+}
 
 export function useUserPanelAPIToken() {
   return useQuery({
@@ -19,10 +30,7 @@ export function useCreateUserPanelAPIToken() {
 
   return useMutation({
     mutationFn: () => getTransport().createUserPanelAPIToken(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: userPanelTokenKeys.all });
-      queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() });
-    },
+    onSuccess: () => refreshUserPanelTokenDependents(queryClient),
   });
 }
 
@@ -31,9 +39,6 @@ export function useRegenerateUserPanelAPIToken() {
 
   return useMutation({
     mutationFn: () => getTransport().regenerateUserPanelAPIToken(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: userPanelTokenKeys.all });
-      queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() });
-    },
+    onSuccess: () => refreshUserPanelTokenDependents(queryClient),
   });
 }

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -2087,23 +2087,44 @@ function MultiTenantUISection() {
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
 
-  const enabled = settings?.ui_multitenant_enabled === 'true';
-  const layout: MultiTenantUILayout =
+  const settingsEnabled = settings?.ui_multitenant_enabled === 'true';
+  const settingsLayout: MultiTenantUILayout =
     settings?.[MULTITENANT_UI_LAYOUT_SETTING_KEY] === 'user_panel' ? 'user_panel' : 'current';
+  const [localEnabled, setLocalEnabled] = useState(settingsEnabled);
+  const [localLayout, setLocalLayout] = useState<MultiTenantUILayout>(settingsLayout);
+
+  useEffect(() => {
+    setLocalEnabled(settingsEnabled);
+    setLocalLayout(settingsLayout);
+  }, [settingsEnabled, settingsLayout]);
 
   const handleToggle = async (checked: boolean) => {
-    await updateSetting.mutateAsync({
-      key: 'ui_multitenant_enabled',
-      value: checked ? 'true' : 'false',
-    });
+    const previous = localEnabled;
+    setLocalEnabled(checked);
+    try {
+      await updateSetting.mutateAsync({
+        key: 'ui_multitenant_enabled',
+        value: checked ? 'true' : 'false',
+      });
+    } catch (error) {
+      setLocalEnabled(previous);
+      throw error;
+    }
   };
 
   const handleLayoutChange = async (value: string) => {
     const nextLayout: MultiTenantUILayout = value === 'user_panel' ? 'user_panel' : 'current';
-    await updateSetting.mutateAsync({
-      key: MULTITENANT_UI_LAYOUT_SETTING_KEY,
-      value: nextLayout,
-    });
+    const previous = localLayout;
+    setLocalLayout(nextLayout);
+    try {
+      await updateSetting.mutateAsync({
+        key: MULTITENANT_UI_LAYOUT_SETTING_KEY,
+        value: nextLayout,
+      });
+    } catch (error) {
+      setLocalLayout(previous);
+      throw error;
+    }
   };
 
   if (isLoading) return null;
@@ -2128,13 +2149,13 @@ function MultiTenantUISection() {
           </div>
           <Switch
             aria-label={t('settings.enableMultiTenantUI')}
-            checked={enabled}
+            checked={localEnabled}
             onCheckedChange={handleToggle}
             disabled={updateSetting.isPending}
           />
         </div>
 
-        {enabled && (
+        {localEnabled && (
           <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <Label className="text-sm font-medium text-foreground">
@@ -2145,13 +2166,13 @@ function MultiTenantUISection() {
               </p>
             </div>
             <Select
-              value={layout}
+              value={localLayout}
               onValueChange={(value) => value && handleLayoutChange(value)}
               disabled={updateSetting.isPending}
             >
               <SelectTrigger className="w-full sm:w-56">
                 <SelectValue>
-                  {layout === 'user_panel'
+                  {localLayout === 'user_panel'
                     ? t('settings.multiTenantUILayoutUserPanel')
                     : t('settings.multiTenantUILayoutCurrent')}
                 </SelectValue>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -20,7 +20,6 @@ import {
   useProxyStatus,
   usePublicSettings,
   useRegenerateUserPanelAPIToken,
-  useResponseModels,
   useUsageStats,
   useUserPanelAPIToken,
 } from '@/hooks/queries';
@@ -139,11 +138,10 @@ export function UserPanelPage() {
   const { user, logout } = useAuth();
   const { data: proxyStatus } = useProxyStatus();
   const { data: settings } = usePublicSettings();
-  const { data: responseModels = [], isLoading: modelsLoading } = useResponseModels();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
-  const [baseURLCopied, setBaseURLCopied] = useState(false);
+  const [copiedEndpointId, setCopiedEndpointId] = useState('');
   const [exampleCopied, setExampleCopied] = useState(false);
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
@@ -171,8 +169,6 @@ export function UserPanelPage() {
   const month = useMemo(() => buildUsageSummary(monthStats), [monthStats]);
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const activeTokens = userPanelToken && getTokenStatus(userPanelToken) === 'active' ? 1 : 0;
-  const visibleModels = responseModels.slice(0, 8);
-  const hiddenModelCount = Math.max(responseModels.length - visibleModels.length, 0);
 
   const tenantLabel = user?.tenantName?.trim()
     ? user.tenantName.trim()
@@ -195,11 +191,11 @@ export function UserPanelPage() {
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'`;
 
-  const handleCopyBaseURL = async () => {
-    if (!openAICodexBaseURL || typeof navigator === 'undefined' || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(openAICodexBaseURL);
-    setBaseURLCopied(true);
-    window.setTimeout(() => setBaseURLCopied(false), 1600);
+  const handleCopyEndpoint = async (endpointId: string, url: string) => {
+    if (!url || typeof navigator === 'undefined' || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(url);
+    setCopiedEndpointId(endpointId);
+    window.setTimeout(() => setCopiedEndpointId(''), 1600);
   };
 
   const handleCopyOneTimeToken = async () => {
@@ -379,28 +375,27 @@ export function UserPanelPage() {
             </CardHeader>
             <CardContent className="space-y-4 pt-5">
               <div className="rounded-xl border border-border bg-muted/25 p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    {t('userPanel.baseURL')}
-                  </p>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 gap-2"
-                    onClick={handleCopyBaseURL}
-                  >
-                    <Copy className="size-3.5" />
-                    {baseURLCopied ? t('common.copied') : t('common.copy')}
-                  </Button>
-                </div>
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {t('userPanel.baseURL')}
+                </p>
                 <div className="mt-3 space-y-2">
                   {endpointHints.map((endpoint) => (
                     <div
                       key={endpoint.id}
-                      className="grid gap-1 rounded-lg bg-background px-3 py-2 text-xs sm:grid-cols-[104px_1fr] sm:items-center"
+                      className="grid gap-2 rounded-lg bg-background px-3 py-2 text-xs sm:grid-cols-[104px_1fr_auto] sm:items-center"
                     >
                       <span className="font-medium text-foreground">{endpoint.label}</span>
                       <code className="break-all text-muted-foreground">{endpoint.url || '—'}</code>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8 gap-2"
+                        aria-label={`${t('common.copy')} ${endpoint.label}`}
+                        onClick={() => handleCopyEndpoint(endpoint.id, endpoint.url)}
+                      >
+                        <Copy className="size-3.5" />
+                        {copiedEndpointId === endpoint.id ? t('common.copied') : t('common.copy')}
+                      </Button>
                     </div>
                   ))}
                 </div>
@@ -414,35 +409,6 @@ export function UserPanelPage() {
                   {t('userPanel.yourKey')}
                   {'>'}
                 </code>
-              </div>
-              <div className="rounded-xl border border-border bg-muted/25 p-4">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {t('userPanel.availableModels')}
-                </p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {modelsLoading ? (
-                    <span className="text-xs text-muted-foreground">{t('common.loading')}</span>
-                  ) : visibleModels.length > 0 ? (
-                    <>
-                      {visibleModels.map((model) => (
-                        <Badge
-                          key={model}
-                          variant="outline"
-                          className="max-w-full truncate text-xs"
-                        >
-                          {model}
-                        </Badge>
-                      ))}
-                      {hiddenModelCount > 0 ? (
-                        <Badge variant="secondary" className="text-xs">
-                          {t('userPanel.moreModels', { count: hiddenModelCount })}
-                        </Badge>
-                      ) : null}
-                    </>
-                  ) : (
-                    <span className="text-xs text-muted-foreground">{t('userPanel.noModels')}</span>
-                  )}
-                </div>
               </div>
               <div className="rounded-xl border border-border bg-muted/25 p-4">
                 <div className="flex items-center justify-between gap-3">

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,17 +1,5 @@
-import { useMemo, useState } from 'react';
-import {
-  Activity,
-  BarChart3,
-  CheckCircle2,
-  Clock3,
-  Copy,
-  KeyRound,
-  LogOut,
-  Server,
-  ShieldCheck,
-  UserRound,
-  XCircle,
-} from 'lucide-react';
+import { useState } from 'react';
+import { Clock3, Copy, KeyRound, LogOut, Server, ShieldCheck, UserRound } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
 import { useAuth } from '@/lib/auth-context';
@@ -20,23 +8,10 @@ import {
   useProxyStatus,
   usePublicSettings,
   useRegenerateUserPanelAPIToken,
-  useUsageStats,
   useUserPanelAPIToken,
 } from '@/hooks/queries';
-import { getTimeRange } from '@/hooks/queries/use-usage-stats';
-import type { APIToken, UsageStats, UsageStatsFilter } from '@/lib/transport';
+import type { APIToken } from '@/lib/transport';
 import { cn } from '@/lib/utils';
-
-interface UsageSummary {
-  totalRequests: number;
-  successfulRequests: number;
-  failedRequests: number;
-  inputTokens: number;
-  outputTokens: number;
-  cost: number;
-  successRate: number;
-  topModel: string;
-}
 
 function maskNumericIdentity(value?: number) {
   if (!value || value <= 0) return '••';
@@ -61,76 +36,10 @@ function formatDateTime(value?: string) {
   }).format(date);
 }
 
-function formatCost(microUsd: number) {
-  if (!microUsd) return '$0.00';
-  return `$${(microUsd / 1_000_000).toFixed(4)}`;
-}
-
-function buildUsageSummary(stats: UsageStats[] | undefined): UsageSummary {
-  const modelCounts = new Map<string, number>();
-  const summary = (stats ?? []).reduce<UsageSummary>(
-    (acc, item) => {
-      acc.totalRequests += item.totalRequests || 0;
-      acc.successfulRequests += item.successfulRequests || 0;
-      acc.failedRequests += item.failedRequests || 0;
-      acc.inputTokens += item.inputTokens || 0;
-      acc.outputTokens += item.outputTokens || 0;
-      acc.cost += item.cost || 0;
-      if (item.model) {
-        modelCounts.set(item.model, (modelCounts.get(item.model) ?? 0) + (item.totalRequests || 0));
-      }
-      return acc;
-    },
-    {
-      totalRequests: 0,
-      successfulRequests: 0,
-      failedRequests: 0,
-      inputTokens: 0,
-      outputTokens: 0,
-      cost: 0,
-      successRate: 0,
-      topModel: '—',
-    },
-  );
-
-  summary.successRate = summary.totalRequests
-    ? Math.round((summary.successfulRequests / summary.totalRequests) * 1000) / 10
-    : 0;
-  summary.topModel = Array.from(modelCounts.entries()).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '—';
-  return summary;
-}
-
 function getTokenStatus(token: APIToken) {
   if (!token.isEnabled) return 'disabled';
   if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) return 'expired';
   return 'active';
-}
-
-function StatCard({
-  title,
-  value,
-  caption,
-  icon: Icon,
-}: {
-  title: string;
-  value: string;
-  caption: string;
-  icon: typeof Activity;
-}) {
-  return (
-    <Card className="border-border bg-card shadow-sm">
-      <CardContent className="flex min-h-28 items-start justify-between gap-3 p-4">
-        <div>
-          <p className="text-xs font-medium text-muted-foreground">{title}</p>
-          <p className="mt-1.5 text-2xl font-semibold tracking-tight">{value}</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">{caption}</p>
-        </div>
-        <div className="flex size-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
-          <Icon className="size-4" />
-        </div>
-      </CardContent>
-    </Card>
-  );
 }
 
 export function UserPanelPage() {
@@ -146,29 +55,7 @@ export function UserPanelPage() {
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
 
-  const todayFilter = useMemo<UsageStatsFilter>(() => {
-    const range = getTimeRange('last_24_hours');
-    return {
-      granularity: range.granularity,
-      start: range.start.toISOString(),
-      end: range.end.toISOString(),
-    };
-  }, []);
-  const monthFilter = useMemo<UsageStatsFilter>(() => {
-    const range = getTimeRange('last_30_days');
-    return {
-      granularity: range.granularity,
-      start: range.start.toISOString(),
-      end: range.end.toISOString(),
-    };
-  }, []);
-  const { data: todayStats } = useUsageStats(todayFilter);
-  const { data: monthStats } = useUsageStats(monthFilter);
-
-  const today = useMemo(() => buildUsageSummary(todayStats), [todayStats]);
-  const month = useMemo(() => buildUsageSummary(monthStats), [monthStats]);
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
-  const activeTokens = userPanelToken && getTokenStatus(userPanelToken) === 'active' ? 1 : 0;
 
   const tenantLabel = user?.tenantName?.trim()
     ? user.tenantName.trim()
@@ -445,73 +332,8 @@ export function UserPanelPage() {
           </Card>
         </section>
 
-        <section className="grid gap-4 md:grid-cols-4">
-          <StatCard
-            title={t('userPanel.todayCalls')}
-            value={formatNumber(today.totalRequests)}
-            caption={t('userPanel.last24Hours')}
-            icon={BarChart3}
-          />
-          <StatCard
-            title={t('userPanel.monthCalls')}
-            value={formatNumber(month.totalRequests)}
-            caption={t('userPanel.last30Days')}
-            icon={Activity}
-          />
-          <StatCard
-            title={t('userPanel.successRate')}
-            value={`${month.successRate}%`}
-            caption={t('userPanel.failedCalls', { count: month.failedRequests })}
-            icon={month.failedRequests > 0 ? XCircle : CheckCircle2}
-          />
-          <StatCard
-            title={t('userPanel.activeKeys')}
-            value={formatNumber(activeTokens)}
-            caption={t('userPanel.totalKeys', { count: userPanelToken ? 1 : 0 })}
-            icon={KeyRound}
-          />
-        </section>
-
         <section className="grid gap-5 lg:grid-cols-3">
-          <Card className="border-border bg-card shadow-sm lg:col-span-2">
-            <CardHeader className="border-b border-border">
-              <CardTitle className="flex items-center gap-2 text-base font-medium">
-                <Activity className="size-4 text-muted-foreground" />
-                {t('userPanel.usageDetails')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 pt-5">
-              {month.totalRequests === 0 ? (
-                <p className="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
-                  {t('userPanel.noUsageHint')}
-                </p>
-              ) : null}
-              <div className="grid gap-4 sm:grid-cols-3">
-                <div className="rounded-xl border border-border bg-muted/25 p-4">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {t('userPanel.topModel')}
-                  </p>
-                  <p className="mt-2 truncate font-semibold">{month.topModel}</p>
-                </div>
-                <div className="rounded-xl border border-border bg-muted/25 p-4">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {t('userPanel.tokens')}
-                  </p>
-                  <p className="mt-2 font-semibold">
-                    {formatNumber(month.inputTokens + month.outputTokens)}
-                  </p>
-                </div>
-                <div className="rounded-xl border border-border bg-muted/25 p-4">
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {t('userPanel.estimatedCost')}
-                  </p>
-                  <p className="mt-2 font-semibold">{formatCost(month.cost)}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="border-border bg-card shadow-sm">
+          <Card className="border-border bg-card shadow-sm lg:col-start-3">
             <CardHeader className="border-b border-border">
               <CardTitle className="flex items-center gap-2 text-base font-medium">
                 <ShieldCheck className="size-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- show the multi-tenant layout selector immediately after enabling the multi-tenant UI switch
- remove the user panel response-models block and the user-panel usage stats sections
- replace the base URL field with separate OpenAI/Codex, Claude, and Gemini copy buttons
- preserve disabled historical user-panel tokens on regeneration and keep the new token active/admin-visible
- refresh user-panel token/admin-token/usage-stats queries after creating or regenerating the dedicated key
- add JS E2E coverage and handler regression coverage for the follow-up flows

## Validation
- `pnpm exec tsc -b --pretty false`
- `pnpm exec eslint src/pages/settings/index.tsx src/pages/user-panel.tsx src/hooks/queries/use-user-panel-token.ts e2e/settings-multitenant-layout-flow.js e2e/user-panel-key-flow.js e2e/multitenant-login-flow.js`
- `pnpm exec vite build`
- `node e2e/settings-multitenant-layout-flow.js`
- `node e2e/user-panel-key-flow.js`
- `node e2e/multitenant-login-flow.js`
- `go test ./...`
- `go test -count=1 ./internal/handler`

## Notes
- This PR does not release anything until merge is complete.