### PR TITLE
fix(user-panel): persist tab state per account

### DIFF
--- a/web/e2e/user-panel-tab-state-flow.js
+++ b/web/e2e/user-panel-tab-state-flow.js
@@ -1,0 +1,188 @@
+import { chromium } from '@playwright/test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:4173';
+const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome-stable';
+const OUT_DIR = process.env.OUT_DIR || '/home/moltbot/clawd-wechat/tmp/maxx-user-panel-tab-state-flow';
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const MEMBER_A = {
+  id: 42,
+  username: 'member-a',
+  tenantID: 1,
+  tenantName: 'Member A',
+  role: 'member',
+};
+
+const MEMBER_B = {
+  id: 43,
+  username: 'member-b',
+  tenantID: 1,
+  tenantName: 'Member B',
+  role: 'member',
+};
+
+const settings = {
+  api_token_auth_enabled: 'true',
+  force_project_binding: 'false',
+  ui_multitenant_enabled: 'true',
+  ui_multitenant_layout: 'user_panel',
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function tokenFor(user) {
+  return {
+    id: 1000 + user.id,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    tenantID: user.tenantID,
+    token: '',
+    tokenPrefix: `maxx_user_${user.id}_prefix...`,
+    name: `User Console Key (user ${user.id})`,
+    description: `managed-by=maxx-user-panel;user-id=${user.id}`,
+    projectID: 0,
+    isEnabled: true,
+    devMode: false,
+    useCount: 2,
+  };
+}
+
+function requestsFor(user) {
+  return [
+    {
+      id: user.id * 100,
+      requestID: `active-${user.id}`,
+      createdAt: nowIso(),
+      startTime: nowIso(),
+      clientType: 'codex',
+      requestModel: 'gpt-5',
+      status: 'IN_PROGRESS',
+      statusCode: 0,
+      duration: 0,
+      inputTokenCount: 0,
+      outputTokenCount: 0,
+      providerID: 1,
+      routeID: 1,
+      apiTokenID: 1000 + user.id,
+      projectID: 0,
+    },
+    {
+      id: user.id * 100 + 1,
+      requestID: `done-${user.id}`,
+      createdAt: nowIso(),
+      startTime: nowIso(),
+      clientType: 'openai',
+      requestModel: 'gpt-4.1',
+      status: 'COMPLETED',
+      statusCode: 200,
+      duration: 120000000,
+      inputTokenCount: 10,
+      outputTokenCount: 20,
+      providerID: 1,
+      routeID: 1,
+      apiTokenID: 1000 + user.id,
+      projectID: 0,
+    },
+  ];
+}
+
+async function installMock(page, user) {
+  await page.route('**/api/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+    const json = async (body, status = 200) => {
+      await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+    };
+
+    if (path === '/api/settings' || path === '/api/admin/settings') return json(settings);
+    if (path === '/api/admin/auth/status') return json({ authEnabled: true, user });
+    if (path === '/api/proxy-status' || path === '/api/admin/proxy-status') {
+      return json({ running: true, address: '127.0.0.1', port: 9880, version: 'v0.99.0-test' });
+    }
+    if (path === '/api/user-panel-token' && method === 'GET') {
+      return json({ apiToken: tokenFor(user) });
+    }
+    if (path === '/api/admin/requests') {
+      return json({ items: requestsFor(user), hasMore: false, firstId: user.id * 100, lastId: user.id * 100 + 1 });
+    }
+    if (path === '/api/admin/requests/count') return json(2);
+    return json([]);
+  });
+}
+
+async function preparePage(context, user) {
+  const page = await context.newPage();
+  await installMock(page, user);
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+  return page;
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({ path: `${OUT_DIR}/${name}.png`, fullPage: true });
+}
+
+async function assertActiveTab(page, name) {
+  await page.getByRole('tab', { name }).waitFor({ state: 'visible', timeout: 10_000 });
+  const selected = await page.getByRole('tab', { name }).getAttribute('aria-selected');
+  assert.equal(selected, 'true', `${name} tab should be selected`);
+}
+
+async function run() {
+  const browser = await chromium.launch({
+    headless: true,
+    executablePath: CHROME,
+    args: ['--no-sandbox'],
+  });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, locale: 'zh-CN' });
+
+  const userA = await preparePage(context, MEMBER_A);
+  await userA.goto(`${BASE_URL}/`);
+  await assertActiveTab(userA, '主页');
+  await userA.getByRole('tab', { name: /请求/ }).click();
+  await assertActiveTab(userA, '请求');
+  assert.match(userA.url(), /[?&]tab=requests/, 'clicking requests should update URL tab');
+  await userA.reload();
+  await assertActiveTab(userA, '请求');
+  await userA.getByText('active-42').waitFor({ state: 'visible', timeout: 10_000 });
+  await userA.getByRole('tab', { name: /请求/ }).getByText('1', { exact: true }).waitFor({ state: 'visible', timeout: 10_000 });
+  await screenshot(userA, '01-user-a-requests-restored-with-badge');
+
+  const userB = await preparePage(context, MEMBER_B);
+  await userB.goto(`${BASE_URL}/`);
+  await assertActiveTab(userB, '主页');
+  await screenshot(userB, '02-user-b-default-home-isolated');
+
+  await userB.getByRole('tab', { name: /请求/ }).click();
+  await assertActiveTab(userB, '请求');
+  await userB.getByRole('tab', { name: '主页' }).click();
+  await assertActiveTab(userB, '主页');
+  await userB.reload();
+  await assertActiveTab(userB, '主页');
+  await screenshot(userB, '03-user-b-home-restored');
+
+  await userA.goto(`${BASE_URL}/`);
+  await assertActiveTab(userA, '请求');
+  await screenshot(userA, '04-user-a-requests-still-isolated');
+
+  await userA.goto(`${BASE_URL}/?tab=unknown`);
+  await assertActiveTab(userA, '请求');
+  await screenshot(userA, '05-invalid-url-falls-back-to-user-a-cache');
+
+  await browser.close();
+  console.log(JSON.stringify({ ok: true, screenshots: fs.readdirSync(OUT_DIR).sort() }, null, 2));
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/web/e2e/user-panel-tab-state-flow.js
+++ b/web/e2e/user-panel-tab-state-flow.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 
 const BASE_URL = process.env.BASE_URL || 'http://127.0.0.1:4173';
 const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome-stable';
-const OUT_DIR = process.env.OUT_DIR || '/home/moltbot/clawd-wechat/tmp/maxx-user-panel-tab-state-flow';
+const OUT_DIR = process.env.OUT_DIR || new URL('./user-panel-tab-state-artifacts', import.meta.url).pathname;
 
 fs.mkdirSync(OUT_DIR, { recursive: true });
 

--- a/web/src/lib/user-panel-tabs.test.ts
+++ b/web/src/lib/user-panel-tabs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getUserPanelTabStorageKey,
+  isUserPanelTab,
+  resolveUserPanelTab,
+  updateUserPanelTabSearch,
+} from './user-panel-tabs';
+
+describe('user-panel-tabs', () => {
+  it('validates only supported user panel tabs', () => {
+    expect(isUserPanelTab('main')).toBe(true);
+    expect(isUserPanelTab('requests')).toBe(true);
+    expect(isUserPanelTab('usage')).toBe(false);
+    expect(isUserPanelTab('')).toBe(false);
+    expect(isUserPanelTab(null)).toBe(false);
+  });
+
+  it('scopes stored tab keys by account id', () => {
+    expect(getUserPanelTabStorageKey(42)).toBe('maxx:user-panel:active-tab:42');
+    expect(getUserPanelTabStorageKey('member')).toBe('maxx:user-panel:active-tab:member');
+    expect(getUserPanelTabStorageKey(null)).toBe('maxx:user-panel:active-tab:anonymous');
+  });
+
+  it('prefers a valid URL tab over a stored tab', () => {
+    expect(resolveUserPanelTab({ urlTab: 'requests', storedTab: 'main' })).toBe('requests');
+  });
+
+  it('falls back to a valid stored tab when URL tab is invalid', () => {
+    expect(resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'requests' })).toBe('requests');
+  });
+
+  it('falls back to main when URL and stored tab are invalid', () => {
+    expect(resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'other' })).toBe('main');
+  });
+
+  it('updates tab in search while preserving unrelated query params', () => {
+    expect(updateUserPanelTabSearch('?foo=bar&tab=main', 'requests')).toBe('?foo=bar&tab=requests');
+  });
+});

--- a/web/src/lib/user-panel-tabs.ts
+++ b/web/src/lib/user-panel-tabs.ts
@@ -1,0 +1,35 @@
+export const USER_PANEL_TABS = ['main', 'requests'] as const;
+
+export type UserPanelTab = (typeof USER_PANEL_TABS)[number];
+
+const DEFAULT_USER_PANEL_TAB: UserPanelTab = 'main';
+const STORAGE_PREFIX = 'maxx:user-panel:active-tab';
+
+export function isUserPanelTab(value: string | null | undefined): value is UserPanelTab {
+  return value === 'main' || value === 'requests';
+}
+
+export function getUserPanelTabStorageKey(userId: number | string | null | undefined): string {
+  const scope = userId === null || userId === undefined || userId === '' ? 'anonymous' : String(userId);
+  return `${STORAGE_PREFIX}:${scope}`;
+}
+
+export function resolveUserPanelTab(params: {
+  urlTab?: string | null;
+  storedTab?: string | null;
+}): UserPanelTab {
+  if (isUserPanelTab(params.urlTab)) {
+    return params.urlTab;
+  }
+  if (isUserPanelTab(params.storedTab)) {
+    return params.storedTab;
+  }
+  return DEFAULT_USER_PANEL_TAB;
+}
+
+export function updateUserPanelTabSearch(search: string, tab: UserPanelTab): string {
+  const params = new URLSearchParams(search);
+  params.set('tab', tab);
+  const next = params.toString();
+  return next ? `?${next}` : '';
+}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Clock3,
   Copy,
@@ -212,16 +212,13 @@ export function UserPanelPage() {
           : t('userPanel.routeGemini'),
   }));
   const curlExample = buildUserPanelChatCompletionsExample({ origin });
-  const urlTab = useMemo(() => {
-    if (typeof window === 'undefined') return null;
-    return new URLSearchParams(window.location.search).get('tab');
-  }, []);
 
   useEffect(() => {
-    const storedTab =
-      typeof window === 'undefined' ? null : window.localStorage.getItem(tabStorageKey);
+    if (typeof window === 'undefined') return;
+    const urlTab = new URLSearchParams(window.location.search).get('tab');
+    const storedTab = window.localStorage.getItem(tabStorageKey);
     setActiveTab(resolveUserPanelTab({ urlTab, storedTab }));
-  }, [tabStorageKey, urlTab]);
+  }, [tabStorageKey]);
 
   const handleTabChange = (value: string | null) => {
     const nextTab = resolveUserPanelTab({ urlTab: value });

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Clock3,
   Copy,
@@ -25,6 +25,8 @@ import {
   TabsTrigger,
 } from '@/components/ui';
 import { LanguageToggle } from '@/components/language-toggle';
+import { MarqueeBackground } from '@/components/ui/marquee-background';
+import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { useAuth } from '@/lib/auth-context';
 import {
   useCreateUserPanelAPIToken,
@@ -32,12 +34,19 @@ import {
   useProxyStatus,
   useRegenerateUserPanelAPIToken,
   useUserPanelAPIToken,
+  useProxyRequestUpdates,
 } from '@/hooks/queries';
 import type { APIToken, ProxyRequest } from '@/lib/transport';
 import {
   buildUserPanelChatCompletionsExample,
   buildUserPanelEndpointHints,
 } from '@/lib/user-panel-endpoints';
+import {
+  getUserPanelTabStorageKey,
+  resolveUserPanelTab,
+  updateUserPanelTabSearch,
+  type UserPanelTab,
+} from '@/lib/user-panel-tabs';
 
 function formatNumber(value: number) {
   return new Intl.NumberFormat().format(value || 0);
@@ -66,6 +75,10 @@ function getTokenStatus(token: APIToken) {
   if (!token.isEnabled) return 'disabled';
   if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) return 'expired';
   return 'active';
+}
+
+function isActiveUserPanelRequest(request: ProxyRequest) {
+  return request.status === 'PENDING' || request.status === 'IN_PROGRESS';
 }
 
 function getRequestStatusVariant(request: ProxyRequest) {
@@ -163,9 +176,11 @@ function UserPanelRequestsTab() {
 
 export function UserPanelPage() {
   const { t } = useTranslation();
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
   const { data: proxyStatus } = useProxyStatus();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
+  const { data: userPanelRequests } = useProxyRequests({ limit: 25 });
+  useProxyRequestUpdates();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
   const [copiedEndpointId, setCopiedEndpointId] = useState('');
@@ -173,7 +188,18 @@ export function UserPanelPage() {
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
   const [showKeyMasked, setShowKeyMasked] = useState(true);
+  const tabStorageKey = getUserPanelTabStorageKey(user?.id);
+  const [activeTab, setActiveTab] = useState<UserPanelTab>(() => {
+    if (typeof window === 'undefined') return 'main';
+    const params = new URLSearchParams(window.location.search);
+    return resolveUserPanelTab({
+      urlTab: params.get('tab'),
+      storedTab: window.localStorage.getItem(getUserPanelTabStorageKey(user?.id)),
+    });
+  });
 
+  const activeRequestCount =
+    userPanelRequests?.items.filter((request) => isActiveUserPanelRequest(request)).length ?? 0;
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
   const endpointHints = buildUserPanelEndpointHints(origin).map((endpoint) => ({
@@ -186,6 +212,27 @@ export function UserPanelPage() {
           : t('userPanel.routeGemini'),
   }));
   const curlExample = buildUserPanelChatCompletionsExample({ origin });
+  const urlTab = useMemo(() => {
+    if (typeof window === 'undefined') return null;
+    return new URLSearchParams(window.location.search).get('tab');
+  }, []);
+
+  useEffect(() => {
+    const storedTab =
+      typeof window === 'undefined' ? null : window.localStorage.getItem(tabStorageKey);
+    setActiveTab(resolveUserPanelTab({ urlTab, storedTab }));
+  }, [tabStorageKey, urlTab]);
+
+  const handleTabChange = (value: string | null) => {
+    const nextTab = resolveUserPanelTab({ urlTab: value });
+    setActiveTab(nextTab);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.localStorage.setItem(tabStorageKey, nextTab);
+    const nextSearch = updateUserPanelTabSearch(window.location.search, nextTab);
+    window.history.replaceState(null, '', `${window.location.pathname}${nextSearch}`);
+  };
 
   const handleCopyEndpoint = async (endpointId: string, url: string) => {
     if (!url || typeof navigator === 'undefined' || !navigator.clipboard) return;
@@ -248,10 +295,20 @@ export function UserPanelPage() {
           </div>
         </header>
 
-        <Tabs defaultValue="main" className="space-y-5">
+        <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-5">
           <TabsList className="grid w-full grid-cols-2 rounded-xl p-1">
             <TabsTrigger value="main">{t('userPanel.mainTab')}</TabsTrigger>
-            <TabsTrigger value="requests">{t('userPanel.requestsTab')}</TabsTrigger>
+            <TabsTrigger value="requests" className="relative overflow-hidden">
+              <MarqueeBackground
+                show={activeRequestCount > 0}
+                color="var(--color-success)"
+                opacity={0.3}
+              />
+              <span className="relative z-10">{t('userPanel.requestsTab')}</span>
+              <span className="relative z-10">
+                <StreamingBadge count={activeRequestCount} color="var(--color-success)" />
+              </span>
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="main" className="space-y-5">


### PR DESCRIPTION
## Summary
- Persist the user console active tab per authenticated account and mirror it into the `tab` query parameter.
- Add a user-scoped request tab activity indicator using the same marquee/badge visuals as the admin requests navigation.
- Add unit coverage for tab state resolution and a Playwright flow for refresh persistence, account isolation, invalid tab fallback, and request badge rendering.

## Verification
- `cd web && pnpm test`
- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm build`
- `OUT_DIR=/home/moltbot/clawd-wechat/tmp/maxx-issue511-e2e/artifacts/user-console-tabs/e2e-final BASE_URL=http://127.0.0.1:4174 node web/e2e/user-panel-tab-state-flow.js`
- `go test ./internal/...`

## Notes
- The request tab activity count is derived from the user panel's own visible request list instead of the admin-only active-requests endpoint, avoiding cross-account/admin data leakage.
- Build still emits the existing Vite large chunk warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 用户面板页签状态会按用户保存，并在重新进入或刷新后恢复。
  * 支持通过 URL 参数直接打开指定页签；无效参数会回退到有效状态。
  * “请求”页签显示进行中请求数量，并提供动态提示效果。
  * 切换页签时会保留其他 URL 查询参数。

* **测试**
  * 新增单元测试和端到端测试，覆盖多用户状态隔离、刷新恢复、非法参数及请求徽标显示等场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->