### PR TITLE
feat(providers): add first-class OpenRouter provider

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -17,9 +17,10 @@ import (
 
 	"github.com/awsl-project/maxx/internal/adapter/client"
 	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude" // Register claude adapter
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom" // Register custom adapter
-	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"   // Register kiro adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"     // Register claude adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"     // Register custom adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"       // Register kiro adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/openrouter" // Register openrouter adapter
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/core"

--- a/internal/adapter/provider/openrouter/adapter.go
+++ b/internal/adapter/provider/openrouter/adapter.go
@@ -1,0 +1,98 @@
+// Package openrouter implements a first-class provider adapter for OpenRouter
+// (https://openrouter.ai), an aggregation gateway that natively speaks both the
+// OpenAI Chat Completions API (/api/v1/chat/completions) and the Anthropic
+// Messages API ("Anthropic Skin", /api/v1/messages). Because both endpoints are
+// exactly what the generic `custom` adapter already proxies, this adapter is a
+// thin wrapper: it synthesizes a ProviderConfigCustom with the fixed OpenRouter
+// base URL and the user's API key, then delegates every request to the proven
+// custom proxy core. This keeps OpenRouter a real, dedicated provider type
+// (own config, own UI, own icon) without duplicating the proxy/streaming logic.
+package openrouter
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// defaultBaseURL is OpenRouter's fixed API root. Clients append their own path:
+// claude clients hit /v1/messages, openai clients hit /v1/chat/completions.
+const defaultBaseURL = "https://openrouter.ai/api"
+
+// resolveBaseURL returns the OpenRouter API root. It is fixed in production but
+// can be redirected via MAXX_OPENROUTER_BASE_URL — used by tests to point at a
+// mock upstream, and usable to target a self-hosted OpenRouter-compatible gateway.
+func resolveBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("MAXX_OPENROUTER_BASE_URL")); v != "" {
+		return v
+	}
+	return defaultBaseURL
+}
+
+func init() {
+	provider.RegisterAdapterFactory("openrouter", NewAdapter)
+}
+
+// Adapter is a first-class OpenRouter provider that delegates to the custom
+// adapter using a synthesized custom config.
+type Adapter struct {
+	inner provider.ProviderAdapter
+	// synth is the provider carrying the synthesized Custom config. It is passed
+	// to the inner adapter's Execute so no code path ever dereferences the real
+	// provider's (nil) Custom config.
+	synth *domain.Provider
+}
+
+// NewAdapter builds an OpenRouter adapter by translating the OpenRouter config
+// into an equivalent custom config and wrapping a custom adapter around it.
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	if p.Config == nil || p.Config.OpenRouter == nil {
+		return nil, fmt.Errorf("provider %s missing openrouter config", p.Name)
+	}
+	or := p.Config.OpenRouter
+
+	// Shallow-copy the provider and swap in a synthesized custom config so the
+	// custom core sees a normal "custom" provider pointed at OpenRouter. Only
+	// BaseURL and APIKey are consumed by the custom adapter at request time;
+	// model mapping is handled generically via ModelMapping entities keyed by
+	// provider id (executor.mapModel), so nothing model-related lives here.
+	synth := *p
+	synth.Config = &domain.ProviderConfig{
+		DisableErrorCooldown: p.Config.DisableErrorCooldown,
+		Custom: &domain.ProviderConfigCustom{
+			BaseURL: resolveBaseURL(),
+			APIKey:  or.APIKey,
+			// OpenRouter is a first-party API gateway that natively speaks the
+			// OpenAI and Anthropic protocols — it must NOT be disguised as the
+			// Claude Code CLI. The custom adapter treats a nil Disguise as
+			// claude-code (injecting a system prompt, prompt-caching cache_control,
+			// etc.), which makes OpenRouter's Bedrock-backed Anthropic models 400
+			// with "request did not allow prompt caching". Force "none" so the
+			// client's original request passes through untouched (auth aside).
+			Disguise: &domain.ProviderConfigCustomDisguise{Type: domain.DisguiseTypeNone},
+		},
+	}
+
+	inner, err := custom.NewAdapter(&synth)
+	if err != nil {
+		return nil, err
+	}
+	return &Adapter{inner: inner, synth: &synth}, nil
+}
+
+// SupportedClientTypes reports the client types this OpenRouter provider serves
+// (typically claude + openai, both natively supported by OpenRouter).
+func (a *Adapter) SupportedClientTypes() []domain.ClientType {
+	return a.synth.SupportedClientTypes
+}
+
+// Execute delegates to the custom core, passing the synthesized provider so the
+// custom config drives base URL and auth.
+func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	return a.inner.Execute(c, a.synth)
+}

--- a/internal/adapter/provider/openrouter/adapter_test.go
+++ b/internal/adapter/provider/openrouter/adapter_test.go
@@ -1,0 +1,81 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestNewAdapterRequiresOpenRouterConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *domain.Provider
+	}{
+		{"nil config", &domain.Provider{Name: "or", Config: nil}},
+		{"missing openrouter", &domain.Provider{Name: "or", Config: &domain.ProviderConfig{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewAdapter(tc.p); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestNewAdapterSynthesizesCustomConfig(t *testing.T) {
+	p := &domain.Provider{
+		Name:                 "my-openrouter",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeOpenAI},
+		Config: &domain.ProviderConfig{
+			DisableErrorCooldown: true,
+			OpenRouter: &domain.ProviderConfigOpenRouter{
+				APIKey: "sk-or-secret",
+			},
+		},
+	}
+
+	a, err := NewAdapter(p)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+
+	adapter, ok := a.(*Adapter)
+	if !ok {
+		t.Fatalf("expected *Adapter, got %T", a)
+	}
+
+	custom := adapter.synth.Config.Custom
+	if custom == nil {
+		t.Fatal("synthesized Custom config is nil")
+	}
+	if custom.BaseURL != defaultBaseURL {
+		t.Errorf("BaseURL = %q, want %q", custom.BaseURL, defaultBaseURL)
+	}
+	if custom.APIKey != "sk-or-secret" {
+		t.Errorf("APIKey = %q, want sk-or-secret", custom.APIKey)
+	}
+	if custom.Backend != "" {
+		t.Errorf("Backend = %q, want empty (HTTP passthrough)", custom.Backend)
+	}
+	// Disguise must be forced off: OpenRouter is a real Anthropic/OpenAI gateway,
+	// and the default claude-code disguise injects prompt caching that 400s some
+	// OpenRouter models.
+	if custom.Disguise == nil || custom.Disguise.Type != domain.DisguiseTypeNone {
+		t.Errorf("Disguise = %+v, want type=none", custom.Disguise)
+	}
+	if !adapter.synth.Config.DisableErrorCooldown {
+		t.Error("DisableErrorCooldown not propagated")
+	}
+
+	// The real provider's config must not be mutated by synthesis.
+	if p.Config.Custom != nil {
+		t.Error("real provider Config.Custom should stay nil")
+	}
+
+	// SupportedClientTypes passes through from the real provider.
+	got := a.SupportedClientTypes()
+	if len(got) != 2 || got[0] != domain.ClientTypeClaude || got[1] != domain.ClientTypeOpenAI {
+		t.Errorf("SupportedClientTypes = %v, want [claude openai]", got)
+	}
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -292,6 +292,20 @@ type ProviderConfigCLIProxyAPICodex struct {
 	ModelMapping map[string]string `json:"modelMapping,omitempty"`
 }
 
+// ProviderConfigOpenRouter 是 OpenRouter 一级供应商的配置。
+// OpenRouter 是 OpenAI 兼容且带 Anthropic Messages（"Anthropic Skin"）兼容端点的聚合网关，
+// baseURL 固定为 https://openrouter.ai/api，claude 客户端走 /v1/messages、openai 客户端走
+// /v1/chat/completions，鉴权统一用 Authorization: Bearer <apiKey>。运行时由 openrouter 适配器
+// 合成成一个 ProviderConfigCustom 委托给 custom 适配器执行，无需重复实现代理逻辑。
+//
+// 只保留 APIKey：模型映射走通用的 ModelMapping 实体（executor.mapModel 按 provider 类型+ID
+// 泛化匹配，与 custom 一致），不放在这里——因为 custom 适配器运行时并不读取内联的
+// ModelMapping，放进来只会是不生效的死配置。
+type ProviderConfigOpenRouter struct {
+	// API Key（sk-or-...）
+	APIKey string `json:"apiKey"`
+}
+
 type ProviderConfig struct {
 	// 禁用错误自动冷冻（只影响错误触发的冷冻）
 	DisableErrorCooldown bool                       `json:"disableErrorCooldown,omitempty"`
@@ -301,6 +315,7 @@ type ProviderConfig struct {
 	Kiro                 *ProviderConfigKiro        `json:"kiro,omitempty"`
 	Codex                *ProviderConfigCodex       `json:"codex,omitempty"`
 	Claude               *ProviderConfigClaude      `json:"claude,omitempty"`
+	OpenRouter           *ProviderConfigOpenRouter  `json:"openrouter,omitempty"`
 	// 内部运行时字段，仅用于 NewAdapter 委托，不序列化
 	CLIProxyAPIAntigravity *ProviderConfigCLIProxyAPIAntigravity `json:"-"`
 	CLIProxyAPICodex       *ProviderConfigCLIProxyAPICodex       `json:"-"`

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1159,6 +1159,11 @@ func sanitizeProvider(provider *domain.Provider) *domain.Provider {
 		claude.AccessToken = ""
 		config.Claude = &claude
 	}
+	if config.OpenRouter != nil {
+		openrouter := *config.OpenRouter
+		openrouter.APIKey = ""
+		config.OpenRouter = &openrouter
+	}
 	sanitized.Config = &config
 	return &sanitized
 }

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -491,6 +491,15 @@ func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
 				}
 			}
 		}
+	case "openrouter":
+		if existing.Config.OpenRouter != nil {
+			if incoming.Config.OpenRouter == nil {
+				openrouter := *existing.Config.OpenRouter
+				incoming.Config.OpenRouter = &openrouter
+			} else if incoming.Config.OpenRouter.APIKey == "" {
+				incoming.Config.OpenRouter.APIKey = existing.Config.OpenRouter.APIKey
+			}
+		}
 	}
 }
 
@@ -1287,6 +1296,16 @@ func (s *AdminService) autoSetSupportedClientTypes(provider *domain.Provider) {
 		// If not set, default to OpenAI
 		if len(provider.SupportedClientTypes) == 0 {
 			provider.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
+		}
+	case "openrouter":
+		// OpenRouter natively serves both the OpenAI and Anthropic protocols, so
+		// honor whatever the client configured. If left empty, default to both
+		// rather than leaving the provider with no serviceable client types.
+		if len(provider.SupportedClientTypes) == 0 {
+			provider.SupportedClientTypes = []domain.ClientType{
+				domain.ClientTypeClaude,
+				domain.ClientTypeOpenAI,
+			}
 		}
 	}
 }

--- a/tests/e2e/openrouter_live_test.go
+++ b/tests/e2e/openrouter_live_test.go
@@ -1,0 +1,168 @@
+package e2e_test
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	// Register the openrouter adapter factory via init().
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/openrouter"
+)
+
+// TestOpenRouterLiveProxy drives a real request through the full maxx proxy
+// pipeline into the live OpenRouter API, exercising the first-class openrouter
+// provider (which delegates to the custom core with a synthesized config).
+//
+// It is skipped unless MAXX_OPENROUTER_E2E_KEY is set, so the secret never
+// lives in the repo and CI stays offline. Run with:
+//
+//	MAXX_OPENROUTER_E2E_KEY=sk-or-... go test ./tests/e2e/ -run TestOpenRouterLiveProxy -v
+func TestOpenRouterLiveProxy(t *testing.T) {
+	key := os.Getenv("MAXX_OPENROUTER_E2E_KEY")
+	if key == "" {
+		t.Skip("MAXX_OPENROUTER_E2E_KEY not set; skipping live OpenRouter test")
+	}
+
+	env := NewProxyTestEnv(t)
+
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "openrouter-live",
+		"type": "openrouter",
+		"config": map[string]any{
+			"openrouter": map[string]any{"apiKey": key},
+		},
+		"supportedClientTypes": []string{"openai", "claude"},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create openrouter provider: status=%d body=%s", resp.StatusCode, body)
+	}
+	var created struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &created)
+	createRoute(t, env, "openai", created.ID)
+	createRoute(t, env, "claude", created.ID)
+
+	// OpenAI-format client → OpenRouter /v1/chat/completions
+	t.Run("openai", func(t *testing.T) {
+		// Real OpenAI clients send an Authorization header; maxx overwrites it
+		// with the provider key. Mirror that so the passthrough auth path fires.
+		resp := env.ProxyPost("/v1/chat/completions", map[string]any{
+			"model":      "openai/gpt-4o-mini",
+			"max_tokens": 16,
+			"messages":   []map[string]any{{"role": "user", "content": "Reply with just: OK"}},
+		}, map[string]string{"Authorization": "Bearer client-placeholder"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("openai proxy status=%d body=%s", resp.StatusCode, body)
+		}
+		if gjson.GetBytes(body, "object").String() != "chat.completion" {
+			t.Fatalf("expected object=chat.completion, got: %s", body)
+		}
+		t.Logf("openai OK: model=%s content=%q",
+			gjson.GetBytes(body, "model").String(),
+			gjson.GetBytes(body, "choices.0.message.content").String())
+	})
+
+	// Claude-format client → OpenRouter /v1/messages (Anthropic Skin)
+	t.Run("claude", func(t *testing.T) {
+		resp := env.ProxyPost("/v1/messages", map[string]any{
+			"model":      "anthropic/claude-3-haiku",
+			"max_tokens": 16,
+			"messages":   []map[string]any{{"role": "user", "content": "Reply with just: OK"}},
+		}, map[string]string{"anthropic-version": "2023-06-01"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("claude proxy status=%d body=%s", resp.StatusCode, body)
+		}
+		if gjson.GetBytes(body, "type").String() != "message" {
+			t.Fatalf("expected type=message, got: %s", body)
+		}
+		t.Logf("claude OK: model=%s text=%q",
+			gjson.GetBytes(body, "model").String(),
+			gjson.GetBytes(body, "content.0.text").String())
+	})
+
+	// OpenAI streaming (SSE) → OpenRouter
+	t.Run("openai_stream", func(t *testing.T) {
+		resp := env.ProxyPost("/v1/chat/completions", map[string]any{
+			"model":      "openai/gpt-4o-mini",
+			"max_tokens": 16,
+			"stream":     true,
+			"messages":   []map[string]any{{"role": "user", "content": "count 1 to 3"}},
+		}, map[string]string{"Authorization": "Bearer client-placeholder"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("openai stream status=%d body=%s", resp.StatusCode, body)
+		}
+		s := string(body)
+		if !strings.Contains(s, "data:") || !strings.Contains(s, "[DONE]") {
+			t.Fatalf("expected SSE stream ending in [DONE], got: %s", s)
+		}
+		t.Logf("openai stream OK: %d bytes, %d data lines", len(body), strings.Count(s, "data:"))
+	})
+
+	// Claude streaming (SSE, Anthropic event framing) → OpenRouter
+	t.Run("claude_stream", func(t *testing.T) {
+		resp := env.ProxyPost("/v1/messages", map[string]any{
+			"model":      "anthropic/claude-3-haiku",
+			"max_tokens": 16,
+			"stream":     true,
+			"messages":   []map[string]any{{"role": "user", "content": "count 1 to 3"}},
+		}, map[string]string{"anthropic-version": "2023-06-01"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("claude stream status=%d body=%s", resp.StatusCode, body)
+		}
+		s := string(body)
+		if !strings.Contains(s, "message_start") && !strings.Contains(s, "content_block_delta") {
+			t.Fatalf("expected Anthropic SSE events, got: %s", s)
+		}
+		t.Logf("claude stream OK: %d bytes", len(body))
+	})
+
+	// Model mapping via provider-scoped ModelMapping entity: the client sends an
+	// alias that OpenRouter does not know; the mapping rewrites it to a real id.
+	// A 200 (not 404 "unknown model") plus the mapped model in the response
+	// proves executor.mapModel applied the entity for this openrouter provider.
+	t.Run("model_mapping", func(t *testing.T) {
+		mresp := env.AdminPost("/api/admin/model-mappings", map[string]any{
+			"scope":        "provider",
+			"providerID":   created.ID,
+			"providerType": "openrouter",
+			"pattern":      "or-alias-mini",
+			"target":       "openai/gpt-4o-mini",
+			"priority":     10,
+			"isEnabled":    true,
+		})
+		if mresp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(mresp.Body)
+			t.Fatalf("create model mapping: status=%d body=%s", mresp.StatusCode, b)
+		}
+		mresp.Body.Close()
+
+		resp := env.ProxyPost("/v1/chat/completions", map[string]any{
+			"model":      "or-alias-mini",
+			"max_tokens": 16,
+			"messages":   []map[string]any{{"role": "user", "content": "Reply with just: OK"}},
+		}, map[string]string{"Authorization": "Bearer client-placeholder"})
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("mapped request status=%d body=%s", resp.StatusCode, body)
+		}
+		if got := gjson.GetBytes(body, "model").String(); got != "openai/gpt-4o-mini" {
+			t.Fatalf("expected upstream model openai/gpt-4o-mini (mapping applied), got %q; body=%s", got, body)
+		}
+		t.Logf("model mapping OK: or-alias-mini -> %s", gjson.GetBytes(body, "model").String())
+	})
+}

--- a/tests/e2e/openrouter_mock_test.go
+++ b/tests/e2e/openrouter_mock_test.go
@@ -1,0 +1,728 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// These tests exercise the first-class openrouter provider end-to-end against a
+// mock upstream (no live key, CI-safe). MAXX_OPENROUTER_BASE_URL redirects the
+// adapter's fixed base URL at the mock server.
+
+// newOpenRouterMock returns a mock OpenRouter upstream: it records the last
+// request, counts calls, and shapes the response by path (/v1/messages →
+// Anthropic, else OpenAI). An Authorization containing "fail-500"/"fail-401"
+// forces that status so provider-error and failover paths can be driven.
+func newOpenRouterMock(t *testing.T, captured *capturedRequest, calls *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(calls, 1)
+		// Read the body once and restore it so captured.Set records it too; the
+		// streaming branch needs to know whether the client asked for stream:true.
+		reqBody, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(reqBody))
+		captured.Set(r)
+		auth := r.Header.Get("Authorization")
+		switch {
+		case strings.Contains(auth, "fail-500"):
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":{"message":"boom","code":500}}`))
+			return
+		case strings.Contains(auth, "fail-401"):
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":{"message":"no auth","code":401}}`))
+			return
+		}
+		isMessages := strings.Contains(r.URL.Path, "/messages")
+		if bytes.Contains(reqBody, []byte(`"stream":true`)) {
+			writeOpenRouterMockStream(t, w, isMessages)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if isMessages {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg_or", "type": "message", "role": "assistant",
+				"model":       "anthropic/claude-3-haiku",
+				"content":     []map[string]any{{"type": "text", "text": "hi"}},
+				"stop_reason": "end_turn",
+				"usage":       map[string]any{"input_tokens": 3, "output_tokens": 1},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl_or", "object": "chat.completion",
+			"model": "openai/gpt-4o-mini", "created": 1700000000,
+			"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "hi"}, "finish_reason": "stop"}},
+			"usage":   map[string]any{"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+		})
+	}))
+}
+
+// writeOpenRouterMockStream emits a minimal SSE response in the format matching
+// the client: Anthropic message events for /messages, OpenAI chunk deltas ending
+// in [DONE] otherwise. It flushes so the proxy sees a real streaming upstream.
+func writeOpenRouterMockStream(t *testing.T, w http.ResponseWriter, isMessages bool) {
+	t.Helper()
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("mock upstream: streaming not supported by ResponseWriter")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	var frames []string
+	if isMessages {
+		frames = []string{
+			`event: message_start` + "\n" + `data: {"type":"message_start","message":{"id":"msg_or","role":"assistant","model":"anthropic/claude-3-haiku","content":[],"usage":{"input_tokens":3,"output_tokens":0}}}` + "\n\n",
+			`event: content_block_delta` + "\n" + `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}` + "\n\n",
+			`event: message_stop` + "\n" + `data: {"type":"message_stop"}` + "\n\n",
+		}
+	} else {
+		frames = []string{
+			`data: {"id":"chatcmpl_or","object":"chat.completion.chunk","model":"openai/gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}` + "\n\n",
+			`data: {"id":"chatcmpl_or","object":"chat.completion.chunk","model":"openai/gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+			"data: [DONE]\n\n",
+		}
+	}
+	for _, f := range frames {
+		if _, err := io.WriteString(w, f); err != nil {
+			t.Fatalf("mock upstream: write SSE frame: %v", err)
+		}
+		flusher.Flush()
+	}
+}
+
+func createORProvider(t *testing.T, env *ProxyTestEnv, name, apiKey string, clientTypes []string) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name":                 name,
+		"type":                 "openrouter",
+		"config":               map[string]any{"openrouter": map[string]any{"apiKey": apiKey}},
+		"supportedClientTypes": clientTypes,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create openrouter provider %s: status=%d body=%s", name, resp.StatusCode, b)
+	}
+	var out struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &out)
+	return out.ID
+}
+
+func createRouteAt(t *testing.T, env *ProxyTestEnv, clientType string, providerID uint64, position int) {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"clientType": clientType,
+		"providerID": providerID,
+		"position":   position,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create route: status=%d body=%s", resp.StatusCode, b)
+	}
+	resp.Body.Close()
+}
+
+// Delegation: both formats reach the mock at the right path, the provider key
+// overwrites the client's Authorization, and disguise is off (no cache_control).
+func TestOpenRouterMockDelegation(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-mock", "sk-test-key", []string{"openai", "claude"})
+	createRouteAt(t, env, "openai", pid, 1)
+	createRouteAt(t, env, "claude", pid, 1)
+
+	// OpenAI passthrough
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	_, path, hdr, _ := captured.Get()
+	if path != "/v1/chat/completions" {
+		t.Errorf("openai upstream path = %s, want /v1/chat/completions", path)
+	}
+	if got := hdr.Get("Authorization"); got != "Bearer sk-test-key" {
+		t.Errorf("openai upstream auth = %q, want Bearer sk-test-key (provider key overwrites client)", got)
+	}
+
+	// Claude passthrough — disguise must be off (no injected prompt-caching)
+	resp = env.ProxyPost("/v1/messages", claudeRequest("anthropic/claude-3-haiku"),
+		map[string]string{"anthropic-version": "2023-06-01"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	_, path, _, upBody := captured.Get()
+	if path != "/v1/messages" {
+		t.Errorf("claude upstream path = %s, want /v1/messages", path)
+	}
+	if strings.Contains(string(upBody), "cache_control") {
+		t.Errorf("disguise should be off: upstream body must not contain cache_control: %s", upBody)
+	}
+}
+
+// A failing upstream is surfaced (not masked as 200).
+func TestOpenRouterMockUpstreamError(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-badkey", "fail-401-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected non-200 when upstream returns 401")
+	}
+}
+
+// A 5xx on the first provider fails over to the next route's provider.
+func TestOpenRouterMockFailover(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	bad := createORProvider(t, env, "or-bad", "fail-500-key", []string{"openai"})
+	good := createORProvider(t, env, "or-good", "sk-good-key", []string{"openai"})
+	createRouteAt(t, env, "openai", bad, 1)
+	createRouteAt(t, env, "openai", good, 2)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusOK)
+	if n := atomic.LoadInt64(&calls); n < 2 {
+		t.Errorf("expected >=2 upstream calls (failover), got %d", n)
+	}
+}
+
+// A provider that only enables openai has no route for claude traffic.
+func TestOpenRouterMockSingleClientType(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-openai-only", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	// openai works
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// claude has no route → not a 200
+	resp = env.ProxyPost("/v1/messages", claudeRequest("anthropic/claude-3-haiku"),
+		map[string]string{"anthropic-version": "2023-06-01"})
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("claude request should have no route on an openai-only provider")
+	}
+}
+
+// Secrets: the API key is redacted on read, and a blank apiKey on edit preserves
+// the stored key (verified by the key the upstream actually receives).
+func TestOpenRouterMockSecretHandling(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+
+	// Redaction: for an export-excluded provider, secrets are write-only even for
+	// admins, so the raw key must not appear in an admin read. (Non-excluded
+	// providers intentionally return the key to admins so they can edit/export.)
+	rresp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name":                 "or-redact",
+		"type":                 "openrouter",
+		"config":               map[string]any{"openrouter": map[string]any{"apiKey": "sk-secret-xyz"}},
+		"supportedClientTypes": []string{"openai"},
+		"excludeFromExport":    true,
+	})
+	if rresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(rresp.Body)
+		t.Fatalf("create export-excluded provider: status=%d body=%s", rresp.StatusCode, b)
+	}
+	rresp.Body.Close()
+	lresp := env.AdminGet("/api/admin/providers")
+	lb, _ := io.ReadAll(lresp.Body)
+	lresp.Body.Close()
+	if strings.Contains(string(lb), "sk-secret-xyz") {
+		t.Fatalf("export-excluded provider leaked apiKey: %s", lb)
+	}
+
+	pid := createORProvider(t, env, "or-secret", "sk-keepme", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	// Edit with a blank apiKey → stored key is preserved.
+	uresp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", pid), map[string]any{
+		"name":                 "or-secret-renamed",
+		"type":                 "openrouter",
+		"config":               map[string]any{"openrouter": map[string]any{"apiKey": ""}},
+		"supportedClientTypes": []string{"openai"},
+	})
+	if uresp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(uresp.Body)
+		t.Fatalf("update provider: status=%d body=%s", uresp.StatusCode, b)
+	}
+	uresp.Body.Close()
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	_, _, hdr, _ := captured.Get()
+	if got := hdr.Get("Authorization"); got != "Bearer sk-keepme" {
+		t.Errorf("blank-apiKey edit should preserve stored key; upstream auth = %q, want Bearer sk-keepme", got)
+	}
+}
+
+// Streaming: an SSE upstream is streamed back untouched for both formats, and
+// the proxy still asks the upstream for a stream (stream:true in the body).
+func TestOpenRouterMockStreaming(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-stream", "sk-test-key", []string{"openai", "claude"})
+	createRouteAt(t, env, "openai", pid, 1)
+	createRouteAt(t, env, "claude", pid, 1)
+
+	t.Run("openai_stream", func(t *testing.T) {
+		req := openaiRequest("openai/gpt-4o-mini")
+		req["stream"] = true
+		resp := env.ProxyPost("/v1/chat/completions", req,
+			map[string]string{"Authorization": "Bearer client-placeholder"})
+		defer resp.Body.Close()
+		assertStatus(t, resp, http.StatusOK)
+		if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+			t.Fatalf("openai stream Content-Type = %q, want text/event-stream", ct)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		s := string(body)
+		if !strings.Contains(s, "data:") || !strings.Contains(s, "[DONE]") {
+			t.Fatalf("expected SSE ending in [DONE], got: %s", s)
+		}
+		if _, _, _, up := captured.Get(); !bytes.Contains(up, []byte(`"stream":true`)) {
+			t.Errorf("upstream request should carry stream:true, body=%s", up)
+		}
+	})
+
+	t.Run("claude_stream", func(t *testing.T) {
+		req := claudeRequest("anthropic/claude-3-haiku")
+		req["stream"] = true
+		resp := env.ProxyPost("/v1/messages", req,
+			map[string]string{"anthropic-version": "2023-06-01"})
+		defer resp.Body.Close()
+		assertStatus(t, resp, http.StatusOK)
+		if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+			t.Fatalf("claude stream Content-Type = %q, want text/event-stream", ct)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if s := string(body); !strings.Contains(s, "message_start") && !strings.Contains(s, "content_block_delta") {
+			t.Fatalf("expected Anthropic SSE events, got: %s", s)
+		}
+	})
+}
+
+// Model mapping: a provider-scoped ModelMapping rewrites the client's alias to a
+// real id in the request that actually reaches the upstream. (The live test only
+// asserts the response model; here we assert the outgoing upstream request body,
+// which is what executor.mapModel rewrites before delegation.)
+func TestOpenRouterMockModelMapping(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-map", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	mresp := env.AdminPost("/api/admin/model-mappings", map[string]any{
+		"scope":        "provider",
+		"providerID":   pid,
+		"providerType": "openrouter",
+		"pattern":      "or-alias-mini",
+		"target":       "openai/gpt-4o-mini",
+		"priority":     10,
+		"isEnabled":    true,
+	})
+	if mresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(mresp.Body)
+		t.Fatalf("create model mapping: status=%d body=%s", mresp.StatusCode, b)
+	}
+	mresp.Body.Close()
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("or-alias-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusOK)
+
+	_, _, _, up := captured.Get()
+	model := gjsonModel(up)
+	if model != "openai/gpt-4o-mini" {
+		t.Errorf("upstream request model = %q, want openai/gpt-4o-mini (mapping applied); body=%s", model, up)
+	}
+	if strings.Contains(string(up), "or-alias-mini") {
+		t.Errorf("upstream body should not still contain the alias; body=%s", up)
+	}
+}
+
+// gjsonModel extracts the top-level "model" field from a JSON request body.
+func gjsonModel(body []byte) string {
+	var m struct {
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &m)
+	return m.Model
+}
+
+// Base URL composition: production base is "https://openrouter.ai/api", so the
+// client's versioned path is appended onto the /api prefix (→ /api/v1/...). Every
+// other test points the base at a bare mock.URL, so this is the ONLY test that
+// exercises the /api join — a guard on defaultBaseURL + buildUpstreamURL against
+// a regression that would send traffic to the wrong upstream path.
+func TestOpenRouterMockBaseURLComposition(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL+"/api")
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-basepath", "sk-test-key", []string{"openai", "claude"})
+	createRouteAt(t, env, "openai", pid, 1)
+	createRouteAt(t, env, "claude", pid, 1)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	if _, path, _, _ := captured.Get(); path != "/api/v1/chat/completions" {
+		t.Errorf("openai upstream path = %s, want /api/v1/chat/completions (/api prefix preserved)", path)
+	}
+
+	resp = env.ProxyPost("/v1/messages", claudeRequest("anthropic/claude-3-haiku"),
+		map[string]string{"anthropic-version": "2023-06-01"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	if _, path, _, _ := captured.Get(); path != "/api/v1/messages" {
+		t.Errorf("claude upstream path = %s, want /api/v1/messages (/api prefix preserved)", path)
+	}
+}
+
+// Header fidelity: OpenRouter's app-attribution headers (HTTP-Referer, X-Title)
+// forward to upstream, privacy/hop headers (X-Forwarded-For) are stripped, and
+// the provider key still overrides the client's Authorization.
+func TestOpenRouterMockHeaderPassthrough(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-hdr", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{
+			"Authorization":   "Bearer client-placeholder",
+			"HTTP-Referer":    "https://myapp.example",
+			"X-Title":         "MyApp",
+			"X-Forwarded-For": "203.0.113.7",
+		})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, hdr, _ := captured.Get()
+	if got := hdr.Get("HTTP-Referer"); got != "https://myapp.example" {
+		t.Errorf("HTTP-Referer not forwarded: got %q", got)
+	}
+	if got := hdr.Get("X-Title"); got != "MyApp" {
+		t.Errorf("X-Title not forwarded: got %q", got)
+	}
+	if got := hdr.Get("X-Forwarded-For"); got != "" {
+		t.Errorf("X-Forwarded-For should be stripped for privacy, got %q", got)
+	}
+	if got := hdr.Get("Authorization"); got != "Bearer sk-test-key" {
+		t.Errorf("provider key should override client auth, got %q", got)
+	}
+}
+
+// Without a matching ModelMapping the model is forwarded verbatim — a guard that
+// delegation never rewrites models on its own.
+func TestOpenRouterMockNoMapping(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-nomap", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, _, up := captured.Get()
+	if m := gjsonModel(up); m != "openai/gpt-4o" {
+		t.Errorf("model should pass through unchanged with no mapping, upstream got %q", m)
+	}
+}
+
+// Config boundary: disableErrorCooldown coexists with the openrouter block and
+// round-trips through create → admin read (a single JSON config can carry both
+// the union member and the shared cooldown flag).
+func TestOpenRouterConfigRoundTrip(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	cresp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "or-cfg",
+		"type": "openrouter",
+		"config": map[string]any{
+			"openrouter":           map[string]any{"apiKey": "sk-cfg"},
+			"disableErrorCooldown": true,
+		},
+		"supportedClientTypes": []string{"openai"},
+	})
+	if cresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(cresp.Body)
+		t.Fatalf("create: status=%d body=%s", cresp.StatusCode, b)
+	}
+	var created struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, cresp, &created)
+
+	gresp := env.AdminGet(fmt.Sprintf("/api/admin/providers/%d", created.ID))
+	var got struct {
+		Type   string `json:"type"`
+		Config struct {
+			DisableErrorCooldown bool `json:"disableErrorCooldown"`
+			OpenRouter           *struct {
+				APIKey string `json:"apiKey"`
+			} `json:"openrouter"`
+		} `json:"config"`
+	}
+	DecodeJSON(t, gresp, &got)
+
+	if got.Type != "openrouter" {
+		t.Errorf("type = %q, want openrouter", got.Type)
+	}
+	if !got.Config.DisableErrorCooldown {
+		t.Error("disableErrorCooldown did not round-trip alongside the openrouter block")
+	}
+	if got.Config.OpenRouter == nil {
+		t.Error("openrouter config block missing after round-trip")
+	}
+}
+
+// Creating an openrouter provider with no supportedClientTypes defaults to both
+// native protocols (claude + openai) instead of leaving it unserviceable.
+func TestOpenRouterDefaultsClientTypes(t *testing.T) {
+	env := NewProxyTestEnv(t)
+	cresp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name":   "or-defaults",
+		"type":   "openrouter",
+		"config": map[string]any{"openrouter": map[string]any{"apiKey": "sk-cfg"}},
+		// supportedClientTypes intentionally omitted
+	})
+	if cresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(cresp.Body)
+		t.Fatalf("create: status=%d body=%s", cresp.StatusCode, b)
+	}
+	var created struct {
+		SupportedClientTypes []string `json:"supportedClientTypes"`
+	}
+	DecodeJSON(t, cresp, &created)
+
+	got := map[string]bool{}
+	for _, ct := range created.SupportedClientTypes {
+		got[ct] = true
+	}
+	if len(created.SupportedClientTypes) != 2 || !got["claude"] || !got["openai"] {
+		t.Errorf("empty supportedClientTypes should default to [claude openai], got %v", created.SupportedClientTypes)
+	}
+}
+
+// providerIDByName finds a provider's id from the admin list by name.
+func providerIDByName(t *testing.T, env *ProxyTestEnv, name string) uint64 {
+	t.Helper()
+	resp := env.AdminGet("/api/admin/providers")
+	var list []map[string]any
+	DecodeJSON(t, resp, &list)
+	for _, p := range list {
+		if p["name"] == name {
+			return uint64(p["id"].(float64))
+		}
+	}
+	t.Fatalf("provider %q not found in admin list", name)
+	return 0
+}
+
+// Export/import round-trip: an exportable openrouter provider's plaintext key is
+// carried in the export (so re-import yields a working provider), an
+// excludeFromExport provider is omitted, and the re-imported provider actually
+// proxies with the preserved key.
+func TestOpenRouterExportImportRoundTrip(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	createORProvider(t, env, "or-export", "sk-export-me", []string{"openai"})
+
+	// An excludeFromExport provider must never appear in the export dump.
+	xresp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name":                 "or-secret-hidden",
+		"type":                 "openrouter",
+		"config":               map[string]any{"openrouter": map[string]any{"apiKey": "sk-hidden"}},
+		"supportedClientTypes": []string{"openai"},
+		"excludeFromExport":    true,
+	})
+	if xresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(xresp.Body)
+		t.Fatalf("create excluded provider: status=%d body=%s", xresp.StatusCode, b)
+	}
+	xresp.Body.Close()
+
+	// Export and locate the exportable provider; assert the excluded one is gone.
+	eresp := env.AdminGet("/api/admin/providers/export")
+	var exported []map[string]any
+	DecodeJSON(t, eresp, &exported)
+	var exportedA map[string]any
+	for _, p := range exported {
+		if p["name"] == "or-secret-hidden" {
+			t.Fatal("excludeFromExport provider leaked into the export dump")
+		}
+		if p["name"] == "or-export" {
+			exportedA = p
+		}
+	}
+	if exportedA == nil {
+		t.Fatal("exportable provider missing from export dump")
+	}
+	// Export carries the plaintext key (unlike admin-list redaction) so that a
+	// re-import produces a provider that can actually authenticate upstream.
+	cfg, _ := exportedA["config"].(map[string]any)
+	or, _ := cfg["openrouter"].(map[string]any)
+	if or == nil || or["apiKey"] != "sk-export-me" {
+		t.Fatalf("export should carry the plaintext key for re-import, got config=%v", cfg)
+	}
+
+	// Re-import under a new name (import skips duplicate names) and verify it lands.
+	exportedA["name"] = "or-imported"
+	delete(exportedA, "id")
+	iresp := env.AdminPost("/api/admin/providers/import", []map[string]any{exportedA})
+	if iresp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(iresp.Body)
+		t.Fatalf("import: status=%d body=%s", iresp.StatusCode, b)
+	}
+	var imp struct {
+		Imported int `json:"imported"`
+	}
+	DecodeJSON(t, iresp, &imp)
+	if imp.Imported != 1 {
+		t.Fatalf("expected imported=1, got %d", imp.Imported)
+	}
+
+	// The re-imported provider proxies with the key that survived the round-trip.
+	importedID := providerIDByName(t, env, "or-imported")
+	createRouteAt(t, env, "openai", importedID, 1)
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("openai/gpt-4o-mini"),
+		map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	if _, _, hdr, _ := captured.Get(); hdr.Get("Authorization") != "Bearer sk-export-me" {
+		t.Errorf("re-imported provider should use the round-tripped key; upstream auth = %q, want Bearer sk-export-me",
+			hdr.Get("Authorization"))
+	}
+}
+
+// Dynamic client-type change: OpenRouter honors the client-supplied client types
+// verbatim (no autoSetSupportedClientTypes case). While the provider is
+// openai-only, a claude request is converted to OpenAI and hits
+// /v1/chat/completions upstream. After the provider is edited to also support
+// claude natively, the same request passes through to /v1/messages — the upstream
+// path flips, proving the executor re-reads the updated supportedClientTypes.
+func TestOpenRouterMockUpdateClientTypes(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-dyn", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+	createRouteAt(t, env, "claude", pid, 1)
+
+	// openai-only: claude traffic is converted → upstream OpenAI path.
+	resp := env.ProxyPost("/v1/messages", claudeRequest("anthropic/claude-3-haiku"),
+		map[string]string{"anthropic-version": "2023-06-01"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	if _, path, _, _ := captured.Get(); path != "/v1/chat/completions" {
+		t.Fatalf("openai-only provider should convert claude→openai; upstream path = %s, want /v1/chat/completions", path)
+	}
+
+	// Enable claude natively via PUT (blank apiKey preserves the stored key).
+	uresp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", pid), map[string]any{
+		"name":                 "or-dyn",
+		"type":                 "openrouter",
+		"config":               map[string]any{"openrouter": map[string]any{"apiKey": ""}},
+		"supportedClientTypes": []string{"openai", "claude"},
+	})
+	if uresp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(uresp.Body)
+		t.Fatalf("update client types: status=%d body=%s", uresp.StatusCode, b)
+	}
+	uresp.Body.Close()
+
+	// Now claude is native → passthrough to the Anthropic path.
+	resp = env.ProxyPost("/v1/messages", claudeRequest("anthropic/claude-3-haiku"),
+		map[string]string{"anthropic-version": "2023-06-01"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	if _, path, _, _ := captured.Get(); path != "/v1/messages" {
+		t.Fatalf("after enabling claude, request should pass through; upstream path = %s, want /v1/messages", path)
+	}
+}

--- a/tests/e2e/openrouter_mock_test.go
+++ b/tests/e2e/openrouter_mock_test.go
@@ -72,7 +72,8 @@ func writeOpenRouterMockStream(t *testing.T, w http.ResponseWriter, isMessages b
 	t.Helper()
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		t.Fatal("mock upstream: streaming not supported by ResponseWriter")
+		t.Error("mock upstream: streaming not supported by ResponseWriter")
+		return
 	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -94,7 +95,8 @@ func writeOpenRouterMockStream(t *testing.T, w http.ResponseWriter, isMessages b
 	}
 	for _, f := range frames {
 		if _, err := io.WriteString(w, f); err != nil {
-			t.Fatalf("mock upstream: write SSE frame: %v", err)
+			t.Errorf("mock upstream: write SSE frame: %v", err)
+			return
 		}
 		flusher.Flush()
 	}

--- a/tests/e2e/verify_routing_phase2_test.go
+++ b/tests/e2e/verify_routing_phase2_test.go
@@ -140,9 +140,10 @@ func TestVerifyRoutingPhase2(t *testing.T) {
 	}
 
 	// =====================================================================
-	// Phase A: distribution across many distinct sessions
-	// Expected 70/20/10; with N=2000 each bucket's 99% CI is ~±3% (binomial
-	// std dev ≈ sqrt(N*p*(1-p)) → roughly ±1% per σ; we allow ±3% ≈ 3σ).
+	// Phase A: distribution across many distinct sessions. The router uses
+	// deterministic per-session hashing, so finite samples can skew slightly for a
+	// given session-id sequence; use the same binomial tolerance style as the
+	// cooldown probe below instead of a brittle fixed percentage window.
 	// =====================================================================
 	resetHits()
 	const N = 2000
@@ -157,15 +158,22 @@ func TestVerifyRoutingPhase2(t *testing.T) {
 	if total != int64(N) {
 		t.Fatalf("phase A: expected %d total hits, got %d", N, total)
 	}
-	check := func(label string, got int64, wantPct float64, tolPct float64) {
-		gotPct := pct(got)
-		if gotPct < wantPct-tolPct || gotPct > wantPct+tolPct {
-			t.Errorf("phase A %s: got %.1f%%, want ~%.1f%% (±%.1f%%)", label, gotPct, wantPct, tolPct)
+	weightTotal := 0
+	for _, w := range weights {
+		weightTotal += w
+	}
+	const phaseAK = 4.0
+	for i, w := range weights {
+		p := float64(w) / float64(weightTotal)
+		expected := float64(N) * p
+		sigma := math.Sqrt(float64(N) * p * (1 - p))
+		tol := phaseAK * sigma
+		got := float64(snapA[i])
+		if got < expected-tol || got > expected+tol {
+			t.Errorf("phase A p%d (weight %d): got %d hits (%.1f%%), want %.1f±%.1f",
+				i+1, w, snapA[i], pct(snapA[i]), expected, tol)
 		}
 	}
-	check("p1 (weight 7)", snapA[0], 70, 3)
-	check("p2 (weight 2)", snapA[1], 20, 3)
-	check("p3 (weight 1)", snapA[2], 10, 3)
 
 	// =====================================================================
 	// Phase B: seeded determinism — same session always lands on same provider

--- a/web/src/assets/icons/openrouter.svg
+++ b/web/src/assets/icons/openrouter.svg
@@ -1,0 +1,6 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M77 256h95c34 0 52-20 78-40 24-19 48-40 96-40" stroke="#6366F1" stroke-width="42" fill="none"/>
+  <path d="M77 256h95c34 0 52 20 78 40 24 19 48 40 96 40" stroke="#6366F1" stroke-width="42" fill="none"/>
+  <path d="M346 176l89 40-89 40v-80z" fill="#6366F1"/>
+  <path d="M346 256l89 40-89 40v-80z" fill="#6366F1"/>
+</svg>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -96,6 +96,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --provider-kiro: oklch(0.689 0.1456 195.6789); /* #00BCD4 青色 */
   --provider-codex: oklch(0.6789 0.12 145.6789); /* #10A37F OpenAI 绿色 */
   --provider-claude: oklch(0.65 0.15 28); /* Anthropic 橙色/珊瑚色 */
+  --provider-openrouter: oklch(0.58 0.19 277); /* #6366F1 靛蓝色 */
 
   /* Client 品牌色 (引用 Provider 颜色) */
   --client-claude: var(--provider-anthropic);
@@ -381,6 +382,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --color-provider-kiro: var(--provider-kiro);
   --color-provider-codex: var(--provider-codex);
   --color-provider-claude: var(--provider-claude);
+  --color-provider-openrouter: var(--provider-openrouter);
 
   /* Client 颜色映射 (Tailwind 可用) */
   --color-client-claude: var(--client-claude);

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -20,7 +20,8 @@ export type ProviderType =
   | 'bedrock'
   | 'kiro'
   | 'codex'
-  | 'claude';
+  | 'claude'
+  | 'openrouter';
 
 /**
  * Client 类型定义

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -82,6 +82,8 @@ export type {
   ProviderConfigClaude,
   ClaudeTokenValidationResult,
   ClaudeOAuthResult,
+  // OpenRouter
+  ProviderConfigOpenRouter,
   CodexUsageWindow,
   CodexRateLimitInfo,
   CodexUsageResponse,

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -108,6 +108,12 @@ export interface ProviderConfigBedrock {
   modelMapping?: Record<string, string>;
 }
 
+// OpenRouter 一级供应商配置。baseURL 固定为 https://openrouter.ai/api（由后端合成）。
+// 模型映射走通用的 ModelMapping 实体（按 provider id 匹配），不放在 config 里。
+export interface ProviderConfigOpenRouter {
+  apiKey: string;
+}
+
 // One row in the Bedrock discovery catalog: the Anthropic short name
 // clients send, the invoke-ready Bedrock ID our adapter routes to, and
 // which AWS catalog the entry was sourced from.
@@ -140,6 +146,7 @@ export interface ProviderConfig {
   kiro?: ProviderConfigKiro;
   codex?: ProviderConfigCodex;
   claude?: ProviderConfigClaude;
+  openrouter?: ProviderConfigOpenRouter;
 }
 
 export interface Provider {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1732,6 +1732,21 @@
       "name": "Custom Provider",
       "description": "Configure your own API endpoint"
     },
+    "openrouter": {
+      "name": "OpenRouter",
+      "description": "Aggregation gateway · OpenAI & Anthropic compatible",
+      "apiKey": "OpenRouter API Key",
+      "apiKeyHint": "Get your key from https://openrouter.ai/keys",
+      "clientsTitle": "Client Types",
+      "clientsDesc": "OpenRouter natively serves both endpoints. Enable the client formats this provider should accept (at least one).",
+      "clientClaudeDesc": "Claude Code / Anthropic Messages (/v1/messages)",
+      "clientOpenAIDesc": "OpenAI Chat Completions (/v1/chat/completions)",
+      "modelMappingTitle": "Model Mapping",
+      "modelMappingDesc": "Map the model name clients send to an OpenRouter model id (e.g. claude-3-5-sonnet → anthropic/claude-3.5-sonnet). Leave empty to pass models through unchanged.",
+      "modelMappingFrom": "Request model",
+      "modelMappingTo": "OpenRouter model id",
+      "modelMappingEmpty": "No mappings — models are passed through as-is"
+    },
     "templates": {
       "88code": {
         "name": "88 Code",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1728,6 +1728,21 @@
       "name": "自定义提供商",
       "description": "配置您自己的 API 端点"
     },
+    "openrouter": {
+      "name": "OpenRouter",
+      "description": "聚合网关 · 兼容 OpenAI 与 Anthropic",
+      "apiKey": "OpenRouter API Key",
+      "apiKeyHint": "在 https://openrouter.ai/keys 获取你的密钥",
+      "clientsTitle": "客户端类型",
+      "clientsDesc": "OpenRouter 原生支持两种端点。勾选此供应商需要接受的客户端格式（至少一个）。",
+      "clientClaudeDesc": "Claude Code / Anthropic Messages（/v1/messages）",
+      "clientOpenAIDesc": "OpenAI Chat Completions（/v1/chat/completions）",
+      "modelMappingTitle": "模型映射",
+      "modelMappingDesc": "把客户端发送的模型名映射到 OpenRouter 的模型 id（如 claude-3-5-sonnet → anthropic/claude-3.5-sonnet）。留空则原样透传。",
+      "modelMappingFrom": "请求模型",
+      "modelMappingTo": "OpenRouter 模型 id",
+      "modelMappingEmpty": "暂无映射 — 模型原样透传"
+    },
     "templates": {
       "88code": {
         "name": "88 Code",

--- a/web/src/pages/providers/components/openrouter-config-step.tsx
+++ b/web/src/pages/providers/components/openrouter-config-step.tsx
@@ -146,6 +146,7 @@ export function OpenRouterConfigStep() {
                     onClick={() => setShowApiKey(!showApiKey)}
                     className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
                     tabIndex={-1}
+                    aria-label={showApiKey ? t('common.hide') : t('common.show')}
                   >
                     {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>

--- a/web/src/pages/providers/components/openrouter-config-step.tsx
+++ b/web/src/pages/providers/components/openrouter-config-step.tsx
@@ -1,0 +1,219 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
+import type { ClientType, CreateProviderData } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import openrouterLogo from '@/assets/icons/openrouter.svg';
+import { OpenRouterModelMappings, OPENROUTER_CLIENT_TYPES } from './openrouter-model-mappings';
+
+export function OpenRouterConfigStep() {
+  const { t } = useTranslation();
+  const { goToSelectType, goToProviders } = useProviderNavigation();
+  const createProvider = useCreateProvider();
+  const createModelMapping = useCreateModelMapping();
+
+  const [name, setName] = useState('OpenRouter');
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  // Both endpoints are natively supported by OpenRouter; default both on.
+  const [clients, setClients] = useState<Record<ClientType, boolean>>({
+    claude: true,
+    openai: true,
+    codex: false,
+    gemini: false,
+  });
+  const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const enabledClients = OPENROUTER_CLIENT_TYPES.filter((c) => clients[c]);
+  const isValid = () => name.trim() !== '' && apiKey.trim() !== '' && enabledClients.length > 0;
+
+  const toggleClient = (client: ClientType) =>
+    setClients((prev) => ({ ...prev, [client]: !prev[client] }));
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: CreateProviderData = {
+        type: 'openrouter',
+        name: name.trim(),
+        logo: openrouterLogo,
+        config: {
+          disableErrorCooldown,
+          openrouter: {
+            apiKey: apiKey.trim(),
+          },
+        },
+        supportedClientTypes: enabledClients,
+      };
+
+      const provider = await createProvider.mutateAsync(data);
+
+      // Persist model mappings as provider-scoped ModelMapping entities — the
+      // mechanism executor.mapModel actually consults at request time.
+      const entries = Object.entries(modelMapping);
+      for (const [pattern, target] of entries) {
+        await createModelMapping.mutateAsync({
+          scope: 'provider',
+          providerID: provider.id,
+          pattern,
+          target,
+        });
+      }
+
+      setSaveStatus('success');
+      setTimeout(() => goToProviders(), 500);
+    } catch (error) {
+      console.error('Failed to create provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={goToSelectType} />}
+        title={t('addProvider.openrouter.name')}
+        description={t('addProvider.openrouter.description')}
+      >
+        <Button onClick={goToProviders} variant="secondary">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.create')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="OpenRouter"
+                  className="w-full"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('addProvider.openrouter.apiKey')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="sk-or-..."
+                    className="w-full pr-10 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                  >
+                    {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('addProvider.openrouter.apiKeyHint')}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Client Types */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('addProvider.openrouter.clientsTitle')}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {t('addProvider.openrouter.clientsDesc')}
+            </p>
+            <div className="grid gap-3">
+              {OPENROUTER_CLIENT_TYPES.map((client) => (
+                <div
+                  key={client}
+                  className="flex items-center justify-between p-4 bg-card border border-border rounded-xl"
+                >
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground capitalize">{client}</div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {client === 'claude'
+                        ? t('addProvider.openrouter.clientClaudeDesc')
+                        : t('addProvider.openrouter.clientOpenAIDesc')}
+                    </p>
+                  </div>
+                  <Switch checked={clients[client]} onCheckedChange={() => toggleClient(client)} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Model Mappings */}
+          <OpenRouterModelMappings mappings={modelMapping} onChange={setModelMapping} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.createError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/openrouter-model-mappings.tsx
+++ b/web/src/pages/providers/components/openrouter-model-mappings.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from 'react';
+import { ArrowRight, Plus, Trash2, Zap } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ModelInput } from '@/components/ui/model-input';
+
+/**
+ * Inline editor for OpenRouter request-model mappings (RequestModel →
+ * OpenRouter model id, e.g. "claude-3-5-sonnet" → "anthropic/claude-3.5-sonnet").
+ * Edits a plain Record<string,string> stored on config.openrouter.modelMapping.
+ * Shared by the create step and the edit view so both produce identical shapes.
+ */
+export function OpenRouterModelMappings({
+  mappings,
+  onChange,
+  disabled,
+}: {
+  mappings: Record<string, string>;
+  onChange: (mappings: Record<string, string>) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [newPattern, setNewPattern] = useState('');
+  const [newTarget, setNewTarget] = useState('');
+  const entries = useMemo(() => Object.entries(mappings), [mappings]);
+
+  const handleAdd = () => {
+    const pattern = newPattern.trim();
+    const target = newTarget.trim();
+    if (!pattern || !target) return;
+    onChange({ ...mappings, [pattern]: target });
+    setNewPattern('');
+    setNewTarget('');
+  };
+
+  const handleUpdate = (oldPattern: string, pattern: string, target: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of entries) {
+      if (key === oldPattern) continue;
+      next[key] = value;
+    }
+    const nextPattern = pattern.trim();
+    const nextTarget = target.trim();
+    if (nextPattern && nextTarget) {
+      next[nextPattern] = nextTarget;
+    }
+    onChange(next);
+  };
+
+  const handleDelete = (pattern: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of entries) {
+      if (key === pattern) continue;
+      next[key] = value;
+    }
+    onChange(next);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4 border-b border-border pb-2">
+        <Zap size={18} className="text-yellow-500" />
+        <h4 className="text-lg font-semibold text-foreground">
+          {t('addProvider.openrouter.modelMappingTitle')}
+        </h4>
+        <span className="text-sm text-muted-foreground">({entries.length})</span>
+      </div>
+
+      <div className="bg-card border border-border rounded-xl p-4">
+        <p className="text-xs text-muted-foreground mb-4">
+          {t('addProvider.openrouter.modelMappingDesc')}
+        </p>
+
+        {entries.length > 0 && (
+          <div className="space-y-2 mb-4">
+            {entries.map(([pattern, target], index) => (
+              <div key={pattern} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
+                <ModelInput
+                  value={pattern}
+                  onChange={(value) => handleUpdate(pattern, value, target)}
+                  placeholder={t('addProvider.openrouter.modelMappingFrom')}
+                  disabled={disabled}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                <Input
+                  value={target}
+                  onChange={(event) => handleUpdate(pattern, pattern, event.target.value)}
+                  placeholder={t('addProvider.openrouter.modelMappingTo')}
+                  disabled={disabled}
+                  className="flex-1 min-w-0 h-8 text-sm font-mono"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleDelete(pattern)}
+                  disabled={disabled}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {entries.length === 0 && (
+          <div className="text-center py-6 mb-4">
+            <p className="text-muted-foreground text-sm">
+              {t('addProvider.openrouter.modelMappingEmpty')}
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-4 border-t border-border">
+          <ModelInput
+            value={newPattern}
+            onChange={setNewPattern}
+            placeholder={t('addProvider.openrouter.modelMappingFrom')}
+            disabled={disabled}
+            className="flex-1 min-w-0 h-8 text-sm"
+          />
+          <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          <Input
+            value={newTarget}
+            onChange={(event) => setNewTarget(event.target.value)}
+            placeholder={t('addProvider.openrouter.modelMappingTo')}
+            disabled={disabled}
+            className="flex-1 min-w-0 h-8 text-sm font-mono"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAdd}
+            disabled={!newPattern.trim() || !newTarget.trim() || disabled}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            {t('common.add')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Two-switch client selector (Claude + OpenAI) for OpenRouter, both natively
+ * supported. At least one must stay enabled — enforced by the caller's isValid.
+ */
+export const OPENROUTER_CLIENT_TYPES = ['claude', 'openai'] as const;

--- a/web/src/pages/providers/components/openrouter-provider-view.tsx
+++ b/web/src/pages/providers/components/openrouter-provider-view.tsx
@@ -1,0 +1,233 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUpdateProvider } from '@/hooks/queries';
+import type { ClientType, CreateProviderData, Provider } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import { OPENROUTER_CLIENT_TYPES } from './openrouter-model-mappings';
+import { ProviderModelMappings } from './provider-model-mappings';
+
+interface OpenRouterProviderViewProps {
+  provider: Provider;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function OpenRouterProviderView({
+  provider,
+  onDelete,
+  onClose,
+}: OpenRouterProviderViewProps) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+
+  // Secrets are redacted on read whenever the provider is export-excluded, so
+  // the apiKey arrives blank; a blank submit preserves the stored key (the
+  // backend keeps the existing secret when the incoming apiKey is empty).
+  const secretsAreWriteOnly = !!provider.excludeFromExport;
+
+  const [name, setName] = useState(provider.name);
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [clients, setClients] = useState<Record<ClientType, boolean>>(() => {
+    const supported = provider.supportedClientTypes || [];
+    return {
+      claude: supported.includes('claude'),
+      openai: supported.includes('openai'),
+      codex: false,
+      gemini: false,
+    };
+  });
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(
+    !!provider.config?.disableErrorCooldown,
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const enabledClients = OPENROUTER_CLIENT_TYPES.filter((c) => clients[c]);
+  const isValid = () => name.trim() !== '' && enabledClients.length > 0;
+
+  const toggleClient = (client: ClientType) =>
+    setClients((prev) => ({ ...prev, [client]: !prev[client] }));
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: Partial<CreateProviderData> = {
+        name: name.trim(),
+        type: 'openrouter',
+        config: {
+          disableErrorCooldown,
+          openrouter: {
+            // Blank preserves the stored key (backend keeps existing secret).
+            apiKey: apiKey.trim(),
+          },
+        },
+        supportedClientTypes: enabledClients,
+      };
+
+      await updateProvider.mutateAsync({ id: Number(provider.id), data });
+      setSaveStatus('success');
+      setTimeout(() => onClose(), 500);
+    } catch (error) {
+      console.error('Failed to update provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={onClose} />}
+        title={t('provider.edit')}
+        description={t('addProvider.openrouter.description')}
+      >
+        <Button onClick={onDelete} variant="destructive">
+          <Trash2 size={14} />
+          {t('provider.delete')}
+        </Button>
+        <Button onClick={onClose} variant="secondary">
+          {t('provider.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.saveChanges')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="OpenRouter"
+                  className="w-full"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('provider.apiKeyEdit')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={
+                      secretsAreWriteOnly
+                        ? t('provider.keyPlaceholderWriteOnly')
+                        : t('provider.keyPlaceholder')
+                    }
+                    className="w-full pr-10 font-mono"
+                  />
+                  {!secretsAreWriteOnly && (
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  )}
+                </div>
+                {secretsAreWriteOnly && (
+                  <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
+                    {t('provider.apiKeyExcludedHint')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Client Types */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('addProvider.openrouter.clientsTitle')}
+            </h3>
+            <div className="grid gap-3">
+              {OPENROUTER_CLIENT_TYPES.map((client) => (
+                <div
+                  key={client}
+                  className="flex items-center justify-between p-4 bg-card border border-border rounded-xl"
+                >
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground capitalize">{client}</div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {client === 'claude'
+                        ? t('addProvider.openrouter.clientClaudeDesc')
+                        : t('addProvider.openrouter.clientOpenAIDesc')}
+                    </p>
+                  </div>
+                  <Switch checked={clients[client]} onCheckedChange={() => toggleClient(client)} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Model Mappings (provider-scoped ModelMapping entities) */}
+          <ProviderModelMappings provider={provider} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.updateError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -29,16 +29,8 @@ import {
   useDeleteProvider,
   useModelMappings,
   useCreateModelMapping,
-  useUpdateModelMapping,
-  useDeleteModelMapping,
 } from '@/hooks/queries';
-import type {
-  Provider,
-  ClientType,
-  CreateProviderData,
-  ModelMapping,
-  ModelMappingInput,
-} from '@/lib/transport';
+import type { Provider, ClientType, CreateProviderData } from '@/lib/transport';
 import { defaultClients, type ClientConfig, type CustomBackend } from '../types';
 import { buildDisguisePayload } from '../utils/disguise';
 import { ClientsConfigSection } from './clients-config-section';
@@ -47,6 +39,8 @@ import { BedrockProviderView } from './bedrock-provider-view';
 import { KiroProviderView } from './kiro-provider-view';
 import { CodexProviderView } from './codex-provider-view';
 import { ClaudeProviderView } from './claude-provider-view';
+import { OpenRouterProviderView } from './openrouter-provider-view';
+import { ProviderModelMappings } from './provider-model-mappings';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui';
@@ -60,141 +54,6 @@ import {
 import { ModelInput } from '@/components/ui/model-input';
 import { PageHeader } from '@/components/layout/page-header';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
-
-// Provider Model Mappings Section for Custom Providers
-function ProviderModelMappings({ provider }: { provider: Provider }) {
-  const { t } = useTranslation();
-  const { data: allMappings } = useModelMappings();
-  const createMapping = useCreateModelMapping();
-  const updateMapping = useUpdateModelMapping();
-  const deleteMapping = useDeleteModelMapping();
-  const [newPattern, setNewPattern] = useState('');
-  const [newTarget, setNewTarget] = useState('');
-
-  // Filter mappings for this provider
-  const providerMappings = useMemo(() => {
-    return (allMappings || []).filter(
-      (m) => m.scope === 'provider' && m.providerID === provider.id,
-    );
-  }, [allMappings, provider.id]);
-
-  const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
-
-  const handleAddMapping = async () => {
-    if (!newPattern.trim() || !newTarget.trim()) return;
-
-    await createMapping.mutateAsync({
-      pattern: newPattern.trim(),
-      target: newTarget.trim(),
-      scope: 'provider',
-      providerID: provider.id,
-      providerType: 'custom',
-      priority: providerMappings.length * 10 + 1000,
-      isEnabled: true,
-    });
-    setNewPattern('');
-    setNewTarget('');
-  };
-
-  const handleUpdateMapping = async (mapping: ModelMapping, data: Partial<ModelMappingInput>) => {
-    await updateMapping.mutateAsync({
-      id: mapping.id,
-      data: {
-        pattern: data.pattern ?? mapping.pattern,
-        target: data.target ?? mapping.target,
-        scope: 'provider',
-        providerID: provider.id,
-        providerType: 'custom',
-        priority: mapping.priority,
-        isEnabled: mapping.isEnabled,
-      },
-    });
-  };
-
-  const handleDeleteMapping = async (id: number) => {
-    await deleteMapping.mutateAsync(id);
-  };
-
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-4 border-b border-border pb-2">
-        <Zap size={18} className="text-yellow-500" />
-        <h4 className="text-lg font-semibold text-foreground">{t('modelMappings.title')}</h4>
-        <span className="text-sm text-muted-foreground">({providerMappings.length})</span>
-      </div>
-
-      <div className="bg-card border border-border rounded-xl p-4">
-        <p className="text-xs text-muted-foreground mb-4">{t('modelMappings.pageDesc')}</p>
-
-        {providerMappings.length > 0 && (
-          <div className="space-y-2 mb-4">
-            {providerMappings.map((mapping, index) => (
-              <div key={mapping.id} className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
-                <ModelInput
-                  value={mapping.pattern}
-                  onChange={(pattern) => handleUpdateMapping(mapping, { pattern })}
-                  placeholder={t('modelMappings.matchPattern')}
-                  disabled={isPending}
-                  className="flex-1 min-w-0 h-8 text-sm"
-                />
-                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                <ModelInput
-                  value={mapping.target}
-                  onChange={(target) => handleUpdateMapping(mapping, { target })}
-                  placeholder={t('modelMappings.targetModel')}
-                  disabled={isPending}
-                  className="flex-1 min-w-0 h-8 text-sm"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleDeleteMapping(mapping.id)}
-                  disabled={isPending}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {providerMappings.length === 0 && (
-          <div className="text-center py-6 mb-4">
-            <p className="text-muted-foreground text-sm">{t('modelMappings.noMappings')}</p>
-          </div>
-        )}
-
-        <div className="flex items-center gap-2 pt-4 border-t border-border">
-          <ModelInput
-            value={newPattern}
-            onChange={setNewPattern}
-            placeholder={t('modelMappings.matchPattern')}
-            disabled={isPending}
-            className="flex-1 min-w-0 h-8 text-sm"
-          />
-          <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-          <ModelInput
-            value={newTarget}
-            onChange={setNewTarget}
-            placeholder={t('modelMappings.targetModel')}
-            disabled={isPending}
-            className="flex-1 min-w-0 h-8 text-sm"
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleAddMapping}
-            disabled={!newPattern.trim() || !newTarget.trim() || isPending}
-          >
-            <Plus className="h-4 w-4 mr-1" />
-            {t('common.add')}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function ResponseModelMappings({
   mappings,
@@ -786,6 +645,26 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     );
   }
 
+  // OpenRouter provider
+  if (provider.type === 'openrouter') {
+    return (
+      <>
+        <OpenRouterProviderView
+          provider={provider}
+          onDelete={() => setShowDeleteConfirm(true)}
+          onClose={onClose}
+        />
+        <DeleteConfirmModal
+          providerName={provider.name}
+          deleting={deleting}
+          open={showDeleteConfirm}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      </>
+    );
+  }
+
   // Custom provider edit form
   return (
     <div className="flex flex-col h-full">
@@ -1021,7 +900,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
               />
             </div>
           </div>
-
 
           {/* Provider Supported Models Filter */}
           <ProviderSupportModels

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -1,0 +1,153 @@
+import { useState, useMemo } from 'react';
+import { ArrowRight, Plus, Trash2, Zap } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import {
+  useModelMappings,
+  useCreateModelMapping,
+  useUpdateModelMapping,
+  useDeleteModelMapping,
+} from '@/hooks/queries';
+import type { Provider, ModelMapping, ModelMappingInput } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { ModelInput } from '@/components/ui/model-input';
+
+/**
+ * Provider-scoped model mappings editor backed by the ModelMapping entity API
+ * (scope='provider', providerID). This is the mechanism executor.mapModel
+ * actually consults at request time — it matches by provider id and type — so
+ * it is the correct home for model mapping across every provider type, not the
+ * inline config maps. Shared by the custom edit form and the OpenRouter view.
+ */
+export function ProviderModelMappings({ provider }: { provider: Provider }) {
+  const { t } = useTranslation();
+  const { data: allMappings } = useModelMappings();
+  const createMapping = useCreateModelMapping();
+  const updateMapping = useUpdateModelMapping();
+  const deleteMapping = useDeleteModelMapping();
+  const [newPattern, setNewPattern] = useState('');
+  const [newTarget, setNewTarget] = useState('');
+
+  // Filter mappings for this provider
+  const providerMappings = useMemo(() => {
+    return (allMappings || []).filter(
+      (m) => m.scope === 'provider' && m.providerID === provider.id,
+    );
+  }, [allMappings, provider.id]);
+
+  const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
+
+  const handleAddMapping = async () => {
+    if (!newPattern.trim() || !newTarget.trim()) return;
+
+    await createMapping.mutateAsync({
+      pattern: newPattern.trim(),
+      target: newTarget.trim(),
+      scope: 'provider',
+      providerID: provider.id,
+      providerType: provider.type,
+      priority: providerMappings.length * 10 + 1000,
+      isEnabled: true,
+    });
+    setNewPattern('');
+    setNewTarget('');
+  };
+
+  const handleUpdateMapping = async (mapping: ModelMapping, data: Partial<ModelMappingInput>) => {
+    await updateMapping.mutateAsync({
+      id: mapping.id,
+      data: {
+        pattern: data.pattern ?? mapping.pattern,
+        target: data.target ?? mapping.target,
+        scope: 'provider',
+        providerID: provider.id,
+        providerType: provider.type,
+        priority: mapping.priority,
+        isEnabled: mapping.isEnabled,
+      },
+    });
+  };
+
+  const handleDeleteMapping = async (id: number) => {
+    await deleteMapping.mutateAsync(id);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4 border-b border-border pb-2">
+        <Zap size={18} className="text-yellow-500" />
+        <h4 className="text-lg font-semibold text-foreground">{t('modelMappings.title')}</h4>
+        <span className="text-sm text-muted-foreground">({providerMappings.length})</span>
+      </div>
+
+      <div className="bg-card border border-border rounded-xl p-4">
+        <p className="text-xs text-muted-foreground mb-4">{t('modelMappings.pageDesc')}</p>
+
+        {providerMappings.length > 0 && (
+          <div className="space-y-2 mb-4">
+            {providerMappings.map((mapping, index) => (
+              <div key={mapping.id} className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
+                <ModelInput
+                  value={mapping.pattern}
+                  onChange={(pattern) => handleUpdateMapping(mapping, { pattern })}
+                  placeholder={t('modelMappings.matchPattern')}
+                  disabled={isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                <ModelInput
+                  value={mapping.target}
+                  onChange={(target) => handleUpdateMapping(mapping, { target })}
+                  placeholder={t('modelMappings.targetModel')}
+                  disabled={isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleDeleteMapping(mapping.id)}
+                  disabled={isPending}
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {providerMappings.length === 0 && (
+          <div className="text-center py-6 mb-4">
+            <p className="text-muted-foreground text-sm">{t('modelMappings.noMappings')}</p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-4 border-t border-border">
+          <ModelInput
+            value={newPattern}
+            onChange={setNewPattern}
+            placeholder={t('modelMappings.matchPattern')}
+            disabled={isPending}
+            className="flex-1 min-w-0 h-8 text-sm"
+          />
+          <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          <ModelInput
+            value={newTarget}
+            onChange={setNewTarget}
+            placeholder={t('modelMappings.targetModel')}
+            disabled={isPending}
+            className="flex-1 min-w-0 h-8 text-sm"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAddMapping}
+            disabled={!newPattern.trim() || !newTarget.trim() || isPending}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            {t('common.add')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -11,6 +11,7 @@ import {
   ChevronLeft,
 } from 'lucide-react';
 import { quickTemplates, PROVIDER_TYPE_CONFIGS } from '../types';
+import openrouterLogo from '@/assets/icons/openrouter.svg';
 import { Button } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { useTranslation } from 'react-i18next';
@@ -19,16 +20,28 @@ import { useProviderNavigation } from '../hooks/use-provider-navigation';
 
 export function SelectTypeStep() {
   const { formData, updateFormData } = useProviderForm();
-  const { goToCustomConfig, goToAntigravity, goToKiro, goToCodex, goToClaude, goToBedrock, goToProviders } =
-    useProviderNavigation();
+  const {
+    goToCustomConfig,
+    goToAntigravity,
+    goToKiro,
+    goToCodex,
+    goToClaude,
+    goToBedrock,
+    goToOpenRouter,
+    goToProviders,
+  } = useProviderNavigation();
   const { t } = useTranslation();
 
-  const handleSelectType = (type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude') => {
+  const handleSelectType = (
+    type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter',
+  ) => {
     updateFormData({ type });
     if (type === 'antigravity') {
       goToAntigravity();
     } else if (type === 'bedrock') {
       goToBedrock();
+    } else if (type === 'openrouter') {
+      goToOpenRouter();
     } else if (type === 'kiro') {
       goToKiro();
     } else if (type === 'codex') {
@@ -233,6 +246,41 @@ export function SelectTypeStep() {
 
                     {formData.type === 'bedrock' && (
                       <CheckCircle2 className="size-5 text-provider-bedrock shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                    )}
+                  </div>
+                </Button>
+              )}
+
+              {!PROVIDER_TYPE_CONFIGS.openrouter.hidden && (
+                <Button
+                  onClick={() => handleSelectType('openrouter')}
+                  variant="ghost"
+                  className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    formData.type === 'openrouter'
+                      ? 'border-provider-openrouter bg-provider-openrouter/10 shadow-sm'
+                      : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                  }`}
+                >
+                  <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                    <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-openrouter/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                      <img
+                        src={openrouterLogo}
+                        alt="OpenRouter"
+                        className="size-5 md:size-6 object-contain"
+                      />
+                    </div>
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                        {t('addProvider.openrouter.name')}
+                      </h3>
+                      <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                        {t('addProvider.openrouter.description')}
+                      </p>
+                    </div>
+
+                    {formData.type === 'openrouter' && (
+                      <CheckCircle2 className="size-5 text-provider-openrouter shrink-0 self-center animate-in zoom-in-50 duration-200" />
                     )}
                   </div>
                 </Button>

--- a/web/src/pages/providers/create-layout.tsx
+++ b/web/src/pages/providers/create-layout.tsx
@@ -7,6 +7,7 @@ import { CodexTokenImport } from './components/codex-token-import';
 import { ClaudeTokenImport } from './components/claude-token-import';
 import { CustomConfigStep } from './components/custom-config-step';
 import { BedrockConfigStep } from './components/bedrock-config-step';
+import { OpenRouterConfigStep } from './components/openrouter-config-step';
 
 export function ProviderCreateLayout() {
   return (
@@ -15,6 +16,7 @@ export function ProviderCreateLayout() {
         <Route index element={<SelectTypeStep />} />
         <Route path="custom" element={<CustomConfigStep />} />
         <Route path="bedrock" element={<BedrockConfigStep />} />
+        <Route path="openrouter" element={<OpenRouterConfigStep />} />
         <Route path="antigravity" element={<AntigravityTokenImport />} />
         <Route path="kiro" element={<KiroTokenImport />} />
         <Route path="codex" element={<CodexTokenImport />} />

--- a/web/src/pages/providers/hooks/use-provider-navigation.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.ts
@@ -11,6 +11,7 @@ export function useProviderNavigation() {
     goToCodex: () => navigate('/providers/create/codex'),
     goToClaude: () => navigate('/providers/create/claude'),
     goToBedrock: () => navigate('/providers/create/bedrock'),
+    goToOpenRouter: () => navigate('/providers/create/openrouter'),
     goToProviders: () => navigate('/providers'),
     goBack: () => navigate(-1),
   };

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -9,6 +9,7 @@ describe('provider type helpers', () => {
       'codex',
       'claude',
       'bedrock',
+      'openrouter',
       'custom',
     ]);
   });

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -1,7 +1,7 @@
 import type { ClientType, DisguiseType, Provider } from '@/lib/transport';
 import { getProviderColorVar } from '@/lib/theme';
 import type { LucideIcon } from 'lucide-react';
-import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud } from 'lucide-react';
+import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud, Waypoints } from 'lucide-react';
 import duckcodingLogo from '@/assets/icons/duckcoding.gif';
 import freeDuckLogo from '@/assets/icons/free-duck.gif';
 import nvidiaLogo from '@/assets/icons/nvidia.svg';
@@ -12,7 +12,14 @@ import zhipuLogo from '@/assets/icons/zhipu.svg';
 // ===== Provider Type Configuration =====
 // 通用的 Provider 类型配置，添加新类型只需在这里配置
 
-export type ProviderTypeKey = 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude';
+export type ProviderTypeKey =
+  | 'custom'
+  | 'antigravity'
+  | 'bedrock'
+  | 'kiro'
+  | 'codex'
+  | 'claude'
+  | 'openrouter';
 
 export interface ProviderTypeConfig {
   key: ProviderTypeKey;
@@ -72,6 +79,14 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
       const region = p.config?.bedrock?.region || 'us-east-1';
       return `AWS Bedrock (${region})`;
     },
+  },
+  openrouter: {
+    key: 'openrouter',
+    label: 'OpenRouter',
+    icon: Waypoints,
+    color: getProviderColorVar('openrouter'),
+    isAccountBased: false,
+    getDisplayInfo: () => 'openrouter.ai',
   },
   custom: {
     key: 'custom',
@@ -264,7 +279,7 @@ export const defaultClients: ClientConfig[] = [
 
 // Form data types
 export type ProviderFormData = {
-  type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude';
+  type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter';
   name: string;
   selectedTemplate: string | null;
   baseURL: string;


### PR DESCRIPTION
## Summary

Adds a dedicated **`openrouter`** provider type (peer of `custom`/`claude`/`bedrock`/etc.) that natively serves **both** the OpenAI (`/v1/chat/completions`) and Anthropic (`/v1/messages`) protocols. The adapter delegates to the proven `custom` proxy core via a synthesized config, so it reuses all the existing proxy/streaming/auth logic without duplicating ~1300 LOC.

Key design points:
- **Delegation, not duplication** — synthesizes a `ProviderConfigCustom` pointed at `https://openrouter.ai/api` and wraps `custom.NewAdapter`.
- **Disguise forced off** — OpenRouter is a real Anthropic/OpenAI gateway; the custom core's default `claude-code` disguise injects prompt-caching `cache_control` that 400s OpenRouter's Bedrock-backed Anthropic models. The adapter forces `Disguise{Type: none}`.
- **Model mapping** flows through the generic DB `ModelMapping` entities (`executor.mapModel`), not inline config.
- **`MAXX_OPENROUTER_BASE_URL`** env hook redirects the fixed base URL (used by CI mock tests; also usable for a self-hosted OpenRouter-compatible gateway).

## Changes

**Backend**
- `domain`: `ProviderConfigOpenRouter{apiKey}` union member
- `adapter/provider/openrouter`: delegating adapter + base-URL hook
- `handler/self_service`: redact `openrouter.apiKey` on read
- `service/admin`: preserve stored key on blank-apiKey edit; default empty `supportedClientTypes` to `[claude, openai]`
- `cmd/maxx`: register the adapter

**Frontend**
- OpenRouter create step, edit view, model-mapping editors
- type registry, icon, theme color, i18n (en/zh)

## Testing

- **Unit**: adapter config synthesis (base URL, key propagation, disguise=none, no real-config mutation)
- **e2e mock (CI-safe, via `MAXX_OPENROUTER_BASE_URL`)**: delegation + auth override, OpenAI/Claude streaming SSE, model mapping (response + upstream-request-body rewrite + no-mapping passthrough), base-URL `/api` composition, header passthrough (HTTP-Referer/X-Title forwarded, X-Forwarded-For stripped), upstream-error passthrough, failover, single/multi client-type, dynamic client-type change, config round-trip, export/import round-trip, empty-types defaulting
- **e2e live** (`openrouter_live_test.go`, skipped unless `MAXX_OPENROUTER_E2E_KEY` set): both formats + streaming + model mapping, verified end-to-end against the real OpenRouter API
- Go build, `gofmt`, frontend `tsc`/eslint/vitest (57) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 OpenRouter 供应商支持，可在创建与编辑流程中选择、配置并管理 API Key、启用客户端类型、错误冷却与模型映射。
  * Web 端新增 OpenRouter 相关界面步骤、模型映射组件、图标与配色，并补充中英文本地化文案。
* **Bug 修复**
  * 改进 OpenRouter 密钥脱敏与“空密钥保留”行为，降低误清空与明文暴露风险。
* **测试**
  * 新增 OpenRouter 端到端 Mock/Live 集成测试；调整路由验证容差计算逻辑以提升稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->