### PR TITLE
fix(requests): count cancelled failures and globalize user keys

### DIFF
--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -49,6 +49,16 @@ func canAPITokenUseProjectBinding(apiToken *domain.APIToken) bool {
 	return !isUserPanelAPIToken(apiToken)
 }
 
+func apiTokenProjectBinding(apiToken *domain.APIToken, currentProjectID uint64) (uint64, bool) {
+	if apiToken == nil || currentProjectID != 0 || apiToken.ProjectID == 0 {
+		return currentProjectID, false
+	}
+	if !canAPITokenUseProjectBinding(apiToken) {
+		return currentProjectID, false
+	}
+	return apiToken.ProjectID, true
+}
+
 // NewProxyHandler creates a new proxy handler
 func NewProxyHandler(
 	clientAdapter *client.Adapter,
@@ -243,8 +253,8 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 	c.Set(flow.KeyProjectID, projectID)
 
 	if apiToken != nil {
-		if canAPITokenUseProjectBinding(apiToken) && apiToken.ProjectID > 0 && projectID == 0 {
-			c.Set(flow.KeyProjectID, apiToken.ProjectID)
+		if tokenProjectID, ok := apiTokenProjectBinding(apiToken, projectID); ok {
+			c.Set(flow.KeyProjectID, tokenProjectID)
 		}
 		if err := h.tokenAuth.AcquireConcurrency(apiToken); err != nil {
 			log.Printf("[Proxy] Token concurrency limit hit: tokenID=%d err=%v", apiToken.ID, err)
@@ -279,16 +289,16 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		if !isUserPanelAPIToken(apiToken) && session.ProjectID > 0 {
 			projectID = session.ProjectID
 			log.Printf("[Proxy] Using project ID from session binding: %d", projectID)
-		} else if canAPITokenUseProjectBinding(apiToken) && projectID == 0 && apiToken != nil && apiToken.ProjectID > 0 {
-			projectID = apiToken.ProjectID
+		} else if tokenProjectID, ok := apiTokenProjectBinding(apiToken, projectID); ok {
+			projectID = tokenProjectID
 			log.Printf("[Proxy] Using project ID from token: %d", projectID)
 		}
 		if touchErr := h.sessionRepo.Touch(tenantID, sessionID, now); touchErr != nil {
 			log.Printf("[Proxy] Failed to touch session %s: %v", sessionID, touchErr)
 		}
 	} else {
-		if canAPITokenUseProjectBinding(apiToken) && projectID == 0 && apiToken != nil && apiToken.ProjectID > 0 {
-			projectID = apiToken.ProjectID
+		if tokenProjectID, ok := apiTokenProjectBinding(apiToken, projectID); ok {
+			projectID = tokenProjectID
 			log.Printf("[Proxy] Using project ID from token for new session: %d", projectID)
 		}
 		session = &domain.Session{

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -140,11 +140,20 @@ func TestUserPanelAPITokenProjectBindingGuard(t *testing.T) {
 	if canAPITokenUseProjectBinding(userPanelToken) {
 		t.Fatal("user panel token must not use header/token/session project binding")
 	}
+	if got, ok := apiTokenProjectBinding(userPanelToken, 0); ok || got != 0 {
+		t.Fatalf("user panel token project binding = (%d, %v), want (0, false)", got, ok)
+	}
 	if isUserPanelAPIToken(regularToken) {
 		t.Fatal("regular token must not be treated as user panel token")
 	}
 	if !canAPITokenUseProjectBinding(regularToken) {
 		t.Fatal("regular token should keep existing project binding behavior")
+	}
+	if got, ok := apiTokenProjectBinding(regularToken, 0); !ok || got != regularToken.ProjectID {
+		t.Fatalf("regular token project binding = (%d, %v), want (%d, true)", got, ok, regularToken.ProjectID)
+	}
+	if got, ok := apiTokenProjectBinding(regularToken, 7); ok || got != 7 {
+		t.Fatalf("existing project binding = (%d, %v), want (7, false)", got, ok)
 	}
 	if !canAPITokenUseProjectBinding(nil) {
 		t.Fatal("nil token should keep unauthenticated/default project behavior")

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1203,6 +1203,10 @@ func (h *SelfServiceHandler) handleUserPanelAPIToken(w http.ResponseWriter, r *h
 		writeSelfServiceInternalError(w, "GetUserPanelAPITokens failed", err)
 		return
 	}
+	if err := ensureUserPanelAPITokensUseGlobalRoutes(h.svc, tenantID, existing); err != nil {
+		writeSelfServiceInternalError(w, "NormalizeUserPanelAPITokens failed", err)
+		return
+	}
 
 	if r.Method == http.MethodGet {
 		writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": sanitizeAPIToken(firstActiveUserPanelAPIToken(existing))})
@@ -1268,6 +1272,19 @@ func findUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint64, u
 		}
 	}
 	return matches, nil
+}
+
+func ensureUserPanelAPITokensUseGlobalRoutes(svc *service.AdminService, tenantID uint64, tokens []*domain.APIToken) error {
+	for _, token := range tokens {
+		if token == nil || token.ProjectID == 0 {
+			continue
+		}
+		token.ProjectID = 0
+		if err := svc.UpdateAPIToken(tenantID, token); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func firstActiveUserPanelAPIToken(tokens []*domain.APIToken) *domain.APIToken {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -2128,6 +2128,66 @@ func TestSelfServiceHandler_GetAPIToken_MemberRedactsPlaintextToken(t *testing.T
 	}
 }
 
+func TestSelfServiceHandler_UserPanelTokenCreatedForGlobalRoutes(t *testing.T) {
+	tokenRepo := &selfServiceAPITokenRepo{}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodPost, "/user-panel-token"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if len(tokenRepo.tokens) != 1 {
+		t.Fatalf("tokens = %d, want 1", len(tokenRepo.tokens))
+	}
+	created := tokenRepo.tokens[0]
+	if created.ProjectID != 0 {
+		t.Fatalf("user panel token projectID = %d, want global route scope 0", created.ProjectID)
+	}
+	if created.Description != userPanelAPITokenDescription(9) {
+		t.Fatalf("description = %q, want user panel marker", created.Description)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelExistingTokenProjectBindingIsCleared(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "User Console Key (user 9)", Description: marker, IsEnabled: true, ProjectID: 42},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodGet, "/user-panel-token"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if tokenRepo.tokens[0].ProjectID != 0 {
+		t.Fatalf("existing user panel token projectID = %d, want normalized global route scope 0", tokenRepo.tokens[0].ProjectID)
+	}
+
+	var result map[string]*domain.APIToken
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["apiToken"] == nil || result["apiToken"].ProjectID != 0 {
+		t.Fatalf("response apiToken = %+v, want projectID 0", result["apiToken"])
+	}
+}
+
 func TestSelfServiceHandler_UserPanelRegenerateDisablesOldTokenAndKeepsHistory(t *testing.T) {
 	marker := userPanelAPITokenDescription(9)
 	tokenRepo := &selfServiceAPITokenRepo{

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -19,7 +19,7 @@ type ProxyRequestRepository struct {
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
 
-var proxyRequestErrorStatuses = []string{"FAILED", "REJECTED"}
+var proxyRequestErrorStatuses = []string{"FAILED", "CANCELLED", "REJECTED"}
 
 func cloneProxyRequestFilter(filter *repository.ProxyRequestFilter) *repository.ProxyRequestFilter {
 	if filter == nil {

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -752,15 +752,15 @@ func TestProxyRequestErrorModeFiltersStatusAndHTTPFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CountWithFilter only failed: %v", err)
 	}
-	if errorCount != 3 {
-		t.Fatalf("error count = %d, want 3", errorCount)
+	if errorCount != 4 {
+		t.Fatalf("error count = %d, want 4", errorCount)
 	}
 
 	errorItems, err := repo.ListCursor(1, 10, 0, 0, errorFilter)
 	if err != nil {
 		t.Fatalf("ListCursor only failed: %v", err)
 	}
-	expectedErrorIDs := []uint64{requests[3].ID, requests[2].ID, requests[1].ID}
+	expectedErrorIDs := []uint64{requests[4].ID, requests[3].ID, requests[2].ID, requests[1].ID}
 	if got := collectRequestIDs(errorItems); fmt.Sprint(got) != fmt.Sprint(expectedErrorIDs) {
 		t.Fatalf("error ids = %v, want %v", got, expectedErrorIDs)
 	}
@@ -770,15 +770,15 @@ func TestProxyRequestErrorModeFiltersStatusAndHTTPFailures(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CountWithFilter exclude failed: %v", err)
 	}
-	if nonErrorCount != 2 {
-		t.Fatalf("non-error count = %d, want 2", nonErrorCount)
+	if nonErrorCount != 1 {
+		t.Fatalf("non-error count = %d, want 1", nonErrorCount)
 	}
 
 	nonErrorItems, err := repo.ListCursor(1, 10, 0, 0, excludeFilter)
 	if err != nil {
 		t.Fatalf("ListCursor exclude failed: %v", err)
 	}
-	expectedNonErrorIDs := []uint64{requests[4].ID, requests[0].ID}
+	expectedNonErrorIDs := []uint64{requests[0].ID}
 	if got := collectRequestIDs(nonErrorItems); fmt.Sprint(got) != fmt.Sprint(expectedNonErrorIDs) {
 		t.Fatalf("non-error ids = %v, want %v", got, expectedNonErrorIDs)
 	}
@@ -823,18 +823,18 @@ func TestProxyRequestErrorStatsAggregatesCurrentFilter(t *testing.T) {
 	if stats.TotalRequests != 5 {
 		t.Fatalf("total requests = %d, want 5", stats.TotalRequests)
 	}
-	if stats.ErrorRequests != 3 {
-		t.Fatalf("error requests = %d, want 3", stats.ErrorRequests)
+	if stats.ErrorRequests != 4 {
+		t.Fatalf("error requests = %d, want 4", stats.ErrorRequests)
 	}
-	if stats.ErrorRate != 0.6 {
-		t.Fatalf("error rate = %v, want 0.6", stats.ErrorRate)
+	if stats.ErrorRate != 0.8 {
+		t.Fatalf("error rate = %v, want 0.8", stats.ErrorRate)
 	}
 
 	statusCounts := map[string]int64{}
 	for _, item := range stats.StatusCounts {
 		statusCounts[item.Name] = item.Count
 	}
-	if statusCounts["FAILED"] != 1 || statusCounts["REJECTED"] != 1 || statusCounts["COMPLETED"] != 1 || statusCounts["CANCELLED"] != 0 {
+	if statusCounts["FAILED"] != 1 || statusCounts["REJECTED"] != 1 || statusCounts["COMPLETED"] != 1 || statusCounts["CANCELLED"] != 1 {
 		t.Fatalf("unexpected status counts: %#v", statusCounts)
 	}
 
@@ -850,7 +850,7 @@ func TestProxyRequestErrorStatsAggregatesCurrentFilter(t *testing.T) {
 	for _, item := range stats.ProviderCounts {
 		providerCounts[item.ProviderID] = item.Count
 	}
-	if providerCounts[7] != 2 || providerCounts[8] != 1 {
+	if providerCounts[7] != 2 || providerCounts[8] != 1 || providerCounts[9] != 1 {
 		t.Fatalf("unexpected provider counts: %#v", providerCounts)
 	}
 
@@ -858,7 +858,7 @@ func TestProxyRequestErrorStatsAggregatesCurrentFilter(t *testing.T) {
 	for _, item := range stats.ModelCounts {
 		modelCounts[item.Name] = item.Count
 	}
-	if modelCounts["claude-sonnet"] != 2 || modelCounts["gpt-5"] != 1 {
+	if modelCounts["claude-sonnet"] != 2 || modelCounts["gpt-5"] != 1 || modelCounts["cancelled-model"] != 1 {
 		t.Fatalf("unexpected model counts: %#v", modelCounts)
 	}
 	if len(stats.Trend) == 0 {
@@ -879,6 +879,8 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 	failed := buildTestProxyRequest("FAILED", 100)
 	failed.StatusCode = 500
 	failed.ProjectID = 10
+	cancelled := buildTestProxyRequest("CANCELLED", 104)
+	cancelled.ProjectID = 10
 	completed := buildTestProxyRequest("COMPLETED", 101)
 	completed.ProjectID = 10
 	active := buildTestProxyRequest("IN_PROGRESS", 102)
@@ -888,13 +890,14 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 	rejectedOtherProject.StatusCode = 403
 	rejectedOtherProject.ProjectID = 99
 
-	for _, req := range []*domain.ProxyRequest{failed, completed, active, rejectedOtherProject} {
+	for _, req := range []*domain.ProxyRequest{failed, cancelled, completed, active, rejectedOtherProject} {
 		if err := repo.Create(req); err != nil {
 			t.Fatalf("create request %s: %v", req.Status, err)
 		}
 	}
 
 	seedAttemptForRequest(t, attemptRepo, db, failed.ID, time.Now())
+	seedAttemptForRequest(t, attemptRepo, db, cancelled.ID, time.Now())
 	seedAttemptForRequest(t, attemptRepo, db, completed.ID, time.Now())
 	seedAttemptForRequest(t, attemptRepo, db, active.ID, time.Now())
 	seedAttemptForRequest(t, attemptRepo, db, rejectedOtherProject.ID, time.Now())
@@ -904,20 +907,23 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 	if err != nil {
 		t.Fatalf("CountFailedWithFilter: %v", err)
 	}
-	if candidateCount != 1 {
-		t.Fatalf("cleanup candidate count = %d, want 1", candidateCount)
+	if candidateCount != 2 {
+		t.Fatalf("cleanup candidate count = %d, want 2", candidateCount)
 	}
 
 	deletedRequests, deletedAttempts, err := repo.DeleteFailedWithFilter(1, filter)
 	if err != nil {
 		t.Fatalf("DeleteFailedWithFilter: %v", err)
 	}
-	if deletedRequests != 1 || deletedAttempts != 1 {
-		t.Fatalf("deleted requests/attempts = %d/%d, want 1/1", deletedRequests, deletedAttempts)
+	if deletedRequests != 2 || deletedAttempts != 2 {
+		t.Fatalf("deleted requests/attempts = %d/%d, want 2/2", deletedRequests, deletedAttempts)
 	}
 
 	if _, err := repo.GetByID(1, failed.ID); err == nil {
 		t.Fatalf("failed request still exists after cleanup")
+	}
+	if _, err := repo.GetByID(1, cancelled.ID); err == nil {
+		t.Fatalf("cancelled request still exists after cleanup")
 	}
 	for _, req := range []*domain.ProxyRequest{completed, active, rejectedOtherProject} {
 		if _, err := repo.GetByID(req.TenantID, req.ID); err != nil {
@@ -926,7 +932,7 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 	}
 
 	var orphanAttempts int64
-	if err := db.gorm.Model(&ProxyUpstreamAttempt{}).Where("proxy_request_id = ?", failed.ID).Count(&orphanAttempts).Error; err != nil {
+	if err := db.gorm.Model(&ProxyUpstreamAttempt{}).Where("proxy_request_id IN ?", []uint64{failed.ID, cancelled.ID}).Count(&orphanAttempts).Error; err != nil {
 		t.Fatalf("count deleted attempts: %v", err)
 	}
 	if orphanAttempts != 0 {

--- a/web/src/hooks/queries/use-requests.test.ts
+++ b/web/src/hooks/queries/use-requests.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { ProxyRequest } from '@/lib/transport';
+import { isProxyRequestError } from './use-requests';
+
+const baseRequest = {
+  id: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  instanceID: 'instance-1',
+  requestID: 'request-1',
+  sessionID: 'session-1',
+  clientType: 'openai',
+  requestModel: 'model-a',
+  responseModel: '',
+  startTime: '2026-01-01T00:00:00Z',
+  endTime: '2026-01-01T00:00:01Z',
+  duration: 1,
+  ttft: 0,
+  isStream: false,
+  statusCode: 200,
+  requestInfo: null,
+  responseInfo: null,
+  error: '',
+  proxyUpstreamAttemptCount: 0,
+  finalProxyUpstreamAttemptID: 0,
+  routeID: 0,
+  providerID: 0,
+  projectID: 0,
+  inputTokenCount: 0,
+  outputTokenCount: 0,
+  cacheReadCount: 0,
+  cacheWriteCount: 0,
+  cache5mWriteCount: 0,
+  cache1hWriteCount: 0,
+  modelPriceId: 0,
+  multiplier: 10000,
+  cost: 0,
+  apiTokenID: 0,
+} satisfies Omit<ProxyRequest, 'status'>;
+
+function request(status: ProxyRequest['status'], statusCode = 200): ProxyRequest {
+  return { ...baseRequest, status, statusCode };
+}
+
+describe('isProxyRequestError', () => {
+  it('treats cancelled requests as error records', () => {
+    expect(isProxyRequestError(request('CANCELLED'))).toBe(true);
+  });
+
+  it('keeps completed 2xx requests out of error records', () => {
+    expect(isProxyRequestError(request('COMPLETED'))).toBe(false);
+  });
+
+  it('treats rejected, failed, and HTTP error responses as error records', () => {
+    expect(isProxyRequestError(request('FAILED'))).toBe(true);
+    expect(isProxyRequestError(request('REJECTED'))).toBe(true);
+    expect(isProxyRequestError(request('COMPLETED', 503))).toBe(true);
+  });
+});

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -46,8 +46,13 @@ export const requestKeys = {
   attempts: (id: number) => [...requestKeys.detail(id), 'attempts'] as const,
 };
 
-function isProxyRequestError(request: ProxyRequest): boolean {
-  return request.status === 'FAILED' || request.status === 'REJECTED' || request.statusCode >= 400;
+export function isProxyRequestError(request: ProxyRequest): boolean {
+  return (
+    request.status === 'FAILED' ||
+    request.status === 'CANCELLED' ||
+    request.status === 'REJECTED' ||
+    request.statusCode >= 400
+  );
 }
 
 function matchesRequestTimeRange(

--- a/web/src/lib/user-panel-endpoints.test.ts
+++ b/web/src/lib/user-panel-endpoints.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildUserPanelChatCompletionsExample, buildUserPanelEndpointHints } from './user-panel-endpoints';
+
+describe('user panel endpoints', () => {
+  it('uses global proxy endpoints for managed user console keys', () => {
+    const endpoints = buildUserPanelEndpointHints('https://maxx.example.com/');
+
+    expect(endpoints).toEqual([
+      { id: 'openai-codex', url: 'https://maxx.example.com/v1' },
+      { id: 'claude', url: 'https://maxx.example.com' },
+      {
+        id: 'gemini',
+        url: 'https://maxx.example.com/v1beta/models/{model}:generateContent',
+      },
+    ]);
+  });
+
+  it('does not append any project route segment by itself', () => {
+    const endpoints = buildUserPanelEndpointHints('https://maxx.example.com');
+    const example = buildUserPanelChatCompletionsExample({
+      origin: 'https://maxx.example.com',
+      tokenLabel: 'your key',
+    });
+
+    expect(endpoints.map((endpoint) => endpoint.url).join('\n')).not.toContain('/project/');
+    expect(example).toContain('https://maxx.example.com/v1/chat/completions');
+    expect(example).not.toContain('/project/');
+  });
+});

--- a/web/src/lib/user-panel-endpoints.ts
+++ b/web/src/lib/user-panel-endpoints.ts
@@ -1,0 +1,29 @@
+export interface UserPanelEndpointHint {
+  id: 'openai-codex' | 'claude' | 'gemini';
+  url: string;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+export function buildUserPanelEndpointHints(origin: string): UserPanelEndpointHint[] {
+  const baseUrl = trimTrailingSlash(origin);
+
+  return [
+    { id: 'openai-codex', url: `${baseUrl}/v1` },
+    { id: 'claude', url: baseUrl },
+    { id: 'gemini', url: `${baseUrl}/v1beta/models/{model}:generateContent` },
+  ];
+}
+
+export function buildUserPanelChatCompletionsExample(params: {
+  origin: string;
+  tokenLabel: string;
+}): string {
+  const baseUrl = trimTrailingSlash(params.origin);
+  return `curl ${baseUrl}/v1/chat/completions \
+  -H "Authorization: Bearer <${params.tokenLabel}>" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'`;
+}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -11,6 +11,10 @@ import {
   useUserPanelAPIToken,
 } from '@/hooks/queries';
 import type { APIToken } from '@/lib/transport';
+import {
+  buildUserPanelChatCompletionsExample,
+  buildUserPanelEndpointHints,
+} from '@/lib/user-panel-endpoints';
 import { cn } from '@/lib/utils';
 
 function maskNumericIdentity(value?: number) {
@@ -65,18 +69,19 @@ export function UserPanelPage() {
   const authProtected = settings?.api_token_auth_enabled === 'true';
   const proxyOnline = proxyStatus?.running ?? true;
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
-  const openAICodexBaseURL = `${origin}/v1`;
-  const claudeBaseURL = origin;
-  const geminiEndpoint = `${origin}/v1beta/models/{model}:generateContent`;
-  const endpointHints = [
-    { id: 'openai-codex', label: t('userPanel.routeOpenAICodex'), url: openAICodexBaseURL },
-    { id: 'claude', label: t('userPanel.routeClaude'), url: claudeBaseURL },
-    { id: 'gemini', label: t('userPanel.routeGemini'), url: geminiEndpoint },
-  ];
-  const curlExample = `curl ${openAICodexBaseURL}/chat/completions \
-  -H "Authorization: Bearer <${t('userPanel.yourKey')}>" \
-  -H "Content-Type: application/json" \
-  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'`;
+  const endpointHints = buildUserPanelEndpointHints(origin).map((endpoint) => ({
+    ...endpoint,
+    label:
+      endpoint.id === 'openai-codex'
+        ? t('userPanel.routeOpenAICodex')
+        : endpoint.id === 'claude'
+          ? t('userPanel.routeClaude')
+          : t('userPanel.routeGemini'),
+  }));
+  const curlExample = buildUserPanelChatCompletionsExample({
+    origin,
+    tokenLabel: t('userPanel.yourKey'),
+  });
 
   const handleCopyEndpoint = async (endpointId: string, url: string) => {
     if (!url || typeof navigator === 'undefined' || !navigator.clipboard) return;


### PR DESCRIPTION
## Summary
- Count `CANCELLED` proxy requests as failure/error records in backend filters, error stats, cleanup, and frontend request filtering.
- Keep managed user-panel API tokens on the global route scope by clearing any historical `ProjectID` binding and ignoring token/session/header project binding for those tokens.
- Move user-panel endpoint construction into a small tested helper so member console examples use global proxy endpoints and do not append project routes.

## Validation
- `go test ./internal/handler ./internal/repository/sqlite`
- `pnpm test -- src/hooks/queries/use-requests.test.ts src/lib/user-panel-endpoints.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `go test ./...`
- `git diff --check`
- `pnpm lint`

## Notes
- First `go test ./...` failed because root package embed requires `web/dist`; after `pnpm build`, `go test ./...` passed.
- This PR does not merge, release, or inspect/trigger CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 用户面板新增了更清晰的 API 端点提示与快速开始示例，支持多种常见服务的调用路径展示。
  * 代理请求相关页面现在会把“已取消”请求也纳入错误识别与统计中。

* **Bug 修复**
  * 修正了用户面板 API Token 的项目绑定行为，避免旧的绑定信息影响全局路由使用。
  * 改进了错误请求清理与统计，确保取消状态的请求会被正确处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->