### PR TITLE
feat(router): clear 400 when a requested model is not in any provider's allowlist

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -14,17 +14,22 @@ var (
 	ErrInvalidState         = errors.New("invalid state")
 	ErrNoRoutes             = errors.New("no routes available")
 	ErrNoAvailableProviders = errors.New("no available providers")
-	ErrAllRoutesFailed      = errors.New("all routes failed")
-	ErrFirstByteTimeout     = errors.New("first byte timeout")
-	ErrStreamIdleTimeout    = errors.New("stream idle timeout")
-	ErrUpstreamError        = errors.New("upstream error")
-	ErrFormatConversion     = errors.New("format conversion error")
-	ErrUnsupportedFormat    = errors.New("unsupported format")
-	ErrInviteCodeRequired   = errors.New("invite code required")
-	ErrInviteCodeInvalid    = errors.New("invite code invalid")
-	ErrInviteCodeExpired    = errors.New("invite code expired")
-	ErrInviteCodeExhausted  = errors.New("invite code exhausted")
-	ErrInviteCodeDisabled   = errors.New("invite code disabled")
+	// ErrModelNotSupported means routes/providers existed for the client type but
+	// every candidate was rejected because the requested model is not in the
+	// provider's SupportModels allowlist — a client-side request error (the model
+	// is disallowed), distinct from the transient ErrNoAvailableProviders.
+	ErrModelNotSupported   = errors.New("model not supported by any provider")
+	ErrAllRoutesFailed     = errors.New("all routes failed")
+	ErrFirstByteTimeout    = errors.New("first byte timeout")
+	ErrStreamIdleTimeout   = errors.New("stream idle timeout")
+	ErrUpstreamError       = errors.New("upstream error")
+	ErrFormatConversion    = errors.New("format conversion error")
+	ErrUnsupportedFormat   = errors.New("unsupported format")
+	ErrInviteCodeRequired  = errors.New("invite code required")
+	ErrInviteCodeInvalid   = errors.New("invite code invalid")
+	ErrInviteCodeExpired   = errors.New("invite code expired")
+	ErrInviteCodeExhausted = errors.New("invite code exhausted")
+	ErrInviteCodeDisabled  = errors.New("invite code disabled")
 )
 
 // ErrorScope defines what resource is broken, determining cooldown granularity

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -31,24 +31,37 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		SessionID:    state.sessionID,
 	})
 	if err != nil {
+		// Default: the match failed for a transient/server reason (no routes, all
+		// providers in cooldown) → 503. A rejected model, by contrast, is a
+		// client-side request error (the model is not in any provider's allowlist)
+		// and gets a 400 with a clear, non-retryable message naming the model.
 		message := fmt.Sprintf("route match failed: %v", err)
+		status := http.StatusServiceUnavailable
+
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
+		if errors.Is(err, domain.ErrModelNotSupported) {
+			message = fmt.Sprintf("model %q is not supported by any configured provider", state.requestModel)
+			status = http.StatusBadRequest
+			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrModelNotSupported, false, message)
+			proxyErr.Code = "model_not_supported"
+			proxyErr.Model = state.requestModel
+		} else if errors.Is(err, domain.ErrNoAvailableProviders) {
+			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
+			proxyErr.Code = "no_available_provider"
+		} else if errors.Is(err, domain.ErrNoRoutes) {
+			proxyErr.Code = "no_routes_available"
+		}
+
 		proxyReq := e.newProxyRequest(c, state, "REJECTED")
-		proxyReq.StatusCode = http.StatusServiceUnavailable
+		proxyReq.StatusCode = status
 		proxyReq.Error = message
 		proxyReq.EndTime = time.Now()
 		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
 		e.createProxyRequest(proxyReq)
 		state.proxyReq = proxyReq
 
-		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
-		if errors.Is(err, domain.ErrNoAvailableProviders) {
-			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
-			proxyErr.Code = "no_available_provider"
-		} else if errors.Is(err, domain.ErrNoRoutes) {
-			proxyErr.Code = "no_routes_available"
-		}
 		proxyErr.Scope = domain.ScopeRequest
-		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+		proxyErr.HTTPStatusCode = status
 		state.lastErr = proxyErr
 		c.Err = proxyErr
 		c.Abort()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -247,6 +247,15 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	var matched []*MatchedRoute
 	providers := r.providerRepo.GetAll()
 
+	// Track why candidates were dropped so an empty result can be reported
+	// precisely: sawModelReject means a route was skipped purely because the model
+	// is not in the provider's SupportModels allowlist (a client request error);
+	// sawTransientSkip means a route was skipped for a transient reason (cooldown)
+	// that might otherwise have served the model — in which case we stay with the
+	// generic ErrNoAvailableProviders rather than blaming the model.
+	sawModelReject := false
+	sawTransientSkip := false
+
 	for _, route := range filtered {
 		prov, ok := providers[route.ProviderID]
 		if !ok {
@@ -255,6 +264,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 
 		// Skip providers in cooldown (checks provider, key, and model-level cooldowns)
 		if r.cooldownManager.IsInCooldown(route.ProviderID, string(clientType), requestModel) {
+			sawTransientSkip = true
 			continue
 		}
 
@@ -270,6 +280,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		// request model here would incorrectly drop valid cross-protocol routes.
 		if adapterSupportsClientType(adp, clientType) && len(prov.SupportModels) > 0 && requestModel != "" {
 			if !r.isModelSupported(requestModel, prov.SupportModels) {
+				sawModelReject = true
 				continue
 			}
 		}
@@ -292,6 +303,12 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	r.mu.RUnlock()
 
 	if len(matched) == 0 {
+		// Only blame the model when the emptiness is entirely due to SupportModels
+		// rejections; a transient skip (cooldown) may hide a provider that does
+		// support it, so fall back to the generic error to avoid mislabeling.
+		if sawModelReject && !sawTransientSkip {
+			return nil, domain.ErrModelNotSupported
+		}
 		return nil, domain.ErrNoAvailableProviders
 	}
 

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1138,7 +1138,7 @@ func TestProxyNoMatchingRoute(t *testing.T) {
 	if got := payload["error"]["retryable"]; got != false {
 		t.Fatalf("error.retryable = %v, want false", got)
 	}
-	assertRouteMatchRejectionRecorded(t, env, 1, "no routes available")
+	assertRouteMatchRejectionRecorded(t, env, 1, "no routes available", http.StatusServiceUnavailable)
 }
 
 func TestProxyRouteWithoutConfiguredProviderRecordsRejectedRequest(t *testing.T) {
@@ -1166,7 +1166,7 @@ func TestProxyRouteWithoutConfiguredProviderRecordsRejectedRequest(t *testing.T)
 	if !strings.Contains(msg, "no available provider") {
 		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
-	assertRouteMatchRejectionRecorded(t, env, 1, "no available providers")
+	assertRouteMatchRejectionRecorded(t, env, 1, "no available providers", http.StatusServiceUnavailable)
 }
 
 func TestProxyMatchedRouteWithUnsupportedProviderModelRecordsRejectedRequest(t *testing.T) {
@@ -1188,19 +1188,24 @@ func TestProxyMatchedRouteWithUnsupportedProviderModelRecordsRejectedRequest(t *
 	AssertStatus(t, providerResp, http.StatusOK)
 	createRoute(t, env, "openai", providerID)
 
+	// The only provider's SupportModels allowlist is ["only-this-model"], so a
+	// request for gpt-4o is rejected before any upstream call. Because the
+	// emptiness is entirely a model-allowlist rejection (no cooldown masking a
+	// provider that might serve it), the client gets a clean, non-retryable 400
+	// naming the model — not the generic 503 "no available provider".
 	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
-	AssertStatus(t, resp, http.StatusServiceUnavailable)
+	AssertStatus(t, resp, http.StatusBadRequest)
 
 	var payload map[string]map[string]any
 	DecodeJSON(t, resp, &payload)
-	if got := payload["error"]["code"]; got != "no_available_provider" {
-		t.Fatalf("error.code = %v, want no_available_provider", got)
+	if got := payload["error"]["code"]; got != "model_not_supported" {
+		t.Fatalf("error.code = %v, want model_not_supported", got)
 	}
 	msg, _ := payload["error"]["message"].(string)
-	if !strings.Contains(msg, "no available provider") {
-		t.Fatalf("error.message = %q, want to contain no available provider", msg)
+	if !strings.Contains(msg, "gpt-4o") || !strings.Contains(msg, "not supported by any configured provider") {
+		t.Fatalf("error.message = %q, want to name gpt-4o and 'not supported by any configured provider'", msg)
 	}
-	assertRouteMatchRejectionRecorded(t, env, 1, "no available providers")
+	assertRouteMatchRejectionRecorded(t, env, 1, "not supported by any configured provider", http.StatusBadRequest)
 }
 
 func TestProxyMatchedRouteWithCooldownProviderRecordsRejectedRequest(t *testing.T) {
@@ -1239,10 +1244,10 @@ func TestProxyMatchedRouteWithCooldownProviderRecordsRejectedRequest(t *testing.
 	if !strings.Contains(msg, "no available provider") {
 		t.Fatalf("error.message = %q, want to contain no available provider", msg)
 	}
-	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers")
+	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers", http.StatusServiceUnavailable)
 }
 
-func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTotal int, wantErrorPart string) {
+func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTotal int, wantErrorPart string, wantStatus int) {
 	t.Helper()
 
 	requests := getProxyRequests(t, env)
@@ -1256,7 +1261,7 @@ func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTota
 			continue
 		}
 		errorMsg, _ := req["error"].(string)
-		if strings.Contains(errorMsg, "route match failed") && strings.Contains(errorMsg, wantErrorPart) {
+		if strings.Contains(errorMsg, wantErrorPart) {
 			matched = append(matched, req)
 		}
 	}
@@ -1264,8 +1269,8 @@ func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTota
 		t.Fatalf("route-match rejected requests = %d, want 1 in %#v", len(matched), requests)
 	}
 	rejected := matched[0]
-	if got := intFromJSONNumber(t, rejected["statusCode"]); got != http.StatusServiceUnavailable {
-		t.Fatalf("statusCode = %d, want %d", got, http.StatusServiceUnavailable)
+	if got := intFromJSONNumber(t, rejected["statusCode"]); got != wantStatus {
+		t.Fatalf("statusCode = %d, want %d", got, wantStatus)
 	}
 	if got := intFromJSONNumber(t, rejected["providerID"]); got != 0 {
 		t.Fatalf("providerID = %d, want 0 for route-match rejection", got)

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1247,6 +1247,80 @@ func TestProxyMatchedRouteWithCooldownProviderRecordsRejectedRequest(t *testing.
 	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers", http.StatusServiceUnavailable)
 }
 
+func TestProxyMatchedRouteWithUnsupportedModelAndCooldownProviderRecords503(t *testing.T) {
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"message": "Rate limit exceeded",
+				"type":    "rate_limit_error",
+			},
+		})
+	}))
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+
+	unsupportedProviderID := createProvider(t, env, "mock-openai-unsupported-model", "http://127.0.0.1:1", []string{"openai"})
+	unsupportedProviderResp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", unsupportedProviderID), map[string]any{
+		"name":                 "mock-openai-unsupported-model",
+		"type":                 "custom",
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        []string{"only-this-model"},
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": "http://127.0.0.1:1",
+				"apiKey":  "sk-mock-test-key",
+			},
+		},
+	})
+	AssertStatus(t, unsupportedProviderResp, http.StatusOK)
+	createRoute(t, env, "openai", unsupportedProviderID)
+
+	cooldownProviderID := createProvider(t, env, "mock-cooldown-supported-model", mock.URL, []string{"openai"})
+	cooldownProviderResp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", cooldownProviderID), map[string]any{
+		"name":                 "mock-cooldown-supported-model",
+		"type":                 "custom",
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        []string{"gpt-4o"},
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": mock.URL,
+				"apiKey":  "sk-mock-test-key",
+			},
+		},
+	})
+	AssertStatus(t, cooldownProviderResp, http.StatusOK)
+	createRoute(t, env, "openai", cooldownProviderID)
+
+	// First request reaches the supported provider and puts it into cooldown.
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusTooManyRequests)
+	if got := len(getProxyRequests(t, env)); got != 1 {
+		t.Fatalf("expected first upstream failure to be recorded, got %d requests", got)
+	}
+
+	// Second request sees both a model allowlist rejection and a transient
+	// cooldown skip. The cooldown may be masking a provider that supports the
+	// model, so the router must keep the generic 503 instead of mislabeling the
+	// model as unsupported.
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	AssertStatus(t, resp, http.StatusServiceUnavailable)
+
+	var payload map[string]map[string]any
+	DecodeJSON(t, resp, &payload)
+	if got := payload["error"]["code"]; got != "no_available_provider" {
+		t.Fatalf("error.code = %v, want no_available_provider", got)
+	}
+	msg, _ := payload["error"]["message"].(string)
+	if !strings.Contains(msg, "no available provider") {
+		t.Fatalf("error.message = %q, want to contain no available provider", msg)
+	}
+	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers", http.StatusServiceUnavailable)
+}
+
 func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTotal int, wantErrorPart string, wantStatus int) {
 	t.Helper()
 


### PR DESCRIPTION
## What & why

A provider can restrict which models it serves via its **`SupportModels`** allowlist (wildcard patterns; empty = allow all). When a client requests a model that matches **no** provider's allowlist, the router dropped every candidate and returned the generic `ErrNoAvailableProviders` → **HTTP 503 "no available provider"**.

That's misleading: 503 reads like a transient upstream outage, so clients back off and retry. But this is a **client-side request error** — the model is disallowed and retrying will never succeed. The caller gets no signal about the real cause.

## Change

- **`router.Match`** now records *why* candidates were dropped. When the candidate set is empty **purely** because of `SupportModels` rejections — and no route was skipped for a transient reason (cooldown) that might have masked a provider which *does* serve the model — it returns a new **`ErrModelNotSupported`** sentinel.
- **route-match middleware** maps `ErrModelNotSupported` to a **non-retryable HTTP 400**, `code: "model_not_supported"`, with a message naming the model (`model "gpt-4o" is not supported by any configured provider`). Scope is `ScopeRequest` (no cooldown, no cross-provider retry).
- **Unchanged:** no-routes and all-providers-in-cooldown still return 503. The transient-skip guard prevents mislabeling a cooled-down-but-supported provider as "unsupported".

## Behavior

| Scenario | Before | After |
|---|---|---|
| Model not in any provider's `SupportModels` | 503 `no_available_provider` | **400 `model_not_supported`** (names the model, non-retryable) |
| No routes for the client type | 503 | 503 (unchanged) |
| All providers in cooldown | 503 | 503 (unchanged) |
| Cooldown hides a provider that *would* serve the model | 503 | 503 (unchanged — not mislabeled) |

## Tests

- Updated the existing `TestProxyMatchedRouteWithUnsupportedProviderModelRecordsRejectedRequest` e2e test to the new 400 / `model_not_supported` contract (it previously pinned the old 503).
- Parameterized the shared `assertRouteMatchRejectionRecorded` helper by expected status code; the three no-routes / cooldown callers keep asserting 503.
- Full `internal/...` + `tests/e2e` suites green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误处理**
  * 当请求模型不受任何已配置提供方支持时，现返回“模型不支持”错误，并以 HTTP 400 响应。
  * 错误信息包含请求的模型名称及“不被配置提供方支持”的原因。
  * 路由匹配失败仍保留对临时/冷却等场景的区分，避免错误码被错误归类为模型不支持。
* **测试**
  * 更新了端到端代理集成测试的拒绝断言，增加对状态码与错误消息片段的校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->