### PR TITLE
fix(providers): use versioned NVIDIA OpenAI API root

### DIFF
--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { PROVIDER_TYPE_ORDER, createProviderTypeGroups, getKnownProviderTypeKey } from './types';
+import {
+  PROVIDER_TYPE_ORDER,
+  createProviderTypeGroups,
+  getKnownProviderTypeKey,
+  quickTemplates,
+} from './types';
 
 describe('provider type helpers', () => {
   it('keeps every configured provider type available for grouped provider UIs', () => {
@@ -40,5 +45,11 @@ describe('provider type helpers', () => {
     expect(getKnownProviderTypeKey('codex')).toBe('codex');
     expect(getKnownProviderTypeKey('custom')).toBe('custom');
     expect(getKnownProviderTypeKey('future-provider')).toBe('custom');
+  });
+
+  it('uses the versioned NVIDIA OpenAI-compatible API root in quick templates', () => {
+    const nvidiaTemplate = quickTemplates.find((template) => template.id === 'nvidia');
+
+    expect(nvidiaTemplate?.clientBaseURLs.openai).toBe('https://integrate.api.nvidia.com/v1');
   });
 });

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -240,7 +240,7 @@ export const quickTemplates: QuickTemplate[] = [
     logoUrl: nvidiaLogo,
     supportedClients: ['openai'],
     clientBaseURLs: {
-      openai: 'https://integrate.api.nvidia.com',
+      openai: 'https://integrate.api.nvidia.com/v1',
     },
     modelMappings: [{ pattern: '*', target: 'minimaxai/minimax-m2.1' }],
   },


### PR DESCRIPTION
## Summary
- update the NVIDIA custom provider quick template to use the versioned OpenAI-compatible API root
- add a regression test that locks the NVIDIA preset to `/v1`

## Validation
- `pnpm test` (web)
- `pnpm typecheck` (web)
- `go test ./internal/adapter/provider/custom -run TestBuildUpstreamURLNormalizesOpenAIBaseRoots -count=1`