### PR TITLE
feat(providers): add Grok CPA flow and cooldown fallback setting

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"     // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"     // Register custom adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/grok"       // Register grok adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"       // Register kiro adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/openrouter" // Register openrouter adapter
 	"github.com/awsl-project/maxx/internal/converter"

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/getlantern/hidden v0.0.0-20190325191715-f02dbb02be55 // indirect
 	github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/gin-gonic/gin v1.10.1 // indirect
+	github.com/gin-gonic/gin v1.10.1
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -123,4 +123,4 @@ require (
 	modernc.org/sqlite v1.23.1 // indirect
 )
 
-replace github.com/router-for-me/CLIProxyAPI/v7 => github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714064441-ef2c05d9c99e
+replace github.com/router-for-me/CLIProxyAPI/v7 => github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714135607-27dae34e5688

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714064441-ef2c05d9c99e h1:LyDkJFzvsSNO7i8zfbh82cgKREfzRcSttK+BPcay7A8=
-github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714064441-ef2c05d9c99e/go.mod h1:f4pcyAej8RoeRhIxJfm+OUMkCKaApiA8WzxR2XVlBh8=
+github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714135607-27dae34e5688 h1:oP5YNId1rpevqh29X9uHMwgtd3dic2pXANgaLnJiLv4=
+github.com/awsl-project/CLIProxyAPI/v7 v7.0.0-20260714135607-27dae34e5688/go.mod h1:f4pcyAej8RoeRhIxJfm+OUMkCKaApiA8WzxR2XVlBh8=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/internal/adapter/provider/antigravity/adapter.go
+++ b/internal/adapter/provider/antigravity/adapter.go
@@ -1187,6 +1187,15 @@ func (a *AntigravityAdapter) parseRateLimitInfo(ctx context.Context, body []byte
 		return "", "", nil, nil
 	}
 
+	// Request-rate throttles are short-lived. They may still use the Google
+	// RESOURCE_EXHAUSTED status, but their body/retry info describes a rate limit
+	// rather than exhausted account quota. Do not route those through the 1-minute
+	// quota fallback; Executor will use Retry-After/RetryInfo when present, or the
+	// rate-limit policy fallback (5s) otherwise.
+	if parseRateLimitReason(string(body)) == RateLimitReasonRateLimitExceeded {
+		return domain.ScopeKey, domain.CooldownReasonRateLimitExceeded, nil, nil
+	}
+
 	// Look for QUOTA_EXHAUSTED with quotaResetTimeStamp in details
 	var resetTime time.Time
 	for _, detail := range errResp.Error.Details {
@@ -1224,8 +1233,7 @@ func (a *AntigravityAdapter) parseRateLimitInfo(ctx context.Context, body []byte
 
 		quota, err := FetchQuotaForProvider(quotaCtx, config.RefreshToken, config.ProjectID)
 		if err != nil {
-			// Failed to fetch quota, send 1-minute cooldown
-			updateChan <- time.Now().Add(time.Minute)
+			// Failed to fetch quota; keep the initial 1-minute quota fallback cooldown.
 			return
 		}
 
@@ -1250,8 +1258,7 @@ func (a *AntigravityAdapter) parseRateLimitInfo(ctx context.Context, body []byte
 			// Quota is 0, send cooldown until reset time
 			updateChan <- earliestReset
 		} else {
-			// Quota is not 0, send 1-minute cooldown
-			updateChan <- time.Now().Add(time.Minute)
+			// Quota is not 0; keep the initial 1-minute quota fallback cooldown.
 		}
 	}()
 

--- a/internal/adapter/provider/antigravity/rate_limit_info_test.go
+++ b/internal/adapter/provider/antigravity/rate_limit_info_test.go
@@ -1,0 +1,151 @@
+package antigravity
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+func TestParseRateLimitInfoRateLimitDoesNotUseQuotaDefault(t *testing.T) {
+	adapter := &AntigravityAdapter{}
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "Resource has been exhausted. Requests per minute exceeded.",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED"},
+				{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"3s"}
+			]
+		}
+	}`)
+
+	scope, reason, until, updateChan := adapter.parseRateLimitInfo(context.Background(), body, nil)
+	if scope != domain.ScopeKey {
+		t.Fatalf("scope = %q, want %q", scope, domain.ScopeKey)
+	}
+	if reason != domain.CooldownReasonRateLimitExceeded {
+		t.Fatalf("reason = %q, want %q", reason, domain.CooldownReasonRateLimitExceeded)
+	}
+	if until != nil {
+		t.Fatalf("rate limit should not force quota cooldown until, got %v", until)
+	}
+	if updateChan != nil {
+		t.Fatal("rate limit should not start quota async update")
+	}
+}
+
+func TestParseRateLimitInfoQuotaWithoutResetUsesDefault(t *testing.T) {
+	adapter := &AntigravityAdapter{}
+	provider := &domain.Provider{Config: &domain.ProviderConfig{}}
+	body := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "Quota exhausted for quota metric",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED"}]
+		}
+	}`)
+
+	scope, reason, until, updateChan := adapter.parseRateLimitInfo(context.Background(), body, provider)
+	if scope != domain.ScopeKey {
+		t.Fatalf("scope = %q, want %q", scope, domain.ScopeKey)
+	}
+	if reason != domain.CooldownReasonQuotaExhausted {
+		t.Fatalf("reason = %q, want %q", reason, domain.CooldownReasonQuotaExhausted)
+	}
+	if until == nil || time.Until(*until) < 55*time.Second || time.Until(*until) > 65*time.Second {
+		t.Fatalf("quota fallback until = %v, want about 60s", until)
+	}
+	if updateChan != nil {
+		t.Fatal("nil antigravity config should not start quota async update")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestExecuteRateLimitResponsePreservesShortRetryInfo(t *testing.T) {
+	var sawUpstreamRequest bool
+
+	provider := &domain.Provider{
+		ID:   9001,
+		Name: "mock-antigravity-rate-limit",
+		Type: "antigravity",
+		Config: &domain.ProviderConfig{Antigravity: &domain.ProviderConfigAntigravity{
+			Email:        "mock@example.com",
+			RefreshToken: "unused-in-test",
+			ProjectID:    "mock-project",
+			Endpoint:     "https://cloudcode-pa.googleapis.com",
+		}},
+	}
+	adapter := &AntigravityAdapter{
+		provider: provider,
+		tokenCache: &TokenCache{
+			AccessToken: "test-access-token",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		},
+		httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			sawUpstreamRequest = true
+			if got := r.Header.Get("Authorization"); got != "Bearer test-access-token" {
+				t.Fatalf("Authorization = %q, want bearer token", got)
+			}
+			if !strings.Contains(r.URL.String(), "cloudcode-pa.googleapis.com") {
+				t.Fatalf("upstream URL = %q, want Antigravity endpoint", r.URL.String())
+			}
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(`{
+					"error": {
+						"code": 429,
+						"message": "Resource exhausted. Requests per minute exceeded.",
+						"status": "RESOURCE_EXHAUSTED",
+						"details": [
+							{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED"},
+							{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"3s"}
+						]
+					}
+				}`)),
+			}, nil
+		})},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", strings.NewReader(`{}`))
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+	c.Set(flow.KeyClientType, domain.ClientTypeGemini)
+	c.Set(flow.KeyRequestModel, "gemini-2.5-pro")
+	c.Set(flow.KeyMappedModel, "gemini-2.5-pro")
+	c.Set(flow.KeyRequestBody, []byte(`{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`))
+
+	err := adapter.Execute(c, provider)
+	if !sawUpstreamRequest {
+		t.Fatalf("expected adapter to call mock Antigravity upstream, got err=%T %v", err, err)
+	}
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("error type = %T, want *domain.ProxyError: %v", err, err)
+	}
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("Scope = %q, want %q", proxyErr.Scope, domain.ScopeKey)
+	}
+	if proxyErr.Reason != domain.CooldownReasonRateLimitExceeded {
+		t.Fatalf("Reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonRateLimitExceeded)
+	}
+	if proxyErr.CooldownUntil != nil {
+		t.Fatalf("CooldownUntil = %v, want nil for request-rate throttle", proxyErr.CooldownUntil)
+	}
+	if proxyErr.RetryAfter < 3*time.Second || proxyErr.RetryAfter > 4*time.Second {
+		t.Fatalf("RetryAfter = %v, want RetryInfo-derived short delay around 3s", proxyErr.RetryAfter)
+	}
+}

--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -1,0 +1,277 @@
+package cliproxyapi_grok
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/usage"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/exec"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+type CLIProxyAPIGrokAdapter struct {
+	provider *domain.Provider
+	authObj  *auth.Auth
+	executor *exec.XAIExecutor
+}
+
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	if p == nil || p.Config == nil || p.Config.Grok == nil {
+		return nil, fmt.Errorf("provider missing grok config")
+	}
+	cfg := p.Config.Grok
+	if strings.TrimSpace(cfg.Type) == "" {
+		cfg.Type = "xai"
+	}
+	if strings.TrimSpace(cfg.AuthKind) == "" {
+		cfg.AuthKind = "oauth"
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.Type), "xai") {
+		return nil, fmt.Errorf("grok provider only accepts CPA xai credentials, got type %q", cfg.Type)
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.AuthKind), "oauth") {
+		return nil, fmt.Errorf("grok provider only accepts oauth credentials, got auth_kind %q", cfg.AuthKind)
+	}
+	if strings.TrimSpace(cfg.AccessToken) == "" && strings.TrimSpace(cfg.RefreshToken) == "" {
+		return nil, fmt.Errorf("grok provider requires access_token or refresh_token")
+	}
+
+	metadata := map[string]any{
+		"type":      "xai",
+		"auth_kind": "oauth",
+	}
+	put := func(key, value string) {
+		if strings.TrimSpace(value) != "" {
+			metadata[key] = value
+		}
+	}
+	put("email", cfg.Email)
+	put("sub", cfg.Sub)
+	put("access_token", cfg.AccessToken)
+	put("refresh_token", cfg.RefreshToken)
+	put("id_token", cfg.IDToken)
+	put("token_type", cfg.TokenType)
+	put("expired", cfg.Expired)
+	put("last_refresh", cfg.LastRefresh)
+	put("redirect_uri", cfg.RedirectURI)
+	put("token_endpoint", cfg.TokenEndpoint)
+	put("base_url", cfg.BaseURL)
+	if cfg.ExpiresIn > 0 {
+		metadata["expires_in"] = cfg.ExpiresIn
+	}
+	if len(cfg.Headers) > 0 {
+		headers := make(map[string]string, len(cfg.Headers))
+		for k, v := range cfg.Headers {
+			if strings.TrimSpace(k) != "" && strings.TrimSpace(v) != "" {
+				headers[k] = v
+			}
+		}
+		metadata["headers"] = headers
+	}
+
+	attributes := map[string]string{
+		"auth_kind": "oauth",
+	}
+	if baseURL := strings.TrimSpace(cfg.BaseURL); baseURL != "" {
+		attributes["base_url"] = baseURL
+	}
+	if cfg.Email != "" {
+		attributes["email"] = cfg.Email
+	}
+
+	authObj := &auth.Auth{
+		ID:         fmt.Sprintf("maxx-grok-%d", p.ID),
+		Provider:   "xai",
+		Attributes: attributes,
+		Metadata:   metadata,
+		Disabled:   cfg.Disabled,
+	}
+
+	return &CLIProxyAPIGrokAdapter{
+		provider: p,
+		authObj:  authObj,
+		executor: exec.NewXAIExecutor(),
+	}, nil
+}
+
+func (a *CLIProxyAPIGrokAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *CLIProxyAPIGrokAdapter) Execute(c *flow.Ctx, p *domain.Provider) error {
+	w := c.Writer
+	clientType := flow.GetClientType(c)
+	if clientType != domain.ClientTypeOpenAI {
+		proxyErr := domain.NewProxyErrorWithMessage(nil, false, fmt.Sprintf("grok provider only supports openai client type, got %s", clientType))
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+
+	requestBody := flow.GetRequestBody(c)
+	stream := flow.GetIsStream(c)
+	requestModel := flow.GetRequestModel(c)
+	model := flow.GetMappedModel(c)
+	if strings.TrimSpace(model) == "" {
+		model = requestModel
+	}
+
+	log.Printf("[CLIProxyAPI-Grok] requestModel=%s, mappedModel=%s, clientType=%s", requestModel, model, clientType)
+
+	var err error
+	requestBody, err = updateModelInBody(requestBody, model)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, fmt.Sprintf("failed to update model in body: %v", err))
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+
+	if eventChan := flow.GetEventChan(c); eventChan != nil {
+		eventChan.SendRequestInfo(&domain.RequestInfo{
+			Method: "POST",
+			URL:    fmt.Sprintf("cliproxyapi://xai/%s", model),
+			Body:   string(requestBody),
+		})
+	}
+
+	sourceFormat := translator.FormatOpenAI
+	execReq := executor.Request{Model: model, Payload: requestBody, Format: sourceFormat}
+	execOpts := executor.Options{Stream: stream, OriginalRequest: requestBody, SourceFormat: sourceFormat}
+	if stream {
+		return a.executeStream(c, w, execReq, execOpts)
+	}
+	return a.executeNonStream(c, w, execReq, execOpts)
+}
+
+func updateModelInBody(body []byte, model string) ([]byte, error) {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	req["model"] = model
+	return json.Marshal(req)
+}
+
+func (a *CLIProxyAPIGrokAdapter) executeNonStream(c *flow.Ctx, w http.ResponseWriter, execReq executor.Request, execOpts executor.Options) error {
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	resp, err := a.executor.Execute(ctx, a.authObj, execReq, execOpts)
+	if err != nil {
+		log.Printf("[CLIProxyAPI-Grok] executeNonStream error: model=%s, err=%v", execReq.Model, err)
+		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor request failed: %v", err))
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return proxyErr
+	}
+	if eventChan := flow.GetEventChan(c); eventChan != nil {
+		eventChan.SendResponseInfo(&domain.ResponseInfo{Status: http.StatusOK, Body: string(resp.Payload)})
+		if metrics := usage.ExtractFromResponse(string(resp.Payload)); metrics != nil {
+			eventChan.SendMetrics(&domain.AdapterMetrics{InputTokens: metrics.InputTokens, OutputTokens: metrics.OutputTokens, CacheReadCount: metrics.CacheReadCount, CacheCreationCount: metrics.CacheCreationCount, Cache5mCreationCount: metrics.Cache5mCreationCount, Cache1hCreationCount: metrics.Cache1hCreationCount})
+		}
+		if model := extractModelFromResponse(resp.Payload); model != "" {
+			eventChan.SendResponseModel(model)
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(resp.Payload)
+	return nil
+}
+
+func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWriter, execReq executor.Request, execOpts executor.Options) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return a.executeNonStream(c, w, execReq, execOpts)
+	}
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
+	stream, err := a.executor.ExecuteStream(ctx, a.authObj, execReq, execOpts)
+	if err != nil {
+		log.Printf("[CLIProxyAPI-Grok] executeStream error: model=%s, err=%v", execReq.Model, err)
+		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor stream request failed: %v", err))
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return proxyErr
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	eventChan := flow.GetEventChan(c)
+	var sseBuffer bytes.Buffer
+	firstChunkSent := false
+	var streamErr error
+	for chunk := range stream.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+			break
+		}
+		if len(chunk.Payload) > 0 {
+			sseBuffer.Write(chunk.Payload)
+			_, _ = w.Write(chunk.Payload)
+			flusher.Flush()
+			if !firstChunkSent && eventChan != nil {
+				eventChan.SendFirstToken(time.Now().UnixMilli())
+				firstChunkSent = true
+			}
+		}
+	}
+	if eventChan != nil && sseBuffer.Len() > 0 {
+		eventChan.SendResponseInfo(&domain.ResponseInfo{Status: http.StatusOK, Body: sseBuffer.String()})
+		if metrics := usage.ExtractFromStreamContent(sseBuffer.String()); metrics != nil {
+			eventChan.SendMetrics(&domain.AdapterMetrics{InputTokens: metrics.InputTokens, OutputTokens: metrics.OutputTokens, CacheReadCount: metrics.CacheReadCount, CacheCreationCount: metrics.CacheCreationCount, Cache5mCreationCount: metrics.Cache5mCreationCount, Cache1hCreationCount: metrics.Cache1hCreationCount})
+		}
+		if model := extractModelFromStream(sseBuffer.String()); model != "" {
+			eventChan.SendResponseModel(model)
+		}
+	}
+	if streamErr != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(streamErr, true, fmt.Sprintf("stream error: %v", streamErr))
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return proxyErr
+	}
+	return nil
+}
+
+func extractModelFromResponse(payload []byte) string {
+	var resp map[string]any
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return ""
+	}
+	if model, ok := resp["model"].(string); ok {
+		return model
+	}
+	return ""
+}
+
+func extractModelFromStream(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		if model := extractModelFromResponse([]byte(data)); model != "" {
+			return model
+		}
+	}
+	return ""
+}

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -1,0 +1,56 @@
+package cliproxyapi_grok
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestNewAdapterAcceptsCPAExportedXAIOAuthJSONShape(t *testing.T) {
+	provider := &domain.Provider{
+		ID:   42,
+		Type: "grok",
+		Name: "Grok Test",
+		Config: &domain.ProviderConfig{Grok: &domain.ProviderConfigGrok{
+			Type:          "xai",
+			AuthKind:      "oauth",
+			Email:         "xai39b5bb@jh.actionvspot.com",
+			Sub:           "88ca5464-ae36-48c5-a7b8-de306101d07f",
+			AccessToken:   "access-token",
+			RefreshToken:  "refresh-token",
+			IDToken:       "id-token",
+			TokenType:     "Bearer",
+			ExpiresIn:     21600,
+			Expired:       "2026-07-11T21:01:55Z",
+			LastRefresh:   "2026-07-11T15:01:56Z",
+			RedirectURI:   "http://127.0.0.1:56121/callback",
+			TokenEndpoint: "https://auth.x.ai/oauth2/token",
+			BaseURL:       "https://cli-chat-proxy.grok.com/v1",
+			Headers: map[string]string{
+				"X-XAI-Token-Auth":      "xai-grok-cli",
+				"x-grok-client-version": "0.2.93",
+			},
+		}},
+	}
+
+	adapter, err := NewAdapter(provider)
+	if err != nil {
+		t.Fatalf("NewAdapter() error = %v", err)
+	}
+	grok, ok := adapter.(*CLIProxyAPIGrokAdapter)
+	if !ok {
+		t.Fatalf("adapter type = %T, want *CLIProxyAPIGrokAdapter", adapter)
+	}
+	if got := grok.authObj.Provider; got != "xai" {
+		t.Fatalf("auth provider = %q, want xai", got)
+	}
+	if got := grok.authObj.Metadata["access_token"]; got != "access-token" {
+		t.Fatalf("access_token metadata = %v", got)
+	}
+	if got := grok.authObj.Metadata["refresh_token"]; got != "refresh-token" {
+		t.Fatalf("refresh_token metadata = %v", got)
+	}
+	if got := grok.authObj.Metadata["base_url"]; got != "https://cli-chat-proxy.grok.com/v1" {
+		t.Fatalf("base_url metadata = %v", got)
+	}
+}

--- a/internal/adapter/provider/grok/adapter.go
+++ b/internal/adapter/provider/grok/adapter.go
@@ -1,0 +1,15 @@
+package grok
+
+import (
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	cliproxyapi "github.com/awsl-project/maxx/internal/adapter/provider/cliproxyapi_grok"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func init() {
+	provider.RegisterAdapterFactory("grok", NewAdapter)
+}
+
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	return cliproxyapi.NewAdapter(p)
+}

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude" // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/codex"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/grok"
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/coordinator"

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -306,6 +306,28 @@ type ProviderConfigOpenRouter struct {
 	APIKey string `json:"apiKey"`
 }
 
+// ProviderConfigGrok stores xAI/Grok OAuth credentials exported by CLIProxyAPI.
+// Sensitive token fields are stored server-side and must be redacted before any UI display/export.
+type ProviderConfigGrok struct {
+	Type          string            `json:"type,omitempty"`
+	AuthKind      string            `json:"authKind,omitempty"`
+	Email         string            `json:"email,omitempty"`
+	Sub           string            `json:"sub,omitempty"`
+	AccessToken   string            `json:"accessToken,omitempty"`
+	RefreshToken  string            `json:"refreshToken,omitempty"`
+	IDToken       string            `json:"idToken,omitempty"`
+	TokenType     string            `json:"tokenType,omitempty"`
+	ExpiresIn     int               `json:"expiresIn,omitempty"`
+	Expired       string            `json:"expired,omitempty"`
+	LastRefresh   string            `json:"lastRefresh,omitempty"`
+	RedirectURI   string            `json:"redirectURI,omitempty"`
+	TokenEndpoint string            `json:"tokenEndpoint,omitempty"`
+	BaseURL       string            `json:"baseURL,omitempty"`
+	Disabled      bool              `json:"disabled,omitempty"`
+	Headers       map[string]string `json:"headers,omitempty"`
+	ModelMapping  map[string]string `json:"modelMapping,omitempty"`
+}
+
 type ProviderConfig struct {
 	// 禁用错误自动冷冻（只影响错误触发的冷冻）
 	DisableErrorCooldown bool                       `json:"disableErrorCooldown,omitempty"`
@@ -316,6 +338,7 @@ type ProviderConfig struct {
 	Codex                *ProviderConfigCodex       `json:"codex,omitempty"`
 	Claude               *ProviderConfigClaude      `json:"claude,omitempty"`
 	OpenRouter           *ProviderConfigOpenRouter  `json:"openrouter,omitempty"`
+	Grok                 *ProviderConfigGrok        `json:"grok,omitempty"`
 	// 内部运行时字段，仅用于 NewAdapter 委托，不序列化
 	CLIProxyAPIAntigravity *ProviderConfigCLIProxyAPIAntigravity `json:"-"`
 	CLIProxyAPICodex       *ProviderConfigCLIProxyAPICodex       `json:"-"`

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -849,6 +849,7 @@ const (
 	SettingKeyRequestDetailRetentionSecondsFailed  = "request_detail_retention_seconds_failed"  // 失败请求详情保留秒数，仅在 split=true 时生效；语义同上，未设置回退到统一键
 	SettingKeyTimezone                             = "timezone"                                 // 时区设置，默认 Asia/Shanghai
 	SettingKeyQuotaRefreshInterval                 = "quota_refresh_interval"                   // Antigravity 配额刷新间隔（分钟），0 表示禁用
+	SettingKeyRateLimitCooldownDefaultSeconds      = "cooldown_rate_limit_default_seconds"      // 429 rate/concurrent limit 无 Retry-After 时默认冻结秒数，默认 5 秒
 	SettingKeyAutoSortAntigravity                  = "auto_sort_antigravity"                    // 是否自动排序 Antigravity 路由，"true" 或 "false"
 	SettingKeyAutoSortCodex                        = "auto_sort_codex"                          // 是否自动排序 Codex 路由，"true" 或 "false"
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"

--- a/internal/executor/cooldown_default_test.go
+++ b/internal/executor/cooldown_default_test.go
@@ -1,0 +1,109 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type fakeSystemSettingRepo struct{ values map[string]string }
+
+func (r fakeSystemSettingRepo) Get(key string) (string, error) { return r.values[key], nil }
+func (r fakeSystemSettingRepo) Set(key, value string) error    { return nil }
+func (r fakeSystemSettingRepo) GetAll() ([]*domain.SystemSetting, error) {
+	return nil, nil
+}
+func (r fakeSystemSettingRepo) Delete(key string) error { return nil }
+
+func TestHandleCooldownDefaultDoesNotOverrideQuotaFallback(t *testing.T) {
+	provider := &domain.Provider{ID: 99001}
+	cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+	defer cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+
+	e := &Executor{settingsRepo: fakeSystemSettingRepo{values: map[string]string{
+		domain.SettingKeyRateLimitCooldownDefaultSeconds: "15",
+	}}}
+	fallbackUntil := time.Now().Add(time.Minute)
+	proxyErr := &domain.ProxyError{
+		Scope:         domain.ScopeKey,
+		Reason:        domain.CooldownReasonQuotaExhausted,
+		CooldownUntil: &fallbackUntil,
+	}
+
+	e.handleCooldown(proxyErr, provider, domain.ClientTypeGemini, "gemini-2.5-pro")
+
+	until := cooldown.Default().GetCooldownUntil(provider.ID, string(domain.ClientTypeGemini), "gemini-2.5-pro")
+	remaining := time.Until(until)
+	if remaining < 55*time.Second || remaining > 65*time.Second {
+		t.Fatalf("remaining cooldown = %v, want original quota fallback around 60s", remaining)
+	}
+}
+
+func TestHandleCooldownRateLimitFallbackUsesSettingWhenNoRetryAfter(t *testing.T) {
+	provider := &domain.Provider{ID: 99002}
+	cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+	defer cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+
+	e := &Executor{settingsRepo: fakeSystemSettingRepo{values: map[string]string{
+		domain.SettingKeyRateLimitCooldownDefaultSeconds: "15",
+	}}}
+	proxyErr := &domain.ProxyError{
+		Scope:  domain.ScopeKey,
+		Reason: domain.CooldownReasonRateLimitExceeded,
+	}
+
+	e.handleCooldown(proxyErr, provider, domain.ClientTypeGemini, "gemini-2.5-pro")
+
+	until := cooldown.Default().GetCooldownUntil(provider.ID, string(domain.ClientTypeGemini), "gemini-2.5-pro")
+	remaining := time.Until(until)
+	if remaining < 10*time.Second || remaining > 20*time.Second {
+		t.Fatalf("remaining cooldown = %v, want configurable rate-limit fallback around 15s", remaining)
+	}
+}
+
+func TestHandleCooldownConcurrentLimitFallbackUsesSettingWhenNoRetryAfter(t *testing.T) {
+	provider := &domain.Provider{ID: 99003}
+	cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+	defer cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+
+	e := &Executor{settingsRepo: fakeSystemSettingRepo{values: map[string]string{
+		domain.SettingKeyRateLimitCooldownDefaultSeconds: "15",
+	}}}
+	proxyErr := &domain.ProxyError{
+		Scope:  domain.ScopeKey,
+		Reason: domain.CooldownReasonConcurrentLimit,
+	}
+
+	e.handleCooldown(proxyErr, provider, domain.ClientTypeGemini, "gemini-2.5-pro")
+
+	until := cooldown.Default().GetCooldownUntil(provider.ID, string(domain.ClientTypeGemini), "gemini-2.5-pro")
+	remaining := time.Until(until)
+	if remaining < 10*time.Second || remaining > 20*time.Second {
+		t.Fatalf("remaining cooldown = %v, want configurable concurrent-limit fallback around 15s", remaining)
+	}
+}
+
+func TestHandleCooldownRateLimitUsesRetryAfterBeforeSettingsDefault(t *testing.T) {
+	provider := &domain.Provider{ID: 99004}
+	cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+	defer cooldown.Default().ClearCooldown(provider.ID, string(domain.ClientTypeGemini), "")
+
+	e := &Executor{settingsRepo: fakeSystemSettingRepo{values: map[string]string{
+		domain.SettingKeyRateLimitCooldownDefaultSeconds: "15",
+	}}}
+	proxyErr := &domain.ProxyError{
+		Scope:      domain.ScopeKey,
+		Reason:     domain.CooldownReasonRateLimitExceeded,
+		RetryAfter: 3 * time.Second,
+	}
+
+	e.handleCooldown(proxyErr, provider, domain.ClientTypeGemini, "gemini-2.5-pro")
+
+	until := cooldown.Default().GetCooldownUntil(provider.ID, string(domain.ClientTypeGemini), "gemini-2.5-pro")
+	remaining := time.Until(until)
+	if remaining < 2*time.Second || remaining > 5*time.Second {
+		t.Fatalf("remaining cooldown = %v, want RetryAfter around 3s and not settings default", remaining)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -259,13 +259,18 @@ func (e *Executor) handleCooldown(proxyErr *domain.ProxyError, provider *domain.
 	// Map domain CooldownReason to cooldown package CooldownReason
 	reason := cooldown.CooldownReason(proxyErr.Reason)
 
-	// Use explicit cooldown time if provided, otherwise let policy decide
+	// Use explicit upstream cooldown time first. Retry-After comes next.
+	// The configurable setting only replaces the local policy fallback for
+	// short request/concurrency throttles (the fixed 5s defaults in
+	// cooldown.DefaultPolicies), not quota reset/default times.
 	var explicitUntil *time.Time
 	if proxyErr.CooldownUntil != nil {
 		explicitUntil = proxyErr.CooldownUntil
 	} else if proxyErr.RetryAfter > 0 {
 		t := time.Now().Add(proxyErr.RetryAfter)
 		explicitUntil = &t
+	} else if isConfigurableRateLimitFallback(reason) {
+		explicitUntil = e.rateLimitDefaultCooldownUntil()
 	}
 
 	// Determine model for cooldown key
@@ -287,6 +292,24 @@ func (e *Executor) handleCooldown(proxyErr *domain.ProxyError, provider *domain.
 		default:
 		}
 	}
+}
+
+func isConfigurableRateLimitFallback(reason cooldown.CooldownReason) bool {
+	return reason == cooldown.ReasonRateLimit || reason == cooldown.ReasonConcurrentLimit
+}
+
+func (e *Executor) rateLimitDefaultCooldownUntil() *time.Time {
+	duration := 5 * time.Second
+	if e != nil && e.settingsRepo != nil {
+		value, err := e.settingsRepo.Get(domain.SettingKeyRateLimitCooldownDefaultSeconds)
+		if err == nil && strings.TrimSpace(value) != "" {
+			if seconds, parseErr := strconv.Atoi(strings.TrimSpace(value)); parseErr == nil && seconds >= 1 && seconds <= 86400 {
+				duration = time.Duration(seconds) * time.Second
+			}
+		}
+	}
+	until := time.Now().Add(duration)
+	return &until
 }
 
 func shouldSkipErrorCooldown(provider *domain.Provider) bool {

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1468,6 +1468,13 @@ func sanitizeProvider(provider *domain.Provider) *domain.Provider {
 		openrouter.APIKey = ""
 		config.OpenRouter = &openrouter
 	}
+	if config.Grok != nil {
+		grok := *config.Grok
+		grok.AccessToken = ""
+		grok.RefreshToken = ""
+		grok.IDToken = ""
+		config.Grok = &grok
+	}
 	sanitized.Config = &config
 	return &sanitized
 }

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -513,6 +513,23 @@ func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
 				incoming.Config.OpenRouter.APIKey = existing.Config.OpenRouter.APIKey
 			}
 		}
+	case "grok":
+		if existing.Config.Grok != nil {
+			if incoming.Config.Grok == nil {
+				grok := *existing.Config.Grok
+				incoming.Config.Grok = &grok
+			} else {
+				if incoming.Config.Grok.AccessToken == "" {
+					incoming.Config.Grok.AccessToken = existing.Config.Grok.AccessToken
+				}
+				if incoming.Config.Grok.RefreshToken == "" {
+					incoming.Config.Grok.RefreshToken = existing.Config.Grok.RefreshToken
+				}
+				if incoming.Config.Grok.IDToken == "" {
+					incoming.Config.Grok.IDToken = existing.Config.Grok.IDToken
+				}
+			}
+		}
 	}
 }
 
@@ -1320,6 +1337,9 @@ func (s *AdminService) autoSetSupportedClientTypes(provider *domain.Provider) {
 				domain.ClientTypeOpenAI,
 			}
 		}
+	case "grok":
+		// Grok CPA xAI executor speaks OpenAI-compatible chat only.
+		provider.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
 	}
 }
 

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/awsl-project/maxx/internal/codexguard"
@@ -15,9 +16,23 @@ func validateSystemSettingValue(key, value string) error {
 		return payloadoverride.ValidateRulesJSON(value)
 	case domain.SettingKeyCodexReasoningGuard:
 		return validateCodexReasoningGuardSetting(value)
+	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
+		return validateRateLimitCooldownDefaultSeconds(value)
 	default:
 		return nil
 	}
+}
+
+func validateRateLimitCooldownDefaultSeconds(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%w: %s cannot be empty", domain.ErrInvalidInput, domain.SettingKeyRateLimitCooldownDefaultSeconds)
+	}
+	seconds, err := strconv.Atoi(trimmed)
+	if err != nil || seconds < 1 || seconds > 86400 {
+		return fmt.Errorf("%w: %s must be an integer between 1 and 86400", domain.ErrInvalidInput, domain.SettingKeyRateLimitCooldownDefaultSeconds)
+	}
+	return nil
 }
 
 func validateCodexReasoningGuardSetting(value string) error {

--- a/tests/e2e/grok_provider_test.go
+++ b/tests/e2e/grok_provider_test.go
@@ -1,0 +1,145 @@
+package e2e_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestGrokConfigRoundTripAndSecretPreserve(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	cresp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": "grok-cfg",
+		"type": "grok",
+		"config": map[string]any{
+			"disableErrorCooldown": true,
+			"grok": map[string]any{
+				"type":          "xai",
+				"authKind":      "oauth",
+				"email":         "user@example.com",
+				"accessToken":   "access-token",
+				"refreshToken":  "refresh-token",
+				"idToken":       "id-token",
+				"baseURL":       "https://cli-chat-proxy.grok.com/v1",
+				"tokenEndpoint": "https://example.test/token",
+			},
+		},
+	})
+	if cresp.StatusCode != http.StatusCreated {
+		b, _ := io.ReadAll(cresp.Body)
+		t.Fatalf("create: status=%d body=%s", cresp.StatusCode, b)
+	}
+	var created struct {
+		ID                   uint64   `json:"id"`
+		SupportedClientTypes []string `json:"supportedClientTypes"`
+	}
+	DecodeJSON(t, cresp, &created)
+	if len(created.SupportedClientTypes) != 1 || created.SupportedClientTypes[0] != "openai" {
+		t.Fatalf("grok supportedClientTypes = %v, want [openai]", created.SupportedClientTypes)
+	}
+
+	uresp := env.AdminPut(fmt.Sprintf("/api/admin/providers/%d", created.ID), map[string]any{
+		"name": "grok-cfg-updated",
+		"type": "grok",
+		"config": map[string]any{
+			"disableErrorCooldown": false,
+			"grok": map[string]any{
+				"type":         "xai",
+				"authKind":     "oauth",
+				"email":        "next@example.com",
+				"accessToken":  "",
+				"refreshToken": "",
+				"idToken":      "",
+			},
+		},
+		"supportedClientTypes": []string{"claude", "openai"},
+	})
+	if uresp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(uresp.Body)
+		t.Fatalf("update: status=%d body=%s", uresp.StatusCode, b)
+	}
+	uresp.Body.Close()
+
+	gresp := env.AdminGet(fmt.Sprintf("/api/admin/providers/%d", created.ID))
+	var got struct {
+		Type                 string   `json:"type"`
+		SupportedClientTypes []string `json:"supportedClientTypes"`
+		Config               struct {
+			DisableErrorCooldown bool `json:"disableErrorCooldown"`
+			Grok                 *struct {
+				Email        string `json:"email"`
+				AccessToken  string `json:"accessToken"`
+				RefreshToken string `json:"refreshToken"`
+				IDToken      string `json:"idToken"`
+			} `json:"grok"`
+		} `json:"config"`
+	}
+	DecodeJSON(t, gresp, &got)
+	if got.Type != "grok" || got.Config.Grok == nil {
+		t.Fatalf("unexpected provider after update: %+v", got)
+	}
+	if got.Config.Grok.Email != "next@example.com" {
+		t.Errorf("email = %q, want next@example.com", got.Config.Grok.Email)
+	}
+	if got.Config.Grok.AccessToken != "access-token" || got.Config.Grok.RefreshToken != "refresh-token" || got.Config.Grok.IDToken != "id-token" {
+		t.Errorf("blank update should preserve stored tokens, got access=%q refresh=%q id=%q", got.Config.Grok.AccessToken, got.Config.Grok.RefreshToken, got.Config.Grok.IDToken)
+	}
+	if got.Config.DisableErrorCooldown {
+		t.Error("disableErrorCooldown should round-trip false after update")
+	}
+	if len(got.SupportedClientTypes) != 1 || got.SupportedClientTypes[0] != "openai" {
+		t.Errorf("grok update should force supportedClientTypes [openai], got %v", got.SupportedClientTypes)
+	}
+}
+
+func TestGrokExportSkipsBlackBoxAndIncludesExportableConfig(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	for _, tc := range []struct {
+		name              string
+		excludeFromExport bool
+	}{
+		{name: "grok-export", excludeFromExport: false},
+		{name: "grok-hidden", excludeFromExport: true},
+	} {
+		resp := env.AdminPost("/api/admin/providers", map[string]any{
+			"name": tc.name,
+			"type": "grok",
+			"config": map[string]any{"grok": map[string]any{
+				"type":         "xai",
+				"authKind":     "oauth",
+				"accessToken":  "access-" + tc.name,
+				"refreshToken": "refresh-" + tc.name,
+			}},
+			"excludeFromExport": tc.excludeFromExport,
+		})
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("create %s: status=%d body=%s", tc.name, resp.StatusCode, b)
+		}
+		resp.Body.Close()
+	}
+
+	eresp := env.AdminGet("/api/admin/providers/export")
+	var exported []map[string]any
+	DecodeJSON(t, eresp, &exported)
+	var found map[string]any
+	for _, provider := range exported {
+		switch provider["name"] {
+		case "grok-hidden":
+			t.Fatal("excludeFromExport Grok provider leaked into export")
+		case "grok-export":
+			found = provider
+		}
+	}
+	if found == nil {
+		t.Fatal("exportable Grok provider missing from export")
+	}
+	cfg, _ := found["config"].(map[string]any)
+	grok, _ := cfg["grok"].(map[string]any)
+	if grok == nil || grok["accessToken"] != "access-grok-export" || grok["refreshToken"] != "refresh-grok-export" {
+		t.Fatalf("export should include Grok tokens for re-import, got config=%v", cfg)
+	}
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -97,6 +97,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --provider-codex: oklch(0.6789 0.12 145.6789); /* #10A37F OpenAI 绿色 */
   --provider-claude: oklch(0.65 0.15 28); /* Anthropic 橙色/珊瑚色 */
   --provider-openrouter: oklch(0.58 0.19 277); /* #6366F1 靛蓝色 */
+  --provider-grok: oklch(0.62 0.18 285); /* xAI/Grok 紫色 */
 
   /* Client 品牌色 (引用 Provider 颜色) */
   --client-claude: var(--provider-anthropic);
@@ -383,6 +384,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --color-provider-codex: var(--provider-codex);
   --color-provider-claude: var(--provider-claude);
   --color-provider-openrouter: var(--provider-openrouter);
+  --color-provider-grok: var(--provider-grok);
 
   /* Client 颜色映射 (Tailwind 可用) */
   --color-client-claude: var(--client-claude);

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -21,7 +21,8 @@ export type ProviderType =
   | 'kiro'
   | 'codex'
   | 'claude'
-  | 'openrouter';
+  | 'openrouter'
+  | 'grok';
 
 /**
  * Client 类型定义

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -114,6 +114,27 @@ export interface ProviderConfigOpenRouter {
   apiKey: string;
 }
 
+
+export interface ProviderConfigGrok {
+  type?: 'xai';
+  authKind?: 'oauth';
+  email?: string;
+  sub?: string;
+  accessToken?: string;
+  refreshToken?: string;
+  idToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  expired?: string;
+  lastRefresh?: string;
+  redirectURI?: string;
+  tokenEndpoint?: string;
+  baseURL?: string;
+  disabled?: boolean;
+  headers?: Record<string, string>;
+  modelMapping?: Record<string, string>;
+}
+
 // One row in the Bedrock discovery catalog: the Anthropic short name
 // clients send, the invoke-ready Bedrock ID our adapter routes to, and
 // which AWS catalog the entry was sourced from.
@@ -147,6 +168,7 @@ export interface ProviderConfig {
   codex?: ProviderConfigCodex;
   claude?: ProviderConfigClaude;
   openrouter?: ProviderConfigOpenRouter;
+  grok?: ProviderConfigGrok;
 }
 
 export interface Provider {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1878,6 +1878,26 @@
         "name": "DeepSeek",
         "description": "DeepSeek · Claude + OpenAI Compatible"
       }
+    },
+    "grok": {
+      "name": "Grok",
+      "description": "Import CPA xAI OAuth JSON and proxy Grok through the OpenAI-compatible client.",
+      "jsonFiles": "JSON files",
+      "selectedCount": "{{count}} credential selected",
+      "selectedCount_plural": "{{count}} credentials selected",
+      "clientsTitle": "Client types",
+      "clientsDesc": "Grok CPA currently serves OpenAI-compatible chat requests.",
+      "clientOpenAIDesc": "Forward OpenAI Chat Completions requests to Grok.",
+      "modelMappingTitle": "Model mappings",
+      "modelMappingDesc": "Map the model name clients send to the Grok model id. Leave empty to pass models through unchanged.",
+      "modelMappingFrom": "Client model pattern",
+      "modelMappingTo": "Grok model id",
+      "modelMappingEmpty": "No model mappings configured.",
+      "importOne": "Import Grok provider",
+      "importMany": "Import {{count}} Grok providers",
+      "email": "Email",
+      "baseURL": "Base URL",
+      "secretWriteOnlyHint": "OAuth tokens are write-only here. Updating this form with blank token fields preserves the stored access/refresh/id tokens."
     }
   },
   "modelMapping": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1874,6 +1874,26 @@
         "name": "DeepSeek",
         "description": "DeepSeek · Claude + OpenAI 兼容"
       }
+    },
+    "grok": {
+      "name": "Grok",
+      "description": "导入 CPA xAI OAuth JSON，并通过 OpenAI 兼容客户端代理 Grok。",
+      "jsonFiles": "JSON 文件",
+      "selectedCount": "已选择 {{count}} 个凭据",
+      "selectedCount_plural": "已选择 {{count}} 个凭据",
+      "clientsTitle": "客户端类型",
+      "clientsDesc": "Grok CPA 当前提供 OpenAI 兼容聊天请求。",
+      "clientOpenAIDesc": "把 OpenAI Chat Completions 请求转发到 Grok。",
+      "modelMappingTitle": "模型映射",
+      "modelMappingDesc": "把客户端发送的模型名映射到 Grok 模型 id。留空则原样透传。",
+      "modelMappingFrom": "客户端模型模式",
+      "modelMappingTo": "Grok 模型 id",
+      "modelMappingEmpty": "暂无模型映射。",
+      "importOne": "导入 Grok 提供商",
+      "importMany": "导入 {{count}} 个 Grok 提供商",
+      "email": "邮箱",
+      "baseURL": "Base URL",
+      "secretWriteOnlyHint": "OAuth token 在这里按只写处理。表单提交空 token 字段时，后端会保留已保存的 access/refresh/id token。"
     }
   },
   "modelMapping": {

--- a/web/src/pages/providers/components/grok-provider-view.tsx
+++ b/web/src/pages/providers/components/grok-provider-view.tsx
@@ -1,0 +1,204 @@
+import { useState } from 'react';
+import { Check, ChevronLeft, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { useUpdateProvider } from '@/hooks/queries';
+import type { ClientType, CreateProviderData, Provider } from '@/lib/transport';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import { ProviderModelMappings } from './provider-model-mappings';
+
+interface GrokProviderViewProps {
+  provider: Provider;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+const GROK_CLIENT_TYPES = ['openai'] as const satisfies readonly ClientType[];
+
+export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderViewProps) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+  const grok = provider.config?.grok;
+
+  const [name, setName] = useState(provider.name);
+  const [email, setEmail] = useState(grok?.email || '');
+  const [baseURL, setBaseURL] = useState(grok?.baseURL || '');
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(
+    !!provider.config?.disableErrorCooldown,
+  );
+  const [blackBox, setBlackBox] = useState(!!provider.blackBox || !!provider.excludeFromExport);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const isValid = () => name.trim() !== '';
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+    setSaving(true);
+    setSaveStatus('idle');
+    try {
+      const data: Partial<CreateProviderData> = {
+        name: name.trim(),
+        type: 'grok',
+        config: {
+          disableErrorCooldown,
+          grok: {
+            type: 'xai',
+            authKind: 'oauth',
+            email: email.trim() || grok?.email,
+            sub: grok?.sub,
+            // Blank/omitted secrets preserve the stored tokens on the backend.
+            accessToken: '',
+            refreshToken: '',
+            idToken: '',
+            tokenType: grok?.tokenType,
+            expiresIn: grok?.expiresIn,
+            expired: grok?.expired,
+            lastRefresh: grok?.lastRefresh,
+            redirectURI: grok?.redirectURI,
+            tokenEndpoint: grok?.tokenEndpoint,
+            baseURL: baseURL.trim() || grok?.baseURL,
+            disabled: grok?.disabled,
+            headers: grok?.headers,
+          },
+        },
+        supportedClientTypes: [...GROK_CLIENT_TYPES],
+        excludeFromExport: blackBox,
+        blackBox,
+      };
+      await updateProvider.mutateAsync({ id: Number(provider.id), data });
+      setSaveStatus('success');
+      setTimeout(() => onClose(), 500);
+    } catch (error) {
+      console.error('Failed to update Grok provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={onClose} />}
+        title={t('provider.edit')}
+        description={t('addProvider.grok.description')}
+      >
+        <Button onClick={onDelete} variant="destructive">
+          <Trash2 size={14} />
+          {t('provider.delete')}
+        </Button>
+        <Button onClick={onClose} variant="secondary">
+          {t('provider.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()}>
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.saveChanges')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  {t('provider.displayName')}
+                </label>
+                <Input value={name} onChange={(event) => setName(event.target.value)} />
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  {t('addProvider.grok.email')}
+                </label>
+                <Input value={email} onChange={(event) => setEmail(event.target.value)} />
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium text-foreground">
+                  {t('addProvider.grok.baseURL')}
+                </label>
+                <Input
+                  value={baseURL}
+                  onChange={(event) => setBaseURL(event.target.value)}
+                  placeholder="https://cli-chat-proxy.grok.com/v1"
+                />
+              </div>
+              <div className="rounded-lg border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+                {t('addProvider.grok.secretWriteOnlyHint')}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('addProvider.grok.clientsTitle')}
+            </h3>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">OpenAI</div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('addProvider.grok.clientOpenAIDesc')}
+                </p>
+              </div>
+              <Switch checked disabled />
+            </div>
+          </div>
+
+          <ProviderModelMappings provider={provider} />
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.visibilityAndExport')}
+            </h3>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">{t('provider.blackBox')}</div>
+                <p className="mt-1 text-xs text-muted-foreground">{t('provider.blackBoxDesc')}</p>
+              </div>
+              <Switch checked={blackBox} onCheckedChange={setBlackBox} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="flex items-center gap-2 rounded-lg border border-error/30 bg-error/10 p-4 text-sm text-error">
+              <div className="h-1.5 w-1.5 rounded-full bg-error" />
+              {t('provider.updateError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/grok-token-import.tsx
+++ b/web/src/pages/providers/components/grok-token-import.tsx
@@ -1,0 +1,405 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowRight, Check, ChevronLeft, FileJson, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { Textarea } from '@/components/ui/textarea';
+import { ModelInput } from '@/components/ui/model-input';
+import { PageHeader } from '@/components/layout/page-header';
+import { useCreateModelMapping, useCreateProvider } from '@/hooks/queries';
+import type { ClientType, CreateProviderData } from '@/lib/transport';
+import type { ProviderConfigGrok } from '@/lib/transport/types';
+
+interface CPAxAIExportJSON {
+  type?: string;
+  auth_kind?: string;
+  email?: string;
+  sub?: string;
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  expired?: string;
+  last_refresh?: string;
+  redirect_uri?: string;
+  token_endpoint?: string;
+  base_url?: string;
+  disabled?: boolean;
+  headers?: Record<string, string>;
+}
+
+interface GrokImportItem {
+  source: string;
+  raw: CPAxAIExportJSON;
+}
+
+const GROK_CLIENT_TYPES = ['openai'] as const satisfies readonly ClientType[];
+
+type ModelMappingsEditorProps = {
+  mappings: Record<string, string>;
+  onChange: (mappings: Record<string, string>) => void;
+};
+
+function ModelMappingsEditor({ mappings, onChange }: ModelMappingsEditorProps) {
+  const { t } = useTranslation();
+  const [newPattern, setNewPattern] = useState('');
+  const [newTarget, setNewTarget] = useState('');
+  const entries = useMemo(() => Object.entries(mappings), [mappings]);
+
+  const updateEntry = (oldPattern: string, pattern: string, target: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of entries) {
+      if (key !== oldPattern) next[key] = value;
+    }
+    const nextPattern = pattern.trim();
+    const nextTarget = target.trim();
+    if (nextPattern && nextTarget) next[nextPattern] = nextTarget;
+    onChange(next);
+  };
+
+  const addEntry = () => {
+    const pattern = newPattern.trim();
+    const target = newTarget.trim();
+    if (!pattern || !target) return;
+    onChange({ ...mappings, [pattern]: target });
+    setNewPattern('');
+    setNewTarget('');
+  };
+
+  const removeEntry = (pattern: string) => {
+    const next: Record<string, string> = {};
+    for (const [key, value] of entries) {
+      if (key !== pattern) next[key] = value;
+    }
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b border-border pb-2">
+        <h3 className="text-lg font-semibold text-foreground">
+          {t('addProvider.grok.modelMappingTitle')}
+        </h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {t('addProvider.grok.modelMappingDesc')}
+        </p>
+      </div>
+      <div className="rounded-xl border border-border bg-card p-4">
+        {entries.length > 0 ? (
+          <div className="mb-4 space-y-2">
+            {entries.map(([pattern, target], index) => (
+              <div key={pattern} className="flex items-center gap-2">
+                <span className="w-6 shrink-0 text-xs text-muted-foreground">{index + 1}.</span>
+                <ModelInput
+                  value={pattern}
+                  onChange={(value) => updateEntry(pattern, value, target)}
+                  placeholder={t('addProvider.grok.modelMappingFrom')}
+                  className="h-8 min-w-0 flex-1 text-sm"
+                />
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <Input
+                  value={target}
+                  onChange={(event) => updateEntry(pattern, pattern, event.target.value)}
+                  placeholder={t('addProvider.grok.modelMappingTo')}
+                  className="h-8 min-w-0 flex-1 font-mono text-sm"
+                />
+                <Button variant="ghost" size="sm" onClick={() => removeEntry(pattern)}>
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="mb-4 py-6 text-center text-sm text-muted-foreground">
+            {t('addProvider.grok.modelMappingEmpty')}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 border-t border-border pt-4">
+          <ModelInput
+            value={newPattern}
+            onChange={setNewPattern}
+            placeholder={t('addProvider.grok.modelMappingFrom')}
+            className="h-8 min-w-0 flex-1 text-sm"
+          />
+          <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Input
+            value={newTarget}
+            onChange={(event) => setNewTarget(event.target.value)}
+            placeholder={t('addProvider.grok.modelMappingTo')}
+            className="h-8 min-w-0 flex-1 font-mono text-sm"
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addEntry}
+            disabled={!newPattern.trim() || !newTarget.trim()}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            {t('common.add')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function normalizeGrokConfig(raw: CPAxAIExportJSON): ProviderConfigGrok {
+  if (raw.type !== 'xai') {
+    throw new Error(`Expected CPA xai credential JSON, got type=${raw.type || '(empty)'}`);
+  }
+  if ((raw.auth_kind || 'oauth') !== 'oauth') {
+    throw new Error(`Expected oauth credential JSON, got auth_kind=${raw.auth_kind || '(empty)'}`);
+  }
+  if (!raw.access_token && !raw.refresh_token) {
+    throw new Error('access_token or refresh_token is required');
+  }
+  return {
+    type: 'xai',
+    authKind: 'oauth',
+    email: raw.email,
+    sub: raw.sub,
+    accessToken: raw.access_token,
+    refreshToken: raw.refresh_token,
+    idToken: raw.id_token,
+    tokenType: raw.token_type,
+    expiresIn: raw.expires_in,
+    expired: raw.expired,
+    lastRefresh: raw.last_refresh,
+    redirectURI: raw.redirect_uri,
+    tokenEndpoint: raw.token_endpoint,
+    baseURL: raw.base_url,
+    disabled: raw.disabled,
+    headers: raw.headers,
+  };
+}
+
+function providerName(grok: ProviderConfigGrok, source: string): string {
+  if (grok.email) return `Grok (${grok.email})`;
+  const stem = source.replace(/\.json$/i, '').trim();
+  return stem ? `Grok (${stem})` : 'Grok';
+}
+
+function parseImportItemsFromText(jsonText: string): GrokImportItem[] {
+  const trimmed = jsonText.trim();
+  if (!trimmed) return [];
+  const parsed = JSON.parse(trimmed) as CPAxAIExportJSON | CPAxAIExportJSON[];
+  if (Array.isArray(parsed)) {
+    return parsed.map((raw, index) => ({ source: `pasted item ${index + 1}`, raw }));
+  }
+  return [{ source: 'pasted JSON', raw: parsed }];
+}
+
+async function parseImportItemsFromFiles(files: FileList): Promise<GrokImportItem[]> {
+  const items: GrokImportItem[] = [];
+  for (const file of Array.from(files)) {
+    const text = await file.text();
+    const parsed = JSON.parse(text) as CPAxAIExportJSON | CPAxAIExportJSON[];
+    if (Array.isArray(parsed)) {
+      parsed.forEach((raw, index) => items.push({ source: `${file.name}#${index + 1}`, raw }));
+    } else {
+      items.push({ source: file.name, raw: parsed });
+    }
+  }
+  return items;
+}
+
+export function GrokTokenImport() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const createProvider = useCreateProvider();
+  const createModelMapping = useCreateModelMapping();
+  const [jsonText, setJsonText] = useState('');
+  const [fileItems, setFileItems] = useState<GrokImportItem[]>([]);
+  const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [blackBox, setBlackBox] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const handleFilesSelected = async (files: FileList | null) => {
+    setError(null);
+    if (!files || files.length === 0) {
+      setFileItems([]);
+      return;
+    }
+    try {
+      setFileItems(await parseImportItemsFromFiles(files));
+    } catch (err) {
+      setFileItems([]);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const submit = async () => {
+    setError(null);
+    setSaveStatus('idle');
+    setSubmitting(true);
+    try {
+      const items = fileItems.length > 0 ? fileItems : parseImportItemsFromText(jsonText);
+      if (items.length === 0) throw new Error('Paste JSON or select files');
+
+      const mappingEntries = Object.entries(modelMapping);
+      for (const item of items) {
+        const grok = normalizeGrokConfig(item.raw);
+        const data: CreateProviderData = {
+          type: 'grok',
+          name: providerName(grok, item.source),
+          config: { disableErrorCooldown, grok },
+          supportedClientTypes: [...GROK_CLIENT_TYPES],
+          excludeFromExport: blackBox,
+          blackBox,
+        };
+        const provider = await createProvider.mutateAsync(data);
+        for (const [pattern, target] of mappingEntries) {
+          await createModelMapping.mutateAsync({
+            scope: 'provider',
+            providerID: provider.id,
+            pattern,
+            target,
+          });
+        }
+      }
+      setSaveStatus('success');
+      navigate('/providers');
+    } catch (err) {
+      setSaveStatus('error');
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const pastedItemCount = useMemo(() => {
+    try {
+      return parseImportItemsFromText(jsonText).length;
+    } catch {
+      return jsonText.trim() ? 1 : 0;
+    }
+  }, [jsonText]);
+  const itemCount = fileItems.length > 0 ? fileItems.length : pastedItemCount;
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={() => navigate('/providers/create')} />}
+        title={t('addProvider.grok.name')}
+        description={t('addProvider.grok.description')}
+      >
+        <Button type="button" variant="secondary" onClick={() => navigate('/providers')}>
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={submit} disabled={submitting || itemCount === 0}>
+          {submitting ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : itemCount > 1 ? (
+            t('addProvider.grok.importMany', { count: itemCount })
+          ) : (
+            t('addProvider.grok.importOne')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="rounded-lg border bg-card p-4">
+              <label className="block text-sm font-medium text-foreground" htmlFor="grok-json-files">
+                <span className="inline-flex items-center gap-2">
+                  <FileJson size={14} /> {t('addProvider.grok.jsonFiles')}
+                </span>
+              </label>
+              <input
+                id="grok-json-files"
+                type="file"
+                accept="application/json,.json"
+                multiple
+                className="mt-2 block w-full text-sm text-muted-foreground file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                onChange={(event) => void handleFilesSelected(event.target.files)}
+              />
+              {fileItems.length > 0 && (
+                <div className="mt-3 text-xs text-muted-foreground">
+                  {t('addProvider.grok.selectedCount', { count: fileItems.length })}
+                </div>
+              )}
+            </div>
+            <Textarea
+              value={jsonText}
+              onChange={(event) => {
+                setJsonText(event.target.value);
+                if (event.target.value.trim()) setFileItems([]);
+              }}
+              placeholder='{"type":"xai","auth_kind":"oauth",...}'
+              className="min-h-64 font-mono text-xs"
+            />
+          </div>
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('addProvider.grok.clientsTitle')}
+            </h3>
+            <p className="text-xs text-muted-foreground">{t('addProvider.grok.clientsDesc')}</p>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">OpenAI</div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('addProvider.grok.clientOpenAIDesc')}
+                </p>
+              </div>
+              <Switch checked disabled />
+            </div>
+          </div>
+
+          <ModelMappingsEditor mappings={modelMapping} onChange={setModelMapping} />
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <h3 className="border-b border-border pb-2 text-lg font-semibold text-foreground">
+              {t('provider.visibilityAndExport')}
+            </h3>
+            <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">{t('provider.blackBox')}</div>
+                <p className="mt-1 text-xs text-muted-foreground">{t('provider.blackBoxDesc')}</p>
+              </div>
+              <Switch checked={blackBox} onCheckedChange={setBlackBox} />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -40,6 +40,7 @@ import { KiroProviderView } from './kiro-provider-view';
 import { CodexProviderView } from './codex-provider-view';
 import { ClaudeProviderView } from './claude-provider-view';
 import { OpenRouterProviderView } from './openrouter-provider-view';
+import { GrokProviderView } from './grok-provider-view';
 import { ProviderModelMappings } from './provider-model-mappings';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -652,6 +653,26 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     return (
       <>
         <OpenRouterProviderView
+          provider={provider}
+          onDelete={() => setShowDeleteConfirm(true)}
+          onClose={onClose}
+        />
+        <DeleteConfirmModal
+          providerName={provider.name}
+          deleting={deleting}
+          open={showDeleteConfirm}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      </>
+    );
+  }
+
+  // Grok provider
+  if (provider.type === 'grok') {
+    return (
+      <>
+        <GrokProviderView
           provider={provider}
           onDelete={() => setShowDeleteConfirm(true)}
           onClose={onClose}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -9,6 +9,7 @@ import {
   Code2,
   Sparkles,
   ChevronLeft,
+  Bot,
 } from 'lucide-react';
 import { quickTemplates, PROVIDER_TYPE_CONFIGS } from '../types';
 import openrouterLogo from '@/assets/icons/openrouter.svg';
@@ -28,12 +29,13 @@ export function SelectTypeStep() {
     goToClaude,
     goToBedrock,
     goToOpenRouter,
+    goToGrok,
     goToProviders,
   } = useProviderNavigation();
   const { t } = useTranslation();
 
   const handleSelectType = (
-    type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter',
+    type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok',
   ) => {
     updateFormData({ type });
     if (type === 'antigravity') {
@@ -44,6 +46,8 @@ export function SelectTypeStep() {
       goToOpenRouter();
     } else if (type === 'kiro') {
       goToKiro();
+    } else if (type === 'grok') {
+      goToGrok();
     } else if (type === 'codex') {
       goToCodex();
     } else if (type === 'claude') {
@@ -285,6 +289,36 @@ export function SelectTypeStep() {
                   </div>
                 </Button>
               )}
+
+              {!PROVIDER_TYPE_CONFIGS.grok.hidden && (
+                <Button
+                  onClick={() => handleSelectType('grok')}
+                  variant="ghost"
+                  className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    formData.type === 'grok'
+                      ? 'border-provider-grok bg-provider-grok/10 shadow-sm'
+                      : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                  }`}
+                >
+                  <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                    <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-grok/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                      <Bot className="size-5 md:size-6 text-provider-grok" />
+                    </div>
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">Grok</h3>
+                      <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                        Import xAI OAuth JSON from CLIProxyAPI
+                      </p>
+                    </div>
+
+                    {formData.type === 'grok' && (
+                      <CheckCircle2 className="size-5 text-provider-grok shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                    )}
+                  </div>
+                </Button>
+              )}
+
 
               <Button
                 onClick={() => handleSelectType('custom')}

--- a/web/src/pages/providers/create-layout.tsx
+++ b/web/src/pages/providers/create-layout.tsx
@@ -4,6 +4,7 @@ import { SelectTypeStep } from './components/select-type-step';
 import { AntigravityTokenImport } from './components/antigravity-token-import';
 import { KiroTokenImport } from './components/kiro-token-import';
 import { CodexTokenImport } from './components/codex-token-import';
+import { GrokTokenImport } from './components/grok-token-import';
 import { ClaudeTokenImport } from './components/claude-token-import';
 import { CustomConfigStep } from './components/custom-config-step';
 import { BedrockConfigStep } from './components/bedrock-config-step';
@@ -20,6 +21,7 @@ export function ProviderCreateLayout() {
         <Route path="antigravity" element={<AntigravityTokenImport />} />
         <Route path="kiro" element={<KiroTokenImport />} />
         <Route path="codex" element={<CodexTokenImport />} />
+        <Route path="grok" element={<GrokTokenImport />} />
         <Route path="claude" element={<ClaudeTokenImport />} />
       </Routes>
     </ProviderFormProvider>

--- a/web/src/pages/providers/hooks/use-provider-navigation.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.ts
@@ -12,6 +12,7 @@ export function useProviderNavigation() {
     goToClaude: () => navigate('/providers/create/claude'),
     goToBedrock: () => navigate('/providers/create/bedrock'),
     goToOpenRouter: () => navigate('/providers/create/openrouter'),
+    goToGrok: () => navigate('/providers/create/grok'),
     goToProviders: () => navigate('/providers'),
     goBack: () => navigate(-1),
   };

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -1,7 +1,7 @@
 import type { ClientType, DisguiseType, Provider } from '@/lib/transport';
 import { getProviderColorVar } from '@/lib/theme';
 import type { LucideIcon } from 'lucide-react';
-import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud, Waypoints } from 'lucide-react';
+import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud, Waypoints, Bot } from 'lucide-react';
 import duckcodingLogo from '@/assets/icons/duckcoding.gif';
 import freeDuckLogo from '@/assets/icons/free-duck.gif';
 import nvidiaLogo from '@/assets/icons/nvidia.svg';
@@ -14,7 +14,7 @@ import deepseekLogo from '@/assets/icons/deepseek.png';
 // 通用的 Provider 类型配置，添加新类型只需在这里配置
 
 export type ProviderTypeKey =
-  'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter';
+  'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok';
 
 export interface ProviderTypeConfig {
   key: ProviderTypeKey;
@@ -82,6 +82,14 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
     color: getProviderColorVar('openrouter'),
     isAccountBased: false,
     getDisplayInfo: () => 'openrouter.ai',
+  },
+  grok: {
+    key: 'grok',
+    label: 'Grok',
+    icon: Bot,
+    color: getProviderColorVar('grok'),
+    isAccountBased: true,
+    getDisplayInfo: (p) => p.config?.grok?.email || 'Grok Account',
   },
   custom: {
     key: 'custom',
@@ -290,7 +298,7 @@ export const defaultClients: ClientConfig[] = [
 
 // Form data types
 export type ProviderFormData = {
-  type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter';
+  type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok';
   name: string;
   selectedTemplate: string | null;
   baseURL: string;


### PR DESCRIPTION
## Summary
- add Grok CPA provider management flow and provider UI support
- make the local cooldown fallback for rate/concurrent-limit errors configurable
- keep upstream-provided cooldown signals authoritative: quota reset/CooldownUntil and Retry-After/RetryInfo are not overridden by the setting

## Cooldown fallback scope
- controls only `ReasonRateLimit` and `ReasonConcurrentLimit` when no upstream retry/cooldown time is provided
- does not control quota reset, quota fallback, Retry-After, or RetryInfo
- keeps `internal/cooldown/policy.go` default 5s policy intact and applies the setting in executor handling only for the targeted fallback path

## Validation
- `go test ./internal/adapter/provider/antigravity ./internal/executor ./internal/cooldown ./internal/handler ./internal/service`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 Grok（xAI）提供商支持，兼容 OpenAI 客户端。
  * 支持通过 OAuth JSON 单个或批量导入凭据，并配置模型映射。
  * 新增 Grok 提供商创建、编辑、删除及导出设置页面。
  * 敏感令牌在编辑和更新时安全保留与脱敏。

* **问题修复**
  * 优化速率限制与并发限制的冷却时间处理，优先使用上游重试时间，并支持配置默认冷却时长。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->