### PR TITLE
fix(custom): tolerate terminal SSE EOF

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -824,11 +824,20 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 		}
 
 		if err != nil {
-			if lineBuffer.Len() > 0 {
+			if err == io.EOF && lineBuffer.Len() > 0 {
 				line := lineBuffer.String()
 				lineBuffer.Reset()
 				if lineErr := processStreamLine(line); lineErr != nil {
 					return lineErr
+				}
+			}
+			if err == io.ErrUnexpectedEOF && lineBuffer.Len() > 0 {
+				line := lineBuffer.String()
+				if strings.TrimSpace(line) == "data: [DONE]" {
+					lineBuffer.Reset()
+					if lineErr := processStreamLine(line); lineErr != nil {
+						return lineErr
+					}
 				}
 			}
 			if err == io.EOF || (err == io.ErrUnexpectedEOF && sawTerminalSSEEvent) {

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -727,6 +727,72 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 	var lineBuffer bytes.Buffer
 	buf := make([]byte, 4096)
 	firstChunkSent := false // Track TTFT
+	sawTerminalSSEEvent := false
+
+	processStreamLine := func(line string) error {
+		processedLine := line
+		if isOAuthToken {
+			trimmedLine := strings.TrimSuffix(processedLine, "\n")
+			stripped := stripClaudeToolPrefixFromStreamLine([]byte(trimmedLine), claudeToolPrefix)
+			processedLine = string(stripped)
+			if strings.HasSuffix(line, "\n") && !strings.HasSuffix(processedLine, "\n") {
+				processedLine += "\n"
+			}
+		}
+
+		// Extract metrics and model incrementally per line
+		collector.ProcessSSELine(processedLine)
+		extractResponseModelFromSSELine(processedLine, clientType, &responseModel)
+
+		// Check for SSE error events in data lines BEFORE writing to client
+		lineStr := processedLine
+		trimmedLine := strings.TrimSpace(lineStr)
+		if trimmedLine == "data: [DONE]" {
+			sawTerminalSSEEvent = true
+		}
+		if strings.HasPrefix(trimmedLine, "data:") {
+			if parseErr := parseSSEError(lineStr); parseErr != nil {
+				sseError = parseErr
+				// If no real data has been written to the client yet,
+				// return the error immediately so retry logic can try another route
+				if !firstChunkSent {
+					sendFinalEvents()
+					return sseError
+				}
+				// Otherwise continue to forward the error to client
+			}
+		}
+
+		// Note: Response format conversion is handled by Executor's ConvertingResponseWriter
+		// Adapter simply passes through the upstream SSE data
+		if len(processedLine) > 0 {
+			_, writeErr := c.Writer.Write([]byte(processedLine))
+			if writeErr != nil {
+				sendFinalEvents()
+				if converter.IsResponseConversionError(writeErr) {
+					proxyErr := domain.NewProxyErrorWithMessage(writeErr, true, "response format conversion failed")
+					proxyErr.Scope = domain.ScopeProvider
+					proxyErr.Reason = domain.CooldownReasonServerError
+					return proxyErr
+				}
+				// Client disconnected
+				proxyErr := domain.NewProxyErrorWithMessage(writeErr, false, "client disconnected")
+				proxyErr.Scope = domain.ScopeRequest
+				return proxyErr
+			}
+			flusher.Flush()
+
+			// Track TTFT: send first token time on first successful write
+			if !firstChunkSent {
+				firstChunkSent = true
+				if eventChan != nil {
+					eventChan.SendFirstToken(time.Now().UnixMilli())
+				}
+			}
+		}
+
+		return nil
+	}
 
 	for {
 		// Check context before reading
@@ -751,66 +817,21 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 					lineBuffer.WriteString(line)
 					break
 				}
-
-				processedLine := line
-				if isOAuthToken {
-					trimmedLine := strings.TrimSuffix(processedLine, "\n")
-					stripped := stripClaudeToolPrefixFromStreamLine([]byte(trimmedLine), claudeToolPrefix)
-					processedLine = string(stripped)
-					if strings.HasSuffix(line, "\n") && !strings.HasSuffix(processedLine, "\n") {
-						processedLine += "\n"
-					}
-				}
-
-				// Extract metrics and model incrementally per line
-				collector.ProcessSSELine(processedLine)
-				extractResponseModelFromSSELine(processedLine, clientType, &responseModel)
-
-				// Check for SSE error events in data lines BEFORE writing to client
-				lineStr := processedLine
-				if strings.HasPrefix(strings.TrimSpace(lineStr), "data:") {
-					if parseErr := parseSSEError(lineStr); parseErr != nil {
-						sseError = parseErr
-						// If no real data has been written to the client yet,
-						// return the error immediately so retry logic can try another route
-						if !firstChunkSent {
-							sendFinalEvents()
-							return sseError
-						}
-						// Otherwise continue to forward the error to client
-					}
-				}
-
-				// Note: Response format conversion is handled by Executor's ConvertingResponseWriter
-				// Adapter simply passes through the upstream SSE data
-				if len(processedLine) > 0 {
-					_, writeErr := c.Writer.Write([]byte(processedLine))
-					if writeErr != nil {
-						sendFinalEvents()
-						if converter.IsResponseConversionError(writeErr) {
-							proxyErr := domain.NewProxyErrorWithMessage(writeErr, true, "response format conversion failed")
-							proxyErr.Scope = domain.ScopeProvider
-							proxyErr.Reason = domain.CooldownReasonServerError
-							return proxyErr
-						}
-						// Client disconnected
-						proxyErr := domain.NewProxyErrorWithMessage(writeErr, false, "client disconnected")
-						proxyErr.Scope = domain.ScopeRequest
-						return proxyErr
-					}
-					flusher.Flush()
-
-					// Track TTFT: send first token time on first successful write
-					if !firstChunkSent && eventChan != nil {
-						firstChunkSent = true
-						eventChan.SendFirstToken(time.Now().UnixMilli())
-					}
+				if lineErr := processStreamLine(line); lineErr != nil {
+					return lineErr
 				}
 			}
 		}
 
 		if err != nil {
-			if err == io.EOF {
+			if lineBuffer.Len() > 0 {
+				line := lineBuffer.String()
+				lineBuffer.Reset()
+				if lineErr := processStreamLine(line); lineErr != nil {
+					return lineErr
+				}
+			}
+			if err == io.EOF || (err == io.ErrUnexpectedEOF && sawTerminalSSEEvent) {
 				sendFinalEvents() // Extract tokens at normal completion
 				// Return SSE error if one was detected during streaming
 				if sseError != nil {

--- a/internal/adapter/provider/custom/stream_eof_test.go
+++ b/internal/adapter/provider/custom/stream_eof_test.go
@@ -1,0 +1,95 @@
+package custom
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+type terminalUnexpectedEOFReadCloser struct {
+	data []byte
+	done bool
+}
+
+func (r *terminalUnexpectedEOFReadCloser) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), io.ErrUnexpectedEOF
+}
+
+func (r *terminalUnexpectedEOFReadCloser) Close() error { return nil }
+
+func TestCustomAdapterStreamDoesNotFailDoneWithoutTrailingNewline(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]")
+	}))
+	defer server.Close()
+
+	adapter, err := NewAdapter(&domain.Provider{
+		Name:                 "test-custom",
+		Type:                 "custom",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+		Config: &domain.ProviderConfig{
+			Custom: &domain.ProviderConfigCustom{
+				BaseURL: server.URL,
+				APIKey:  "sk-test",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAdapter error: %v", err)
+	}
+
+	body := []byte(`{"model":"gpt-test","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+	ctx.Set(flow.KeyOriginalClientType, domain.ClientTypeOpenAI)
+	ctx.Set(flow.KeyRequestHeaders, req.Header.Clone())
+	ctx.Set(flow.KeyRequestURI, "/v1/chat/completions")
+	ctx.Set(flow.KeyRequestBody, body)
+
+	if err := adapter.Execute(ctx, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("stream body missing DONE event: %q", body)
+	}
+}
+
+func TestCustomAdapterStreamDoesNotFailUnexpectedEOFAfterDone(t *testing.T) {
+	adapter := &CustomAdapter{provider: &domain.Provider{
+		Type: "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "http://upstream.test",
+		}},
+	}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &terminalUnexpectedEOFReadCloser{data: []byte(
+			"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]",
+		)},
+	}
+
+	if err := adapter.handleStreamResponse(ctx, resp, domain.ClientTypeOpenAI, false); err != nil {
+		t.Fatalf("handleStreamResponse error: %v", err)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("stream body missing DONE event: %q", body)
+	}
+}

--- a/internal/adapter/provider/custom/stream_eof_test.go
+++ b/internal/adapter/provider/custom/stream_eof_test.go
@@ -67,12 +67,7 @@ func TestCustomAdapterStreamDoesNotFailDoneWithoutTrailingNewline(t *testing.T) 
 }
 
 func TestCustomAdapterStreamDoesNotFailUnexpectedEOFAfterDone(t *testing.T) {
-	adapter := &CustomAdapter{provider: &domain.Provider{
-		Type: "custom",
-		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
-			BaseURL: "http://upstream.test",
-		}},
-	}}
+	adapter := newTestCustomAdapter()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
@@ -92,4 +87,36 @@ func TestCustomAdapterStreamDoesNotFailUnexpectedEOFAfterDone(t *testing.T) {
 	if body := rec.Body.String(); !strings.Contains(body, "data: [DONE]") {
 		t.Fatalf("stream body missing DONE event: %q", body)
 	}
+}
+
+func TestCustomAdapterStreamDoesNotFlushPartialLineOnUnexpectedEOF(t *testing.T) {
+	adapter := newTestCustomAdapter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &terminalUnexpectedEOFReadCloser{data: []byte(
+			"data: {\"choices\":[{\"delta\":{\"content\":\"partial",
+		)},
+	}
+
+	if err := adapter.handleStreamResponse(ctx, resp, domain.ClientTypeOpenAI, false); err == nil {
+		t.Fatal("handleStreamResponse error = nil, want unexpected EOF error")
+	}
+	if body := rec.Body.String(); body != "" {
+		t.Fatalf("partial line was forwarded: %q", body)
+	}
+}
+
+func newTestCustomAdapter() *CustomAdapter {
+	return &CustomAdapter{provider: &domain.Provider{
+		Type: "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "http://upstream.test",
+		}},
+	}}
 }


### PR DESCRIPTION
## Summary
- flush buffered partial SSE lines only on normal EOF, so final terminal events without a trailing newline are not dropped
- treat `io.ErrUnexpectedEOF` as normal completion only after a terminal `data: [DONE]` event
- avoid forwarding incomplete non-terminal lines on real unexpected EOF, preserving retry/failover semantics before a response has started
- mark first chunk as sent after a successful client write even when no event channel is attached

## Why
`upstream stream read error after response started: unexpected EOF` can still indicate a real upstream abort. But the custom SSE adapter also mishandled completed streams when the final `data: [DONE]` event arrived without a trailing newline or with `io.ErrUnexpectedEOF`, which could drop the terminal event or mark the request failed after successful completion.

The follow-up commit also keeps the defensive boundary intact: true unexpected EOF with only an incomplete partial line is not flushed to the client, so the executor can still classify it as a pre-response upstream failure instead of poisoning the client stream with a fragment.

## Validation
- `go test ./internal/adapter/provider/custom -run 'TestCustomAdapterStreamDoesNot.*EOF' -count=1`
- `go test ./internal/adapter/provider/custom`
- `go test ./internal/executor`
- `git diff --check`