### PR TITLE
fix(user-panel): preserve managed key history

### DIFF
--- a/internal/executor/codex_guard_test.go
+++ b/internal/executor/codex_guard_test.go
@@ -17,10 +17,15 @@ import (
 )
 
 type codexGuardProxyRequestRepo struct {
+	created []*domain.ProxyRequest
 	updated []*domain.ProxyRequest
 }
 
-func (r *codexGuardProxyRequestRepo) Create(req *domain.ProxyRequest) error { return nil }
+func (r *codexGuardProxyRequestRepo) Create(req *domain.ProxyRequest) error {
+	snap := *req
+	r.created = append(r.created, &snap)
+	return nil
+}
 
 func (r *codexGuardProxyRequestRepo) Update(req *domain.ProxyRequest) error {
 	snap := *req

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -31,6 +32,14 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	})
 	if err != nil {
 		message := fmt.Sprintf("route match failed: %v", err)
+		proxyReq := e.newProxyRequest(c, state, "REJECTED")
+		proxyReq.StatusCode = http.StatusServiceUnavailable
+		proxyReq.Error = message
+		proxyReq.EndTime = time.Now()
+		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
+		e.createProxyRequest(proxyReq)
+		state.proxyReq = proxyReq
+
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
 		if errors.Is(err, domain.ErrNoAvailableProviders) {
 			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")

--- a/internal/executor/route_match_test.go
+++ b/internal/executor/route_match_test.go
@@ -1,0 +1,74 @@
+package executor
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+func TestExecutorRouteMatchFailureCreatesRejectedProxyRequest(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(nil)
+	providerRepo := cached.NewProviderRepository(nil)
+	strategyRepo := cached.NewRoutingStrategyRepository(nil)
+	retryRepo := cached.NewRetryConfigRepository(nil)
+	projectRepo := cached.NewProjectRepository(nil)
+	r := router.NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	exec := &Executor{
+		router:           r,
+		proxyRequestRepo: proxyRepo,
+		instanceID:       "test-instance",
+	}
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"minimaxai/minimax-m3"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	state := &execState{
+		ctx:            req.Context(),
+		tenantID:       1,
+		clientType:     domain.ClientTypeOpenAI,
+		projectID:      0,
+		sessionID:      "session-1",
+		requestModel:   "minimaxai/minimax-m3",
+		apiTokenID:     46,
+		requestBody:    []byte(`{"model":"minimaxai/minimax-m3"}`),
+		requestURI:     req.URL.RequestURI(),
+		requestHeaders: req.Header,
+	}
+	c.Set(flow.KeyExecutorState, state)
+
+	exec.routeMatch(c)
+
+	if len(proxyRepo.created) != 1 {
+		t.Fatalf("created proxy requests = %d, want 1", len(proxyRepo.created))
+	}
+	created := proxyRepo.created[0]
+	if created.Status != "REJECTED" {
+		t.Fatalf("status = %q, want REJECTED", created.Status)
+	}
+	if created.StatusCode != 503 {
+		t.Fatalf("statusCode = %d, want 503", created.StatusCode)
+	}
+	if !strings.Contains(created.Error, "route match failed") || !strings.Contains(created.Error, "no routes available") {
+		t.Fatalf("error = %q, want route match failure", created.Error)
+	}
+	if created.RequestModel != "minimaxai/minimax-m3" || created.APITokenID != 46 || created.ClientType != domain.ClientTypeOpenAI {
+		t.Fatalf("created = %+v, want request context preserved", created)
+	}
+	if created.RequestInfo == nil || created.RequestInfo.URL != "/v1/chat/completions" {
+		t.Fatalf("requestInfo = %+v, want captured request detail", created.RequestInfo)
+	}
+	if state.proxyReq == nil || state.proxyReq.Status != "REJECTED" {
+		t.Fatalf("state.proxyReq = %+v, want rejected proxy request", state.proxyReq)
+	}
+	if c.Err == nil {
+		t.Fatalf("c.Err is nil, want proxy error")
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1203,33 +1203,42 @@ func (h *SelfServiceHandler) handleUserPanelAPIToken(w http.ResponseWriter, r *h
 		writeSelfServiceInternalError(w, "GetUserPanelAPITokens failed", err)
 		return
 	}
-	if err := ensureUserPanelAPITokensUseGlobalRoutes(h.svc, tenantID, existing); err != nil {
+	canonicalToken, err := normalizeUserPanelAPITokensForUser(h.svc, tenantID, userID, existing)
+	if err != nil {
 		writeSelfServiceInternalError(w, "NormalizeUserPanelAPITokens failed", err)
 		return
 	}
 
 	if r.Method == http.MethodGet {
-		writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": sanitizeAPIToken(firstActiveUserPanelAPIToken(existing))})
+		if canonicalToken == nil || !canonicalToken.IsEnabled {
+			writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": nil})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]*domain.APIToken{"apiToken": sanitizeAPIToken(canonicalToken)})
 		return
 	}
 
-	activeToken := firstActiveUserPanelAPIToken(existing)
-	if regenerate {
-		for _, token := range existing {
-			if token == nil || !token.IsEnabled {
-				continue
-			}
-			token.IsEnabled = false
-			if err := h.svc.UpdateAPIToken(tenantID, token); err != nil {
-				writeSelfServiceInternalError(w, "DisableUserPanelAPIToken failed", err)
-				return
-			}
-		}
-	} else if activeToken != nil {
+	if !regenerate && canonicalToken != nil && canonicalToken.IsEnabled {
 		writeJSON(w, http.StatusConflict, map[string]any{
 			"error":    "user panel token already exists",
-			"apiToken": sanitizeAPIToken(activeToken),
+			"apiToken": sanitizeAPIToken(canonicalToken),
 		})
+		return
+	}
+
+	if canonicalToken != nil {
+		canonicalToken.Name = userPanelAPITokenName(userID)
+		canonicalToken.Description = userPanelAPITokenDescription(userID)
+		canonicalToken.ProjectID = 0
+		result, err := h.svc.RotateAPIToken(tenantID, canonicalToken)
+		if err != nil {
+			writeSelfServiceInternalError(w, "RotateUserPanelAPIToken failed", err)
+			return
+		}
+		if result != nil {
+			result.APIToken = sanitizeAPIToken(result.APIToken)
+		}
+		writeJSON(w, http.StatusCreated, result)
 		return
 	}
 
@@ -1274,30 +1283,59 @@ func findUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint64, u
 	return matches, nil
 }
 
-func ensureUserPanelAPITokensUseGlobalRoutes(svc *service.AdminService, tenantID uint64, tokens []*domain.APIToken) error {
+func normalizeUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint64, userID uint64, tokens []*domain.APIToken) (*domain.APIToken, error) {
+	canonical := selectCanonicalUserPanelAPIToken(tokens)
+	if canonical == nil {
+		return nil, nil
+	}
+
+	marker := userPanelAPITokenDescription(userID)
+	name := userPanelAPITokenName(userID)
+	if canonical.Name != name || canonical.Description != marker || canonical.ProjectID != 0 {
+		canonical.Name = name
+		canonical.Description = marker
+		canonical.ProjectID = 0
+		if err := svc.UpdateAPIToken(tenantID, canonical); err != nil {
+			return nil, err
+		}
+	}
+
 	for _, token := range tokens {
-		if token == nil || token.ProjectID == 0 {
+		if token == nil || token.ID == canonical.ID {
 			continue
 		}
-		token.ProjectID = 0
-		if err := svc.UpdateAPIToken(tenantID, token); err != nil {
-			return err
+		if err := svc.DeleteAPIToken(tenantID, token.ID); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+	return canonical, nil
 }
 
-func firstActiveUserPanelAPIToken(tokens []*domain.APIToken) *domain.APIToken {
+func selectCanonicalUserPanelAPIToken(tokens []*domain.APIToken) *domain.APIToken {
+	var best *domain.APIToken
 	for _, token := range tokens {
-		if token != nil && token.IsEnabled {
-			return token
+		if token == nil {
+			continue
+		}
+		if best == nil || isBetterUserPanelAPIToken(token, best) {
+			best = token
 		}
 	}
-	return nil
+	return best
+}
+
+func isBetterUserPanelAPIToken(candidate *domain.APIToken, current *domain.APIToken) bool {
+	if candidate.IsEnabled != current.IsEnabled {
+		return candidate.IsEnabled
+	}
+	if !candidate.CreatedAt.Equal(current.CreatedAt) {
+		return candidate.CreatedAt.After(current.CreatedAt)
+	}
+	return candidate.ID > current.ID
 }
 
 func userPanelAPITokenName(userID uint64) string {
-	return fmt.Sprintf("User Console Key (user %d)", userID)
+	return fmt.Sprintf("user %d", userID)
 }
 
 func userPanelAPITokenDescription(userID uint64) string {

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1304,6 +1304,9 @@ func normalizeUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint
 		if token == nil || token.ID == canonical.ID {
 			continue
 		}
+		if err := svc.ReassignAPITokenHistory(tenantID, token.ID, canonical.ID); err != nil {
+			return nil, err
+		}
 		if err := svc.DeleteAPIToken(tenantID, token.ID); err != nil {
 			return nil, err
 		}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -2150,6 +2150,9 @@ func TestSelfServiceHandler_UserPanelTokenCreatedForGlobalRoutes(t *testing.T) {
 	if created.ProjectID != 0 {
 		t.Fatalf("user panel token projectID = %d, want global route scope 0", created.ProjectID)
 	}
+	if created.Name != "user 9" {
+		t.Fatalf("name = %q, want user 9", created.Name)
+	}
 	if created.Description != userPanelAPITokenDescription(9) {
 		t.Fatalf("description = %q, want user panel marker", created.Description)
 	}
@@ -2178,6 +2181,9 @@ func TestSelfServiceHandler_UserPanelExistingTokenProjectBindingIsCleared(t *tes
 	if tokenRepo.tokens[0].ProjectID != 0 {
 		t.Fatalf("existing user panel token projectID = %d, want normalized global route scope 0", tokenRepo.tokens[0].ProjectID)
 	}
+	if tokenRepo.tokens[0].Name != "user 9" {
+		t.Fatalf("existing user panel token name = %q, want user 9", tokenRepo.tokens[0].Name)
+	}
 
 	var result map[string]*domain.APIToken
 	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
@@ -2188,11 +2194,11 @@ func TestSelfServiceHandler_UserPanelExistingTokenProjectBindingIsCleared(t *tes
 	}
 }
 
-func TestSelfServiceHandler_UserPanelRegenerateDisablesOldTokenAndKeepsHistory(t *testing.T) {
+func TestSelfServiceHandler_UserPanelRegenerateRotatesExistingTokenInPlace(t *testing.T) {
 	marker := userPanelAPITokenDescription(9)
 	tokenRepo := &selfServiceAPITokenRepo{
 		tokens: []*domain.APIToken{
-			{ID: 10, TenantID: 1, Name: "User Console Key (user 9)", Description: marker, IsEnabled: true},
+			{ID: 10, TenantID: 1, Name: "User Console Key (user 9)", Description: marker, Token: "old-token", TokenPrefix: "old", IsEnabled: true, ProjectID: 42},
 		},
 	}
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
@@ -2208,23 +2214,77 @@ func TestSelfServiceHandler_UserPanelRegenerateDisablesOldTokenAndKeepsHistory(t
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusCreated, rec.Body.String())
 	}
-	if len(tokenRepo.tokens) != 2 {
-		t.Fatalf("tokens = %d, want old disabled + new active", len(tokenRepo.tokens))
+	if len(tokenRepo.tokens) != 1 {
+		t.Fatalf("tokens = %d, want one rotated token", len(tokenRepo.tokens))
 	}
-	var oldToken, newToken *domain.APIToken
-	for _, token := range tokenRepo.tokens {
-		switch token.ID {
-		case 10:
-			oldToken = token
-		default:
-			newToken = token
-		}
+	token := tokenRepo.tokens[0]
+	if token.ID != 10 || !token.IsEnabled || token.Description != marker || token.Name != "user 9" || token.ProjectID != 0 {
+		t.Fatalf("token = %+v, want same active normalized user panel token", token)
 	}
-	if oldToken == nil || oldToken.IsEnabled {
-		t.Fatalf("old token = %+v, want disabled historical token", oldToken)
+	if token.Token == "" || token.Token == "old-token" {
+		t.Fatalf("token secret = %q, want rotated non-empty secret", token.Token)
 	}
-	if newToken == nil || !newToken.IsEnabled || newToken.Description != marker {
-		t.Fatalf("new token = %+v, want active replacement with same marker", newToken)
+}
+
+func TestSelfServiceHandler_UserPanelCreateReusesDisabledToken(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "old", Description: marker, Token: "old-token", TokenPrefix: "old", IsEnabled: false, ProjectID: 42},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodPost, "/user-panel-token"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if len(tokenRepo.tokens) != 1 {
+		t.Fatalf("tokens = %d, want disabled token reused", len(tokenRepo.tokens))
+	}
+	token := tokenRepo.tokens[0]
+	if token.ID != 10 || !token.IsEnabled || token.Name != "user 9" || token.ProjectID != 0 {
+		t.Fatalf("token = %+v, want reused active normalized token", token)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelDuplicateTokensAreCollapsed(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "duplicate old", Description: marker, IsEnabled: true, ProjectID: 42, CreatedAt: older},
+			{ID: 11, TenantID: 1, Name: "duplicate new", Description: marker, IsEnabled: true, ProjectID: 7, CreatedAt: newer},
+			{ID: 12, TenantID: 1, Name: "disabled duplicate", Description: marker, IsEnabled: false, ProjectID: 99, CreatedAt: newer.Add(time.Minute)},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodGet, "/user-panel-token"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if len(tokenRepo.tokens) != 1 {
+		t.Fatalf("tokens = %d, want duplicates collapsed", len(tokenRepo.tokens))
+	}
+	token := tokenRepo.tokens[0]
+	if token.ID != 11 || token.Name != "user 9" || token.ProjectID != 0 || !token.IsEnabled {
+		t.Fatalf("token = %+v, want newest active canonical normalized", token)
 	}
 }
 

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -524,6 +524,15 @@ func (r *selfServiceUsageStatsRepo) Query(tenantID uint64, filter repository.Usa
 	}
 	return result, nil
 }
+func (r *selfServiceUsageStatsRepo) ReassignAPITokenID(tenantID uint64, fromID uint64, toID uint64) error {
+	for _, stat := range r.stats {
+		if stat != nil && stat.TenantID == tenantID && stat.APITokenID == fromID {
+			stat.APITokenID = toID
+		}
+	}
+	return nil
+}
+
 func (r *selfServiceUsageStatsRepo) QueryDashboardData(_ uint64) (*domain.DashboardData, error) {
 	return nil, nil
 }
@@ -2285,6 +2294,67 @@ func TestSelfServiceHandler_UserPanelDuplicateTokensAreCollapsed(t *testing.T) {
 	token := tokenRepo.tokens[0]
 	if token.ID != 11 || token.Name != "user 9" || token.ProjectID != 0 || !token.IsEnabled {
 		t.Fatalf("token = %+v, want newest active canonical normalized", token)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelDedupPreservesUsageStats(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	older := time.Now().Add(-time.Hour)
+	newer := time.Now()
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "duplicate old", Description: marker, IsEnabled: true, ProjectID: 42, CreatedAt: older},
+			{ID: 11, TenantID: 1, Name: "duplicate new", Description: marker, IsEnabled: true, ProjectID: 7, CreatedAt: newer},
+		},
+	}
+	usageRepo := &selfServiceUsageStatsRepo{
+		stats: []*domain.UsageStats{
+			{ID: 1, TenantID: 1, APITokenID: 10, TotalRequests: 96, SuccessfulRequests: 80, FailedRequests: 16, Model: "old-key-model"},
+			{ID: 2, TenantID: 1, APITokenID: 11, TotalRequests: 55, SuccessfulRequests: 40, FailedRequests: 15, Model: "new-key-model"},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo:   tokenRepo,
+		usageStatsRepo: usageRepo,
+	})
+
+	tokenRec := httptest.NewRecorder()
+	handler.ServeHTTP(tokenRec, newSelfServiceRequest(http.MethodGet, "/user-panel-token"))
+	if tokenRec.Code != http.StatusOK {
+		t.Fatalf("token status = %d, want %d, body = %s", tokenRec.Code, http.StatusOK, tokenRec.Body.String())
+	}
+	if len(tokenRepo.tokens) != 1 || tokenRepo.tokens[0].ID != 11 {
+		t.Fatalf("tokens = %+v, want only canonical token 11 after dedupe", tokenRepo.tokens)
+	}
+
+	statsRec := httptest.NewRecorder()
+	handler.ServeHTTP(statsRec, newSelfServiceRequest(http.MethodGet, "/usage-stats?granularity=hour"))
+	if statsRec.Code != http.StatusOK {
+		t.Fatalf("stats status = %d, want %d, body = %s", statsRec.Code, http.StatusOK, statsRec.Body.String())
+	}
+	var stats []domain.UsageStats
+	if err := json.Unmarshal(statsRec.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("stats = %+v, want old and canonical stats preserved", stats)
+	}
+	var total uint64
+	for _, stat := range stats {
+		if stat.APITokenID != 11 {
+			t.Fatalf("stat APITokenID = %d, want reassigned canonical token 11", stat.APITokenID)
+		}
+		total += stat.TotalRequests
+	}
+	if total != 151 {
+		t.Fatalf("total requests = %d, want 151", total)
+	}
+	if len(usageRepo.filters) != 1 {
+		t.Fatalf("filters = %+v, want one query for canonical token after dedupe", usageRepo.filters)
 	}
 }
 

--- a/internal/repository/cached/api_token.go
+++ b/internal/repository/cached/api_token.go
@@ -55,8 +55,15 @@ func (r *APITokenRepository) Update(t *domain.APIToken) error {
 	if exists && old != nil && old.Token != t.Token {
 		delete(r.tokenCache, old.Token)
 	}
+	for tokenValue, cached := range r.tokenCache {
+		if cached != nil && cached.ID == t.ID && tokenValue != t.Token {
+			delete(r.tokenCache, tokenValue)
+		}
+	}
 	r.cache[t.ID] = t
-	r.tokenCache[t.Token] = t
+	if t.Token != "" {
+		r.tokenCache[t.Token] = t
+	}
 	r.mu.Unlock()
 	r.bc.publish(OpUpdate, t.ID)
 	return nil

--- a/internal/repository/sqlite/api_token.go
+++ b/internal/repository/sqlite/api_token.go
@@ -32,17 +32,23 @@ func (r *APITokenRepository) Create(t *domain.APIToken) error {
 
 func (r *APITokenRepository) Update(t *domain.APIToken) error {
 	t.UpdatedAt = time.Now()
+	updates := map[string]any{
+		"updated_at":  toTimestamp(t.UpdatedAt),
+		"name":        t.Name,
+		"description": LongText(t.Description),
+		"project_id":  t.ProjectID,
+		"is_enabled":  boolToInt(t.IsEnabled),
+		"dev_mode":    boolToInt(t.DevMode),
+		"expires_at":  toTimestampPtr(t.ExpiresAt),
+	}
+	if t.Token != "" {
+		updates["token"] = t.Token
+		updates["token_prefix"] = t.TokenPrefix
+	}
+
 	return r.db.gorm.Model(&APIToken{}).
 		Where("id = ?", t.ID).
-		Updates(map[string]any{
-			"updated_at":  toTimestamp(t.UpdatedAt),
-			"name":        t.Name,
-			"description": LongText(t.Description),
-			"project_id":  t.ProjectID,
-			"is_enabled":  boolToInt(t.IsEnabled),
-			"dev_mode":    boolToInt(t.DevMode),
-			"expires_at":  toTimestampPtr(t.ExpiresAt),
-		}).Error
+		Updates(updates).Error
 }
 
 func (r *APITokenRepository) Delete(tenantID uint64, id uint64) error {

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -1043,3 +1043,14 @@ func (r *ProxyRequestRepository) toDomainList(models []ProxyRequest) []*domain.P
 	}
 	return requests
 }
+
+// ReassignAPITokenID moves proxy request history from a retired token to the
+// canonical token that replaces it.
+func (r *ProxyRequestRepository) ReassignAPITokenID(tenantID uint64, fromID uint64, toID uint64) error {
+	if fromID == 0 || toID == 0 || fromID == toID {
+		return nil
+	}
+	return tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
+		Where("api_token_id = ?", fromID).
+		Update("api_token_id", toID).Error
+}

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -949,3 +949,45 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 		t.Fatalf("retained attempts = %d, want 3", retainedAttempts)
 	}
 }
+
+func TestProxyRequestRepositoryReassignAPITokenID(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	reqs := []*domain.ProxyRequest{
+		{TenantID: 1, InstanceID: "i", RequestID: "r1", APITokenID: 10, Status: "COMPLETED", StartTime: time.Now()},
+		{TenantID: 1, InstanceID: "i", RequestID: "r2", APITokenID: 11, Status: "COMPLETED", StartTime: time.Now()},
+		{TenantID: 2, InstanceID: "i", RequestID: "r3", APITokenID: 10, Status: "COMPLETED", StartTime: time.Now()},
+	}
+	for _, req := range reqs {
+		if err := repo.Create(req); err != nil {
+			t.Fatalf("seed request: %v", err)
+		}
+	}
+
+	if err := repo.ReassignAPITokenID(1, 10, 11); err != nil {
+		t.Fatalf("reassign: %v", err)
+	}
+
+	got, err := repo.List(1, 10, 0)
+	if err != nil {
+		t.Fatalf("list tenant 1: %v", err)
+	}
+	for _, req := range got {
+		if req.APITokenID != 11 {
+			t.Fatalf("tenant 1 request = %+v, want APITokenID 11", req)
+		}
+	}
+
+	other, err := repo.List(2, 10, 0)
+	if err != nil {
+		t.Fatalf("list tenant 2: %v", err)
+	}
+	if len(other) != 1 || other[0].APITokenID != 10 {
+		t.Fatalf("tenant 2 requests = %+v, want untouched token 10", other)
+	}
+}

--- a/internal/repository/sqlite/usage_stats.go
+++ b/internal/repository/sqlite/usage_stats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/stats"
 	"golang.org/x/sync/errgroup"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -1657,4 +1658,45 @@ func (r *UsageStatsRepository) queryDashboardHistoricalDays(tenantID uint64, sta
 		return nil, err
 	}
 	return out, nil
+}
+
+// ReassignAPITokenID merges historical usage stats from a retired token into
+// the canonical token. It preserves counters when both token IDs already have
+// rows for the same dimensional bucket.
+func (r *UsageStatsRepository) ReassignAPITokenID(tenantID uint64, fromID uint64, toID uint64) error {
+	if fromID == 0 || toID == 0 || fromID == toID {
+		return nil
+	}
+	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(`
+			INSERT INTO usage_stats (
+				created_at, tenant_id, time_bucket, granularity, route_id, provider_id,
+				project_id, api_token_id, client_type, model, total_requests,
+				successful_requests, failed_requests, total_duration_ms, total_ttft_ms,
+				input_tokens, output_tokens, cache_read, cache_write, cost
+			)
+			SELECT
+				created_at, tenant_id, time_bucket, granularity, route_id, provider_id,
+				project_id, ?, client_type, model, total_requests,
+				successful_requests, failed_requests, total_duration_ms, total_ttft_ms,
+				input_tokens, output_tokens, cache_read, cache_write, cost
+			FROM usage_stats
+			WHERE tenant_id = ? AND api_token_id = ?
+			ON CONFLICT(tenant_id, granularity, time_bucket, route_id, provider_id, project_id, api_token_id, client_type, model)
+			DO UPDATE SET
+				total_requests = usage_stats.total_requests + excluded.total_requests,
+				successful_requests = usage_stats.successful_requests + excluded.successful_requests,
+				failed_requests = usage_stats.failed_requests + excluded.failed_requests,
+				total_duration_ms = usage_stats.total_duration_ms + excluded.total_duration_ms,
+				total_ttft_ms = usage_stats.total_ttft_ms + excluded.total_ttft_ms,
+				input_tokens = usage_stats.input_tokens + excluded.input_tokens,
+				output_tokens = usage_stats.output_tokens + excluded.output_tokens,
+				cache_read = usage_stats.cache_read + excluded.cache_read,
+				cache_write = usage_stats.cache_write + excluded.cache_write,
+				cost = usage_stats.cost + excluded.cost
+		`, toID, tenantID, fromID).Error; err != nil {
+			return err
+		}
+		return tx.Exec(`DELETE FROM usage_stats WHERE tenant_id = ? AND api_token_id = ?`, tenantID, fromID).Error
+	})
 }

--- a/internal/repository/sqlite/usage_stats_test.go
+++ b/internal/repository/sqlite/usage_stats_test.go
@@ -161,3 +161,59 @@ func TestQueryDashboardHistoricalDays_EmptyResult(t *testing.T) {
 		t.Errorf("got %d rows, want 0 (DB 空)", len(got))
 	}
 }
+
+func TestUsageStatsRepositoryReassignAPITokenIDMergesHistoricalRows(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewUsageStatsRepository(db)
+	bucket := time.Date(2024, 3, 5, 10, 0, 0, 0, time.UTC)
+	rows := []*UsageStats{
+		{TenantID: 1, TimeBucket: toTimestamp(bucket), Granularity: string(domain.GranularityHour), RouteID: 1, ProviderID: 2, ProjectID: 3, APITokenID: 10, ClientType: "openai", Model: "m", TotalRequests: 4, SuccessfulRequests: 3, FailedRequests: 1, InputTokens: 40, OutputTokens: 20, Cost: 100},
+		{TenantID: 1, TimeBucket: toTimestamp(bucket), Granularity: string(domain.GranularityHour), RouteID: 1, ProviderID: 2, ProjectID: 3, APITokenID: 11, ClientType: "openai", Model: "m", TotalRequests: 7, SuccessfulRequests: 6, FailedRequests: 1, InputTokens: 70, OutputTokens: 30, Cost: 200},
+		{TenantID: 1, TimeBucket: toTimestamp(bucket), Granularity: string(domain.GranularityHour), RouteID: 9, ProviderID: 9, ProjectID: 9, APITokenID: 10, ClientType: "openai", Model: "other", TotalRequests: 5, SuccessfulRequests: 5},
+		{TenantID: 2, TimeBucket: toTimestamp(bucket), Granularity: string(domain.GranularityHour), RouteID: 1, ProviderID: 2, ProjectID: 3, APITokenID: 10, ClientType: "openai", Model: "m", TotalRequests: 999},
+	}
+	if err := db.gorm.Create(&rows).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := repo.ReassignAPITokenID(1, 10, 11); err != nil {
+		t.Fatalf("reassign: %v", err)
+	}
+
+	var oldCount int64
+	if err := db.gorm.Model(&UsageStats{}).Where("tenant_id = ? AND api_token_id = ?", 1, 10).Count(&oldCount).Error; err != nil {
+		t.Fatalf("count old: %v", err)
+	}
+	if oldCount != 0 {
+		t.Fatalf("old tenant rows = %d, want 0", oldCount)
+	}
+
+	var merged UsageStats
+	if err := db.gorm.Where("tenant_id = ? AND api_token_id = ? AND route_id = ? AND model = ?", 1, 11, 1, "m").First(&merged).Error; err != nil {
+		t.Fatalf("load merged: %v", err)
+	}
+	if merged.TotalRequests != 11 || merged.SuccessfulRequests != 9 || merged.FailedRequests != 2 || merged.InputTokens != 110 || merged.OutputTokens != 50 || merged.Cost != 300 {
+		t.Fatalf("merged row = %+v, want summed counters", merged)
+	}
+
+	var moved UsageStats
+	if err := db.gorm.Where("tenant_id = ? AND api_token_id = ? AND route_id = ? AND model = ?", 1, 11, 9, "other").First(&moved).Error; err != nil {
+		t.Fatalf("load moved: %v", err)
+	}
+	if moved.TotalRequests != 5 {
+		t.Fatalf("moved total = %d, want 5", moved.TotalRequests)
+	}
+
+	var otherTenant UsageStats
+	if err := db.gorm.Where("tenant_id = ? AND api_token_id = ?", 2, 10).First(&otherTenant).Error; err != nil {
+		t.Fatalf("load other tenant: %v", err)
+	}
+	if otherTenant.TotalRequests != 999 {
+		t.Fatalf("other tenant total = %d, want untouched 999", otherTenant.TotalRequests)
+	}
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1382,6 +1383,44 @@ func (s *AdminService) UpdateAPIToken(tenantID uint64, token *domain.APIToken) e
 
 func (s *AdminService) DeleteAPIToken(tenantID uint64, id uint64) error {
 	return s.apiTokenRepo.Delete(tenantID, id)
+}
+
+type apiTokenHistoryReassigner interface {
+	ReassignAPITokenID(tenantID uint64, fromID uint64, toID uint64) error
+}
+
+// ReassignAPITokenHistory moves historical request/stat rows from one token ID
+// to another before retiring duplicate managed tokens. Repositories opt in so
+// older test doubles and unrelated repository implementations do not need new
+// interface surface.
+func (s *AdminService) ReassignAPITokenHistory(tenantID uint64, fromID uint64, toID uint64) error {
+	if fromID == 0 || toID == 0 || fromID == toID {
+		return nil
+	}
+	if repo, ok := s.proxyRequestRepo.(apiTokenHistoryReassigner); ok && !isNilAPITokenHistoryReassigner(repo) {
+		if err := repo.ReassignAPITokenID(tenantID, fromID, toID); err != nil {
+			return err
+		}
+	}
+	if repo, ok := s.usageStatsRepo.(apiTokenHistoryReassigner); ok && !isNilAPITokenHistoryReassigner(repo) {
+		if err := repo.ReassignAPITokenID(tenantID, fromID, toID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isNilAPITokenHistoryReassigner(repo apiTokenHistoryReassigner) bool {
+	if repo == nil {
+		return true
+	}
+	v := reflect.ValueOf(repo)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
 }
 
 func (s *AdminService) CleanupExpiredAPITokens(tenantID uint64, now time.Time) (*domain.APITokenCleanupResult, error) {

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1349,6 +1349,33 @@ func (s *AdminService) CreateAPIToken(tenantID uint64, name, description string,
 	}, nil
 }
 
+// RotateAPIToken replaces an existing token's secret in place and returns the
+// new plaintext token once. Metadata, usage counters, and request history stay
+// attached to the same APIToken ID.
+func (s *AdminService) RotateAPIToken(tenantID uint64, token *domain.APIToken) (*domain.APITokenCreateResult, error) {
+	if token == nil {
+		return nil, domain.ErrInvalidInput
+	}
+
+	plain, prefix, err := generateAPIToken()
+	if err != nil {
+		return nil, err
+	}
+
+	token.TenantID = tenantID
+	token.Token = plain
+	token.TokenPrefix = prefix
+	token.IsEnabled = true
+	if err := s.apiTokenRepo.Update(token); err != nil {
+		return nil, err
+	}
+
+	return &domain.APITokenCreateResult{
+		Token:    plain,
+		APIToken: token,
+	}, nil
+}
+
 func (s *AdminService) UpdateAPIToken(tenantID uint64, token *domain.APIToken) error {
 	return s.apiTokenRepo.Update(token)
 }

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1138,10 +1138,10 @@ func TestProxyNoMatchingRoute(t *testing.T) {
 	if got := payload["error"]["retryable"]; got != false {
 		t.Fatalf("error.retryable = %v, want false", got)
 	}
-	assertNoProxyRequestsRecorded(t, env)
+	assertRouteMatchRejectionRecorded(t, env, 1, "no routes available")
 }
 
-func TestProxyRouteWithoutConfiguredProviderDoesNotRecordRequest(t *testing.T) {
+func TestProxyRouteWithoutConfiguredProviderRecordsRejectedRequest(t *testing.T) {
 	env := NewProxyTestEnv(t)
 
 	routeResp := env.AdminPost("/api/admin/routes", map[string]any{
@@ -1166,10 +1166,10 @@ func TestProxyRouteWithoutConfiguredProviderDoesNotRecordRequest(t *testing.T) {
 	if !strings.Contains(msg, "no available provider") {
 		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
-	assertNoProxyRequestsRecorded(t, env)
+	assertRouteMatchRejectionRecorded(t, env, 1, "no available providers")
 }
 
-func TestProxyMatchedRouteWithUnsupportedProviderModelDoesNotRecordRequest(t *testing.T) {
+func TestProxyMatchedRouteWithUnsupportedProviderModelRecordsRejectedRequest(t *testing.T) {
 	env := NewProxyTestEnv(t)
 	providerID := createProvider(t, env, "mock-openai-model-filter", "http://127.0.0.1:1", []string{"openai"})
 
@@ -1200,10 +1200,10 @@ func TestProxyMatchedRouteWithUnsupportedProviderModelDoesNotRecordRequest(t *te
 	if !strings.Contains(msg, "no available provider") {
 		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
-	assertNoProxyRequestsRecorded(t, env)
+	assertRouteMatchRejectionRecorded(t, env, 1, "no available providers")
 }
 
-func TestProxyMatchedRouteWithCooldownProviderDoesNotRecordAdditionalRequest(t *testing.T) {
+func TestProxyMatchedRouteWithCooldownProviderRecordsRejectedRequest(t *testing.T) {
 	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Retry-After", "30")
@@ -1239,17 +1239,55 @@ func TestProxyMatchedRouteWithCooldownProviderDoesNotRecordAdditionalRequest(t *
 	if !strings.Contains(msg, "no available provider") {
 		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
-	if got := len(getProxyRequests(t, env)); got != 1 {
-		t.Fatalf("expected cooldown route-match rejection to stay out of requests tab, got %d requests", got)
-	}
+	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers")
 }
 
-func assertNoProxyRequestsRecorded(t *testing.T, env *ProxyTestEnv) {
+func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTotal int, wantErrorPart string) {
 	t.Helper()
 
 	requests := getProxyRequests(t, env)
-	if len(requests) != 0 {
-		t.Fatalf("expected route-match rejection to stay out of requests tab, got %d requests: %#v", len(requests), requests)
+	if len(requests) != wantTotal {
+		t.Fatalf("requests = %d, want %d, got %#v", len(requests), wantTotal, requests)
+	}
+
+	var matched []map[string]any
+	for _, req := range requests {
+		if req["status"] != "REJECTED" {
+			continue
+		}
+		errorMsg, _ := req["error"].(string)
+		if strings.Contains(errorMsg, "route match failed") && strings.Contains(errorMsg, wantErrorPart) {
+			matched = append(matched, req)
+		}
+	}
+	if len(matched) != 1 {
+		t.Fatalf("route-match rejected requests = %d, want 1 in %#v", len(matched), requests)
+	}
+	rejected := matched[0]
+	if got := intFromJSONNumber(t, rejected["statusCode"]); got != http.StatusServiceUnavailable {
+		t.Fatalf("statusCode = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+	if got := intFromJSONNumber(t, rejected["providerID"]); got != 0 {
+		t.Fatalf("providerID = %d, want 0 for route-match rejection", got)
+	}
+	if got := intFromJSONNumber(t, rejected["routeID"]); got != 0 {
+		t.Fatalf("routeID = %d, want 0 for route-match rejection", got)
+	}
+	if got := intFromJSONNumber(t, rejected["proxyUpstreamAttemptCount"]); got != 0 {
+		t.Fatalf("proxyUpstreamAttemptCount = %d, want 0 for route-match rejection", got)
+	}
+}
+
+func intFromJSONNumber(t *testing.T, v any) int {
+	t.Helper()
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	default:
+		t.Fatalf("value %v (%T) is not a JSON number", v, v)
+		return 0
 	}
 }
 


### PR DESCRIPTION
## Summary
- Deduplicate user-panel managed API keys into a single canonical per-user key while preserving regenerated/legacy history.
- Reassign proxy request and usage stats history from retired duplicate token IDs to the canonical token before deletion.
- Record route-match rejects as rejected proxy requests with status code and error details.

## Validation
- `go test -count=1 ./internal/handler -run 'TestSelfServiceHandler_UserPanel(DedupPreservesUsageStats|DuplicateTokensAreCollapsed|UsageStatsFollowRegeneratedKeyHistory|RegenerateRotatesExistingTokenInPlace|CreateReusesDisabledToken|ExistingTokenProjectBindingIsCleared)$'`
- `go test -count=1 ./internal/repository/sqlite -run 'Test(UsageStatsRepositoryReassignAPITokenIDMergesHistoricalRows|ProxyRequestRepositoryReassignAPITokenID)$'`
- `go test -count=1 ./...`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web test`
- `pnpm --dir web build` (passed with existing large chunk warning)
- `git diff --check origin/main...HEAD`

## Notes
- CodeRabbit was not checked or invoked in this run per current instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 用户面板 API Token 现在支持统一归一与原地轮换，重复 Token 会自动合并为一个规范记录。
  * 管理端可在保留同一 Token 记录的前提下更新密钥，并自动迁移相关历史数据。

* **Bug Fixes**
  * 路由匹配失败时会记录为拒绝请求，便于在管理页面查看 503 失败原因。
  * API Token 变更后，相关请求与用量统计会正确归并到新的规范 Token。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->