### PR TITLE
fix(codex): sanitize WebSocket HTTP fallback

### DIFF
--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -189,6 +190,7 @@ func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.P
 	if session == nil && previousResponseID != "" {
 		// A response ID is tied to the provider/session that produced it. If route
 		// selection moved elsewhere, use the handler's full-transcript HTTP fallback.
+		log.Printf("[Codex] Responses WebSocket session unavailable for provider=%d; falling back to HTTP/SSE", provider.ID)
 		return false, nil
 	}
 
@@ -226,12 +228,14 @@ func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.P
 			if response != nil {
 				body := readCodexWebSocketHandshakeBody(response)
 				if response.StatusCode == http.StatusUpgradeRequired {
+					log.Printf("[Codex] Responses WebSocket upgrade rejected with status=%d url=%s; falling back to HTTP/SSE", response.StatusCode, webSocketURL)
 					return false, nil
 				}
 				return true, classifyCodexHTTPError(response.StatusCode, body, response.Header, flow.GetMappedModel(c))
 			}
 			// A transport-level upgrade failure is safe to retry through the existing
 			// HTTP/SSE path because no upstream WebSocket event reached the client.
+			log.Printf("[Codex] Responses WebSocket upgrade failed url=%s error=%v; falling back to HTTP/SSE", webSocketURL, err)
 			return false, nil
 		}
 		globalCodexWebSocketSessions.put(key, session)
@@ -258,6 +262,7 @@ func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.P
 
 	if err = session.write(rawRequest); err != nil {
 		globalCodexWebSocketSessions.remove(key, session)
+		log.Printf("[Codex] Responses WebSocket write failed provider=%d error=%v; falling back to HTTP/SSE", provider.ID, err)
 		return false, nil
 	}
 

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -74,7 +74,7 @@ func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
 		}
 	})
 
-	firstRaw := []byte(`{"type":"response.create","model":"client-model","stream":true,"background":true,"input":[]}`)
+	firstRaw := []byte(`{"type":"response.create","model":"client-model","generate":false,"stream":true,"background":true,"input":[]}`)
 	firstCtx := newCodexWebSocketTestContext(t, firstRaw, sessionID)
 	handled, err := adapter.executeResponsesWebSocket(firstCtx, provider)
 	if !handled || err != nil {
@@ -89,6 +89,10 @@ func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
 	}
 	if gjson.GetBytes(firstUpstream, "stream").Exists() || gjson.GetBytes(firstUpstream, "background").Exists() {
 		t.Fatalf("websocket-only implicit fields not removed: %s", firstUpstream)
+	}
+	generate := gjson.GetBytes(firstUpstream, "generate")
+	if !generate.Exists() || generate.Bool() {
+		t.Fatalf("native v2 prewarm generate = %s, want false", generate.Raw)
 	}
 
 	secondRaw := []byte(`{"type":"response.append","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
@@ -113,7 +117,7 @@ func TestExecuteResponsesWebSocket_SkipsProtocolConversion(t *testing.T) {
 	provider := &domain.Provider{ID: 1, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{}}}
 	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{}}
 	raw := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
-	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", strings.NewReader(`{"model":"gpt-test","stream":true,"input":[]}`))
 	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), "session", raw))
 	c := flow.NewCtx(httptest.NewRecorder(), request)
 	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
@@ -127,7 +131,7 @@ func TestExecuteResponsesWebSocket_SkipsProtocolConversion(t *testing.T) {
 
 func newCodexWebSocketTestContext(t *testing.T, raw []byte, sessionID string) *flow.Ctx {
 	t.Helper()
-	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", strings.NewReader(`{"model":"gpt-test","stream":true,"input":[]}`))
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
 	request.Header.Set("User-Agent", "codex-test/1.0")
 	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), sessionID, raw))
 	c := flow.NewCtx(httptest.NewRecorder(), request)

--- a/internal/handler/responses_websocket.go
+++ b/internal/handler/responses_websocket.go
@@ -140,6 +140,7 @@ func (s *responsesWebSocketSessionState) normalizeRequest(payload []byte) ([]byt
 
 func normalizeInitialResponsesWebSocketRequest(request map[string]json.RawMessage) ([]byte, error) {
 	delete(request, "type")
+	delete(request, "generate")
 	request["stream"] = json.RawMessage("true")
 	if _, ok := request["input"]; !ok {
 		request["input"] = json.RawMessage("[]")
@@ -178,6 +179,7 @@ func (s *responsesWebSocketSessionState) normalizeSubsequentResponsesWebSocketRe
 	}
 
 	delete(request, "type")
+	delete(request, "generate")
 	delete(request, "previous_response_id")
 	request["stream"] = json.RawMessage("true")
 	request["input"], err = json.Marshal(mergedInput)

--- a/internal/handler/responses_websocket_test.go
+++ b/internal/handler/responses_websocket_test.go
@@ -107,12 +107,11 @@ func TestResponsesWebSocket_PreservesNativePayloadAndSession(t *testing.T) {
 		t.Fatal("websocket session ID is empty")
 	}
 	firstBody := decodeTestObject(t, first.body)
-	var generate bool
-	if err := json.Unmarshal(firstBody["generate"], &generate); err != nil || generate {
-		t.Fatalf("fallback generate = %s, want false", firstBody["generate"])
+	if _, ok := firstBody["generate"]; ok {
+		t.Fatalf("fallback request leaked websocket-only generate field: %s", first.body)
 	}
 
-	secondPayload := []byte(`{"type":"response.create","previous_response_id":"resp_test","input":[]}`)
+	secondPayload := []byte(`{"type":"response.create","previous_response_id":"resp_test","generate":false,"input":[]}`)
 	if err := conn.WriteMessage(websocket.TextMessage, secondPayload); err != nil {
 		t.Fatalf("write second request: %v", err)
 	}
@@ -123,6 +122,10 @@ func TestResponsesWebSocket_PreservesNativePayloadAndSession(t *testing.T) {
 	}
 	if string(second.metadata.Payload) != string(secondPayload) {
 		t.Fatalf("second native payload = %s, want %s", second.metadata.Payload, secondPayload)
+	}
+	secondBody := decodeTestObject(t, second.body)
+	if _, ok := secondBody["generate"]; ok {
+		t.Fatalf("subsequent fallback request leaked websocket-only generate field: %s", second.body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the official Responses WebSocket v2 `generate: false` prewarm field on native Codex upstream WebSocket frames
- strip the WebSocket-only `generate` field from MAXX's normalized HTTP/SSE fallback body
- log why a native upstream WebSocket session falls back, so Docker/proxy upgrade failures can be diagnosed

## Root cause

MAXX keeps the original downstream WebSocket frame in request context for the native Codex provider path, while also constructing an HTTP Responses body for fallback. The fallback body still contained `generate`, so if the upstream WebSocket upgrade could not be established, MAXX POSTed that WebSocket-only field to CPA. CPA correctly rejected it as an unsupported ordinary HTTP Responses parameter.

This change keeps the two transport contracts separate: native WebSocket gets `generate: false`; HTTP fallback does not.

## Verification

- `go test ./internal/adapter/provider/codex ./internal/handler ./internal/core -count=1`
- `go vet ./internal/adapter/provider/codex ./internal/handler ./internal/core`
- `go test ./... -count=1` (all relevant packages and e2e pass; two pre-existing Windows-only failures remain in `cmd/maxx-cli/internal/cfg`: Unix mode 0600 expectation and legacy temp-path migration)
- `git diff --check`

The existing pprof behavior remains unchanged and verified: listener address is built with `0.0.0.0`, while the settings link uses the browser's current hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 WebSocket 请求转发，避免内部参数泄漏到后端请求中。
  * 在 WebSocket 不可用、升级失败或写入失败时，自动回退至 HTTP/SSE 通道，提升连接稳定性。
  * 增强回退场景的日志记录，便于排查连接问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->