### PR TITLE
feat: support Codex Responses WebSocket proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,23 @@ model_provider = "maxx"
 name = "maxx"
 base_url = "http://localhost:9880"
 wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = true
 request_max_retries = 4
 stream_max_retries = 10
 stream_idle_timeout_ms = 300000
 ```
+
+`supports_websockets = true` makes Codex upgrade `GET /v1/responses` and send
+`response.create` events over a persistent connection. Older Codex builds that
+still gate the v2 transport may additionally require:
+
+```toml
+[features]
+responses_websockets_v2 = true
+```
+
+Configure each TOML key only once.
 
 **auth.json**
 
@@ -287,11 +300,11 @@ codex
 |------|----------|
 | Claude | `POST /v1/messages` |
 | OpenAI | `POST /v1/chat/completions` |
-| Codex | `POST /v1/responses` |
+| Codex | `POST /v1/responses` or WebSocket `GET /v1/responses` |
 | Gemini | `POST /v1beta/models/{model}:generateContent` |
 | Project Proxy | `/project/{project-slug}/v1/messages` (etc.) |
 | Admin API | `/api/admin/*` |
-| WebSocket | `ws://localhost:9880/ws` |
+| Admin UI WebSocket | `ws://localhost:9880/ws` |
 | Health Check | `GET /health` |
 | Web UI | `http://localhost:9880/` |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -238,10 +238,23 @@ model_provider = "maxx"
 name = "maxx"
 base_url = "http://localhost:9880"
 wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = true
 request_max_retries = 4
 stream_max_retries = 10
 stream_idle_timeout_ms = 300000
 ```
+
+`supports_websockets = true` 会让 Codex 对 `GET /v1/responses` 发起
+WebSocket 升级，并在持久连接上发送 `response.create` 事件。仍把 v2 传输
+作为实验功能的旧版 Codex 可能还需要：
+
+```toml
+[features]
+responses_websockets_v2 = true
+```
+
+同一个 TOML 键只配置一次。
 
 **auth.json**
 
@@ -285,11 +298,11 @@ codex
 |------|------|
 | Claude | `POST /v1/messages` |
 | OpenAI | `POST /v1/chat/completions` |
-| Codex | `POST /v1/responses` |
+| Codex | `POST /v1/responses` 或 WebSocket `GET /v1/responses` |
 | Gemini | `POST /v1beta/models/{model}:generateContent` |
 | 项目代理 | `/project/{project-slug}/v1/messages` (等) |
 | 管理 API | `/api/admin/*` |
-| WebSocket | `ws://localhost:9880/ws` |
+| 管理界面 WebSocket | `ws://localhost:9880/ws` |
 | 健康检查 | `GET /health` |
 | Web UI | `http://localhost:9880/` |
 

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -126,6 +126,10 @@ func (a *CodexAdapter) SupportedClientTypes() []domain.ClientType {
 }
 
 func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
+	if handled, err := a.executeResponsesWebSocket(c, provider); handled {
+		return err
+	}
+
 	requestBody := flow.GetRequestBody(c)
 	clientWantsStream := flow.GetIsStream(c)
 	request := c.Request

--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -1,0 +1,550 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/codexutil"
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/payloadoverride"
+	"github.com/awsl-project/maxx/internal/usage"
+	"github.com/gorilla/websocket"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	codexResponsesWebSocketBetaHeader = "responses_websockets=2026-02-06"
+	codexResponsesWebSocketHandshake  = 30 * time.Second
+)
+
+type codexWebSocketRead struct {
+	messageType int
+	payload     []byte
+	err         error
+}
+
+type codexWebSocketSession struct {
+	requestMu sync.Mutex
+	writeMu   sync.Mutex
+	closeOnce sync.Once
+
+	conn            *websocket.Conn
+	handshakeHeader http.Header
+	reads           chan codexWebSocketRead
+	done            chan struct{}
+}
+
+func newCodexWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header) *codexWebSocketSession {
+	session := &codexWebSocketSession{
+		conn:            conn,
+		handshakeHeader: handshakeHeader.Clone(),
+		reads:           make(chan codexWebSocketRead, 4096),
+		done:            make(chan struct{}),
+	}
+	conn.SetPingHandler(func(data string) error {
+		session.writeMu.Lock()
+		defer session.writeMu.Unlock()
+		return conn.WriteControl(websocket.PongMessage, []byte(data), time.Now().Add(10*time.Second))
+	})
+	go session.readLoop()
+	return session
+}
+
+func (s *codexWebSocketSession) readLoop() {
+	defer close(s.reads)
+	for {
+		messageType, payload, err := s.conn.ReadMessage()
+		if err != nil {
+			select {
+			case s.reads <- codexWebSocketRead{err: err}:
+			case <-s.done:
+			}
+			s.close()
+			return
+		}
+		select {
+		case s.reads <- codexWebSocketRead{messageType: messageType, payload: payload}:
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *codexWebSocketSession) write(payload []byte) error {
+	if s == nil || s.conn == nil {
+		return errors.New("codex websocket session is not connected")
+	}
+	select {
+	case <-s.done:
+		return errors.New("codex websocket session is closed")
+	default:
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+func (s *codexWebSocketSession) close() {
+	if s == nil {
+		return
+	}
+	s.closeOnce.Do(func() {
+		close(s.done)
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
+	})
+}
+
+func (s *codexWebSocketSession) isClosed() bool {
+	if s == nil {
+		return true
+	}
+	select {
+	case <-s.done:
+		return true
+	default:
+		return false
+	}
+}
+
+type codexWebSocketSessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]*codexWebSocketSession
+}
+
+var globalCodexWebSocketSessions = &codexWebSocketSessionStore{
+	sessions: make(map[string]*codexWebSocketSession),
+}
+
+func (s *codexWebSocketSessionStore) get(key string) *codexWebSocketSession {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session := s.sessions[key]
+	if session != nil && session.isClosed() {
+		delete(s.sessions, key)
+		return nil
+	}
+	return session
+}
+
+func (s *codexWebSocketSessionStore) put(key string, session *codexWebSocketSession) {
+	s.mu.Lock()
+	previous := s.sessions[key]
+	s.sessions[key] = session
+	s.mu.Unlock()
+	if previous != nil && previous != session {
+		previous.close()
+	}
+}
+
+func (s *codexWebSocketSessionStore) remove(key string, session *codexWebSocketSession) {
+	s.mu.Lock()
+	if s.sessions[key] == session {
+		delete(s.sessions, key)
+	}
+	s.mu.Unlock()
+	if session != nil {
+		session.close()
+	}
+}
+
+func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.Provider) (bool, error) {
+	if c == nil || provider == nil || c.Request == nil ||
+		flow.GetClientType(c) != domain.ClientTypeCodex ||
+		flow.GetOriginalClientType(c) != domain.ClientTypeCodex ||
+		flow.IsProtocolConversion(c) {
+		return false, nil
+	}
+
+	metadata, ok := maxxctx.GetResponsesWebSocketRequest(c.Request.Context())
+	if !ok {
+		return false, nil
+	}
+
+	rawRequest, err := prepareCodexWebSocketRequest(metadata.Payload, c, provider)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "invalid Codex websocket request")
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusBadRequest
+		return true, proxyErr
+	}
+
+	key := strconv.FormatUint(provider.ID, 10) + ":" + metadata.SessionID
+	session := globalCodexWebSocketSessions.get(key)
+	previousResponseID := strings.TrimSpace(gjson.GetBytes(rawRequest, "previous_response_id").String())
+	if session == nil && previousResponseID != "" {
+		// A response ID is tied to the provider/session that produced it. If route
+		// selection moved elsewhere, use the handler's full-transcript HTTP fallback.
+		return false, nil
+	}
+
+	ctx := c.Request.Context()
+	config := ensureCodexConfig(provider)
+	accessToken, err := a.getAccessToken(ctx, false, "")
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to get access token")
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonAuthFailure
+		return true, proxyErr
+	}
+
+	webSocketURL, err := codexResponsesWebSocketURL(c, config)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to build Codex websocket URL")
+		proxyErr.Scope = domain.ScopeEndpoint
+		return true, proxyErr
+	}
+	headers := buildCodexWebSocketHeaders(c, accessToken, config.AccountID, rawRequest)
+
+	if session == nil {
+		var response *http.Response
+		session, response, err = dialCodexWebSocket(ctx, webSocketURL, headers)
+		if err != nil && response != nil && response.StatusCode == http.StatusUnauthorized {
+			body := readCodexWebSocketHandshakeBody(response)
+			accessToken, err = a.getAccessToken(ctx, true, accessToken)
+			if err != nil {
+				return true, classifyCodexHTTPError(http.StatusUnauthorized, body, response.Header, flow.GetMappedModel(c))
+			}
+			headers.Set("Authorization", "Bearer "+accessToken)
+			session, response, err = dialCodexWebSocket(ctx, webSocketURL, headers)
+		}
+		if err != nil {
+			if response != nil {
+				body := readCodexWebSocketHandshakeBody(response)
+				if response.StatusCode == http.StatusUpgradeRequired {
+					return false, nil
+				}
+				return true, classifyCodexHTTPError(response.StatusCode, body, response.Header, flow.GetMappedModel(c))
+			}
+			// A transport-level upgrade failure is safe to retry through the existing
+			// HTTP/SSE path because no upstream WebSocket event reached the client.
+			return false, nil
+		}
+		globalCodexWebSocketSessions.put(key, session)
+		if done := ctx.Done(); done != nil {
+			go func() {
+				<-done
+				globalCodexWebSocketSessions.remove(key, session)
+			}()
+		}
+	}
+
+	session.requestMu.Lock()
+	defer session.requestMu.Unlock()
+
+	eventChan := flow.GetEventChan(c)
+	if eventChan != nil {
+		eventChan.SendRequestInfo(&domain.RequestInfo{
+			Method:  "WEBSOCKET",
+			URL:     webSocketURL,
+			Headers: flattenHeaders(headers),
+			Body:    string(rawRequest),
+		})
+	}
+
+	if err = session.write(rawRequest); err != nil {
+		globalCodexWebSocketSessions.remove(key, session)
+		return false, nil
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		globalCodexWebSocketSessions.remove(key, session)
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "streaming not supported")
+		proxyErr.Scope = domain.ScopeRequest
+		return true, proxyErr
+	}
+
+	var collector usage.StreamCollector
+	responseModel := ""
+	firstChunkSent := false
+	for {
+		select {
+		case <-ctx.Done():
+			globalCodexWebSocketSessions.remove(key, session)
+			proxyErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
+			proxyErr.Scope = domain.ScopeRequest
+			return true, proxyErr
+		case read, open := <-session.reads:
+			if !open || read.err != nil {
+				globalCodexWebSocketSessions.remove(key, session)
+				readErr := read.err
+				if readErr == nil {
+					readErr = io.ErrUnexpectedEOF
+				}
+				// The request frame was already written successfully, so retrying it
+				// through HTTP or another provider could duplicate side effects.
+				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, "Codex websocket closed before response.completed")
+				proxyErr.Scope = domain.ScopeRequest
+				proxyErr.HTTPStatusCode = http.StatusBadGateway
+				return true, proxyErr
+			}
+			if read.messageType != websocket.TextMessage {
+				continue
+			}
+			payload := bytes.TrimSpace(read.payload)
+			if len(payload) == 0 {
+				continue
+			}
+
+			eventType := gjson.GetBytes(payload, "type").String()
+			if eventType == "error" || eventType == "response.failed" {
+				globalCodexWebSocketSessions.remove(key, session)
+				return true, classifyCodexWebSocketEvent(payload, flow.GetMappedModel(c))
+			}
+
+			collector.ProcessSSELine("data: " + string(payload))
+			if model := strings.TrimSpace(gjson.GetBytes(payload, "response.model").String()); model != "" {
+				responseModel = model
+			} else if model := strings.TrimSpace(gjson.GetBytes(payload, "model").String()); model != "" {
+				responseModel = model
+			}
+
+			if _, err = c.Writer.Write([]byte("data: ")); err == nil {
+				_, err = c.Writer.Write(payload)
+			}
+			if err == nil {
+				_, err = c.Writer.Write([]byte("\n\n"))
+			}
+			if err != nil {
+				globalCodexWebSocketSessions.remove(key, session)
+				proxyErr := domain.NewProxyErrorWithMessage(err, false, "client disconnected")
+				proxyErr.Scope = domain.ScopeRequest
+				return true, proxyErr
+			}
+			flusher.Flush()
+			if !firstChunkSent {
+				firstChunkSent = true
+				if eventChan != nil {
+					eventChan.SendFirstToken(time.Now().UnixMilli())
+				}
+			}
+
+			if eventType == "response.completed" || eventType == "response.done" {
+				sendCodexWebSocketFinalEvents(eventChan, session.handshakeHeader, &collector, responseModel)
+				return true, nil
+			}
+		}
+	}
+}
+
+func prepareCodexWebSocketRequest(raw []byte, c *flow.Ctx, provider *domain.Provider) ([]byte, error) {
+	if !gjson.ValidBytes(raw) || !gjson.ParseBytes(raw).IsObject() {
+		return nil, errors.New("expected a JSON object")
+	}
+	body := bytes.Clone(raw)
+	body, _ = sjson.SetBytes(body, "type", "response.create")
+	if model := strings.TrimSpace(flow.GetMappedModel(c)); model != "" {
+		body, _ = sjson.SetBytes(body, "model", model)
+	}
+	body, _ = sjson.DeleteBytes(body, "stream")
+	body, _ = sjson.DeleteBytes(body, "background")
+	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
+	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	if maxOutput := gjson.GetBytes(body, "max_output_tokens"); maxOutput.Exists() {
+		if !gjson.GetBytes(body, "max_tokens").Exists() {
+			body, _ = sjson.SetBytes(body, "max_tokens", maxOutput.Value())
+		}
+		body, _ = sjson.DeleteBytes(body, "max_output_tokens")
+	}
+	if !gjson.GetBytes(body, "previous_response_id").Exists() && !gjson.GetBytes(body, "instructions").Exists() {
+		body, _ = sjson.SetBytes(body, "instructions", "")
+	}
+	body = codexutil.NormalizeCodexInput(body)
+
+	config := ensureCodexConfig(provider)
+	if config.Reasoning != "" {
+		body, _ = sjson.SetBytes(body, "reasoning.effort", config.Reasoning)
+	}
+	if config.ServiceTier != "" {
+		body, _ = sjson.SetBytes(body, "service_tier", config.ServiceTier)
+	}
+	return payloadoverride.ApplyGlobal(body, "codex", flow.GetMappedModel(c)), nil
+}
+
+func codexResponsesWebSocketURL(c *flow.Ctx, config *domain.ProviderConfigCodex) (string, error) {
+	baseURL := CodexBaseURL
+	custom := config != nil && strings.TrimSpace(config.BaseURL) != ""
+	if custom {
+		baseURL = strings.TrimRight(config.BaseURL, "/")
+	}
+
+	path := "/responses"
+	if custom && domain.ResponsesPassthroughEnabled(config.ResponsesPassthrough) {
+		path = flow.GetResponsesClientPath(c)
+		if path == "" {
+			path = "/v1/responses"
+		}
+	}
+	parsed, err := url.Parse(baseURL + path)
+	if err != nil {
+		return "", err
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "http":
+		parsed.Scheme = "ws"
+	case "https":
+		parsed.Scheme = "wss"
+	default:
+		return "", fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", errors.New("websocket URL host is empty")
+	}
+	return parsed.String(), nil
+}
+
+func buildCodexWebSocketHeaders(c *flow.Ctx, accessToken, accountID string, body []byte) http.Header {
+	headers := make(http.Header)
+	if c != nil && c.Request != nil {
+		for key, values := range c.Request.Header {
+			lowerKey := strings.ToLower(key)
+			if codexFilteredHeaders[lowerKey] || lowerKey == "authorization" || strings.HasPrefix(lowerKey, "sec-websocket-") {
+				continue
+			}
+			for _, value := range values {
+				headers.Add(key, value)
+			}
+		}
+	}
+	if strings.TrimSpace(accessToken) != "" {
+		headers.Set("Authorization", "Bearer "+accessToken)
+	}
+	betaHeader := strings.TrimSpace(headers.Get("OpenAI-Beta"))
+	if !strings.Contains(betaHeader, "responses_websockets=") {
+		headers.Set("OpenAI-Beta", codexResponsesWebSocketBetaHeader)
+	}
+	if c != nil {
+		headers.Set("User-Agent", flow.ResolveUpstreamUserAgent(c, CodexUserAgent))
+	}
+	if sessionID := strings.TrimSpace(headers.Get("Session_id")); sessionID == "" {
+		if promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String()); promptCacheKey != "" {
+			headers.Set("Session_id", promptCacheKey)
+			headers.Set("Conversation_id", promptCacheKey)
+		}
+	}
+	if strings.TrimSpace(accessToken) != "" {
+		if headers.Get("Originator") == "" {
+			headers.Set("Originator", CodexOriginator)
+		}
+		if accountID != "" {
+			headers.Set("Chatgpt-Account-Id", accountID)
+		}
+	}
+	return headers
+}
+
+func dialCodexWebSocket(ctx context.Context, target string, headers http.Header) (*codexWebSocketSession, *http.Response, error) {
+	dialer := &websocket.Dialer{
+		Proxy:             http.ProxyFromEnvironment,
+		HandshakeTimeout:  codexResponsesWebSocketHandshake,
+		EnableCompression: true,
+		NetDialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+	}
+	conn, response, err := dialer.DialContext(ctx, target, headers)
+	if err != nil {
+		return nil, response, err
+	}
+	responseHeaders := make(http.Header)
+	if response != nil {
+		responseHeaders = response.Header.Clone()
+		if response.Body != nil {
+			_ = response.Body.Close()
+		}
+	}
+	return newCodexWebSocketSession(conn, responseHeaders), response, nil
+}
+
+func readCodexWebSocketHandshakeBody(response *http.Response) []byte {
+	if response == nil || response.Body == nil {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	_ = response.Body.Close()
+	return body
+}
+
+func classifyCodexWebSocketEvent(payload []byte, model string) *domain.ProxyError {
+	message := strings.TrimSpace(gjson.GetBytes(payload, "error.message").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(payload, "response.error.message").String())
+	}
+	if message == "" {
+		message = "upstream websocket returned an error"
+	}
+	code := strings.TrimSpace(gjson.GetBytes(payload, "error.code").String())
+	if code == "" {
+		code = strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String())
+	}
+	errorType := strings.ToLower(gjson.GetBytes(payload, "error.type").String() + " " + code)
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New(string(payload)), true, message)
+	proxyErr.Code = code
+	proxyErr.ClientType = string(domain.ClientTypeCodex)
+	switch {
+	case strings.Contains(errorType, "rate_limit") || strings.Contains(errorType, "quota"):
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonRateLimitExceeded
+		proxyErr.HTTPStatusCode = http.StatusTooManyRequests
+	case strings.Contains(errorType, "auth") || strings.Contains(errorType, "unauthorized"):
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonAuthFailure
+		proxyErr.HTTPStatusCode = http.StatusUnauthorized
+		proxyErr.Retryable = false
+	case strings.Contains(errorType, "model"):
+		proxyErr.Scope = domain.ScopeModel
+		proxyErr.Reason = domain.CooldownReasonModelUnavailable
+		proxyErr.Model = model
+		proxyErr.HTTPStatusCode = http.StatusNotFound
+		proxyErr.Retryable = false
+	case strings.Contains(errorType, "invalid"):
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusBadRequest
+		proxyErr.Retryable = false
+	default:
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		proxyErr.HTTPStatusCode = http.StatusBadGateway
+	}
+	return proxyErr
+}
+
+func sendCodexWebSocketFinalEvents(eventChan domain.AdapterEventChan, headers http.Header, collector *usage.StreamCollector, model string) {
+	if eventChan == nil {
+		return
+	}
+	eventChan.SendResponseInfo(&domain.ResponseInfo{
+		Status:  http.StatusSwitchingProtocols,
+		Headers: flattenHeaders(headers),
+		Body:    "[websocket streaming]",
+	})
+	if collector != nil && collector.Metrics != nil && !collector.Metrics.IsEmpty() {
+		metrics := usage.AdjustForClientType(collector.Metrics, domain.ClientTypeCodex)
+		eventChan.SendMetrics(&domain.AdapterMetrics{
+			InputTokens:    metrics.InputTokens,
+			OutputTokens:   metrics.OutputTokens,
+			CacheReadCount: metrics.CacheReadCount,
+		})
+	}
+	eventChan.SendResponseModel(model)
+}

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -1,0 +1,140 @@
+package codex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/tidwall/gjson"
+)
+
+func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
+	var connectionCount atomic.Int32
+	requests := make(chan []byte, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/responses" {
+			t.Errorf("path = %q, want /v1/responses", r.URL.Path)
+		}
+		if got := r.Header.Get("OpenAI-Beta"); got != codexResponsesWebSocketBetaHeader {
+			t.Errorf("OpenAI-Beta = %q", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "codex-test/1.0" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		connectionCount.Add(1)
+		for turn := 1; turn <= 2; turn++ {
+			_, payload, errRead := conn.ReadMessage()
+			if errRead != nil {
+				t.Errorf("read turn %d: %v", turn, errRead)
+				return
+			}
+			requests <- payload
+			responseID := "resp_" + string(rune('0'+turn))
+			completed := `{"type":"response.completed","response":{"id":"` + responseID + `","model":"gpt-test","output":[],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`
+			if errWrite := conn.WriteMessage(websocket.TextMessage, []byte(completed)); errWrite != nil {
+				t.Errorf("write turn %d: %v", turn, errWrite)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{
+		ID:   42,
+		Type: "codex",
+		Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+			AccessToken: "test-token",
+			BaseURL:     server.URL,
+		}},
+	}
+	adapter := &CodexAdapter{
+		provider:   provider,
+		tokenCache: &TokenCache{AccessToken: "test-token"},
+		httpClient: newUpstreamHTTPClient(),
+	}
+	sessionID := uuid.NewString()
+	storeKey := "42:" + sessionID
+	t.Cleanup(func() {
+		if session := globalCodexWebSocketSessions.get(storeKey); session != nil {
+			globalCodexWebSocketSessions.remove(storeKey, session)
+		}
+	})
+
+	firstRaw := []byte(`{"type":"response.create","model":"client-model","stream":true,"background":true,"input":[]}`)
+	firstCtx := newCodexWebSocketTestContext(t, firstRaw, sessionID)
+	handled, err := adapter.executeResponsesWebSocket(firstCtx, provider)
+	if !handled || err != nil {
+		t.Fatalf("first execute handled=%v err=%v", handled, err)
+	}
+	firstUpstream := <-requests
+	if got := gjson.GetBytes(firstUpstream, "type").String(); got != "response.create" {
+		t.Fatalf("type = %q", got)
+	}
+	if got := gjson.GetBytes(firstUpstream, "model").String(); got != "gpt-test" {
+		t.Fatalf("model = %q, want mapped model", got)
+	}
+	if gjson.GetBytes(firstUpstream, "stream").Exists() || gjson.GetBytes(firstUpstream, "background").Exists() {
+		t.Fatalf("websocket-only implicit fields not removed: %s", firstUpstream)
+	}
+
+	secondRaw := []byte(`{"type":"response.append","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
+	secondCtx := newCodexWebSocketTestContext(t, secondRaw, sessionID)
+	handled, err = adapter.executeResponsesWebSocket(secondCtx, provider)
+	if !handled || err != nil {
+		t.Fatalf("second execute handled=%v err=%v", handled, err)
+	}
+	secondUpstream := <-requests
+	if got := gjson.GetBytes(secondUpstream, "type").String(); got != "response.create" {
+		t.Fatalf("second type = %q", got)
+	}
+	if got := gjson.GetBytes(secondUpstream, "previous_response_id").String(); got != "resp_1" {
+		t.Fatalf("previous_response_id = %q", got)
+	}
+	if connectionCount.Load() != 1 {
+		t.Fatalf("connections = %d, want 1", connectionCount.Load())
+	}
+}
+
+func TestExecuteResponsesWebSocket_SkipsProtocolConversion(t *testing.T) {
+	provider := &domain.Provider{ID: 1, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{}}}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{}}
+	raw := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), "session", raw))
+	c := flow.NewCtx(httptest.NewRecorder(), request)
+	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
+	c.Set(flow.KeyOriginalClientType, domain.ClientTypeClaude)
+
+	handled, err := adapter.executeResponsesWebSocket(c, provider)
+	if handled || err != nil {
+		t.Fatalf("conversion handled=%v err=%v", handled, err)
+	}
+}
+
+func newCodexWebSocketTestContext(t *testing.T, raw []byte, sessionID string) *flow.Ctx {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", strings.NewReader(`{"model":"gpt-test","stream":true,"input":[]}`))
+	request.Header.Set("User-Agent", "codex-test/1.0")
+	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), sessionID, raw))
+	c := flow.NewCtx(httptest.NewRecorder(), request)
+	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
+	c.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
+	c.Set(flow.KeyMappedModel, "gpt-test")
+	c.Set(flow.KeyIsStream, true)
+	c.Set(flow.KeyResponsesClientPath, "/v1/responses")
+	return c
+}

--- a/internal/context/responses_websocket.go
+++ b/internal/context/responses_websocket.go
@@ -1,0 +1,36 @@
+package context
+
+import (
+	"bytes"
+	stdcontext "context"
+)
+
+type responsesWebSocketRequestKey struct{}
+
+// ResponsesWebSocketRequest carries the original downstream WebSocket event
+// alongside the HTTP/SSE fallback request built by the handler.
+type ResponsesWebSocketRequest struct {
+	SessionID string
+	Payload   []byte
+}
+
+// WithResponsesWebSocketRequest attaches WebSocket request metadata to ctx.
+func WithResponsesWebSocketRequest(ctx stdcontext.Context, sessionID string, payload []byte) stdcontext.Context {
+	return stdcontext.WithValue(ctx, responsesWebSocketRequestKey{}, ResponsesWebSocketRequest{
+		SessionID: sessionID,
+		Payload:   bytes.Clone(payload),
+	})
+}
+
+// GetResponsesWebSocketRequest returns a copy of the WebSocket request metadata.
+func GetResponsesWebSocketRequest(ctx stdcontext.Context) (ResponsesWebSocketRequest, bool) {
+	if ctx == nil {
+		return ResponsesWebSocketRequest{}, false
+	}
+	request, ok := ctx.Value(responsesWebSocketRequestKey{}).(ResponsesWebSocketRequest)
+	if !ok || request.SessionID == "" || len(request.Payload) == 0 {
+		return ResponsesWebSocketRequest{}, false
+	}
+	request.Payload = bytes.Clone(request.Payload)
+	return request, true
+}

--- a/internal/core/pprof_manager.go
+++ b/internal/core/pprof_manager.go
@@ -168,7 +168,7 @@ func (m *PprofManager) startServerLocked() error {
 		return fmt.Errorf("pprof server already running")
 	}
 
-	addr := fmt.Sprintf("localhost:%d", m.config.Port)
+	addr := pprofListenAddress(m.config.Port)
 
 	// 先尝试绑定端口以验证是否可用
 	listener, err := net.Listen("tcp", addr)
@@ -223,6 +223,10 @@ func (m *PprofManager) startServerLocked() error {
 	}()
 
 	return nil
+}
+
+func pprofListenAddress(port int) string {
+	return net.JoinHostPort("0.0.0.0", strconv.Itoa(port))
 }
 
 // stopServerLocked 停止 pprof 服务（需要持有锁）

--- a/internal/core/pprof_manager_test.go
+++ b/internal/core/pprof_manager_test.go
@@ -1,0 +1,9 @@
+package core
+
+import "testing"
+
+func TestPprofListenAddressBindsAllInterfaces(t *testing.T) {
+	if got, want := pprofListenAddress(6060), "0.0.0.0:6060"; got != want {
+		t.Fatalf("pprofListenAddress(6060) = %q, want %q", got, want)
+	}
+}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -91,6 +91,22 @@ func (h *ProxyHandler) SetRequestTracker(tracker RequestTracker) {
 
 // ServeHTTP handles proxy requests
 func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isResponsesWebSocketUpgrade(r) {
+		if h.tokenAuth != nil {
+			if _, err := h.tokenAuth.ValidateRequest(r, domain.ClientTypeCodex); err != nil {
+				writeError(w, http.StatusUnauthorized, err.Error())
+				return
+			}
+		}
+
+		var readLimit int64
+		if h.uploadLimiter != nil {
+			readLimit = h.uploadLimiter.maxBytes
+		}
+		serveResponsesWebSocket(w, r, h, readLimit)
+		return
+	}
+
 	ctx := flow.NewCtx(w, r)
 	handlers := make([]flow.HandlerFunc, len(h.extra)+1)
 	copy(handlers, h.extra)

--- a/internal/handler/responses_websocket.go
+++ b/internal/handler/responses_websocket.go
@@ -1,0 +1,558 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+const (
+	responsesWebSocketRequestCreate = "response.create"
+	responsesWebSocketRequestAppend = "response.append"
+)
+
+var responsesWebSocketUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin: func(*http.Request) bool {
+		return true
+	},
+}
+
+type responsesWebSocketSessionState struct {
+	lastRequest        []byte
+	lastResponseOutput []json.RawMessage
+}
+
+func isResponsesWebSocketUpgrade(r *http.Request) bool {
+	if r == nil || r.URL == nil || r.Method != http.MethodGet || !websocket.IsWebSocketUpgrade(r) {
+		return false
+	}
+	return r.URL.Path == "/v1/responses" || r.URL.Path == "/responses"
+}
+
+func serveResponsesWebSocket(w http.ResponseWriter, r *http.Request, next http.Handler, readLimit int64) {
+	if next == nil {
+		writeError(w, http.StatusInternalServerError, "responses websocket proxy is not configured")
+		return
+	}
+
+	conn, err := responsesWebSocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	if readLimit > 0 {
+		conn.SetReadLimit(readLimit)
+	}
+
+	state := &responsesWebSocketSessionState{}
+	sessionID := uuid.NewString()
+	for {
+		messageType, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			return
+		}
+		if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
+			continue
+		}
+
+		requestBody, errNormalize := state.normalizeRequest(payload)
+		if errNormalize != nil {
+			if errWrite := writeResponsesWebSocketError(conn, http.StatusBadRequest, errNormalize.Error(), nil); errWrite != nil {
+				return
+			}
+			continue
+		}
+
+		request := newResponsesWebSocketHTTPRequest(r, requestBody, sessionID, payload)
+		writer := newResponsesWebSocketResponseWriter(conn)
+		next.ServeHTTP(writer, request)
+		if errFinish := writer.finish(); errFinish != nil {
+			return
+		}
+		if writer.completed {
+			state.lastRequest = bytes.Clone(requestBody)
+			state.lastResponseOutput = cloneRawMessages(writer.completedOutput)
+		}
+	}
+}
+
+func newResponsesWebSocketHTTPRequest(original *http.Request, body []byte, sessionID string, payload []byte) *http.Request {
+	ctx := maxxctx.WithResponsesWebSocketRequest(original.Context(), sessionID, payload)
+	request := original.Clone(ctx)
+	request.Method = http.MethodPost
+	request.Body = http.NoBody
+	if len(body) > 0 {
+		request.Body = io.NopCloser(bytes.NewReader(body))
+	}
+	request.ContentLength = int64(len(body))
+	request.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	request.Header = original.Header.Clone()
+	for _, key := range []string{
+		"Connection",
+		"Upgrade",
+		"Sec-Websocket-Key",
+		"Sec-Websocket-Version",
+		"Sec-Websocket-Extensions",
+		"Sec-Websocket-Protocol",
+		"Content-Length",
+	} {
+		request.Header.Del(key)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "text/event-stream")
+	return request
+}
+
+func (s *responsesWebSocketSessionState) normalizeRequest(payload []byte) ([]byte, error) {
+	request, err := decodeJSONObject(payload)
+	if err != nil {
+		return nil, fmt.Errorf("invalid websocket request JSON: %w", err)
+	}
+
+	requestType := jsonString(request["type"])
+	switch requestType {
+	case responsesWebSocketRequestCreate:
+		if len(s.lastRequest) == 0 {
+			return normalizeInitialResponsesWebSocketRequest(request)
+		}
+		return s.normalizeSubsequentResponsesWebSocketRequest(request)
+	case responsesWebSocketRequestAppend:
+		if len(s.lastRequest) == 0 {
+			return nil, fmt.Errorf("websocket request received before response.create")
+		}
+		return s.normalizeSubsequentResponsesWebSocketRequest(request)
+	default:
+		return nil, fmt.Errorf("unsupported websocket request type: %s", requestType)
+	}
+}
+
+func normalizeInitialResponsesWebSocketRequest(request map[string]json.RawMessage) ([]byte, error) {
+	delete(request, "type")
+	request["stream"] = json.RawMessage("true")
+	if _, ok := request["input"]; !ok {
+		request["input"] = json.RawMessage("[]")
+	}
+	if strings.TrimSpace(jsonString(request["model"])) == "" {
+		return nil, fmt.Errorf("missing model in response.create request")
+	}
+	normalized, err := json.Marshal(request)
+	return normalized, err
+}
+
+func (s *responsesWebSocketSessionState) normalizeSubsequentResponsesWebSocketRequest(request map[string]json.RawMessage) ([]byte, error) {
+	nextInput, err := decodeJSONArray(request["input"])
+	if err != nil {
+		return nil, fmt.Errorf("websocket request requires array field: input")
+	}
+
+	lastRequest, err := decodeJSONObject(s.lastRequest)
+	if err != nil {
+		return nil, fmt.Errorf("invalid previous websocket request state: %w", err)
+	}
+
+	previousResponseID := strings.TrimSpace(jsonString(request["previous_response_id"]))
+	var mergedInput []json.RawMessage
+	if previousResponseID == "" && responsesWebSocketInputReplacesTranscript(nextInput) {
+		mergedInput = cloneRawMessages(nextInput)
+	} else {
+		lastInput, errLastInput := decodeJSONArray(lastRequest["input"])
+		if errLastInput != nil {
+			return nil, fmt.Errorf("invalid previous websocket input: %w", errLastInput)
+		}
+		mergedInput = append(mergedInput, cloneRawMessages(lastInput)...)
+		mergedInput = append(mergedInput, cloneRawMessages(s.lastResponseOutput)...)
+		mergedInput = append(mergedInput, cloneRawMessages(nextInput)...)
+		mergedInput = dedupeResponsesWebSocketItems(mergedInput)
+	}
+
+	delete(request, "type")
+	delete(request, "previous_response_id")
+	request["stream"] = json.RawMessage("true")
+	request["input"], err = json.Marshal(mergedInput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge websocket input: %w", err)
+	}
+	if _, ok := request["model"]; !ok {
+		request["model"] = bytes.Clone(lastRequest["model"])
+	}
+	if _, ok := request["instructions"]; !ok {
+		if instructions, exists := lastRequest["instructions"]; exists {
+			request["instructions"] = bytes.Clone(instructions)
+		}
+	}
+
+	normalized, err := json.Marshal(request)
+	return normalized, err
+}
+
+func responsesWebSocketInputReplacesTranscript(input []json.RawMessage) bool {
+	for _, item := range input {
+		object, err := decodeJSONObject(item)
+		if err != nil {
+			continue
+		}
+		switch jsonString(object["type"]) {
+		case "compaction", "compaction_summary", "function_call", "custom_tool_call":
+			return true
+		case "message":
+			if jsonString(object["role"]) == "assistant" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func dedupeResponsesWebSocketItems(items []json.RawMessage) []json.RawMessage {
+	seenItemIDs := make(map[string]struct{}, len(items))
+	seenCallIDs := make(map[string]struct{}, len(items))
+	result := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		object, err := decodeJSONObject(item)
+		if err == nil {
+			if id := strings.TrimSpace(jsonString(object["id"])); id != "" {
+				if _, exists := seenItemIDs[id]; exists {
+					continue
+				}
+				seenItemIDs[id] = struct{}{}
+			}
+			switch jsonString(object["type"]) {
+			case "function_call", "custom_tool_call":
+				if callID := strings.TrimSpace(jsonString(object["call_id"])); callID != "" {
+					if _, exists := seenCallIDs[callID]; exists {
+						continue
+					}
+					seenCallIDs[callID] = struct{}{}
+				}
+			}
+		}
+		result = append(result, bytes.Clone(item))
+	}
+	return result
+}
+
+func newResponsesWebSocketResponseWriter(conn *websocket.Conn) *responsesWebSocketResponseWriter {
+	return &responsesWebSocketResponseWriter{
+		conn:               conn,
+		header:             make(http.Header),
+		statusCode:         http.StatusOK,
+		outputItemsByIndex: make(map[int]json.RawMessage),
+	}
+}
+
+type responsesWebSocketResponseWriter struct {
+	conn        *websocket.Conn
+	header      http.Header
+	statusCode  int
+	wroteHeader bool
+
+	modeSSE    bool
+	modeChosen bool
+	lineBuffer []byte
+	eventData  bytes.Buffer
+	rawBody    bytes.Buffer
+
+	outputItemsByIndex  map[int]json.RawMessage
+	outputItemsFallback []json.RawMessage
+	completed           bool
+	completedOutput     []json.RawMessage
+	sentError           bool
+	writeErr            error
+}
+
+func (w *responsesWebSocketResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *responsesWebSocketResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.statusCode = statusCode
+	w.wroteHeader = true
+}
+
+func (w *responsesWebSocketResponseWriter) Write(p []byte) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if !w.modeChosen {
+		contentType := strings.ToLower(w.header.Get("Content-Type"))
+		trimmed := bytes.TrimSpace(p)
+		w.modeSSE = strings.Contains(contentType, "text/event-stream") || bytes.HasPrefix(trimmed, []byte("data:"))
+		w.modeChosen = true
+	}
+	if !w.modeSSE {
+		_, _ = w.rawBody.Write(p)
+		return len(p), nil
+	}
+
+	w.lineBuffer = append(w.lineBuffer, p...)
+	w.processSSELines(false)
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return len(p), nil
+}
+
+func (w *responsesWebSocketResponseWriter) Flush() {
+	if w.modeSSE {
+		w.processSSELines(false)
+	}
+}
+
+func (w *responsesWebSocketResponseWriter) finish() error {
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	if w.modeSSE {
+		w.processSSELines(true)
+	} else if w.rawBody.Len() > 0 {
+		w.forwardRawResponse()
+	}
+	if w.writeErr != nil {
+		return w.writeErr
+	}
+	if !w.completed && !w.sentError {
+		w.writeErr = writeResponsesWebSocketError(w.conn, http.StatusBadGateway, "stream closed before response.completed", nil)
+	}
+	return w.writeErr
+}
+
+func (w *responsesWebSocketResponseWriter) processSSELines(final bool) {
+	for {
+		index := bytes.IndexByte(w.lineBuffer, '\n')
+		if index < 0 {
+			break
+		}
+		line := bytes.TrimSuffix(w.lineBuffer[:index], []byte("\r"))
+		w.lineBuffer = w.lineBuffer[index+1:]
+		w.processSSELine(line)
+		if w.writeErr != nil {
+			return
+		}
+	}
+	if final {
+		if len(w.lineBuffer) > 0 {
+			w.processSSELine(bytes.TrimSuffix(w.lineBuffer, []byte("\r")))
+			w.lineBuffer = nil
+		}
+		w.flushSSEEvent()
+	}
+}
+
+func (w *responsesWebSocketResponseWriter) processSSELine(line []byte) {
+	if len(line) == 0 {
+		w.flushSSEEvent()
+		return
+	}
+	if !bytes.HasPrefix(line, []byte("data:")) {
+		return
+	}
+	data := bytes.TrimSpace(line[len("data:"):])
+	if w.eventData.Len() > 0 {
+		w.eventData.WriteByte('\n')
+	}
+	w.eventData.Write(data)
+}
+
+func (w *responsesWebSocketResponseWriter) flushSSEEvent() {
+	if w.eventData.Len() == 0 || w.writeErr != nil {
+		w.eventData.Reset()
+		return
+	}
+	payload := bytes.Clone(w.eventData.Bytes())
+	w.eventData.Reset()
+	if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
+		return
+	}
+	w.forwardPayload(payload)
+}
+
+func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
+	object, err := decodeJSONObject(payload)
+	if err != nil {
+		w.writeErr = writeResponsesWebSocketError(w.conn, http.StatusBadGateway, "invalid JSON event from upstream", nil)
+		w.sentError = true
+		return
+	}
+
+	eventType := jsonString(object["type"])
+	if eventType == "response.output_item.done" {
+		if item, ok := object["item"]; ok && len(item) > 0 {
+			if outputIndex, okIndex := jsonInt(object["output_index"]); okIndex {
+				w.outputItemsByIndex[outputIndex] = bytes.Clone(item)
+			} else {
+				w.outputItemsFallback = append(w.outputItemsFallback, bytes.Clone(item))
+			}
+		}
+	}
+
+	if eventType == "response.completed" || eventType == "response.done" {
+		response, errResponse := decodeJSONObject(object["response"])
+		if errResponse == nil {
+			output, errOutput := decodeJSONArray(response["output"])
+			if errOutput != nil || len(output) == 0 {
+				output = w.collectedOutput()
+				if encodedOutput, errMarshal := json.Marshal(output); errMarshal == nil {
+					response["output"] = encodedOutput
+					if encodedResponse, errMarshalResponse := json.Marshal(response); errMarshalResponse == nil {
+						object["response"] = encodedResponse
+					}
+				}
+			}
+			w.completedOutput = cloneRawMessages(output)
+		}
+		w.completed = true
+	}
+	if eventType == "error" {
+		w.sentError = true
+	}
+
+	encoded, errMarshal := json.Marshal(object)
+	if errMarshal != nil {
+		w.writeErr = errMarshal
+		return
+	}
+	w.writeErr = w.conn.WriteMessage(websocket.TextMessage, encoded)
+}
+
+func (w *responsesWebSocketResponseWriter) collectedOutput() []json.RawMessage {
+	indexes := make([]int, 0, len(w.outputItemsByIndex))
+	for index := range w.outputItemsByIndex {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	result := make([]json.RawMessage, 0, len(indexes)+len(w.outputItemsFallback))
+	for _, index := range indexes {
+		result = append(result, bytes.Clone(w.outputItemsByIndex[index]))
+	}
+	result = append(result, cloneRawMessages(w.outputItemsFallback)...)
+	return result
+}
+
+func (w *responsesWebSocketResponseWriter) forwardRawResponse() {
+	payload := bytes.TrimSpace(w.rawBody.Bytes())
+	if len(payload) == 0 {
+		return
+	}
+	object, err := decodeJSONObject(payload)
+	if err != nil {
+		w.writeErr = writeResponsesWebSocketError(w.conn, w.statusCode, string(payload), nil)
+		w.sentError = true
+		return
+	}
+	if _, ok := object["type"]; ok {
+		w.forwardPayload(payload)
+		return
+	}
+	if errorBody, ok := object["error"]; ok || w.statusCode >= http.StatusBadRequest {
+		w.writeErr = writeResponsesWebSocketError(w.conn, w.statusCode, http.StatusText(w.statusCode), errorBody)
+		w.sentError = true
+		return
+	}
+
+	completion := map[string]any{
+		"type":            "response.completed",
+		"sequence_number": 0,
+		"response":        json.RawMessage(payload),
+	}
+	encoded, errMarshal := json.Marshal(completion)
+	if errMarshal != nil {
+		w.writeErr = errMarshal
+		return
+	}
+	w.forwardPayload(encoded)
+}
+
+func writeResponsesWebSocketError(conn *websocket.Conn, status int, message string, errorBody json.RawMessage) error {
+	if status < http.StatusBadRequest || status > 599 {
+		status = http.StatusInternalServerError
+	}
+	if strings.TrimSpace(message) == "" {
+		message = http.StatusText(status)
+	}
+	var detail any = map[string]any{
+		"type":    "proxy_error",
+		"message": message,
+	}
+	if len(bytes.TrimSpace(errorBody)) > 0 && json.Valid(errorBody) {
+		detail = json.RawMessage(errorBody)
+	}
+	payload, err := json.Marshal(map[string]any{
+		"type":   "error",
+		"status": status,
+		"error":  detail,
+	})
+	if err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+func decodeJSONObject(raw []byte) (map[string]json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("empty JSON object")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	return object, nil
+}
+
+func decodeJSONArray(raw []byte) ([]json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("missing JSON array")
+	}
+	var array []json.RawMessage
+	if err := json.Unmarshal(raw, &array); err != nil {
+		return nil, err
+	}
+	if array == nil {
+		array = []json.RawMessage{}
+	}
+	return array, nil
+}
+
+func jsonString(raw json.RawMessage) string {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return value
+}
+
+func jsonInt(raw json.RawMessage) (int, bool) {
+	var value int
+	if json.Unmarshal(raw, &value) != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func cloneRawMessages(messages []json.RawMessage) []json.RawMessage {
+	result := make([]json.RawMessage, len(messages))
+	for index := range messages {
+		result[index] = bytes.Clone(messages[index])
+	}
+	return result
+}

--- a/internal/handler/responses_websocket_test.go
+++ b/internal/handler/responses_websocket_test.go
@@ -1,0 +1,247 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/gorilla/websocket"
+)
+
+func TestResponsesWebSocket_ReplaysTranscriptThroughHTTPProxy(t *testing.T) {
+	requestBodies := make(chan []byte, 2)
+	callCount := 0
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Upgrade"); got != "" {
+			t.Errorf("Upgrade header leaked to HTTP proxy: %q", got)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			return
+		}
+		requestBodies <- body
+		callCount++
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if callCount == 1 {
+			writeTestSSEEvent(t, w, `{"type":"response.created","response":{"id":"resp_1"}}`)
+			writeTestSSEEvent(t, w, `{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{}"}}`)
+			writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_1","output":[]}}`)
+			return
+		}
+		writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_2","output":[{"type":"message","id":"msg_2","role":"assistant","content":[]}]}}`)
+	})
+
+	conn := dialResponsesWebSocket(t, backend)
+	defer conn.Close()
+
+	firstRequest := `{"type":"response.create","model":"gpt-test","instructions":"be concise","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"call the tool"}]}]}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(firstRequest)); err != nil {
+		t.Fatalf("write first request: %v", err)
+	}
+	firstCompleted := readWebSocketEventType(t, conn, "response.completed")
+	firstResponse := decodeTestObject(t, firstCompleted["response"])
+	firstOutput := decodeTestArray(t, firstResponse["output"])
+	if len(firstOutput) != 1 {
+		t.Fatalf("first completion output length = %d, want 1", len(firstOutput))
+	}
+	firstBody := receiveTestBody(t, requestBodies)
+	assertNormalizedWebSocketHTTPBody(t, firstBody, "gpt-test", 1)
+
+	secondRequest := `{"type":"response.create","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"tool result"}]}`
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(secondRequest)); err != nil {
+		t.Fatalf("write second request: %v", err)
+	}
+	readWebSocketEventType(t, conn, "response.completed")
+	secondBody := receiveTestBody(t, requestBodies)
+	assertNormalizedWebSocketHTTPBody(t, secondBody, "gpt-test", 3)
+
+	secondObject := decodeTestObject(t, secondBody)
+	if _, exists := secondObject["previous_response_id"]; exists {
+		t.Fatal("previous_response_id must be removed for transcript replay")
+	}
+	if got := jsonString(secondObject["instructions"]); got != "be concise" {
+		t.Fatalf("instructions = %q, want inherited value", got)
+	}
+}
+
+func TestResponsesWebSocket_PreservesNativePayloadAndSession(t *testing.T) {
+	type capturedRequest struct {
+		body     []byte
+		metadata maxxctx.ResponsesWebSocketRequest
+	}
+	requests := make(chan capturedRequest, 2)
+	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		metadata, ok := maxxctx.GetResponsesWebSocketRequest(r.Context())
+		if !ok {
+			t.Error("missing responses websocket request metadata")
+		}
+		requests <- capturedRequest{body: body, metadata: metadata}
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_test","output":[]}}`)
+	})
+
+	conn := dialResponsesWebSocket(t, backend)
+	defer conn.Close()
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-test","generate":false,"input":[]}`)
+	if err := conn.WriteMessage(websocket.TextMessage, firstPayload); err != nil {
+		t.Fatalf("write first request: %v", err)
+	}
+	readWebSocketEventType(t, conn, "response.completed")
+	first := <-requests
+	if string(first.metadata.Payload) != string(firstPayload) {
+		t.Fatalf("native payload = %s, want %s", first.metadata.Payload, firstPayload)
+	}
+	if first.metadata.SessionID == "" {
+		t.Fatal("websocket session ID is empty")
+	}
+	firstBody := decodeTestObject(t, first.body)
+	var generate bool
+	if err := json.Unmarshal(firstBody["generate"], &generate); err != nil || generate {
+		t.Fatalf("fallback generate = %s, want false", firstBody["generate"])
+	}
+
+	secondPayload := []byte(`{"type":"response.create","previous_response_id":"resp_test","input":[]}`)
+	if err := conn.WriteMessage(websocket.TextMessage, secondPayload); err != nil {
+		t.Fatalf("write second request: %v", err)
+	}
+	readWebSocketEventType(t, conn, "response.completed")
+	second := <-requests
+	if second.metadata.SessionID != first.metadata.SessionID {
+		t.Fatalf("session ID changed: %q -> %q", first.metadata.SessionID, second.metadata.SessionID)
+	}
+	if string(second.metadata.Payload) != string(secondPayload) {
+		t.Fatalf("second native payload = %s, want %s", second.metadata.Payload, secondPayload)
+	}
+}
+
+func TestResponsesWebSocket_MapsHTTPErrorToWebSocketError(t *testing.T) {
+	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"bad token"}}`))
+	})
+
+	conn := dialResponsesWebSocket(t, backend)
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	event := readWebSocketEventType(t, conn, "error")
+	var status int
+	if err := json.Unmarshal(event["status"], &status); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	if status != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", status, http.StatusUnauthorized)
+	}
+	errorBody := decodeTestObject(t, event["error"])
+	if got := jsonString(errorBody["message"]); got != "bad token" {
+		t.Fatalf("error message = %q, want bad token", got)
+	}
+}
+
+func dialResponsesWebSocket(t *testing.T, backend http.Handler) *websocket.Conn {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serveResponsesWebSocket(w, r, backend, 0)
+	}))
+	t.Cleanup(server.Close)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
+	conn, response, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial responses websocket: %v (status %s)", err, response.Status)
+		}
+		t.Fatalf("dial responses websocket: %v", err)
+	}
+	return conn
+}
+
+func writeTestSSEEvent(t *testing.T, w http.ResponseWriter, payload string) {
+	t.Helper()
+	if _, err := io.WriteString(w, "data: "+payload+"\n\n"); err != nil {
+		t.Errorf("write SSE event: %v", err)
+		return
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func readWebSocketEventType(t *testing.T, conn *websocket.Conn, wantedType string) map[string]json.RawMessage {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set websocket read deadline: %v", err)
+	}
+	for {
+		_, payload, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read websocket event %s: %v", wantedType, err)
+		}
+		event := decodeTestObject(t, payload)
+		if jsonString(event["type"]) == wantedType {
+			return event
+		}
+	}
+}
+
+func receiveTestBody(t *testing.T, bodies <-chan []byte) []byte {
+	t.Helper()
+	select {
+	case body := <-bodies:
+		return body
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for proxied request body")
+		return nil
+	}
+}
+
+func assertNormalizedWebSocketHTTPBody(t *testing.T, body []byte, model string, inputLength int) {
+	t.Helper()
+	object := decodeTestObject(t, body)
+	if _, exists := object["type"]; exists {
+		t.Fatal("websocket event type leaked into HTTP Responses body")
+	}
+	var stream bool
+	if err := json.Unmarshal(object["stream"], &stream); err != nil || !stream {
+		t.Fatalf("stream = %s, want true", object["stream"])
+	}
+	if got := jsonString(object["model"]); got != model {
+		t.Fatalf("model = %q, want %q", got, model)
+	}
+	input := decodeTestArray(t, object["input"])
+	if len(input) != inputLength {
+		t.Fatalf("input length = %d, want %d; body=%s", len(input), inputLength, body)
+	}
+}
+
+func decodeTestObject(t *testing.T, raw []byte) map[string]json.RawMessage {
+	t.Helper()
+	object, err := decodeJSONObject(raw)
+	if err != nil {
+		t.Fatalf("decode JSON object %s: %v", raw, err)
+	}
+	return object
+}
+
+func decodeTestArray(t *testing.T, raw []byte) []json.RawMessage {
+	t.Helper()
+	array, err := decodeJSONArray(raw)
+	if err != nil {
+		t.Fatalf("decode JSON array %s: %v", raw, err)
+	}
+	return array
+}

--- a/web/src/lib/backend-config.test.ts
+++ b/web/src/lib/backend-config.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BackendStorageError,
+  buildPprofUrl,
   buildTransportConfig,
   getBackendUrl,
   setBackendUrl,
@@ -122,5 +123,16 @@ describe('buildTransportConfig', () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+});
+
+describe('buildPprofUrl', () => {
+  it('uses the current page hostname for the same-origin backend', () => {
+    expect(buildPprofUrl(6060)).toBe(`http://${window.location.hostname}:6060/debug/pprof/`);
+  });
+
+  it('uses the configured backend hostname without its application port or path', () => {
+    setBackendUrl('https://api.example.com:9880/maxx');
+    expect(buildPprofUrl('6061')).toBe('http://api.example.com:6061/debug/pprof/');
   });
 });

--- a/web/src/lib/backend-config.ts
+++ b/web/src/lib/backend-config.ts
@@ -152,3 +152,25 @@ export function buildTransportConfig(): TransportConfig | undefined {
     wsURL,
   };
 }
+
+/**
+ * Builds the externally reachable pprof URL. The pprof server has its own
+ * port, so use the configured backend hostname (or the current page hostname)
+ * without carrying over the application's HTTP port.
+ */
+export function buildPprofUrl(port: string | number): string {
+  const backend = getBackendUrl();
+  let hostname = '';
+
+  if (backend) {
+    hostname = new URL(backend).hostname;
+  } else if (typeof window !== 'undefined') {
+    hostname = window.location.hostname;
+  }
+
+  hostname ||= 'localhost';
+  if (hostname.includes(':') && !hostname.startsWith('[')) {
+    hostname = `[${hostname}]`;
+  }
+  return `http://${hostname}:${port}/debug/pprof/`;
+}

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -44,6 +44,7 @@ import { PageHeader } from '@/components/layout/page-header';
 import { BackendAddressControl } from '@/components/backend-address-control';
 import { useSettings, useUpdateSetting, useDeleteSetting } from '@/hooks/queries';
 import { useAuth } from '@/lib/auth-context';
+import { buildPprofUrl } from '@/lib/backend-config';
 import { useTransport } from '@/lib/transport/context';
 import type { BackupFile, BackupImportResult } from '@/lib/transport/types';
 import { getDefaultThemes, getLuxuryThemes, isLuxuryTheme } from '@/lib/theme';
@@ -1611,6 +1612,7 @@ function PprofSection() {
   const [initialized, setInitialized] = useState(false);
   const [passwordError, setPasswordError] = useState('');
   const [portError, setPortError] = useState('');
+  const pprofUrl = buildPprofUrl(portDraft);
 
   useEffect(() => {
     if (!isLoading && !initialized) {
@@ -1863,12 +1865,12 @@ function PprofSection() {
                 <p className="flex items-center gap-2">
                   <span>{t('settings.pprofAccessHint')}:</span>
                   <a
-                    href={`http://localhost:${portDraft}/debug/pprof/`}
+                    href={pprofUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-blue-700 dark:hover:text-blue-300 font-medium"
                   >
-                    http://localhost:{portDraft}/debug/pprof/
+                    {pprofUrl}
                   </a>
                 </p>
                 {usePasswordDraft && (


### PR DESCRIPTION
## Summary

- accept Codex Responses API WebSocket upgrades on `GET /v1/responses` and `/responses`
- forward raw `response.create` events over a persistent upstream WebSocket only for native Codex client -> Codex provider requests
- retain HTTP/SSE transcript replay for protocol-converted requests, provider failover, and WebSocket upgrade fallback
- bind pprof to `0.0.0.0` and generate the settings-page pprof URL from the configured backend/current hostname
- document Codex `supports_websockets` / legacy `responses_websockets_v2` configuration

## Implementation notes

The downstream WebSocket handler builds an internal HTTP/SSE fallback request for the existing routing, authentication, billing, retry, and response-capture pipeline, while attaching the original WebSocket event to request context. The native Codex adapter consumes that metadata only when both original and target client types are Codex. Persistent upstream sessions are scoped by provider and downstream WebSocket connection.

## Validation

- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s` for all `./cmd/... ./internal/...` packages except the two pre-existing Windows-only `cmd/maxx-cli/internal/cfg` permission/path failures
- `go test ./internal/adapter/provider/codex ./internal/handler ./internal/core -count=1`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run src/lib/backend-config.test.ts`

On this Windows host, `go test ./...` otherwise passes but still reports the existing `TestSavePermissionsAre0600` and `TestLegacyMigration` platform failures. Linux CI is expected to exercise the complete backend suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Codex Responses 现支持 WebSocket 持久连接与事件流转发，并兼容会话复用、错误反馈及鉴权处理。
  * 优化 Pprof 访问链接生成，可根据实际后端地址正确打开调试页面。
  * Pprof 服务支持从所有网络接口访问。

* **文档**
  * 更新中英文配置示例、API 端点说明及 WebSocket 使用提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->