### PR TITLE
fix(user-panel): add request tab and scope member requests

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1004,6 +1004,61 @@ func parseProxyRequestFilter(r *http.Request) (*repository.ProxyRequestFilter, e
 	return filter, nil
 }
 
+func emptyProxyRequestsCursorResult() *service.CursorPaginationResult {
+	return &service.CursorPaginationResult{Items: []*domain.ProxyRequest{}}
+}
+
+func emptyProxyRequestErrorStats() *repository.ProxyRequestErrorStats {
+	return &repository.ProxyRequestErrorStats{
+		StatusCounts:     []repository.ProxyRequestCountBucket{},
+		HTTPStatusCounts: []repository.ProxyRequestHTTPStatusBucket{},
+		ProviderCounts:   []repository.ProxyRequestProviderBucket{},
+		ModelCounts:      []repository.ProxyRequestCountBucket{},
+		Trend:            []repository.ProxyRequestTrendPoint{},
+	}
+}
+
+func (h *AdminHandler) userPanelMemberRequestTokenID(r *http.Request, tenantID uint64) (uint64, bool, error) {
+	if !h.userPanelMemberUsageStatsEnabled(r) {
+		return 0, false, nil
+	}
+
+	canonicalToken, err := h.userPanelMemberCanonicalAPIToken(tenantID, maxxctx.GetUserID(r.Context()))
+	if err != nil {
+		return 0, true, err
+	}
+	if canonicalToken == nil || canonicalToken.ID == 0 || !canonicalToken.IsEnabled {
+		return 0, true, nil
+	}
+	return canonicalToken.ID, true, nil
+}
+
+func (h *AdminHandler) userPanelMemberCanonicalAPIToken(tenantID uint64, userID uint64) (*domain.APIToken, error) {
+	if tenantID == 0 || userID == 0 {
+		return nil, nil
+	}
+	tokens, err := findUserPanelAPITokensForUser(h.svc, tenantID, userID)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeUserPanelAPITokensForUser(h.svc, tenantID, userID, tokens)
+}
+
+func applyUserPanelMemberRequestFilter(filter *repository.ProxyRequestFilter, tokenID uint64) *repository.ProxyRequestFilter {
+	if filter == nil {
+		filter = &repository.ProxyRequestFilter{}
+	} else {
+		copy := *filter
+		filter = &copy
+	}
+	filter.APITokenID = &tokenID
+	return filter
+}
+
+func requestBelongsToUserPanelToken(req *domain.ProxyRequest, tokenID uint64) bool {
+	return req != nil && tokenID != 0 && req.APITokenID == tokenID
+}
+
 // ProxyRequest handlers
 // Routes: /admin/requests, /admin/requests/count, /admin/requests/error-stats, /admin/requests/active, /admin/requests/{id}, /admin/requests/{id}/attempts, /admin/requests/{id}/recalculate-cost
 func (h *AdminHandler) handleProxyRequests(w http.ResponseWriter, r *http.Request, id uint64, parts []string) {
@@ -1053,9 +1108,14 @@ func (h *AdminHandler) handleProxyRequests(w http.ResponseWriter, r *http.Reques
 
 	switch r.Method {
 	case http.MethodGet:
+		memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
 		if id > 0 {
 			req, err := h.svc.GetProxyRequest(tenantID, id)
-			if err != nil {
+			if err != nil || (memberScoped && !requestBelongsToUserPanelToken(req, memberTokenID)) {
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "proxy request not found"})
 				return
 			}
@@ -1077,6 +1137,14 @@ func (h *AdminHandler) handleProxyRequests(w http.ResponseWriter, r *http.Reques
 			if err != nil {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 				return
+			}
+
+			if memberScoped {
+				if memberTokenID == 0 {
+					writeJSON(w, http.StatusOK, emptyProxyRequestsCursorResult())
+					return
+				}
+				filter = applyUserPanelMemberRequestFilter(filter, memberTokenID)
 			}
 
 			result, err := h.svc.GetProxyRequestsCursor(tenantID, limit, before, after, filter)
@@ -1106,6 +1174,18 @@ func (h *AdminHandler) handleCleanupFailedProxyRequestsCount(w http.ResponseWrit
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if memberScoped {
+		if memberTokenID == 0 {
+			writeJSON(w, http.StatusOK, 0)
+			return
+		}
+		filter = applyUserPanelMemberRequestFilter(filter, memberTokenID)
+	}
 	count, err := h.svc.CountFailedProxyRequests(tenantID, filter)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -1127,6 +1207,18 @@ func (h *AdminHandler) handleCleanupFailedProxyRequests(w http.ResponseWriter, r
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if memberScoped {
+		if memberTokenID == 0 {
+			writeJSON(w, http.StatusOK, &domain.ProxyRequestCleanupFailedResult{})
+			return
+		}
+		filter = applyUserPanelMemberRequestFilter(filter, memberTokenID)
+	}
 	result, err := h.svc.CleanupFailedProxyRequests(tenantID, filter)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -1147,6 +1239,19 @@ func (h *AdminHandler) handleProxyRequestsCount(w http.ResponseWriter, r *http.R
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
+	}
+
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if memberScoped {
+		if memberTokenID == 0 {
+			writeJSON(w, http.StatusOK, 0)
+			return
+		}
+		filter = applyUserPanelMemberRequestFilter(filter, memberTokenID)
 	}
 
 	count, err := h.svc.GetProxyRequestsCountWithFilter(tenantID, filter)
@@ -1173,6 +1278,19 @@ func (h *AdminHandler) handleProxyRequestsErrorStats(w http.ResponseWriter, r *h
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if memberScoped {
+		if memberTokenID == 0 {
+			writeJSON(w, http.StatusOK, emptyProxyRequestErrorStats())
+			return
+		}
+		filter = applyUserPanelMemberRequestFilter(filter, memberTokenID)
+	}
+
 	stats, err := h.svc.GetProxyRequestErrorStats(tenantID, filter)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -1189,10 +1307,24 @@ func (h *AdminHandler) handleActiveProxyRequests(w http.ResponseWriter, r *http.
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	requests, err := h.svc.GetActiveProxyRequests(tenantID)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	if memberScoped {
+		filtered := make([]*domain.ProxyRequest, 0, len(requests))
+		for _, req := range requests {
+			if requestBelongsToUserPanelToken(req, memberTokenID) {
+				filtered = append(filtered, req)
+			}
+		}
+		requests = filtered
 	}
 	writeJSON(w, http.StatusOK, requests)
 }
@@ -1205,6 +1337,18 @@ func (h *AdminHandler) handleProxyUpstreamAttempts(w http.ResponseWriter, r *htt
 	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
+	memberTokenID, memberScoped, err := h.userPanelMemberRequestTokenID(r, tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if memberScoped {
+		req, err := h.svc.GetProxyRequest(tenantID, proxyRequestID)
+		if err != nil || !requestBelongsToUserPanelToken(req, memberTokenID) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "proxy request not found"})
+			return
+		}
+	}
 	attempts, err := h.svc.GetProxyUpstreamAttempts(tenantID, proxyRequestID)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/handler/admin_requests_user_panel_test.go
+++ b/internal/handler/admin_requests_user_panel_test.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
+	"github.com/awsl-project/maxx/internal/service"
+)
+
+func newAdminHandlerWithRequestRepos(t *testing.T) (*AdminHandler, *sqlite.APITokenRepository, *sqlite.ProxyRequestRepository) {
+	t.Helper()
+
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	settingsRepo := sqlite.NewSystemSettingRepository(db)
+	if err := settingsRepo.Set("ui_multitenant_enabled", "true"); err != nil {
+		t.Fatalf("enable multitenant setting: %v", err)
+	}
+	if err := settingsRepo.Set("ui_multitenant_layout", "user_panel"); err != nil {
+		t.Fatalf("enable user panel layout setting: %v", err)
+	}
+
+	apiTokenRepo := sqlite.NewAPITokenRepository(db)
+	proxyRequestRepo := sqlite.NewProxyRequestRepository(db)
+	attemptRepo := sqlite.NewProxyUpstreamAttemptRepository(db)
+
+	adminSvc := service.NewAdminService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		proxyRequestRepo,
+		attemptRepo,
+		settingsRepo,
+		apiTokenRepo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+
+	return NewAdminHandler(adminSvc, nil, ""), apiTokenRepo, proxyRequestRepo
+}
+
+func createUserPanelTokenForTest(t *testing.T, repo *sqlite.APITokenRepository, tenantID uint64, userID uint64) *domain.APIToken {
+	t.Helper()
+	token := &domain.APIToken{
+		TenantID:    tenantID,
+		Name:        userPanelAPITokenName(userID),
+		Description: userPanelAPITokenDescription(userID),
+		Token:       "test-token",
+		TokenPrefix: "test",
+		IsEnabled:   true,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("create user panel token: %v", err)
+	}
+	return token
+}
+
+func createRegularTokenForTest(t *testing.T, repo *sqlite.APITokenRepository, tenantID uint64) *domain.APIToken {
+	t.Helper()
+	token := &domain.APIToken{
+		TenantID:    tenantID,
+		Name:        "regular",
+		Description: "regular token",
+		Token:       "regular-token",
+		TokenPrefix: "regular",
+		IsEnabled:   true,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("create regular token: %v", err)
+	}
+	return token
+}
+
+func createProxyRequestForTokenTest(t *testing.T, repo *sqlite.ProxyRequestRepository, tenantID uint64, apiTokenID uint64, requestID string) *domain.ProxyRequest {
+	t.Helper()
+	now := time.Now().UTC()
+	req := &domain.ProxyRequest{
+		TenantID:     tenantID,
+		InstanceID:   "test-instance",
+		RequestID:    requestID,
+		SessionID:    requestID + "-session",
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "gpt-test",
+		StartTime:    now,
+		EndTime:      now.Add(time.Second),
+		Duration:     time.Second,
+		Status:       "COMPLETED",
+		StatusCode:   http.StatusOK,
+		APITokenID:   apiTokenID,
+	}
+	if err := repo.Create(req); err != nil {
+		t.Fatalf("create proxy request: %v", err)
+	}
+	return req
+}
+
+func newUserPanelMemberAdminRequest(method, path string, userID uint64) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	ctx := maxxctx.WithTenantID(req.Context(), 1)
+	ctx = maxxctx.WithUserID(ctx, userID)
+	ctx = maxxctx.WithUserRole(ctx, string(domain.UserRoleMember))
+	return req.WithContext(ctx)
+}
+
+func TestAdminHandler_UserPanelMemberRequestsAreScopedToCurrentUserToken(t *testing.T) {
+	handler, tokenRepo, requestRepo := newAdminHandlerWithRequestRepos(t)
+	memberToken := createUserPanelTokenForTest(t, tokenRepo, 1, 9)
+	regularToken := createRegularTokenForTest(t, tokenRepo, 1)
+	memberReq := createProxyRequestForTokenTest(t, requestRepo, 1, memberToken.ID, "member-request")
+	otherReq := createProxyRequestForTokenTest(t, requestRepo, 1, regularToken.ID, "other-request")
+
+	listRec := httptest.NewRecorder()
+	handler.ServeHTTP(listRec, newUserPanelMemberAdminRequest(http.MethodGet, "/admin/requests?limit=100", 9))
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, want %d, body = %s", listRec.Code, http.StatusOK, listRec.Body.String())
+	}
+	var list service.CursorPaginationResult
+	if err := json.Unmarshal(listRec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Items) != 1 || list.Items[0].ID != memberReq.ID {
+		t.Fatalf("member list items = %+v, want only request %d", list.Items, memberReq.ID)
+	}
+
+	countRec := httptest.NewRecorder()
+	handler.ServeHTTP(countRec, newUserPanelMemberAdminRequest(http.MethodGet, "/admin/requests/count", 9))
+	if countRec.Code != http.StatusOK {
+		t.Fatalf("count status = %d, want %d, body = %s", countRec.Code, http.StatusOK, countRec.Body.String())
+	}
+	var count int64
+	if err := json.Unmarshal(countRec.Body.Bytes(), &count); err != nil {
+		t.Fatalf("decode count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+
+	detailRec := httptest.NewRecorder()
+	handler.ServeHTTP(detailRec, newUserPanelMemberAdminRequest(http.MethodGet, "/admin/requests/"+jsonNumber(otherReq.ID), 9))
+	if detailRec.Code != http.StatusNotFound {
+		t.Fatalf("other detail status = %d, want %d, body = %s", detailRec.Code, http.StatusNotFound, detailRec.Body.String())
+	}
+}
+
+func jsonNumber(n uint64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}

--- a/web/src/lib/user-panel-endpoints.test.ts
+++ b/web/src/lib/user-panel-endpoints.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildUserPanelChatCompletionsExample, buildUserPanelEndpointHints } from './user-panel-endpoints';
+import {
+  buildUserPanelChatCompletionsExample,
+  buildUserPanelEndpointHints,
+} from './user-panel-endpoints';
 
 describe('user panel endpoints', () => {
   it('uses global proxy endpoints for managed user console keys', () => {
@@ -20,11 +23,11 @@ describe('user panel endpoints', () => {
     const endpoints = buildUserPanelEndpointHints('https://maxx.example.com');
     const example = buildUserPanelChatCompletionsExample({
       origin: 'https://maxx.example.com',
-      tokenLabel: 'your key',
     });
 
     expect(endpoints.map((endpoint) => endpoint.url).join('\n')).not.toContain('/project/');
     expect(example).toContain('https://maxx.example.com/v1/chat/completions');
     expect(example).not.toContain('/project/');
+    expect(example).not.toContain('Authorization: Bearer');
   });
 });

--- a/web/src/lib/user-panel-endpoints.ts
+++ b/web/src/lib/user-panel-endpoints.ts
@@ -17,13 +17,9 @@ export function buildUserPanelEndpointHints(origin: string): UserPanelEndpointHi
   ];
 }
 
-export function buildUserPanelChatCompletionsExample(params: {
-  origin: string;
-  tokenLabel: string;
-}): string {
+export function buildUserPanelChatCompletionsExample(params: { origin: string }): string {
   const baseUrl = trimTrailingSlash(params.origin);
   return `curl ${baseUrl}/v1/chat/completions \
-  -H "Authorization: Bearer <${params.tokenLabel}>" \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'`;
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -173,7 +173,15 @@
     "usageStats": "Usage & Stats",
     "showKey": "Show key",
     "hideKey": "Hide key",
-    "noUsageData": "No usage yet. Generate a key to start tracking."
+    "noUsageData": "No usage yet. Generate a key to start tracking.",
+    "mainTab": "Main",
+    "requestsTab": "Requests",
+    "requestsLoadFailed": "Failed to load requests.",
+    "noRequests": "No requests yet",
+    "noRequestsDescription": "Only requests made with your dedicated key will appear here.",
+    "requestDuration": "Duration",
+    "requestInputTokens": "Input tokens",
+    "requestOutputTokens": "Output tokens"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -169,7 +169,11 @@
     "routeOpenAICodex": "OpenAI / Codex",
     "availableModels": "Available models",
     "moreModels": "+{{count}} more",
-    "noModels": "No models"
+    "noModels": "No models",
+    "usageStats": "Usage & Stats",
+    "showKey": "Show key",
+    "hideKey": "Hide key",
+    "noUsageData": "No usage yet. Generate a key to start tracking."
   },
   "dashboard": {
     "title": "Dashboard",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -173,7 +173,15 @@
     "usageStats": "用量与统计",
     "showKey": "显示 Key",
     "hideKey": "隐藏 Key",
-    "noUsageData": "暂无调用，生成 Key 后开始统计。"
+    "noUsageData": "暂无调用，生成 Key 后开始统计。",
+    "mainTab": "主页",
+    "requestsTab": "请求",
+    "requestsLoadFailed": "请求加载失败。",
+    "noRequests": "暂无请求",
+    "noRequestsDescription": "这里只显示你自己的专用 Key 发起的请求。",
+    "requestDuration": "耗时",
+    "requestInputTokens": "输入 Token",
+    "requestOutputTokens": "输出 Token"
   },
   "dashboard": {
     "title": "仪表板",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -169,7 +169,11 @@
     "routeOpenAICodex": "OpenAI / Codex",
     "availableModels": "当前可用模型",
     "moreModels": "+{{count}} 个",
-    "noModels": "暂无模型"
+    "noModels": "暂无模型",
+    "usageStats": "用量与统计",
+    "showKey": "显示 Key",
+    "hideKey": "隐藏 Key",
+    "noUsageData": "暂无调用，生成 Key 后开始统计。"
   },
   "dashboard": {
     "title": "仪表板",

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,28 +1,43 @@
 import { useState } from 'react';
-import { Clock3, Copy, Eye, EyeOff, KeyRound, LogOut, Server, ShieldCheck, UserRound } from 'lucide-react';
+import {
+  Clock3,
+  Copy,
+  Eye,
+  EyeOff,
+  KeyRound,
+  ListChecks,
+  LogOut,
+  Server,
+  UserRound,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Input } from '@/components/ui';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui';
+import { LanguageToggle } from '@/components/language-toggle';
 import { useAuth } from '@/lib/auth-context';
 import {
   useCreateUserPanelAPIToken,
+  useProxyRequests,
   useProxyStatus,
-  usePublicSettings,
   useRegenerateUserPanelAPIToken,
   useUserPanelAPIToken,
 } from '@/hooks/queries';
-import type { APIToken } from '@/lib/transport';
+import type { APIToken, ProxyRequest } from '@/lib/transport';
 import {
   buildUserPanelChatCompletionsExample,
   buildUserPanelEndpointHints,
 } from '@/lib/user-panel-endpoints';
-import { cn } from '@/lib/utils';
-
-function maskNumericIdentity(value?: number) {
-  if (!value || value <= 0) return '••';
-  const raw = String(value);
-  if (raw.length <= 2) return `••${raw}`;
-  return `${'•'.repeat(Math.max(2, raw.length - 2))}${raw.slice(-2)}`;
-}
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat().format(value || 0);
@@ -40,17 +55,116 @@ function formatDateTime(value?: string) {
   }).format(date);
 }
 
+function formatDuration(value?: number) {
+  if (!value || value <= 0) return '—';
+  const milliseconds = value / 1_000_000;
+  if (milliseconds < 1000) return `${Math.round(milliseconds)}ms`;
+  return `${(milliseconds / 1000).toFixed(2)}s`;
+}
+
 function getTokenStatus(token: APIToken) {
   if (!token.isEnabled) return 'disabled';
   if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) return 'expired';
   return 'active';
 }
 
+function getRequestStatusVariant(request: ProxyRequest) {
+  if (request.status === 'COMPLETED' && request.statusCode < 400) return 'success';
+  if (request.status === 'PENDING' || request.status === 'IN_PROGRESS') return 'warning';
+  if (
+    request.status === 'FAILED' ||
+    request.status === 'CANCELLED' ||
+    request.status === 'REJECTED'
+  ) {
+    return 'danger';
+  }
+  if (request.statusCode >= 400) return 'danger';
+  return 'secondary';
+}
+
+function UserPanelRequestsTab() {
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useProxyRequests({ limit: 25 });
+  const requests = data?.items ?? [];
+
+  return (
+    <Card className="min-h-[820px] border-border bg-card shadow-sm">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="flex items-center gap-2 text-base font-medium">
+          <ListChecks className="size-4 text-muted-foreground" />
+          {t('userPanel.requestsTab')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-[744px] flex-col p-5">
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center text-center text-sm text-muted-foreground">
+            {t('common.loading')}
+          </div>
+        ) : isError ? (
+          <div className="flex flex-1 items-center justify-center">
+            <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+              {t('userPanel.requestsLoadFailed')}
+            </div>
+          </div>
+        ) : requests.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center text-center">
+            <ListChecks className="size-9 text-muted-foreground" />
+            <p className="mt-3 font-medium">{t('userPanel.noRequests')}</p>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+              {t('userPanel.noRequestsDescription')}
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-border rounded-xl border border-border">
+            {requests.map((request) => (
+              <div key={request.id} className="space-y-3 p-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="truncate font-mono text-sm font-medium">
+                      {request.requestID || `#${request.id}`}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {formatDateTime(request.createdAt)} · {request.clientType || '—'} ·{' '}
+                      {request.requestModel || '—'}
+                    </p>
+                  </div>
+                  <Badge variant={getRequestStatusVariant(request)}>
+                    {request.statusCode || '—'} · {request.status || '—'}
+                  </Badge>
+                </div>
+                <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+                  <div className="rounded-lg bg-muted/25 px-3 py-2">
+                    <span className="block">{t('userPanel.requestDuration')}</span>
+                    <span className="mt-1 block font-mono text-foreground">
+                      {formatDuration(request.duration)}
+                    </span>
+                  </div>
+                  <div className="rounded-lg bg-muted/25 px-3 py-2">
+                    <span className="block">{t('userPanel.requestInputTokens')}</span>
+                    <span className="mt-1 block font-mono text-foreground">
+                      {formatNumber(request.inputTokenCount)}
+                    </span>
+                  </div>
+                  <div className="rounded-lg bg-muted/25 px-3 py-2">
+                    <span className="block">{t('userPanel.requestOutputTokens')}</span>
+                    <span className="mt-1 block font-mono text-foreground">
+                      {formatNumber(request.outputTokenCount)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export function UserPanelPage() {
   const { t } = useTranslation();
-  const { user, logout } = useAuth();
+  const { logout } = useAuth();
   const { data: proxyStatus } = useProxyStatus();
-  const { data: settings } = usePublicSettings();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
@@ -61,14 +175,6 @@ export function UserPanelPage() {
   const [showKeyMasked, setShowKeyMasked] = useState(true);
 
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
-
-  const tenantLabel = user?.tenantName?.trim()
-    ? user.tenantName.trim()
-    : user?.tenantID
-      ? t('nav.tenantFallback', { id: user.tenantID })
-      : t('nav.tenantUnknown');
-  const authProtected = settings?.api_token_auth_enabled === 'true';
-  const proxyOnline = proxyStatus?.running ?? true;
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
   const endpointHints = buildUserPanelEndpointHints(origin).map((endpoint) => ({
     ...endpoint,
@@ -79,10 +185,7 @@ export function UserPanelPage() {
           ? t('userPanel.routeClaude')
           : t('userPanel.routeGemini'),
   }));
-  const curlExample = buildUserPanelChatCompletionsExample({
-    origin,
-    tokenLabel: t('userPanel.yourKey'),
-  });
+  const curlExample = buildUserPanelChatCompletionsExample({ origin });
 
   const handleCopyEndpoint = async (endpointId: string, url: string) => {
     if (!url || typeof navigator === 'undefined' || !navigator.clipboard) return;
@@ -132,13 +235,8 @@ export function UserPanelPage() {
               <p className="text-sm text-muted-foreground">{t('userPanel.description')}</p>
             </div>
           </div>
-          <div className="flex flex-col gap-3 sm:items-end">
-            <div className="flex flex-wrap items-center gap-2">
-              <Badge variant={proxyOnline ? 'success' : 'danger'}>
-                {proxyOnline ? t('userPanel.online') : t('userPanel.offline')}
-              </Badge>
-              <Badge variant="outline">{tenantLabel}</Badge>
-            </div>
+          <div className="flex items-center gap-2 self-start sm:self-center">
+            <LanguageToggle />
             <Button
               variant="outline"
               className="gap-2 border-destructive/30 text-destructive hover:bg-destructive/10"
@@ -150,272 +248,242 @@ export function UserPanelPage() {
           </div>
         </header>
 
-        <section className="grid gap-5 lg:grid-cols-[1fr_1fr]">
-          <Card className="border-border bg-card shadow-sm">
-            <CardHeader className="border-b border-border">
-              <CardTitle className="flex items-center gap-2 text-base font-medium">
-                <KeyRound className="size-4 text-muted-foreground" />
-                {t('userPanel.myKey')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 p-5">
-              {oneTimeToken ? (
-                <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <p className="font-medium text-emerald-700 dark:text-emerald-300">
-                        {t('userPanel.oneTimeKeyTitle')}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {t('userPanel.oneTimeKeyDescription')}
-                      </p>
-                    </div>
-                    <Button size="sm" className="gap-2" onClick={handleCopyOneTimeToken}>
-                      <Copy className="size-3.5" />
-                      {keyCopied ? t('common.copied') : t('userPanel.copyKey')}
-                    </Button>
-                  </div>
-                  <p className="mt-3 break-all rounded-lg bg-background px-3 py-2 font-mono text-xs">
-                    {oneTimeToken}
-                  </p>
-                </div>
-              ) : null}
+        <Tabs defaultValue="main" className="space-y-5">
+          <TabsList className="grid w-full grid-cols-2 rounded-xl p-1">
+            <TabsTrigger value="main">{t('userPanel.mainTab')}</TabsTrigger>
+            <TabsTrigger value="requests">{t('userPanel.requestsTab')}</TabsTrigger>
+          </TabsList>
 
-              {tokenLoading ? (
-                <div className="text-sm text-muted-foreground">{t('common.loading')}</div>
-              ) : userPanelToken ? (
-                <div className="space-y-4">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <p className="truncate font-medium">{userPanelToken.name}</p>
-                        <Badge
-                          variant={
-                            getTokenStatus(userPanelToken) === 'active'
-                              ? 'success'
-                              : getTokenStatus(userPanelToken) === 'expired'
-                                ? 'warning'
-                                : 'danger'
-                          }
-                        >
-                          {t(`userPanel.keyStatus.${getTokenStatus(userPanelToken)}`)}
-                        </Badge>
+          <TabsContent value="main" className="space-y-5">
+            <section className="grid gap-5 lg:grid-cols-[1fr_1fr]">
+              <Card className="border-border bg-card shadow-sm">
+                <CardHeader className="border-b border-border">
+                  <CardTitle className="flex items-center gap-2 text-base font-medium">
+                    <KeyRound className="size-4 text-muted-foreground" />
+                    {t('userPanel.myKey')}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 p-5">
+                  {oneTimeToken ? (
+                    <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="font-medium text-emerald-700 dark:text-emerald-300">
+                            {t('userPanel.oneTimeKeyTitle')}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t('userPanel.oneTimeKeyDescription')}
+                          </p>
+                        </div>
+                        <Button size="sm" className="gap-2" onClick={handleCopyOneTimeToken}>
+                          <Copy className="size-3.5" />
+                          {keyCopied ? t('common.copied') : t('userPanel.copyKey')}
+                        </Button>
                       </div>
+                      <p className="mt-3 break-all rounded-lg bg-background px-3 py-2 font-mono text-xs">
+                        {oneTimeToken}
+                      </p>
                     </div>
-                    <Button
-                      variant="outline"
-                      className="gap-2 border-destructive/30 text-destructive hover:bg-destructive/10"
-                      disabled={tokenActionPending}
-                      onClick={handleRegenerateUserPanelToken}
-                    >
-                      <KeyRound className="size-4" />
-                      {tokenActionPending ? t('common.loading') : t('userPanel.regenerateKey')}
-                    </Button>
-                  </div>
+                  ) : null}
 
-                  <div className="relative">
-                    <Input
-                      readOnly
-                      type={showKeyMasked ? 'password' : 'text'}
-                      value={userPanelToken.tokenPrefix || 'maxx_••••'}
-                      className="h-9 pr-9 font-mono text-xs"
-                      aria-label={t('userPanel.myKey')}
-                    />
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      className="absolute right-1 top-1/2 -translate-y-1/2 size-7"
-                      aria-label={showKeyMasked ? t('userPanel.showKey') : t('userPanel.hideKey')}
-                      onClick={() => setShowKeyMasked((prev) => !prev)}
-                    >
-                      {showKeyMasked ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {t('userPanel.existingKeyHint')}
-                  </p>
-                </div>
-              ) : (
-                <div className="rounded-xl border border-dashed border-border bg-muted/20 p-5 text-center">
-                  <KeyRound className="mx-auto size-9 text-muted-foreground" />
-                  <p className="mt-3 font-medium">{t('userPanel.noDedicatedKey')}</p>
-                  <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
-                    {t('userPanel.noDedicatedKeyDescription')}
-                  </p>
-                  <Button
-                    className="mt-4 gap-2"
-                    disabled={tokenActionPending}
-                    onClick={handleCreateUserPanelToken}
-                  >
-                    <KeyRound className="size-4" />
-                    {tokenActionPending ? t('common.loading') : t('userPanel.createKey')}
-                  </Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+                  {tokenLoading ? (
+                    <div className="text-sm text-muted-foreground">{t('common.loading')}</div>
+                  ) : userPanelToken ? (
+                    <div className="space-y-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="truncate font-medium">{userPanelToken.name}</p>
+                            <Badge
+                              variant={
+                                getTokenStatus(userPanelToken) === 'active'
+                                  ? 'success'
+                                  : getTokenStatus(userPanelToken) === 'expired'
+                                    ? 'warning'
+                                    : 'danger'
+                              }
+                            >
+                              {t(`userPanel.keyStatus.${getTokenStatus(userPanelToken)}`)}
+                            </Badge>
+                          </div>
+                        </div>
+                        <Button
+                          variant="outline"
+                          className="gap-2 border-destructive/30 text-destructive hover:bg-destructive/10"
+                          disabled={tokenActionPending}
+                          onClick={handleRegenerateUserPanelToken}
+                        >
+                          <KeyRound className="size-4" />
+                          {tokenActionPending ? t('common.loading') : t('userPanel.regenerateKey')}
+                        </Button>
+                      </div>
 
-          <Card className="border-border bg-card shadow-sm">
-            <CardHeader className="border-b border-border">
-              <CardTitle className="flex items-center gap-2 text-base font-medium">
-                <Server className="size-4 text-muted-foreground" />
-                {t('userPanel.usageStats')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 p-5">
-              {userPanelToken ? (
-                <>
-                  <div className="grid gap-3">
-                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                      <div className="relative">
+                        <Input
+                          readOnly
+                          type={showKeyMasked ? 'password' : 'text'}
+                          value={userPanelToken.tokenPrefix || 'maxx_••••'}
+                          className="h-9 pr-9 font-mono text-xs"
+                          aria-label={t('userPanel.myKey')}
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="absolute right-1 top-1/2 size-7 -translate-y-1/2"
+                          aria-label={
+                            showKeyMasked ? t('userPanel.showKey') : t('userPanel.hideKey')
+                          }
+                          onClick={() => setShowKeyMasked((prev) => !prev)}
+                        >
+                          {showKeyMasked ? (
+                            <Eye className="size-3.5" />
+                          ) : (
+                            <EyeOff className="size-3.5" />
+                          )}
+                        </Button>
+                      </div>
                       <p className="text-xs text-muted-foreground">
-                        {t('userPanel.useCount')}
-                      </p>
-                      <p className="mt-1 text-xl font-bold tabular-nums text-foreground">
-                        {formatNumber(userPanelToken.useCount)}
+                        {t('userPanel.existingKeyHint')}
                       </p>
                     </div>
-                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
-                      <p className="text-xs text-muted-foreground">
-                        {t('userPanel.lastUsed')}
+                  ) : (
+                    <div className="rounded-xl border border-dashed border-border bg-muted/20 p-5 text-center">
+                      <KeyRound className="mx-auto size-9 text-muted-foreground" />
+                      <p className="mt-3 font-medium">{t('userPanel.noDedicatedKey')}</p>
+                      <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+                        {t('userPanel.noDedicatedKeyDescription')}
                       </p>
-                      <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
-                        {formatDateTime(userPanelToken.lastUsedAt)}
-                      </p>
+                      <Button
+                        className="mt-4 gap-2"
+                        disabled={tokenActionPending}
+                        onClick={handleCreateUserPanelToken}
+                      >
+                        <KeyRound className="size-4" />
+                        {tokenActionPending ? t('common.loading') : t('userPanel.createKey')}
+                      </Button>
                     </div>
-                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
-                      <p className="text-xs text-muted-foreground">
-                        {t('userPanel.expiresAt')}
-                      </p>
-                      <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
-                        {formatDateTime(userPanelToken.expiresAt)}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="grid gap-3 text-sm text-muted-foreground border-t border-border pt-4">
-                    <div className="flex items-center justify-between gap-3">
-                      <span>{t('userPanel.version')}</span>
-                      <span className="font-mono text-foreground">{proxyStatus?.version || '—'}</span>
-                    </div>
-                    <div className="flex items-center justify-between gap-3">
-                      <span>{t('userPanel.auth')}</span>
-                      <Badge variant={authProtected ? 'info' : 'secondary'}>
-                        {authProtected ? t('nav.accountStatusProtected') : t('nav.accountStatusLocal')}
-                      </Badge>
-                    </div>
-                  </div>
-                </>
-              ) : (
-                <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <Server className="size-9 text-muted-foreground" />
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    {t('userPanel.noUsageData')}
-                  </p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </section>
+                  )}
+                </CardContent>
+              </Card>
 
-        <Card className="border-border bg-card shadow-sm">
-          <CardHeader className="border-b border-border">
-            <CardTitle className="flex items-center gap-2 text-base font-medium">
-              <Server className="size-4 text-muted-foreground" />
-              {t('userPanel.apiAccess')}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4 p-5">
-            <div className="rounded-xl border border-border bg-muted/25 p-4">
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('userPanel.baseURL')}
-              </p>
-              <div className="mt-3 space-y-2">
-                {endpointHints.map((endpoint) => (
-                  <div
-                    key={endpoint.id}
-                    className="flex items-center gap-3 rounded-lg bg-background px-3 py-2 text-xs"
-                  >
-                    <span className="w-20 shrink-0 font-medium text-foreground">{endpoint.label}</span>
-                    <code className="min-w-0 flex-1 break-all text-muted-foreground">{endpoint.url || '—'}</code>
+              <Card className="border-border bg-card shadow-sm">
+                <CardHeader className="border-b border-border">
+                  <CardTitle className="flex items-center gap-2 text-base font-medium">
+                    <Server className="size-4 text-muted-foreground" />
+                    {t('userPanel.usageStats')}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4 p-5">
+                  {userPanelToken ? (
+                    <>
+                      <div className="grid gap-3">
+                        <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                          <p className="text-xs text-muted-foreground">{t('userPanel.useCount')}</p>
+                          <p className="mt-1 text-xl font-bold tabular-nums text-foreground">
+                            {formatNumber(userPanelToken.useCount)}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                          <p className="text-xs text-muted-foreground">{t('userPanel.lastUsed')}</p>
+                          <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
+                            {formatDateTime(userPanelToken.lastUsedAt)}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                          <p className="text-xs text-muted-foreground">
+                            {t('userPanel.expiresAt')}
+                          </p>
+                          <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
+                            {formatDateTime(userPanelToken.expiresAt)}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="grid gap-3 border-t border-border pt-4 text-sm text-muted-foreground">
+                        <div className="flex items-center justify-between gap-3">
+                          <span>{t('userPanel.version')}</span>
+                          <span className="font-mono text-foreground">
+                            {proxyStatus?.version || '—'}
+                          </span>
+                        </div>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center py-8 text-center">
+                      <Server className="size-9 text-muted-foreground" />
+                      <p className="mt-3 text-sm text-muted-foreground">
+                        {t('userPanel.noUsageData')}
+                      </p>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </section>
+
+            <Card className="border-border bg-card shadow-sm">
+              <CardHeader className="border-b border-border">
+                <CardTitle className="flex items-center gap-2 text-base font-medium">
+                  <Server className="size-4 text-muted-foreground" />
+                  {t('userPanel.apiAccess')}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4 p-5">
+                <div className="rounded-xl border border-border bg-muted/25 p-4">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t('userPanel.baseURL')}
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    {endpointHints.map((endpoint) => (
+                      <div
+                        key={endpoint.id}
+                        className="flex items-center gap-3 rounded-lg bg-background px-3 py-2 text-xs"
+                      >
+                        <span className="w-20 shrink-0 font-medium text-foreground">
+                          {endpoint.label}
+                        </span>
+                        <code className="min-w-0 flex-1 break-all text-muted-foreground">
+                          {endpoint.url || '—'}
+                        </code>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-8 shrink-0 gap-2"
+                          aria-label={`${t('common.copy')} ${endpoint.label}`}
+                          onClick={() => handleCopyEndpoint(endpoint.id, endpoint.url)}
+                        >
+                          <Copy className="size-3.5" />
+                          {copiedEndpointId === endpoint.id ? t('common.copied') : t('common.copy')}
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-border bg-muted/25 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {t('userPanel.quickStart')}
+                    </p>
                     <Button
                       variant="outline"
                       size="sm"
-                      className="h-8 shrink-0 gap-2"
-                      aria-label={`${t('common.copy')} ${endpoint.label}`}
-                      onClick={() => handleCopyEndpoint(endpoint.id, endpoint.url)}
+                      className="h-8 gap-2"
+                      onClick={handleCopyExample}
                     >
                       <Copy className="size-3.5" />
-                      {copiedEndpointId === endpoint.id ? t('common.copied') : t('common.copy')}
+                      {exampleCopied ? t('common.copied') : t('common.copy')}
                     </Button>
                   </div>
-                ))}
-              </div>
-            </div>
-            <div className="rounded-xl border border-border bg-muted/25 p-4">
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                {t('userPanel.authMethod')}
-              </p>
-              <code className="mt-3 block rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                Authorization: Bearer {'<'}
-                {t('userPanel.yourKey')}
-                {'>'}
-              </code>
-            </div>
-            <div className="rounded-xl border border-border bg-muted/25 p-4">
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {t('userPanel.quickStart')}
-                </p>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 gap-2"
-                  onClick={handleCopyExample}
-                >
-                  <Copy className="size-3.5" />
-                  {exampleCopied ? t('common.copied') : t('common.copy')}
-                </Button>
-              </div>
-              <pre className="mt-3 overflow-x-auto rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                <code>{curlExample}</code>
-              </pre>
-            </div>
-          </CardContent>
-        </Card>
-
-        <section className="grid gap-5 lg:grid-cols-2">
-          <Card className="border-border bg-card shadow-sm">
-            <CardHeader className="border-b border-border">
-              <CardTitle className="flex items-center gap-2 text-base font-medium">
-                <ShieldCheck className="size-4 text-muted-foreground" />
-                {t('userPanel.accountCard')}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 pt-5 text-sm">
-              {[
-                [t('userPanel.username'), user?.username || t('nav.accountFallback')],
-                [
-                  t('userPanel.role'),
-                  user?.role === 'admin' ? t('users.roleAdmin') : t('users.roleMember'),
-                ],
-                [t('userPanel.workspace'), tenantLabel],
-                [t('userPanel.userId'), maskNumericIdentity(user?.id)],
-                [t('userPanel.tenantId'), maskNumericIdentity(user?.tenantID)],
-              ].map(([label, value]) => (
-                <div key={label} className="flex items-center justify-between gap-3">
-                  <span className="text-muted-foreground">{label}</span>
-                  <span
-                    className={cn(
-                      'truncate text-right font-medium',
-                      label === t('userPanel.userId') && 'font-mono',
-                    )}
-                  >
-                    {value}
-                  </span>
+                  <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
+                    <code>{curlExample}</code>
+                  </pre>
                 </div>
-              ))}
-            </CardContent>
-          </Card>
-        </section>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="requests">
+            <UserPanelRequestsTab />
+          </TabsContent>
+        </Tabs>
 
         <footer className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
           <Clock3 className="size-3.5" />

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { Clock3, Copy, KeyRound, LogOut, Server, ShieldCheck, UserRound } from 'lucide-react';
+import { Clock3, Copy, Eye, EyeOff, KeyRound, LogOut, Server, ShieldCheck, UserRound } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Input } from '@/components/ui';
 import { useAuth } from '@/lib/auth-context';
 import {
   useCreateUserPanelAPIToken,
@@ -58,6 +58,7 @@ export function UserPanelPage() {
   const [exampleCopied, setExampleCopied] = useState(false);
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
+  const [showKeyMasked, setShowKeyMasked] = useState(true);
 
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
 
@@ -120,8 +121,8 @@ export function UserPanelPage() {
 
   return (
     <main className="min-h-svh bg-muted/30 px-4 py-6 text-foreground sm:px-6 lg:px-8">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
-        <header className="flex flex-col gap-4 rounded-2xl border border-border bg-card/95 p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5">
+        <header className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <div className="flex size-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
               <UserRound className="size-5" />
@@ -149,7 +150,7 @@ export function UserPanelPage() {
           </div>
         </header>
 
-        <section className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]">
+        <section className="grid gap-5 lg:grid-cols-[1fr_1fr]">
           <Card className="border-border bg-card shadow-sm">
             <CardHeader className="border-b border-border">
               <CardTitle className="flex items-center gap-2 text-base font-medium">
@@ -183,7 +184,7 @@ export function UserPanelPage() {
               {tokenLoading ? (
                 <div className="text-sm text-muted-foreground">{t('common.loading')}</div>
               ) : userPanelToken ? (
-                <div className="rounded-xl border border-border bg-muted/25 p-4">
+                <div className="space-y-4">
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
@@ -200,12 +201,6 @@ export function UserPanelPage() {
                           {t(`userPanel.keyStatus.${getTokenStatus(userPanelToken)}`)}
                         </Badge>
                       </div>
-                      <p className="mt-2 font-mono text-xs text-muted-foreground">
-                        {userPanelToken.tokenPrefix || 'maxx_••••'}••••
-                      </p>
-                      <p className="mt-2 text-xs text-muted-foreground">
-                        {t('userPanel.existingKeyHint')}
-                      </p>
                     </div>
                     <Button
                       variant="outline"
@@ -217,26 +212,28 @@ export function UserPanelPage() {
                       {tokenActionPending ? t('common.loading') : t('userPanel.regenerateKey')}
                     </Button>
                   </div>
-                  <div className="mt-4 grid gap-3 text-xs text-muted-foreground sm:grid-cols-3">
-                    <div>
-                      <p>{t('userPanel.useCount')}</p>
-                      <p className="mt-1 font-medium text-foreground">
-                        {formatNumber(userPanelToken.useCount)}
-                      </p>
-                    </div>
-                    <div>
-                      <p>{t('userPanel.lastUsed')}</p>
-                      <p className="mt-1 font-medium text-foreground">
-                        {formatDateTime(userPanelToken.lastUsedAt)}
-                      </p>
-                    </div>
-                    <div>
-                      <p>{t('userPanel.expiresAt')}</p>
-                      <p className="mt-1 font-medium text-foreground">
-                        {formatDateTime(userPanelToken.expiresAt)}
-                      </p>
-                    </div>
+
+                  <div className="relative">
+                    <Input
+                      readOnly
+                      type={showKeyMasked ? 'password' : 'text'}
+                      value={userPanelToken.tokenPrefix || 'maxx_••••'}
+                      className="h-9 pr-9 font-mono text-xs"
+                      aria-label={t('userPanel.myKey')}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="absolute right-1 top-1/2 -translate-y-1/2 size-7"
+                      aria-label={showKeyMasked ? t('userPanel.showKey') : t('userPanel.hideKey')}
+                      onClick={() => setShowKeyMasked((prev) => !prev)}
+                    >
+                      {showKeyMasked ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
+                    </Button>
                   </div>
+                  <p className="text-xs text-muted-foreground">
+                    {t('userPanel.existingKeyHint')}
+                  </p>
                 </div>
               ) : (
                 <div className="rounded-xl border border-dashed border-border bg-muted/20 p-5 text-center">
@@ -262,83 +259,131 @@ export function UserPanelPage() {
             <CardHeader className="border-b border-border">
               <CardTitle className="flex items-center gap-2 text-base font-medium">
                 <Server className="size-4 text-muted-foreground" />
-                {t('userPanel.apiAccess')}
+                {t('userPanel.usageStats')}
               </CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4 pt-5">
-              <div className="rounded-xl border border-border bg-muted/25 p-4">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {t('userPanel.baseURL')}
-                </p>
-                <div className="mt-3 space-y-2">
-                  {endpointHints.map((endpoint) => (
-                    <div
-                      key={endpoint.id}
-                      className="grid gap-2 rounded-lg bg-background px-3 py-2 text-xs sm:grid-cols-[104px_1fr_auto] sm:items-center"
-                    >
-                      <span className="font-medium text-foreground">{endpoint.label}</span>
-                      <code className="break-all text-muted-foreground">{endpoint.url || '—'}</code>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-8 gap-2"
-                        aria-label={`${t('common.copy')} ${endpoint.label}`}
-                        onClick={() => handleCopyEndpoint(endpoint.id, endpoint.url)}
-                      >
-                        <Copy className="size-3.5" />
-                        {copiedEndpointId === endpoint.id ? t('common.copied') : t('common.copy')}
-                      </Button>
+            <CardContent className="space-y-4 p-5">
+              {userPanelToken ? (
+                <>
+                  <div className="grid gap-3">
+                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                      <p className="text-xs text-muted-foreground">
+                        {t('userPanel.useCount')}
+                      </p>
+                      <p className="mt-1 text-xl font-bold tabular-nums text-foreground">
+                        {formatNumber(userPanelToken.useCount)}
+                      </p>
                     </div>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-xl border border-border bg-muted/25 p-4">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  {t('userPanel.authMethod')}
-                </p>
-                <code className="mt-3 block rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                  Authorization: Bearer {'<'}
-                  {t('userPanel.yourKey')}
-                  {'>'}
-                </code>
-              </div>
-              <div className="rounded-xl border border-border bg-muted/25 p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    {t('userPanel.quickStart')}
+                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                      <p className="text-xs text-muted-foreground">
+                        {t('userPanel.lastUsed')}
+                      </p>
+                      <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
+                        {formatDateTime(userPanelToken.lastUsedAt)}
+                      </p>
+                    </div>
+                    <div className="rounded-lg border border-border bg-muted/25 px-3 py-2.5">
+                      <p className="text-xs text-muted-foreground">
+                        {t('userPanel.expiresAt')}
+                      </p>
+                      <p className="mt-1 font-mono text-sm tabular-nums text-foreground">
+                        {formatDateTime(userPanelToken.expiresAt)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid gap-3 text-sm text-muted-foreground border-t border-border pt-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <span>{t('userPanel.version')}</span>
+                      <span className="font-mono text-foreground">{proxyStatus?.version || '—'}</span>
+                    </div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>{t('userPanel.auth')}</span>
+                      <Badge variant={authProtected ? 'info' : 'secondary'}>
+                        {authProtected ? t('nav.accountStatusProtected') : t('nav.accountStatusLocal')}
+                      </Badge>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-center">
+                  <Server className="size-9 text-muted-foreground" />
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {t('userPanel.noUsageData')}
                   </p>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 gap-2"
-                    onClick={handleCopyExample}
-                  >
-                    <Copy className="size-3.5" />
-                    {exampleCopied ? t('common.copied') : t('common.copy')}
-                  </Button>
                 </div>
-                <pre className="mt-3 overflow-x-auto rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                  <code>{curlExample}</code>
-                </pre>
-              </div>
-              <div className="grid gap-3 text-sm text-muted-foreground">
-                <div className="flex items-center justify-between gap-3">
-                  <span>{t('userPanel.version')}</span>
-                  <span className="font-mono text-foreground">{proxyStatus?.version || '—'}</span>
-                </div>
-                <div className="flex items-center justify-between gap-3">
-                  <span>{t('userPanel.auth')}</span>
-                  <Badge variant={authProtected ? 'info' : 'secondary'}>
-                    {authProtected ? t('nav.accountStatusProtected') : t('nav.accountStatusLocal')}
-                  </Badge>
-                </div>
-              </div>
+              )}
             </CardContent>
           </Card>
         </section>
 
-        <section className="grid gap-5 lg:grid-cols-3">
-          <Card className="border-border bg-card shadow-sm lg:col-start-3">
+        <Card className="border-border bg-card shadow-sm">
+          <CardHeader className="border-b border-border">
+            <CardTitle className="flex items-center gap-2 text-base font-medium">
+              <Server className="size-4 text-muted-foreground" />
+              {t('userPanel.apiAccess')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 p-5">
+            <div className="rounded-xl border border-border bg-muted/25 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {t('userPanel.baseURL')}
+              </p>
+              <div className="mt-3 space-y-2">
+                {endpointHints.map((endpoint) => (
+                  <div
+                    key={endpoint.id}
+                    className="flex items-center gap-3 rounded-lg bg-background px-3 py-2 text-xs"
+                  >
+                    <span className="w-20 shrink-0 font-medium text-foreground">{endpoint.label}</span>
+                    <code className="min-w-0 flex-1 break-all text-muted-foreground">{endpoint.url || '—'}</code>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 shrink-0 gap-2"
+                      aria-label={`${t('common.copy')} ${endpoint.label}`}
+                      onClick={() => handleCopyEndpoint(endpoint.id, endpoint.url)}
+                    >
+                      <Copy className="size-3.5" />
+                      {copiedEndpointId === endpoint.id ? t('common.copied') : t('common.copy')}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="rounded-xl border border-border bg-muted/25 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {t('userPanel.authMethod')}
+              </p>
+              <code className="mt-3 block rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
+                Authorization: Bearer {'<'}
+                {t('userPanel.yourKey')}
+                {'>'}
+              </code>
+            </div>
+            <div className="rounded-xl border border-border bg-muted/25 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {t('userPanel.quickStart')}
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-2"
+                  onClick={handleCopyExample}
+                >
+                  <Copy className="size-3.5" />
+                  {exampleCopied ? t('common.copied') : t('common.copy')}
+                </Button>
+              </div>
+              <pre className="mt-3 overflow-x-auto rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
+                <code>{curlExample}</code>
+              </pre>
+            </div>
+          </CardContent>
+        </Card>
+
+        <section className="grid gap-5 lg:grid-cols-2">
+          <Card className="border-border bg-card shadow-sm">
             <CardHeader className="border-b border-border">
               <CardTitle className="flex items-center gap-2 text-base font-medium">
                 <ShieldCheck className="size-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- refine the user console into Main / Requests tabs with language switching and a simplified header
- remove user-console Auth Header / Account / Online / Default UI blocks and omit the bearer header from Quick Start
- scope member user-panel request APIs to the current user's managed key on the backend

## Validation
- `git diff --check`
- `go test ./internal/handler ./internal/core`
- `pnpm -C web exec tsc --noEmit`
- `pnpm -C web exec vitest run`
- `pnpm -C web build`
- local user-console screenshots for Main and Requests tabs

## Notes
- Requests tab reuses the existing requests API, with member/user-panel scoping enforced server-side.
- Release should not be monitored after triggering unless explicitly requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 用户面板新增 API Key 显示/隐藏切换，并提供更完善的用量/请求统计展示与无数据提示。
  * API 访问示例代码更新：不再包含 `Authorization: Bearer` 头，更贴合实际使用场景。
  * 管理侧用户面板成员在请求列表与统计中按权限范围可见对应内容。

* **界面优化**
  * 用户面板改为 Tab 布局；请求与统计信息以卡片式分块展示，空状态与已有 Key 区域更清晰。
  * 页面宽度与网格布局调整，信息层级更集中。

* **其他**
  * 中英文文案同步扩展。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->