### PR TITLE
fix: preserve protocol-native user agents

### DIFF
--- a/internal/adapter/provider/claude/adapter.go
+++ b/internal/adapter/provider/claude/adapter.go
@@ -124,6 +124,7 @@ func (a *ClaudeAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 	// Apply headers
 	a.applyClaudeHeaders(upstreamReq, request, accessToken, clientWantsStream, extraBetas)
+	upstreamReq.Header["User-Agent"] = []string{flow.ResolveUpstreamUserAgent(c, ClaudeUserAgent)}
 
 	// Send request info via EventChannel
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
@@ -171,6 +172,7 @@ func (a *ClaudeAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			return proxyErr
 		}
 		a.applyClaudeHeaders(upstreamReq, request, accessToken, clientWantsStream, extraBetas)
+		upstreamReq.Header["User-Agent"] = []string{flow.ResolveUpstreamUserAgent(c, ClaudeUserAgent)}
 
 		resp, err = a.httpClient.Do(upstreamReq)
 		if err != nil {
@@ -592,7 +594,11 @@ func (a *ClaudeAdapter) applyClaudeHeaders(upstreamReq, clientReq *http.Request,
 	}
 
 	// Set User-Agent
-	upstreamReq.Header.Set("User-Agent", resolveClaudeUserAgent(clientReq))
+	clientUserAgent := ""
+	if clientReq != nil {
+		clientUserAgent = clientReq.Header.Get("User-Agent")
+	}
+	upstreamReq.Header["User-Agent"] = []string{clientUserAgent}
 }
 
 // isClaudeOAuthToken checks if the token is an OAuth access token
@@ -606,20 +612,6 @@ func ensureHeader(dst http.Header, clientReq *http.Request, key, defaultValue st
 		return
 	}
 	dst.Set(key, defaultValue)
-}
-
-func resolveClaudeUserAgent(clientReq *http.Request) string {
-	if clientReq != nil {
-		if ua := clientReq.Header.Get("User-Agent"); strings.TrimSpace(ua) != "" {
-			return ua
-		}
-	}
-	return ClaudeUserAgent
-}
-
-func isClaudeCLIUserAgent(userAgent string) bool {
-	ua := strings.ToLower(strings.TrimSpace(userAgent))
-	return strings.HasPrefix(ua, "claude-cli/") || strings.HasPrefix(ua, "claude-code/")
 }
 
 func newUpstreamHTTPClient() *http.Client {

--- a/internal/adapter/provider/claude/adapter_test.go
+++ b/internal/adapter/provider/claude/adapter_test.go
@@ -28,7 +28,7 @@ func TestApplyClaudeHeadersPreservesProvidedUA(t *testing.T) {
 	}
 }
 
-func TestApplyClaudeHeadersUsesDefaultUAWhenMissing(t *testing.T) {
+func TestApplyClaudeHeadersPreservesBlankOrMissingUA(t *testing.T) {
 	a := &ClaudeAdapter{}
 	upstreamReq, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
 	clientReq, _ := http.NewRequest("POST", "http://localhost/v1/messages", nil)
@@ -36,14 +36,14 @@ func TestApplyClaudeHeadersUsesDefaultUAWhenMissing(t *testing.T) {
 
 	a.applyClaudeHeaders(upstreamReq, clientReq, "sk-ant-oat-123", true, nil)
 
-	if got := upstreamReq.Header.Get("User-Agent"); got != ClaudeUserAgent {
-		t.Fatalf("expected default Claude User-Agent when client UA is blank, got %q", got)
+	if got := upstreamReq.Header.Get("User-Agent"); got != "   " {
+		t.Fatalf("expected blank client User-Agent passthrough, got %q", got)
 	}
 
 	upstreamReq2, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
 	a.applyClaudeHeaders(upstreamReq2, nil, "sk-ant-oat-123", true, nil)
-	if got := upstreamReq2.Header.Get("User-Agent"); got != ClaudeUserAgent {
-		t.Fatalf("expected default Claude User-Agent when client request is nil, got %q", got)
+	if got := upstreamReq2.Header.Get("User-Agent"); got != "" {
+		t.Fatalf("expected missing client User-Agent to remain empty, got %q", got)
 	}
 }
 

--- a/internal/adapter/provider/cliproxyapi_codex/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/payloadoverride"
 	"github.com/awsl-project/maxx/internal/usage"
+	"github.com/gin-gonic/gin"
 	"github.com/tidwall/sjson"
 )
 
@@ -289,6 +290,7 @@ func (a *CLIProxyAPICodexAdapter) Execute(c *flow.Ctx, p *domain.Provider) error
 
 	execOpts := executor.Options{
 		Stream:          stream,
+		Headers:         cliProxyAPIRequestHeaders(c),
 		OriginalRequest: requestBody,
 		SourceFormat:    sourceFormat,
 	}
@@ -299,11 +301,40 @@ func (a *CLIProxyAPICodexAdapter) Execute(c *flow.Ctx, p *domain.Provider) error
 	return a.executeNonStream(c, w, execReq, execOpts)
 }
 
-func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseWriter, execReq executor.Request, execOpts executor.Options) error {
-	ctx := context.Background()
-	if c.Request != nil {
-		ctx = c.Request.Context()
+func cliProxyAPIRequestHeaders(c *flow.Ctx) http.Header {
+	headers := make(http.Header)
+	if c != nil && c.Request != nil {
+		for _, name := range []string{"User-Agent", "Version"} {
+			if values, ok := c.Request.Header[name]; ok {
+				headers[name] = append([]string(nil), values...)
+			}
+		}
 	}
+	if c != nil {
+		originalClientType := flow.GetOriginalClientType(c)
+		targetClientType := flow.GetClientType(c)
+		if originalClientType != "" && targetClientType != "" && originalClientType != targetClientType {
+			headers.Del("User-Agent")
+			headers.Del("Version")
+		}
+	}
+	return headers
+}
+
+func cliProxyAPIRequestContext(c *flow.Ctx, headers http.Header) context.Context {
+	ctx := context.Background()
+	if c == nil || c.Request == nil {
+		return ctx
+	}
+	ctx = c.Request.Context()
+	request := c.Request.Clone(ctx)
+	request.Header = headers.Clone()
+	// CLIProxyAPI reads passthrough headers from the Gin request in its execution context.
+	return context.WithValue(ctx, "gin", &gin.Context{Request: request})
+}
+
+func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseWriter, execReq executor.Request, execOpts executor.Options) error {
+	ctx := cliProxyAPIRequestContext(c, execOpts.Headers)
 
 	resp, err := a.executor.Execute(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
@@ -381,10 +412,7 @@ func (a *CLIProxyAPICodexAdapter) executeStream(c *flow.Ctx, w http.ResponseWrit
 		return a.executeNonStream(c, w, execReq, execOpts)
 	}
 
-	ctx := context.Background()
-	if c.Request != nil {
-		ctx = c.Request.Context()
-	}
+	ctx := cliProxyAPIRequestContext(c, execOpts.Headers)
 
 	stream, err := a.executor.ExecuteStream(ctx, a.authObj, execReq, execOpts)
 	if err != nil {

--- a/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/awsl-project/maxx/internal/codexguard"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/gin-gonic/gin"
 )
 
 func TestNewAdapterSetsBaseURLAttribute(t *testing.T) {
@@ -69,5 +70,51 @@ func TestCodexReasoningGuardProxyErrorNoMatch(t *testing.T) {
 
 	if err := codexReasoningGuardProxyError(ctx, []byte(`{"usage":{"output_tokens_details":{"reasoning_tokens":128}}}`)); err != nil {
 		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestCLIProxyAPIRequestHeadersFollowProtocolBoundary(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	req.Header.Set("User-Agent", "codex_cli_rs/0.144.1")
+	req.Header.Set("Version", "0.144.1")
+	req.Header.Set("Authorization", "Bearer source-token")
+	req.Header.Set("X-Codex-Responses-Lite", "true")
+	ctx := flow.NewCtx(httptest.NewRecorder(), req)
+	ctx.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeCodex)
+
+	sameProtocolHeaders := cliProxyAPIRequestHeaders(ctx)
+	if got := sameProtocolHeaders.Get("User-Agent"); got != "codex_cli_rs/0.144.1" {
+		t.Fatalf("same-protocol User-Agent = %q", got)
+	}
+	if got := sameProtocolHeaders.Get("Version"); got != "0.144.1" {
+		t.Fatalf("same-protocol Version = %q", got)
+	}
+	if got := sameProtocolHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("source Authorization leaked into executor headers: %q", got)
+	}
+	if got := sameProtocolHeaders.Get("X-Codex-Responses-Lite"); got != "" {
+		t.Fatalf("unrelated source header leaked into executor headers: %q", got)
+	}
+
+	ctx.Set(flow.KeyOriginalClientType, domain.ClientTypeClaude)
+	convertedHeaders := cliProxyAPIRequestHeaders(ctx)
+	if got := convertedHeaders.Get("User-Agent"); got != "" {
+		t.Fatalf("converted User-Agent = %q, want empty", got)
+	}
+	if got := convertedHeaders.Get("Version"); got != "" {
+		t.Fatalf("converted Version = %q, want empty", got)
+	}
+	if got := req.Header.Get("User-Agent"); got != "codex_cli_rs/0.144.1" {
+		t.Fatalf("source request was mutated: User-Agent = %q", got)
+	}
+
+	execCtx := cliProxyAPIRequestContext(ctx, convertedHeaders)
+	ginCtx, ok := execCtx.Value("gin").(*gin.Context)
+	if !ok || ginCtx.Request == nil {
+		t.Fatal("expected SDK request context")
+	}
+	if got := ginCtx.Request.Header.Get("User-Agent"); got != "" {
+		t.Fatalf("SDK context User-Agent = %q, want empty", got)
 	}
 }

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -212,6 +212,7 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 	// Apply headers with passthrough support (client headers take priority)
 	a.applyCodexHeaders(upstreamReq, request, accessToken, config.AccountID, upstreamStream, cacheID)
+	applyCodexProtocolIdentity(c, upstreamReq)
 
 	// Send request info via EventChannel
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
@@ -257,6 +258,7 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			return proxyErr
 		}
 		a.applyCodexHeaders(upstreamReq, request, accessToken, config.AccountID, upstreamStream, cacheID)
+		applyCodexProtocolIdentity(c, upstreamReq)
 
 		resp, err = a.httpClient.Do(upstreamReq)
 		if err != nil {
@@ -288,6 +290,13 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		return a.handleStreamResponse(c, resp)
 	}
 	return a.handleNonStreamResponse(c, resp)
+}
+
+func applyCodexProtocolIdentity(c *flow.Ctx, upstreamReq *http.Request) {
+	upstreamReq.Header["User-Agent"] = []string{flow.ResolveUpstreamUserAgent(c, CodexUserAgent)}
+	if flow.IsProtocolConversion(c) {
+		upstreamReq.Header.Del("Version")
+	}
 }
 
 // WarmToken pre-warms the access token cache to avoid blocking during Execute
@@ -1049,7 +1058,6 @@ func (a *CodexAdapter) applyCodexHeaders(upstreamReq, clientReq *http.Request, a
 	upstreamReq.Header.Set("Connection", "Keep-Alive")
 
 	// Set Codex-specific headers only if client didn't provide them
-	ensureHeader(upstreamReq.Header, clientReq, "Version", CodexVersion)
 	ensureHeader(upstreamReq.Header, clientReq, "Openai-Beta", OpenAIBetaHeader)
 	if cacheID != "" {
 		upstreamReq.Header.Set("Conversation_id", cacheID)
@@ -1057,7 +1065,11 @@ func (a *CodexAdapter) applyCodexHeaders(upstreamReq, clientReq *http.Request, a
 	} else {
 		ensureHeader(upstreamReq.Header, clientReq, "Session_id", uuid.NewString())
 	}
-	upstreamReq.Header.Set("User-Agent", resolveCodexUserAgent(clientReq))
+	clientUserAgent := ""
+	if clientReq != nil {
+		clientUserAgent = clientReq.Header.Get("User-Agent")
+	}
+	upstreamReq.Header["User-Agent"] = []string{clientUserAgent}
 	if hasAccessToken {
 		ensureHeader(upstreamReq.Header, clientReq, "Originator", CodexOriginator)
 	}
@@ -1075,20 +1087,6 @@ func ensureHeader(dst http.Header, clientReq *http.Request, key, defaultValue st
 		return
 	}
 	dst.Set(key, defaultValue)
-}
-
-func resolveCodexUserAgent(clientReq *http.Request) string {
-	if clientReq != nil {
-		if ua := clientReq.Header.Get("User-Agent"); strings.TrimSpace(ua) != "" {
-			return ua
-		}
-	}
-	return CodexUserAgent
-}
-
-func isCodexCLIUserAgent(userAgent string) bool {
-	ua := strings.ToLower(strings.TrimSpace(userAgent))
-	return strings.HasPrefix(ua, "codex_cli_rs/") || strings.HasPrefix(ua, "codex-cli/")
 }
 
 var codexFilteredHeaders = map[string]bool{

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -135,6 +135,39 @@ func TestApplyCodexHeadersFiltersSensitiveAndPreservesUA(t *testing.T) {
 	}
 }
 
+func TestApplyCodexProtocolIdentity(t *testing.T) {
+	tests := []struct {
+		name               string
+		originalClientType domain.ClientType
+		expectedUserAgent  string
+		expectedVersion    string
+	}{
+		{"same protocol preserves identity", domain.ClientTypeCodex, "source-client/1.0", "source-version"},
+		{"conversion uses target identity", domain.ClientTypeClaude, CodexUserAgent, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientReq := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+			clientReq.Header.Set("User-Agent", "source-client/1.0")
+			ctx := flow.NewCtx(httptest.NewRecorder(), clientReq)
+			ctx.Set(flow.KeyOriginalClientType, tt.originalClientType)
+			ctx.Set(flow.KeyClientType, domain.ClientTypeCodex)
+
+			upstreamReq := httptest.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+			upstreamReq.Header.Set("Version", "source-version")
+			applyCodexProtocolIdentity(ctx, upstreamReq)
+
+			if got := upstreamReq.Header.Get("User-Agent"); got != tt.expectedUserAgent {
+				t.Fatalf("User-Agent = %q, want %q", got, tt.expectedUserAgent)
+			}
+			if got := upstreamReq.Header.Get("Version"); got != tt.expectedVersion {
+				t.Fatalf("Version = %q, want %q", got, tt.expectedVersion)
+			}
+		})
+	}
+}
+
 func TestIsCodexResponseCompletedLine(t *testing.T) {
 	if !isCodexResponseCompletedLine("data: {\"type\":\"response.completed\",\"response\":{}}\n") {
 		t.Fatal("expected response.completed line to be detected")
@@ -164,18 +197,18 @@ func TestApplyCodexHeadersPreservesProvidedUA(t *testing.T) {
 	}
 }
 
-func TestApplyCodexHeadersUsesDefaultUAWhenClientReqNil(t *testing.T) {
+func TestApplyCodexHeadersPreservesMissingUAWhenClientReqNil(t *testing.T) {
 	a := &CodexAdapter{}
 	upstreamReq, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
 
 	a.applyCodexHeaders(upstreamReq, nil, "token-1", "acct-1", true, "")
 
-	if got := upstreamReq.Header.Get("User-Agent"); got != CodexUserAgent {
-		t.Fatalf("expected default Codex User-Agent when client request is nil, got %q", got)
+	if got := upstreamReq.Header.Get("User-Agent"); got != "" {
+		t.Fatalf("expected missing client User-Agent to remain empty, got %q", got)
 	}
 }
 
-func TestApplyCodexHeadersUsesDefaultUAWhenClientUAIsBlank(t *testing.T) {
+func TestApplyCodexHeadersPreservesBlankClientUA(t *testing.T) {
 	a := &CodexAdapter{}
 	upstreamReq, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
 	clientReq, _ := http.NewRequest("POST", "http://localhost/responses", nil)
@@ -183,8 +216,26 @@ func TestApplyCodexHeadersUsesDefaultUAWhenClientUAIsBlank(t *testing.T) {
 
 	a.applyCodexHeaders(upstreamReq, clientReq, "token-1", "acct-1", true, "")
 
-	if got := upstreamReq.Header.Get("User-Agent"); got != CodexUserAgent {
-		t.Fatalf("expected default Codex User-Agent when client UA is blank, got %q", got)
+	if got := upstreamReq.Header.Get("User-Agent"); got != "   " {
+		t.Fatalf("expected blank client User-Agent passthrough, got %q", got)
+	}
+}
+
+func TestApplyCodexHeadersPreservesVersionOnlyWhenProvided(t *testing.T) {
+	a := &CodexAdapter{}
+	clientReq, _ := http.NewRequest("POST", "http://localhost/responses", nil)
+	clientReq.Header.Set("Version", "0.144.1")
+	upstreamReq, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
+
+	a.applyCodexHeaders(upstreamReq, clientReq, "token-1", "acct-1", true, "")
+	if got := upstreamReq.Header.Get("Version"); got != "0.144.1" {
+		t.Fatalf("expected client Version passthrough, got %q", got)
+	}
+
+	upstreamReq2, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
+	a.applyCodexHeaders(upstreamReq2, nil, "token-1", "acct-1", true, "")
+	if _, ok := upstreamReq2.Header["Version"]; ok {
+		t.Fatalf("expected missing client Version to remain absent, got %q", upstreamReq2.Header.Get("Version"))
 	}
 }
 

--- a/internal/adapter/provider/codex/settings.go
+++ b/internal/adapter/provider/codex/settings.go
@@ -22,11 +22,8 @@ const (
 	// Codex Usage/Quota API URL
 	CodexUsageURL = "https://chatgpt.com/backend-api/wham/usage"
 
-	// API Version
-	CodexVersion = "0.98.0"
-
 	// User-Agent (mimics codex CLI)
-	CodexUserAgent = "codex_cli_rs/0.98.0 (Mac OS 26.0.1; arm64) Apple_Terminal/464"
+	CodexUserAgent = "codex_cli_rs/0.144.1 (Mac OS 26.0.1; arm64) Apple_Terminal/464"
 
 	// Originator header
 	CodexOriginator = "codex_cli_rs"

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -134,6 +134,7 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 	// Set headers based on client type
 	isOAuthToken := false
+	targetUserAgent := ""
 	switch clientType {
 	case domain.ClientTypeClaude:
 		// Claude: Following CLIProxyAPI pattern
@@ -199,8 +200,10 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			//     api.anthropic.com, Authorization: Bearer for every other host)
 			//   - is a no-op when apiKey is empty
 			setClaudeAuthForURL(upstreamReq, apiKey, useAPIKey)
+			targetUserAgent = defaultClaudeUserAgent
 		default:
 			applyClaudeHeaders(upstreamReq, request, apiKey, useAPIKey, extraBetas, stream)
+			targetUserAgent = defaultClaudeUserAgent
 		}
 
 		// 3. Update request body and ContentLength (IMPORTANT: body was modified)
@@ -209,9 +212,11 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	case domain.ClientTypeCodex:
 		// Codex: Use Codex CLI-style headers with passthrough support
 		applyCodexHeaders(upstreamReq, request, a.provider.Config.Custom.APIKey)
+		targetUserAgent = codexUserAgent
 	case domain.ClientTypeGemini:
 		// Gemini: Use Gemini-style headers with passthrough support
 		applyGeminiHeaders(upstreamReq, request, a.provider.Config.Custom.APIKey)
+		targetUserAgent = geminiUserAgent
 	default:
 		// Other types: Preserve original header forwarding logic
 		originalHeaders := flow.GetRequestHeaders(c)
@@ -225,6 +230,7 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			setAuthHeader(upstreamReq, clientType, a.provider.Config.Custom.APIKey, isConversion)
 		}
 	}
+	applyCustomProtocolIdentity(c, clientType, targetUserAgent, upstreamReq.Header)
 
 	// Forward X-Mock-* headers from client request to upstream (test mode only)
 	if mockMode && request != nil {
@@ -312,6 +318,15 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	}
 
 	return handleErr
+}
+
+func applyCustomProtocolIdentity(c *flow.Ctx, clientType domain.ClientType, targetUserAgent string, headers http.Header) {
+	if targetUserAgent != "" {
+		headers["User-Agent"] = []string{flow.ResolveUpstreamUserAgent(c, targetUserAgent)}
+	}
+	if clientType == domain.ClientTypeCodex && flow.IsProtocolConversion(c) {
+		headers.Del("Version")
+	}
 }
 
 func (a *CustomAdapter) supportsClientType(ct domain.ClientType) bool {

--- a/internal/adapter/provider/custom/adapter_user_agent_test.go
+++ b/internal/adapter/provider/custom/adapter_user_agent_test.go
@@ -11,36 +11,83 @@ import (
 )
 
 func TestCustomAdapterExecutePreservesProvidedClaudeUserAgent(t *testing.T) {
-	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeClaude, "/v1/messages", "Mozilla/5.0 maxx-ua-regression", "Mozilla/5.0 maxx-ua-regression")
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeClaude, domain.ClientTypeClaude, "/v1/messages", "Mozilla/5.0 maxx-ua-regression", "Mozilla/5.0 maxx-ua-regression")
 }
 
-func TestCustomAdapterExecuteFallsBackClaudeUserAgentWhenMissing(t *testing.T) {
-	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeClaude, "/v1/messages", "", defaultClaudeUserAgent)
+func TestCustomAdapterExecutePreservesMissingClaudeUserAgent(t *testing.T) {
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeClaude, domain.ClientTypeClaude, "/v1/messages", "", "")
 }
 
 func TestCustomAdapterExecutePreservesProvidedCodexUserAgent(t *testing.T) {
-	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeCodex, "/v1/responses", "custom-codex-client/9.9", "custom-codex-client/9.9")
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeCodex, domain.ClientTypeCodex, "/v1/responses", "custom-codex-client/9.9", "custom-codex-client/9.9")
 }
 
-func TestCustomAdapterExecuteFallsBackCodexUserAgentWhenMissing(t *testing.T) {
-	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeCodex, "/v1/responses", "", codexUserAgent)
+func TestCustomAdapterExecutePreservesMissingCodexUserAgent(t *testing.T) {
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeCodex, domain.ClientTypeCodex, "/v1/responses", "", "")
 }
 
-func assertCustomAdapterExecuteUserAgent(t *testing.T, clientType domain.ClientType, requestURI string, clientUA string, expectedUA string) {
+func TestCustomAdapterExecutePreservesProvidedGeminiUserAgent(t *testing.T) {
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeGemini, domain.ClientTypeGemini, "/v1beta/models/gemini-2.5-pro:generateContent", "gemini-cli/custom", "gemini-cli/custom")
+}
+
+func TestCustomAdapterExecutePreservesMissingGeminiUserAgent(t *testing.T) {
+	assertCustomAdapterExecuteUserAgent(t, domain.ClientTypeGemini, domain.ClientTypeGemini, "/v1beta/models/gemini-2.5-pro:generateContent", "", "")
+}
+
+func TestCustomAdapterExecuteUsesTargetUserAgentAfterConversion(t *testing.T) {
+	tests := []struct {
+		name               string
+		originalClientType domain.ClientType
+		targetClientType   domain.ClientType
+		requestURI         string
+		expectedUA         string
+	}{
+		{"Codex to Claude", domain.ClientTypeCodex, domain.ClientTypeClaude, "/v1/messages", defaultClaudeUserAgent},
+		{"Claude to Codex", domain.ClientTypeClaude, domain.ClientTypeCodex, "/v1/responses", codexUserAgent},
+		{"Claude to Gemini", domain.ClientTypeClaude, domain.ClientTypeGemini, "/v1beta/models/gemini-2.5-pro:generateContent", geminiUserAgent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertCustomAdapterExecuteUserAgent(t, tt.originalClientType, tt.targetClientType, tt.requestURI, "source-client/1.0", tt.expectedUA)
+		})
+	}
+}
+
+func TestApplyCustomProtocolIdentityDropsSourceVersionForCodexConversion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	req.Header.Set("User-Agent", "source-client/1.0")
+	ctx := flow.NewCtx(httptest.NewRecorder(), req)
+	ctx.Set(flow.KeyOriginalClientType, domain.ClientTypeClaude)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeCodex)
+
+	headers := make(http.Header)
+	headers.Set("Version", "source-version")
+	applyCustomProtocolIdentity(ctx, domain.ClientTypeCodex, codexUserAgent, headers)
+
+	if got := headers.Get("User-Agent"); got != codexUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", got, codexUserAgent)
+	}
+	if got := headers.Get("Version"); got != "" {
+		t.Fatalf("Version = %q, want empty after conversion", got)
+	}
+}
+
+func assertCustomAdapterExecuteUserAgent(t *testing.T, originalClientType, targetClientType domain.ClientType, requestURI string, clientUA string, expectedUA string) {
 	t.Helper()
 
 	var capturedUA string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedUA = r.Header.Get("User-Agent")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, mockUpstreamResponseForClientType(clientType))
+		_, _ = io.WriteString(w, mockUpstreamResponseForClientType(targetClientType))
 	}))
 	defer server.Close()
 
 	adapter, err := NewAdapter(&domain.Provider{
 		Name:                 "test-custom",
 		Type:                 "custom",
-		SupportedClientTypes: []domain.ClientType{clientType},
+		SupportedClientTypes: []domain.ClientType{targetClientType},
 		Config: &domain.ProviderConfig{
 			Custom: &domain.ProviderConfigCustom{
 				BaseURL: server.URL,
@@ -59,9 +106,11 @@ func assertCustomAdapterExecuteUserAgent(t *testing.T, clientType domain.ClientT
 
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
-	ctx.Set(flow.KeyClientType, clientType)
+	ctx.Set(flow.KeyClientType, targetClientType)
+	ctx.Set(flow.KeyOriginalClientType, originalClientType)
+	ctx.Set(flow.KeyRequestHeaders, req.Header.Clone())
 	ctx.Set(flow.KeyRequestURI, requestURI)
-	ctx.Set(flow.KeyRequestBody, mockRequestBodyForClientType(clientType))
+	ctx.Set(flow.KeyRequestBody, mockRequestBodyForClientType(targetClientType))
 
 	if err := adapter.Execute(ctx, &domain.Provider{}); err != nil {
 		t.Fatalf("Execute error: %v", err)
@@ -80,6 +129,8 @@ func mockRequestBodyForClientType(clientType domain.ClientType) []byte {
 		return []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello"}],"stream":false}`)
 	case domain.ClientTypeCodex:
 		return []byte(`{"model":"gpt-5","input":"hello","stream":false}`)
+	case domain.ClientTypeGemini:
+		return []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
 	default:
 		return []byte(`{}`)
 	}
@@ -91,6 +142,8 @@ func mockUpstreamResponseForClientType(clientType domain.ClientType) string {
 		return `{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[{"type":"text","text":"ok"}]}`
 	case domain.ClientTypeCodex:
 		return `{"id":"resp_123","model":"gpt-5","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`
+	case domain.ClientTypeGemini:
+		return `{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}]}`
 	default:
 		return `{}`
 	}

--- a/internal/adapter/provider/custom/claude_headers.go
+++ b/internal/adapter/provider/custom/claude_headers.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	defaultAnthropicVersion = "2023-06-01"
-	defaultClaudeUserAgent  = "claude-cli/2.1.17 (external, cli)"
+	defaultClaudeUserAgent  = "claude-cli/2.1.63 (external, cli)"
 
 	// defaultBedrockCompatUserAgent mimics the User-Agent string emitted by a real
 	// AWS SDK for Go v2 Bedrock Runtime client. Used by the "bedrock" disguise mode
@@ -131,11 +131,7 @@ func applyClaudeHeaders(req *http.Request, clientReq *http.Request, apiKey strin
 	if clientHeaders != nil {
 		clientUA = clientHeaders.Get("User-Agent")
 	}
-	if strings.TrimSpace(clientUA) != "" {
-		req.Header.Set("User-Agent", clientUA)
-	} else {
-		req.Header.Set("User-Agent", defaultClaudeUserAgent)
-	}
+	req.Header["User-Agent"] = []string{clientUA}
 
 	// 6. Set connection and encoding headers (always override)
 	req.Header.Set("Connection", "keep-alive")

--- a/internal/adapter/provider/custom/claude_headers_test.go
+++ b/internal/adapter/provider/custom/claude_headers_test.go
@@ -91,8 +91,8 @@ func TestApplyClaudeHeadersDefaults(t *testing.T) {
 	if req.Header.Get("Anthropic-Version") == "" {
 		t.Error("Anthropic-Version should be set")
 	}
-	if req.Header.Get("User-Agent") == "" {
-		t.Error("User-Agent should be set")
+	if values, ok := req.Header["User-Agent"]; !ok || len(values) != 1 || values[0] != "" {
+		t.Fatalf("missing client User-Agent should be preserved as an empty header, got %#v", values)
 	}
 	if req.Header.Get("X-Stainless-Runtime") == "" {
 		t.Error("X-Stainless-Runtime should be set")
@@ -128,20 +128,20 @@ func TestApplyClaudeHeadersUserAgentPassthroughWhenProvided(t *testing.T) {
 	}
 }
 
-func TestApplyClaudeHeadersUserAgentFallsBackWhenMissing(t *testing.T) {
+func TestApplyClaudeHeadersUserAgentPreservesBlankOrMissing(t *testing.T) {
 	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
 	clientReq, _ := http.NewRequest("POST", "https://example.com", nil)
 	clientReq.Header.Set("User-Agent", "   ")
 
 	applyClaudeHeaders(req, clientReq, "sk-test", true, nil, true)
-	if got := req.Header.Get("User-Agent"); got != defaultClaudeUserAgent {
-		t.Fatalf("expected default User-Agent when client UA is blank, got %q", got)
+	if got := req.Header.Get("User-Agent"); got != "   " {
+		t.Fatalf("expected blank client User-Agent passthrough, got %q", got)
 	}
 
 	req2, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", nil)
 	applyClaudeHeaders(req2, nil, "sk-test", true, nil, true)
-	if got := req2.Header.Get("User-Agent"); got != defaultClaudeUserAgent {
-		t.Fatalf("expected default User-Agent when client request is nil, got %q", got)
+	if got := req2.Header.Get("User-Agent"); got != "" {
+		t.Fatalf("expected missing client User-Agent to remain empty, got %q", got)
 	}
 }
 

--- a/internal/adapter/provider/custom/codex_headers.go
+++ b/internal/adapter/provider/custom/codex_headers.go
@@ -6,11 +6,8 @@ import (
 )
 
 const (
-	// Codex API version
-	codexVersion = "0.21.0"
-
 	// User-Agent mimics Codex CLI
-	codexUserAgent = "codex_cli_rs/0.50.0 (Mac OS 26.0.1; arm64)"
+	codexUserAgent = "codex_cli_rs/0.144.1 (Mac OS 26.0.1; arm64) Apple_Terminal/464"
 
 	// Originator header
 	codexOriginator = "codex_cli_rs"
@@ -38,24 +35,13 @@ func applyCodexHeaders(upstreamReq, clientReq *http.Request, apiKey string) {
 	}
 
 	// 4. Set Codex-specific headers only if client didn't provide them
-	ensureCodexHeader(upstreamReq.Header, clientReq, "Version", codexVersion)
 	ensureCodexHeader(upstreamReq.Header, clientReq, "Openai-Beta", openAIBetaHeader)
-	upstreamReq.Header.Set("User-Agent", resolveCodexUserAgent(clientReq))
-	ensureCodexHeader(upstreamReq.Header, clientReq, "Originator", codexOriginator)
-}
-
-func resolveCodexUserAgent(clientReq *http.Request) string {
+	clientUserAgent := ""
 	if clientReq != nil {
-		if ua := clientReq.Header.Get("User-Agent"); strings.TrimSpace(ua) != "" {
-			return ua
-		}
+		clientUserAgent = clientReq.Header.Get("User-Agent")
 	}
-	return codexUserAgent
-}
-
-func isCodexCLIUserAgent(userAgent string) bool {
-	ua := strings.ToLower(strings.TrimSpace(userAgent))
-	return strings.HasPrefix(ua, "codex_cli_rs/") || strings.HasPrefix(ua, "codex-cli/")
+	upstreamReq.Header["User-Agent"] = []string{clientUserAgent}
+	ensureCodexHeader(upstreamReq.Header, clientReq, "Originator", codexOriginator)
 }
 
 // copyCodexPassthroughHeaders copies headers from client request, excluding hop-by-hop, auth, and proxy headers

--- a/internal/adapter/provider/custom/codex_headers_test.go
+++ b/internal/adapter/provider/custom/codex_headers_test.go
@@ -25,19 +25,36 @@ func TestApplyCodexHeadersUserAgentPassthroughWhenProvided(t *testing.T) {
 	}
 }
 
-func TestApplyCodexHeadersUserAgentFallsBackWhenMissing(t *testing.T) {
+func TestApplyCodexHeadersUserAgentPreservesBlankOrMissing(t *testing.T) {
 	upstreamReq, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
 	clientReq, _ := http.NewRequest("POST", "http://localhost/responses", nil)
 	clientReq.Header.Set("User-Agent", "   ")
 
 	applyCodexHeaders(upstreamReq, clientReq, "token-1")
-	if got := upstreamReq.Header.Get("User-Agent"); got != codexUserAgent {
-		t.Fatalf("expected default User-Agent when client UA is blank, got %q", got)
+	if got := upstreamReq.Header.Get("User-Agent"); got != "   " {
+		t.Fatalf("expected blank client User-Agent passthrough, got %q", got)
 	}
 
 	upstreamReq2, _ := http.NewRequest("POST", "https://chatgpt.com/backend-api/codex/responses", nil)
 	applyCodexHeaders(upstreamReq2, nil, "token-1")
-	if got := upstreamReq2.Header.Get("User-Agent"); got != codexUserAgent {
-		t.Fatalf("expected default User-Agent when client request is nil, got %q", got)
+	if got := upstreamReq2.Header.Get("User-Agent"); got != "" {
+		t.Fatalf("expected missing client User-Agent to remain empty, got %q", got)
+	}
+}
+
+func TestApplyCodexHeadersPreservesVersionOnlyWhenProvided(t *testing.T) {
+	clientReq, _ := http.NewRequest("POST", "http://localhost/responses", nil)
+	clientReq.Header.Set("Version", "0.144.1")
+	upstreamReq, _ := http.NewRequest("POST", "https://example.com/responses", nil)
+
+	applyCodexHeaders(upstreamReq, clientReq, "token-1")
+	if got := upstreamReq.Header.Get("Version"); got != "0.144.1" {
+		t.Fatalf("expected client Version passthrough, got %q", got)
+	}
+
+	upstreamReq2, _ := http.NewRequest("POST", "https://example.com/responses", nil)
+	applyCodexHeaders(upstreamReq2, nil, "token-1")
+	if _, ok := upstreamReq2.Header["Version"]; ok {
+		t.Fatalf("expected missing client Version to remain absent, got %q", upstreamReq2.Header.Get("Version"))
 	}
 }

--- a/internal/adapter/provider/custom/gemini_headers.go
+++ b/internal/adapter/provider/custom/gemini_headers.go
@@ -30,10 +30,12 @@ func applyGeminiHeaders(upstreamReq, clientReq *http.Request, apiKey string) {
 		upstreamReq.Header.Del("Authorization")
 	}
 
-	// 4. Set User-Agent if client didn't provide one
-	if clientReq == nil || clientReq.Header.Get("User-Agent") == "" {
-		upstreamReq.Header.Set("User-Agent", geminiUserAgent)
+	// 4. Preserve the client User-Agent; Execute replaces it after conversion.
+	clientUserAgent := ""
+	if clientReq != nil {
+		clientUserAgent = clientReq.Header.Get("User-Agent")
 	}
+	upstreamReq.Header["User-Agent"] = []string{clientUserAgent}
 
 	// 5. Set Accept header based on URL (streaming or not)
 	if strings.Contains(upstreamReq.URL.String(), "streamGenerateContent") {

--- a/internal/flow/helpers.go
+++ b/internal/flow/helpers.go
@@ -25,6 +25,30 @@ func GetOriginalClientType(c *Ctx) domain.ClientType {
 	return ""
 }
 
+func IsProtocolConversion(c *Ctx) bool {
+	if c == nil {
+		return false
+	}
+	originalClientType := GetOriginalClientType(c)
+	targetClientType := GetClientType(c)
+	return originalClientType != "" && targetClientType != "" && originalClientType != targetClientType
+}
+
+// ResolveUpstreamUserAgent preserves the inbound User-Agent for protocol-native
+// requests and uses the target protocol default only after format conversion.
+func ResolveUpstreamUserAgent(c *Ctx, targetDefault string) string {
+	if c == nil {
+		return ""
+	}
+	if IsProtocolConversion(c) {
+		return targetDefault
+	}
+	if c.Request == nil {
+		return ""
+	}
+	return c.Request.Header.Get("User-Agent")
+}
+
 func GetSessionID(c *Ctx) string {
 	if v, ok := c.Get(KeySessionID); ok {
 		if s, ok := v.(string); ok {

--- a/internal/flow/helpers_test.go
+++ b/internal/flow/helpers_test.go
@@ -1,0 +1,53 @@
+package flow
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestResolveUpstreamUserAgent(t *testing.T) {
+	tests := []struct {
+		name         string
+		originalType domain.ClientType
+		targetType   domain.ClientType
+		clientUA     string
+		targetUA     string
+		want         string
+	}{
+		{"same protocol preserves arbitrary UA", domain.ClientTypeCodex, domain.ClientTypeCodex, "custom-client/1.0", "codex/default", "custom-client/1.0"},
+		{"same protocol preserves missing UA", domain.ClientTypeClaude, domain.ClientTypeClaude, "", "claude/default", ""},
+		{"conversion uses target UA", domain.ClientTypeClaude, domain.ClientTypeGemini, "claude-cli/source", "gemini/default", "gemini/default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodPost, "http://localhost", nil)
+			if tt.clientUA != "" {
+				req.Header.Set("User-Agent", tt.clientUA)
+			}
+			ctx := NewCtx(nil, req)
+			ctx.Set(KeyOriginalClientType, tt.originalType)
+			ctx.Set(KeyClientType, tt.targetType)
+
+			if got := ResolveUpstreamUserAgent(ctx, tt.targetUA); got != tt.want {
+				t.Fatalf("ResolveUpstreamUserAgent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsProtocolConversion(t *testing.T) {
+	ctx := NewCtx(nil, nil)
+	ctx.Set(KeyOriginalClientType, domain.ClientTypeClaude)
+	ctx.Set(KeyClientType, domain.ClientTypeCodex)
+	if !IsProtocolConversion(ctx) {
+		t.Fatal("expected different source and target protocols to be a conversion")
+	}
+
+	ctx.Set(KeyOriginalClientType, domain.ClientTypeCodex)
+	if IsProtocolConversion(ctx) {
+		t.Fatal("expected matching source and target protocols not to be a conversion")
+	}
+}


### PR DESCRIPTION
## Summary

- preserve the inbound `User-Agent` exactly for protocol-native Codex, Claude, and Gemini requests
- replace the source identity with the target protocol's standard `User-Agent` only after protocol conversion
- stop injecting stale hard-coded Codex `Version` values; preserve an explicit native Codex version and discard source-protocol versions during conversion
- pass only `User-Agent` and `Version` into the embedded CLIProxyAPI Codex executor context

## Root cause

The adapters selected headers from the target provider without considering whether the request protocol had changed. Missing or unrecognized user agents fell back to hard-coded identities, and Codex paths injected fixed `Version` values (`0.21.0` or `0.98.0`). Current Codex clients could therefore be rejected as outdated even when the installed CLI was current.

The embedded CLIProxyAPI adapter also did not expose the inbound Codex identity headers through the Gin request context consumed by its executor.

## Behavior after this change

- native request: retain the client's `User-Agent`, including a deliberately blank value
- converted request: discard the source identity and use the target protocol default
- native Codex request: retain an explicit client `Version`; do not invent one when absent
- converted-to-Codex request: remove any source-protocol `Version`
- embedded CPA request: expose only `User-Agent` and `Version`, avoiding credentials and unrelated header-driven behavior

## Relationship to #669

This PR is stacked on #669 while the CLIProxyAPI dependency update is under review. It does not add or change dependency metadata. After #669 merges, the base will be changed to `main`.

## Validation

- `go test -count=1 ./internal/flow ./internal/adapter/provider/custom ./internal/adapter/provider/codex ./internal/adapter/provider/claude ./internal/adapter/provider/cliproxyapi_codex ./internal/adapter/provider/cliproxyapi_antigravity`
- `go vet ./cmd/... ./internal/...`
- `go build -o .codex-maxx-ci-build.exe ./cmd/maxx`
- `pnpm run lint`, `pnpm run typecheck`, and `pnpm run build` in `web/`
- `git diff --check`

If this behavior regresses, inspect `original_client_type`, `client_type`, and the final upstream `User-Agent` and `Version` values to identify whether the fault is in dispatch, protocol conversion, adapter header selection, or the embedded CPA executor boundary.
