### PR TITLE
perf(proxy): reduce JSON and WebSocket allocation overhead

### DIFF
--- a/internal/adapter/client/adapter.go
+++ b/internal/adapter/client/adapter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -13,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
 )
 
 // RequestInfo contains extracted request information
@@ -73,38 +73,8 @@ func (a *Adapter) detectFromBody(req *http.Request) (domain.ClientType, bool) {
 	// Restore body for later use
 	req.Body = io.NopCloser(bytes.NewReader(body))
 
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err != nil {
-		return "", false
-	}
-
-	// Check for Gemini format
-	if _, ok := data["contents"]; ok {
-		if _, hasRequest := data["request"]; !hasRequest {
-			return domain.ClientTypeGemini, true
-		}
-	}
-
-	// Check for Gemini CLI (envelope)
-	if _, ok := data["request"]; ok {
-		return domain.ClientTypeGemini, true
-	}
-
-	// Check for Codex (Response API)
-	if _, ok := data["input"]; ok {
-		return domain.ClientTypeCodex, true
-	}
-
-	// Check for Claude vs OpenAI
-	if _, ok := data["messages"]; ok {
-		// Claude has system as array or string at top level
-		if _, hasSystem := data["system"]; hasSystem {
-			return domain.ClientTypeClaude, true
-		}
-		return domain.ClientTypeOpenAI, true
-	}
-
-	return "", false
+	detected := a.detectFromBodyBytes(body)
+	return detected, detected != ""
 }
 
 // ExtractInfo extracts session ID and model from the request
@@ -141,36 +111,27 @@ func (a *Adapter) extractSessionID(req *http.Request, clientType domain.ClientTy
 		}
 	}
 
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err == nil {
-		// 2. For Codex client, try previous_response_id or prompt_cache_key
-		if clientType == domain.ClientTypeCodex {
-			// First try previous_response_id (used for conversation tracking in Codex)
-			if prevID, ok := data["previous_response_id"].(string); ok && prevID != "" {
-				return prevID
-			}
-			// Then try prompt_cache_key (used for session identification)
-			if cacheKey, ok := data["prompt_cache_key"].(string); ok && cacheKey != "" {
-				return cacheKey
-			}
+	// Read the few session fields directly instead of materializing the complete
+	// request into map[string]interface{}. Responses transcripts can be tens of
+	// MiB, so a full decode here dominates both CPU and allocation volume.
+	if clientType == domain.ClientTypeCodex {
+		if prevID := jsonStringField(body, "previous_response_id"); prevID != "" {
+			return prevID
 		}
+		if cacheKey := jsonStringField(body, "prompt_cache_key"); cacheKey != "" {
+			return cacheKey
+		}
+	}
 
-		// 3. Try metadata.session_id or metadata.user_id (Claude)
-		if metadata, ok := data["metadata"].(map[string]interface{}); ok {
-			// First try explicit session_id
-			if sid, ok := metadata["session_id"].(string); ok && sid != "" {
-				return sid
-			}
-			// Then try user_id (Claude Code format: "user_{hash}_account__session_{uuid}")
-			if userID, ok := metadata["user_id"].(string); ok && userID != "" {
-				const sessionMarker = "_session_"
-				if idx := strings.LastIndex(userID, sessionMarker); idx != -1 {
-					return userID[idx+len(sessionMarker):]
-				}
-				// Fallback: return full user_id if no _session_ marker
-				return userID
-			}
+	if sid := jsonStringField(body, "metadata.session_id"); sid != "" {
+		return sid
+	}
+	if userID := jsonStringField(body, "metadata.user_id"); userID != "" {
+		const sessionMarker = "_session_"
+		if idx := strings.LastIndex(userID, sessionMarker); idx != -1 {
+			return userID[idx+len(sessionMarker):]
 		}
+		return userID
 	}
 
 	// 4. Try Header X-Session-Id
@@ -241,32 +202,31 @@ func (a *Adapter) DetectClientType(req *http.Request, body []byte) domain.Client
 }
 
 func (a *Adapter) detectFromBodyBytes(body []byte) domain.ClientType {
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err != nil {
+	if !gjson.ValidBytes(body) {
 		return ""
 	}
 
 	// Check for Gemini format
-	if _, ok := data["contents"]; ok {
-		if _, hasRequest := data["request"]; !hasRequest {
+	if gjson.GetBytes(body, "contents").Exists() {
+		if !gjson.GetBytes(body, "request").Exists() {
 			return domain.ClientTypeGemini
 		}
 	}
 
 	// Check for Gemini CLI (envelope)
-	if _, ok := data["request"]; ok {
+	if gjson.GetBytes(body, "request").Exists() {
 		return domain.ClientTypeGemini
 	}
 
 	// Check for Codex (Response API)
-	if _, ok := data["input"]; ok {
+	if gjson.GetBytes(body, "input").Exists() {
 		return domain.ClientTypeCodex
 	}
 
 	// Check for Claude vs OpenAI
-	if _, ok := data["messages"]; ok {
+	if gjson.GetBytes(body, "messages").Exists() {
 		// Claude has system as array or string at top level
-		if _, hasSystem := data["system"]; hasSystem {
+		if gjson.GetBytes(body, "system").Exists() {
 			return domain.ClientTypeClaude
 		}
 		return domain.ClientTypeOpenAI
@@ -305,10 +265,9 @@ func (a *Adapter) ExtractModel(req *http.Request, body []byte, clientType domain
 		}
 	}
 
-	// Try JSON body (chat/completions, images/generations, messages, ...).
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err == nil {
-		if model, ok := data["model"].(string); ok {
+	// Try the JSON field directly without decoding the complete request tree.
+	if gjson.ValidBytes(body) {
+		if model := jsonStringField(body, "model"); model != "" {
 			return model
 		}
 		return ""
@@ -371,15 +330,16 @@ func (a *Adapter) IsStreamRequest(req *http.Request, body []byte) bool {
 		return true
 	}
 
-	// Claude/OpenAI use body field
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err != nil {
-		return false
-	}
+	// Claude/OpenAI use a top-level boolean field. Avoid materializing the full
+	// body merely to read it.
+	stream := gjson.GetBytes(body, "stream")
+	return stream.Type == gjson.True
+}
 
-	if stream, ok := data["stream"].(bool); ok {
-		return stream
+func jsonStringField(body []byte, path string) string {
+	value := gjson.GetBytes(body, path)
+	if value.Type != gjson.String {
+		return ""
 	}
-
-	return false
+	return value.String()
 }

--- a/internal/adapter/client/adapter_test.go
+++ b/internal/adapter/client/adapter_test.go
@@ -123,3 +123,60 @@ func TestDetectClientTypeRecognizesV1ResponsesPath(t *testing.T) {
 		t.Fatalf("client type = %s, want %s", got, domain.ClientTypeCodex)
 	}
 }
+
+func TestExtractSessionIDFromJSONFields(t *testing.T) {
+	adapter := NewAdapter()
+	tests := []struct {
+		name       string
+		clientType domain.ClientType
+		body       string
+		want       string
+	}{
+		{
+			name:       "codex previous response",
+			clientType: domain.ClientTypeCodex,
+			body:       `{"previous_response_id":"resp_123","prompt_cache_key":"cache_ignored"}`,
+			want:       "resp_123",
+		},
+		{
+			name:       "codex prompt cache",
+			clientType: domain.ClientTypeCodex,
+			body:       `{"prompt_cache_key":"cache_123"}`,
+			want:       "cache_123",
+		},
+		{
+			name:       "metadata session",
+			clientType: domain.ClientTypeClaude,
+			body:       `{"metadata":{"session_id":"session_123"}}`,
+			want:       "session_123",
+		},
+		{
+			name:       "claude user session suffix",
+			clientType: domain.ClientTypeClaude,
+			body:       `{"metadata":{"user_id":"user_hash_account__session_uuid-123"}}`,
+			want:       "uuid-123",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(test.body)
+			req := httptest.NewRequest("POST", "/unknown", bytes.NewReader(body))
+			if got := adapter.ExtractSessionID(req, body, test.clientType); got != test.want {
+				t.Fatalf("session ID = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsStreamRequestReadsBooleanOnly(t *testing.T) {
+	adapter := NewAdapter()
+	req := httptest.NewRequest("POST", "/v1/responses", nil)
+	if !adapter.IsStreamRequest(req, []byte(`{"stream":true,"input":[]}`)) {
+		t.Fatal("stream=true was not detected")
+	}
+	for _, body := range []string{`{"stream":false}`, `{"stream":"true"}`, `{}`} {
+		if adapter.IsStreamRequest(req, []byte(body)) {
+			t.Fatalf("unexpected stream detection for %s", body)
+		}
+	}
+}

--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -316,7 +316,7 @@ func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.P
 				return true, classifyCodexWebSocketEvent(payload, flow.GetMappedModel(c))
 			}
 
-			collector.ProcessSSELine("data: " + string(payload))
+			collector.ProcessSSEPayload(payload)
 			if model := strings.TrimSpace(gjson.GetBytes(payload, "response.model").String()); model != "" {
 				responseModel = model
 			} else if model := strings.TrimSpace(gjson.GetBytes(payload, "model").String()); model != "" {

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -23,7 +22,10 @@ import (
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/jsonutil"
 	"github.com/awsl-project/maxx/internal/usage"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // mockMode enables forwarding X-Mock-* headers to upstream (for testing).
@@ -245,11 +247,19 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 	// Send request info via EventChannel
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
+		contentType := ""
+		if request != nil {
+			contentType = request.Header.Get("Content-Type")
+		}
+		devMode := false
+		if proxyRequest := flow.GetProxyRequest(c); proxyRequest != nil {
+			devMode = proxyRequest.DevMode
+		}
 		eventChan.SendRequestInfo(&domain.RequestInfo{
 			Method:  upstreamReq.Method,
 			URL:     upstreamURL,
 			Headers: sanitizeHeadersForEvent(upstreamReq.Header),
-			Body:    string(requestBody),
+			Body:    domain.RequestBodySnapshot(requestBody, contentType, devMode),
 		})
 	}
 
@@ -399,11 +409,15 @@ func (a *CustomAdapter) retryWithFixer(
 		retryReq.ContentLength = int64(len(fixedBody))
 
 		if eventChan := flow.GetEventChan(c); eventChan != nil {
+			devMode := false
+			if proxyRequest := flow.GetProxyRequest(c); proxyRequest != nil {
+				devMode = proxyRequest.DevMode
+			}
 			eventChan.SendRequestInfo(&domain.RequestInfo{
 				Method:  retryReq.Method,
 				URL:     retryReq.URL.String(),
 				Headers: sanitizeHeadersForEvent(retryReq.Header),
-				Body:    string(fixedBody),
+				Body:    domain.RequestBodySnapshot(fixedBody, retryReq.Header.Get("Content-Type"), devMode),
 			})
 		}
 
@@ -652,20 +666,8 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 		}
 	}
 
-	// Helper to parse SSE error event from data line
-	parseSSEError := func(dataLine string) error {
-		// Remove "data:" prefix and trim whitespace
-		data := strings.TrimSpace(strings.TrimPrefix(dataLine, "data:"))
-		if data == "" || data == "[DONE]" {
-			return nil
-		}
-
-		// Try to parse as JSON
-		var payload map[string]interface{}
-		if err := json.Unmarshal([]byte(data), &payload); err != nil {
-			return nil
-		}
-
+	// Helper to inspect an already decoded SSE payload for provider errors.
+	parseSSEErrorPayload := func(payload map[string]interface{}) error {
 		// Check for Claude-style error: {"type": "error", "error": {...}}
 		if payloadType, ok := payload["type"].(string); ok && payloadType == "error" {
 			if errObj, ok := payload["error"].(map[string]interface{}); ok {
@@ -740,26 +742,32 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 			}
 		}
 
-		// Extract metrics and model incrementally per line
-		collector.ProcessSSELine(processedLine)
-		extractResponseModelFromSSELine(processedLine, clientType, &responseModel)
-
-		// Check for SSE error events in data lines BEFORE writing to client
+		// Parse each SSE data payload once, then share it between usage, model,
+		// and error extraction. Previously every token event was decoded three
+		// separate times.
 		lineStr := processedLine
 		trimmedLine := strings.TrimSpace(lineStr)
 		if trimmedLine == "data: [DONE]" {
 			sawTerminalSSEEvent = true
 		}
 		if strings.HasPrefix(trimmedLine, "data:") {
-			if parseErr := parseSSEError(lineStr); parseErr != nil {
-				sseError = parseErr
-				// If no real data has been written to the client yet,
-				// return the error immediately so retry logic can try another route
-				if !firstChunkSent {
-					sendFinalEvents()
-					return sseError
+			data := strings.TrimSpace(strings.TrimPrefix(trimmedLine, "data:"))
+			if data != "" && data != "[DONE]" {
+				var payload map[string]interface{}
+				if jsonutil.UnmarshalString(data, &payload) == nil {
+					collector.ProcessParsedPayload(payload)
+					extractResponseModelFromPayload(payload, clientType, &responseModel)
+					if parseErr := parseSSEErrorPayload(payload); parseErr != nil {
+						sseError = parseErr
+						// If no real data has been written to the client yet,
+						// return the error immediately so retry logic can try another route.
+						if !firstChunkSent {
+							sendFinalEvents()
+							return sseError
+						}
+						// Otherwise continue to forward the error to client.
+					}
 				}
-				// Otherwise continue to forward the error to client
 			}
 		}
 
@@ -877,12 +885,7 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 // Helper functions
 
 func isStreamRequest(body []byte) bool {
-	var req map[string]interface{}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return false
-	}
-	stream, _ := req["stream"].(bool)
-	return stream
+	return gjson.GetBytes(body, "stream").Type == gjson.True
 }
 
 func updateModelInBody(body []byte, model string, clientType domain.ClientType) ([]byte, error) {
@@ -891,12 +894,14 @@ func updateModelInBody(body []byte, model string, clientType domain.ClientType) 
 		return body, nil
 	}
 
-	var req map[string]interface{}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, err
+	if !gjson.ValidBytes(body) {
+		return nil, fmt.Errorf("invalid JSON request body")
 	}
-	req["model"] = model
-	return json.Marshal(req)
+	currentModel := gjson.GetBytes(body, "model")
+	if currentModel.Type == gjson.String && currentModel.String() == model {
+		return body, nil
+	}
+	return sjson.SetBytes(body, "model", model)
 }
 
 // updateModelInMultipartForm rewrites the "model" form field of a
@@ -1357,7 +1362,7 @@ func classify429Error(proxyErr *domain.ProxyError, body []byte, bodyLower string
 			Code    string `json:"code"`
 		} `json:"error"`
 	}
-	if json.Unmarshal(body, &errResp) == nil {
+	if jsonutil.Unmarshal(body, &errResp) == nil {
 		if errResp.Error.Type == "insufficient_quota" || errResp.Error.Code == "insufficient_quota" {
 			proxyErr.Reason = domain.CooldownReasonQuotaExhausted
 		}
@@ -1414,7 +1419,7 @@ func parseRetryAfterHeader(value string) (time.Duration, *time.Time) {
 
 func extractStructuredResetTime(body []byte) time.Time {
 	var payload interface{}
-	if err := json.Unmarshal(body, &payload); err != nil {
+	if err := jsonutil.Unmarshal(body, &payload); err != nil {
 		return time.Time{}
 	}
 	return findResetTime(payload)
@@ -1474,43 +1479,23 @@ func extractTimeFromMessage(msg string) time.Time {
 
 // extractResponseModel extracts the model name from response body based on target type
 func extractResponseModel(body []byte, targetType domain.ClientType) string {
-	var data map[string]interface{}
-	if err := json.Unmarshal(body, &data); err != nil {
-		return ""
-	}
-
 	switch targetType {
 	case domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex:
-		// Claude/OpenAI/Codex: "model" field at root level
-		if model, ok := data["model"].(string); ok {
-			return model
+		if model := gjson.GetBytes(body, "model"); model.Type == gjson.String {
+			return model.String()
 		}
 	case domain.ClientTypeGemini:
-		// Gemini: "modelVersion" field at root level
-		if model, ok := data["modelVersion"].(string); ok {
-			return model
+		if model := gjson.GetBytes(body, "modelVersion"); model.Type == gjson.String {
+			return model.String()
 		}
 	}
 
 	return ""
 }
 
-// extractResponseModelFromSSELine extracts the model name from a single SSE line based on target type.
-func extractResponseModelFromSSELine(line string, targetType domain.ClientType, model *string) {
-	line = strings.TrimSpace(line)
-	if !strings.HasPrefix(line, "data:") {
-		return
-	}
-	dataStr := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-	if dataStr == "" || dataStr == "[DONE]" {
-		return
-	}
-
-	var payload map[string]interface{}
-	if err := json.Unmarshal([]byte(dataStr), &payload); err != nil {
-		return
-	}
-
+// extractResponseModelFromPayload extracts a model name from an already decoded
+// SSE data payload.
+func extractResponseModelFromPayload(payload map[string]interface{}, targetType domain.ClientType, model *string) {
 	switch targetType {
 	case domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex:
 		// Claude/OpenAI: check for "model" in various places

--- a/internal/adapter/provider/custom/images_multipart_test.go
+++ b/internal/adapter/provider/custom/images_multipart_test.go
@@ -2,13 +2,16 @@ package custom
 
 import (
 	"bytes"
+	stdjson "encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
 )
 
 func TestIsMultipartForm(t *testing.T) {
@@ -45,6 +48,64 @@ func TestUpdateModelInBody_FailsOnMultipart(t *testing.T) {
 	multipartBody := []byte("--abc\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\ngpt-image-2\r\n--abc--\r\n")
 	if _, err := updateModelInBody(multipartBody, "gpt-image-2", domain.ClientTypeOpenAI); err == nil {
 		t.Fatal("expected updateModelInBody to fail on multipart body (this is why Execute must skip it)")
+	}
+}
+
+func TestUpdateModelInBody_ReusesUnchangedJSON(t *testing.T) {
+	body := []byte(`{"model":"gpt-test","input":[{"type":"message","content":"hello"}]}`)
+
+	updated, err := updateModelInBody(body, "gpt-test", domain.ClientTypeCodex)
+	if err != nil {
+		t.Fatalf("updateModelInBody: %v", err)
+	}
+	if len(updated) == 0 || &updated[0] != &body[0] {
+		t.Fatal("unchanged model should reuse the original request body")
+	}
+}
+
+func TestUpdateModelInBody_RewritesOnlyModel(t *testing.T) {
+	body := []byte(`{"model":"client-model","input":[{"type":"message","content":"hello"}],"stream":true}`)
+
+	updated, err := updateModelInBody(body, "provider-model", domain.ClientTypeCodex)
+	if err != nil {
+		t.Fatalf("updateModelInBody: %v", err)
+	}
+	if got := gjson.GetBytes(updated, "model").String(); got != "provider-model" {
+		t.Fatalf("model = %q, want provider-model", got)
+	}
+	if got := gjson.GetBytes(updated, "input.0.content").String(); got != "hello" {
+		t.Fatalf("input content = %q, want hello", got)
+	}
+	if !gjson.GetBytes(updated, "stream").Bool() {
+		t.Fatal("stream field was not preserved")
+	}
+}
+
+func BenchmarkUpdateModelInBodyUnchanged(b *testing.B) {
+	body := []byte(`{"model":"gpt-test","input":[{"type":"message","role":"user","content":"` + strings.Repeat("x", 1<<20) + `"}],"stream":true}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for i := 0; i < b.N; i++ {
+		updated, err := updateModelInBody(body, "gpt-test", domain.ClientTypeCodex)
+		if err != nil || len(updated) != len(body) {
+			b.Fatalf("updateModelInBody = %d bytes, %v", len(updated), err)
+		}
+	}
+}
+
+func BenchmarkUpdateModelInBodyLegacy(b *testing.B) {
+	body := []byte(`{"model":"gpt-test","input":[{"type":"message","role":"user","content":"` + strings.Repeat("x", 1<<20) + `"}],"stream":true}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	for i := 0; i < b.N; i++ {
+		var request map[string]interface{}
+		if err := stdjson.Unmarshal(body, &request); err != nil {
+			b.Fatal(err)
+		}
+		request["model"] = "gpt-test"
+		if _, err := stdjson.Marshal(request); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/internal/context/responses_websocket.go
+++ b/internal/context/responses_websocket.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"bytes"
 	stdcontext "context"
 )
 
@@ -14,15 +13,17 @@ type ResponsesWebSocketRequest struct {
 	Payload   []byte
 }
 
-// WithResponsesWebSocketRequest attaches WebSocket request metadata to ctx.
+// WithResponsesWebSocketRequest attaches immutable WebSocket request metadata to
+// ctx. The payload is valid for the synchronous lifetime of the proxied request;
+// consumers must treat it as read-only and copy before modifying it.
 func WithResponsesWebSocketRequest(ctx stdcontext.Context, sessionID string, payload []byte) stdcontext.Context {
 	return stdcontext.WithValue(ctx, responsesWebSocketRequestKey{}, ResponsesWebSocketRequest{
 		SessionID: sessionID,
-		Payload:   bytes.Clone(payload),
+		Payload:   payload,
 	})
 }
 
-// GetResponsesWebSocketRequest returns a copy of the WebSocket request metadata.
+// GetResponsesWebSocketRequest returns immutable WebSocket request metadata.
 func GetResponsesWebSocketRequest(ctx stdcontext.Context) (ResponsesWebSocketRequest, bool) {
 	if ctx == nil {
 		return ResponsesWebSocketRequest{}, false
@@ -31,6 +32,5 @@ func GetResponsesWebSocketRequest(ctx stdcontext.Context) (ResponsesWebSocketReq
 	if !ok || request.SessionID == "" || len(request.Payload) == 0 {
 		return ResponsesWebSocketRequest{}, false
 	}
-	request.Payload = bytes.Clone(request.Payload)
 	return request, true
 }

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -184,12 +184,16 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		}
 		bodyReader = io.LimitReader(r.Body, limit)
 	}
-	body, err := io.ReadAll(bodyReader)
-	if err != nil {
-		_ = r.Body.Close()
-		writeError(w, http.StatusBadRequest, "failed to read request body")
-		c.Abort()
-		return
+	body := maxxctx.GetRequestBody(r.Context())
+	if body == nil {
+		var readErr error
+		body, readErr = io.ReadAll(bodyReader)
+		if readErr != nil {
+			_ = r.Body.Close()
+			writeError(w, http.StatusBadRequest, "failed to read request body")
+			c.Abort()
+			return
+		}
 	}
 	_ = r.Body.Close()
 	if h.uploadLimiter != nil && h.uploadLimiter.maxBytes > 0 && int64(len(body)) > h.uploadLimiter.maxBytes {
@@ -217,6 +221,7 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		return
 	}
 
+	var err error
 	var apiToken *domain.APIToken
 	var apiTokenID uint64
 	if h.tokenAuth != nil {

--- a/internal/handler/responses_websocket.go
+++ b/internal/handler/responses_websocket.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"bytes"
-	"encoding/json"
+	stdjson "encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,8 +10,11 @@ import (
 	"strings"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/jsonutil"
+	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -28,8 +31,18 @@ var responsesWebSocketUpgrader = websocket.Upgrader{
 }
 
 type responsesWebSocketSessionState struct {
-	lastRequest        []byte
-	lastResponseOutput []json.RawMessage
+	initialized        bool
+	lastInput          []sonic.NoCopyRawMessage
+	model              sonic.NoCopyRawMessage
+	instructions       sonic.NoCopyRawMessage
+	lastResponseOutput []stdjson.RawMessage
+}
+
+type responsesWebSocketNormalizedRequest struct {
+	body         []byte
+	input        []sonic.NoCopyRawMessage
+	model        sonic.NoCopyRawMessage
+	instructions sonic.NoCopyRawMessage
 }
 
 func isResponsesWebSocketUpgrade(r *http.Request) bool {
@@ -65,7 +78,7 @@ func serveResponsesWebSocket(w http.ResponseWriter, r *http.Request, next http.H
 			continue
 		}
 
-		requestBody, errNormalize := state.normalizeRequest(payload)
+		normalized, errNormalize := state.normalizeRequest(payload)
 		if errNormalize != nil {
 			if errWrite := writeResponsesWebSocketError(conn, http.StatusBadRequest, errNormalize.Error(), nil); errWrite != nil {
 				return
@@ -73,21 +86,25 @@ func serveResponsesWebSocket(w http.ResponseWriter, r *http.Request, next http.H
 			continue
 		}
 
-		request := newResponsesWebSocketHTTPRequest(r, requestBody, sessionID, payload)
+		request := newResponsesWebSocketHTTPRequest(r, normalized.body, sessionID, payload)
 		writer := newResponsesWebSocketResponseWriter(conn)
 		next.ServeHTTP(writer, request)
 		if errFinish := writer.finish(); errFinish != nil {
 			return
 		}
 		if writer.completed {
-			state.lastRequest = bytes.Clone(requestBody)
-			state.lastResponseOutput = cloneRawMessages(writer.completedOutput)
+			state.initialized = true
+			state.lastInput = normalized.input
+			state.model = normalized.model
+			state.instructions = normalized.instructions
+			state.lastResponseOutput = writer.completedOutput
 		}
 	}
 }
 
 func newResponsesWebSocketHTTPRequest(original *http.Request, body []byte, sessionID string, payload []byte) *http.Request {
 	ctx := maxxctx.WithResponsesWebSocketRequest(original.Context(), sessionID, payload)
+	ctx = maxxctx.WithRequestBody(ctx, body)
 	request := original.Clone(ctx)
 	request.Method = http.MethodPost
 	request.Body = http.NoBody
@@ -115,101 +132,118 @@ func newResponsesWebSocketHTTPRequest(original *http.Request, body []byte, sessi
 	return request
 }
 
-func (s *responsesWebSocketSessionState) normalizeRequest(payload []byte) ([]byte, error) {
-	request, err := decodeJSONObject(payload)
+func (s *responsesWebSocketSessionState) normalizeRequest(payload []byte) (responsesWebSocketNormalizedRequest, error) {
+	request, err := decodeJSONObjectNoCopy(payload)
 	if err != nil {
-		return nil, fmt.Errorf("invalid websocket request JSON: %w", err)
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("invalid websocket request JSON: %w", err)
 	}
 
 	requestType := jsonString(request["type"])
 	switch requestType {
 	case responsesWebSocketRequestCreate:
-		if len(s.lastRequest) == 0 {
+		if !s.initialized {
 			return normalizeInitialResponsesWebSocketRequest(request)
 		}
 		return s.normalizeSubsequentResponsesWebSocketRequest(request)
 	case responsesWebSocketRequestAppend:
-		if len(s.lastRequest) == 0 {
-			return nil, fmt.Errorf("websocket request received before response.create")
+		if !s.initialized {
+			return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request received before response.create")
 		}
 		return s.normalizeSubsequentResponsesWebSocketRequest(request)
 	default:
-		return nil, fmt.Errorf("unsupported websocket request type: %s", requestType)
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("unsupported websocket request type: %s", requestType)
 	}
 }
 
-func normalizeInitialResponsesWebSocketRequest(request map[string]json.RawMessage) ([]byte, error) {
+func normalizeInitialResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage) (responsesWebSocketNormalizedRequest, error) {
 	delete(request, "type")
 	delete(request, "generate")
-	request["stream"] = json.RawMessage("true")
+	request["stream"] = sonic.NoCopyRawMessage("true")
 	if _, ok := request["input"]; !ok {
-		request["input"] = json.RawMessage("[]")
+		request["input"] = sonic.NoCopyRawMessage("[]")
 	}
 	if strings.TrimSpace(jsonString(request["model"])) == "" {
-		return nil, fmt.Errorf("missing model in response.create request")
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("missing model in response.create request")
 	}
-	normalized, err := json.Marshal(request)
-	return normalized, err
+	input, err := decodeJSONArrayNoCopy(request["input"])
+	if err != nil {
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request requires array field: input")
+	}
+	normalized, err := marshalResponsesWebSocketRequest(request, input)
+	if err != nil {
+		return responsesWebSocketNormalizedRequest{}, err
+	}
+	return responsesWebSocketNormalizedRequest{
+		body:         normalized,
+		input:        input,
+		model:        request["model"],
+		instructions: request["instructions"],
+	}, nil
 }
 
-func (s *responsesWebSocketSessionState) normalizeSubsequentResponsesWebSocketRequest(request map[string]json.RawMessage) ([]byte, error) {
-	nextInput, err := decodeJSONArray(request["input"])
+func (s *responsesWebSocketSessionState) normalizeSubsequentResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage) (responsesWebSocketNormalizedRequest, error) {
+	nextInput, err := decodeJSONArrayNoCopy(request["input"])
 	if err != nil {
-		return nil, fmt.Errorf("websocket request requires array field: input")
-	}
-
-	lastRequest, err := decodeJSONObject(s.lastRequest)
-	if err != nil {
-		return nil, fmt.Errorf("invalid previous websocket request state: %w", err)
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request requires array field: input")
 	}
 
 	previousResponseID := strings.TrimSpace(jsonString(request["previous_response_id"]))
-	var mergedInput []json.RawMessage
+	var mergedInput []sonic.NoCopyRawMessage
 	if previousResponseID == "" && responsesWebSocketInputReplacesTranscript(nextInput) {
-		mergedInput = cloneRawMessages(nextInput)
+		mergedInput = nextInput
 	} else {
-		lastInput, errLastInput := decodeJSONArray(lastRequest["input"])
-		if errLastInput != nil {
-			return nil, fmt.Errorf("invalid previous websocket input: %w", errLastInput)
+		mergedInput = make([]sonic.NoCopyRawMessage, 0, len(s.lastInput)+len(s.lastResponseOutput)+len(nextInput))
+		mergedInput = append(mergedInput, s.lastInput...)
+		for _, output := range s.lastResponseOutput {
+			mergedInput = append(mergedInput, sonic.NoCopyRawMessage(output))
 		}
-		mergedInput = append(mergedInput, cloneRawMessages(lastInput)...)
-		mergedInput = append(mergedInput, cloneRawMessages(s.lastResponseOutput)...)
-		mergedInput = append(mergedInput, cloneRawMessages(nextInput)...)
+		mergedInput = append(mergedInput, nextInput...)
 		mergedInput = dedupeResponsesWebSocketItems(mergedInput)
 	}
 
 	delete(request, "type")
 	delete(request, "generate")
 	delete(request, "previous_response_id")
-	request["stream"] = json.RawMessage("true")
-	request["input"], err = json.Marshal(mergedInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge websocket input: %w", err)
-	}
+	request["stream"] = sonic.NoCopyRawMessage("true")
 	if _, ok := request["model"]; !ok {
-		request["model"] = bytes.Clone(lastRequest["model"])
+		request["model"] = s.model
 	}
 	if _, ok := request["instructions"]; !ok {
-		if instructions, exists := lastRequest["instructions"]; exists {
-			request["instructions"] = bytes.Clone(instructions)
+		if len(s.instructions) > 0 {
+			request["instructions"] = s.instructions
 		}
 	}
 
-	normalized, err := json.Marshal(request)
-	return normalized, err
+	normalized, err := marshalResponsesWebSocketRequest(request, mergedInput)
+	if err != nil {
+		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("failed to merge websocket input: %w", err)
+	}
+	return responsesWebSocketNormalizedRequest{
+		body:         normalized,
+		input:        mergedInput,
+		model:        request["model"],
+		instructions: request["instructions"],
+	}, nil
 }
 
-func responsesWebSocketInputReplacesTranscript(input []json.RawMessage) bool {
-	for _, item := range input {
-		object, err := decodeJSONObject(item)
-		if err != nil {
-			continue
+func marshalResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage, input []sonic.NoCopyRawMessage) ([]byte, error) {
+	wireRequest := make(map[string]interface{}, len(request))
+	for key, value := range request {
+		if key != "input" {
+			wireRequest[key] = value
 		}
-		switch jsonString(object["type"]) {
+	}
+	wireRequest["input"] = input
+	return jsonutil.Marshal(wireRequest)
+}
+
+func responsesWebSocketInputReplacesTranscript(input []sonic.NoCopyRawMessage) bool {
+	for _, item := range input {
+		switch gjson.GetBytes(item, "type").String() {
 		case "compaction", "compaction_summary", "function_call", "custom_tool_call":
 			return true
 		case "message":
-			if jsonString(object["role"]) == "assistant" {
+			if gjson.GetBytes(item, "role").String() == "assistant" {
 				return true
 			}
 		}
@@ -217,30 +251,27 @@ func responsesWebSocketInputReplacesTranscript(input []json.RawMessage) bool {
 	return false
 }
 
-func dedupeResponsesWebSocketItems(items []json.RawMessage) []json.RawMessage {
+func dedupeResponsesWebSocketItems(items []sonic.NoCopyRawMessage) []sonic.NoCopyRawMessage {
 	seenItemIDs := make(map[string]struct{}, len(items))
 	seenCallIDs := make(map[string]struct{}, len(items))
-	result := make([]json.RawMessage, 0, len(items))
+	result := make([]sonic.NoCopyRawMessage, 0, len(items))
 	for _, item := range items {
-		object, err := decodeJSONObject(item)
-		if err == nil {
-			if id := strings.TrimSpace(jsonString(object["id"])); id != "" {
-				if _, exists := seenItemIDs[id]; exists {
+		if id := strings.TrimSpace(gjson.GetBytes(item, "id").String()); id != "" {
+			if _, exists := seenItemIDs[id]; exists {
+				continue
+			}
+			seenItemIDs[id] = struct{}{}
+		}
+		switch gjson.GetBytes(item, "type").String() {
+		case "function_call", "custom_tool_call":
+			if callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String()); callID != "" {
+				if _, exists := seenCallIDs[callID]; exists {
 					continue
 				}
-				seenItemIDs[id] = struct{}{}
-			}
-			switch jsonString(object["type"]) {
-			case "function_call", "custom_tool_call":
-				if callID := strings.TrimSpace(jsonString(object["call_id"])); callID != "" {
-					if _, exists := seenCallIDs[callID]; exists {
-						continue
-					}
-					seenCallIDs[callID] = struct{}{}
-				}
+				seenCallIDs[callID] = struct{}{}
 			}
 		}
-		result = append(result, bytes.Clone(item))
+		result = append(result, item)
 	}
 	return result
 }
@@ -250,7 +281,7 @@ func newResponsesWebSocketResponseWriter(conn *websocket.Conn) *responsesWebSock
 		conn:               conn,
 		header:             make(http.Header),
 		statusCode:         http.StatusOK,
-		outputItemsByIndex: make(map[int]json.RawMessage),
+		outputItemsByIndex: make(map[int]stdjson.RawMessage),
 	}
 }
 
@@ -266,10 +297,10 @@ type responsesWebSocketResponseWriter struct {
 	eventData  bytes.Buffer
 	rawBody    bytes.Buffer
 
-	outputItemsByIndex  map[int]json.RawMessage
-	outputItemsFallback []json.RawMessage
+	outputItemsByIndex  map[int]stdjson.RawMessage
+	outputItemsFallback []stdjson.RawMessage
 	completed           bool
-	completedOutput     []json.RawMessage
+	completedOutput     []stdjson.RawMessage
 	sentError           bool
 	writeErr            error
 }
@@ -378,12 +409,13 @@ func (w *responsesWebSocketResponseWriter) flushSSEEvent() {
 		w.eventData.Reset()
 		return
 	}
-	payload := bytes.Clone(w.eventData.Bytes())
-	w.eventData.Reset()
+	payload := w.eventData.Bytes()
 	if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
+		w.eventData.Reset()
 		return
 	}
 	w.forwardPayload(payload)
+	w.eventData.Reset()
 }
 
 func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
@@ -398,9 +430,9 @@ func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
 	if eventType == "response.output_item.done" {
 		if item, ok := object["item"]; ok && len(item) > 0 {
 			if outputIndex, okIndex := jsonInt(object["output_index"]); okIndex {
-				w.outputItemsByIndex[outputIndex] = bytes.Clone(item)
+				w.outputItemsByIndex[outputIndex] = item
 			} else {
-				w.outputItemsFallback = append(w.outputItemsFallback, bytes.Clone(item))
+				w.outputItemsFallback = append(w.outputItemsFallback, item)
 			}
 		}
 	}
@@ -411,14 +443,14 @@ func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
 			output, errOutput := decodeJSONArray(response["output"])
 			if errOutput != nil || len(output) == 0 {
 				output = w.collectedOutput()
-				if encodedOutput, errMarshal := json.Marshal(output); errMarshal == nil {
+				if encodedOutput, errMarshal := jsonutil.Marshal(output); errMarshal == nil {
 					response["output"] = encodedOutput
-					if encodedResponse, errMarshalResponse := json.Marshal(response); errMarshalResponse == nil {
+					if encodedResponse, errMarshalResponse := jsonutil.Marshal(response); errMarshalResponse == nil {
 						object["response"] = encodedResponse
 					}
 				}
 			}
-			w.completedOutput = cloneRawMessages(output)
+			w.completedOutput = output
 		}
 		w.completed = true
 	}
@@ -426,7 +458,7 @@ func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
 		w.sentError = true
 	}
 
-	encoded, errMarshal := json.Marshal(object)
+	encoded, errMarshal := jsonutil.Marshal(object)
 	if errMarshal != nil {
 		w.writeErr = errMarshal
 		return
@@ -434,17 +466,17 @@ func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
 	w.writeErr = w.conn.WriteMessage(websocket.TextMessage, encoded)
 }
 
-func (w *responsesWebSocketResponseWriter) collectedOutput() []json.RawMessage {
+func (w *responsesWebSocketResponseWriter) collectedOutput() []stdjson.RawMessage {
 	indexes := make([]int, 0, len(w.outputItemsByIndex))
 	for index := range w.outputItemsByIndex {
 		indexes = append(indexes, index)
 	}
 	sort.Ints(indexes)
-	result := make([]json.RawMessage, 0, len(indexes)+len(w.outputItemsFallback))
+	result := make([]stdjson.RawMessage, 0, len(indexes)+len(w.outputItemsFallback))
 	for _, index := range indexes {
-		result = append(result, bytes.Clone(w.outputItemsByIndex[index]))
+		result = append(result, w.outputItemsByIndex[index])
 	}
-	result = append(result, cloneRawMessages(w.outputItemsFallback)...)
+	result = append(result, w.outputItemsFallback...)
 	return result
 }
 
@@ -472,9 +504,9 @@ func (w *responsesWebSocketResponseWriter) forwardRawResponse() {
 	completion := map[string]any{
 		"type":            "response.completed",
 		"sequence_number": 0,
-		"response":        json.RawMessage(payload),
+		"response":        stdjson.RawMessage(payload),
 	}
-	encoded, errMarshal := json.Marshal(completion)
+	encoded, errMarshal := jsonutil.Marshal(completion)
 	if errMarshal != nil {
 		w.writeErr = errMarshal
 		return
@@ -482,7 +514,7 @@ func (w *responsesWebSocketResponseWriter) forwardRawResponse() {
 	w.forwardPayload(encoded)
 }
 
-func writeResponsesWebSocketError(conn *websocket.Conn, status int, message string, errorBody json.RawMessage) error {
+func writeResponsesWebSocketError(conn *websocket.Conn, status int, message string, errorBody stdjson.RawMessage) error {
 	if status < http.StatusBadRequest || status > 599 {
 		status = http.StatusInternalServerError
 	}
@@ -493,10 +525,10 @@ func writeResponsesWebSocketError(conn *websocket.Conn, status int, message stri
 		"type":    "proxy_error",
 		"message": message,
 	}
-	if len(bytes.TrimSpace(errorBody)) > 0 && json.Valid(errorBody) {
-		detail = json.RawMessage(errorBody)
+	if len(bytes.TrimSpace(errorBody)) > 0 && stdjson.Valid(errorBody) {
+		detail = stdjson.RawMessage(errorBody)
 	}
-	payload, err := json.Marshal(map[string]any{
+	payload, err := jsonutil.Marshal(map[string]any{
 		"type":   "error",
 		"status": status,
 		"error":  detail,
@@ -507,12 +539,12 @@ func writeResponsesWebSocketError(conn *websocket.Conn, status int, message stri
 	return conn.WriteMessage(websocket.TextMessage, payload)
 }
 
-func decodeJSONObject(raw []byte) (map[string]json.RawMessage, error) {
+func decodeJSONObject(raw []byte) (map[string]stdjson.RawMessage, error) {
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return nil, fmt.Errorf("empty JSON object")
 	}
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &object); err != nil {
+	var object map[string]stdjson.RawMessage
+	if err := jsonutil.Unmarshal(raw, &object); err != nil {
 		return nil, err
 	}
 	if object == nil {
@@ -521,40 +553,63 @@ func decodeJSONObject(raw []byte) (map[string]json.RawMessage, error) {
 	return object, nil
 }
 
-func decodeJSONArray(raw []byte) ([]json.RawMessage, error) {
+func decodeJSONObjectNoCopy(raw []byte) (map[string]sonic.NoCopyRawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("empty JSON object")
+	}
+	if !gjson.ValidBytes(raw) {
+		return nil, fmt.Errorf("invalid JSON object")
+	}
+	var object map[string]sonic.NoCopyRawMessage
+	if err := jsonutil.Unmarshal(raw, &object); err != nil {
+		return nil, err
+	}
+	if object == nil {
+		return nil, fmt.Errorf("expected JSON object")
+	}
+	return object, nil
+}
+
+func decodeJSONArray(raw []byte) ([]stdjson.RawMessage, error) {
 	if len(bytes.TrimSpace(raw)) == 0 {
 		return nil, fmt.Errorf("missing JSON array")
 	}
-	var array []json.RawMessage
-	if err := json.Unmarshal(raw, &array); err != nil {
+	var array []stdjson.RawMessage
+	if err := jsonutil.Unmarshal(raw, &array); err != nil {
 		return nil, err
 	}
 	if array == nil {
-		array = []json.RawMessage{}
+		array = []stdjson.RawMessage{}
 	}
 	return array, nil
 }
 
-func jsonString(raw json.RawMessage) string {
+func decodeJSONArrayNoCopy(raw []byte) ([]sonic.NoCopyRawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("missing JSON array")
+	}
+	var array []sonic.NoCopyRawMessage
+	if err := jsonutil.Unmarshal(raw, &array); err != nil {
+		return nil, err
+	}
+	if array == nil {
+		array = []sonic.NoCopyRawMessage{}
+	}
+	return array, nil
+}
+
+func jsonString(raw []byte) string {
 	var value string
-	if json.Unmarshal(raw, &value) != nil {
+	if jsonutil.Unmarshal(raw, &value) != nil {
 		return ""
 	}
 	return value
 }
 
-func jsonInt(raw json.RawMessage) (int, bool) {
+func jsonInt(raw []byte) (int, bool) {
 	var value int
-	if json.Unmarshal(raw, &value) != nil {
+	if jsonutil.Unmarshal(raw, &value) != nil {
 		return 0, false
 	}
 	return value, true
-}
-
-func cloneRawMessages(messages []json.RawMessage) []json.RawMessage {
-	result := make([]json.RawMessage, len(messages))
-	for index := range messages {
-		result[index] = bytes.Clone(messages[index])
-	}
-	return result
 }

--- a/internal/handler/responses_websocket_test.go
+++ b/internal/handler/responses_websocket_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/bytedance/sonic"
 	"github.com/gorilla/websocket"
 )
 
@@ -126,6 +128,50 @@ func TestResponsesWebSocket_PreservesNativePayloadAndSession(t *testing.T) {
 	secondBody := decodeTestObject(t, second.body)
 	if _, ok := secondBody["generate"]; ok {
 		t.Fatalf("subsequent fallback request leaked websocket-only generate field: %s", second.body)
+	}
+}
+
+func TestNewResponsesWebSocketHTTPRequestReusesImmutableBodies(t *testing.T) {
+	original := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	body := []byte(`{"model":"gpt-test","stream":true,"input":[]}`)
+	payload := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+
+	request := newResponsesWebSocketHTTPRequest(original, body, "session-test", payload)
+	preloaded := maxxctx.GetRequestBody(request.Context())
+	if len(preloaded) == 0 || &preloaded[0] != &body[0] {
+		t.Fatal("internal HTTP request should reuse the normalized body")
+	}
+	metadata, ok := maxxctx.GetResponsesWebSocketRequest(request.Context())
+	if !ok {
+		t.Fatal("missing websocket request metadata")
+	}
+	if len(metadata.Payload) == 0 || &metadata.Payload[0] != &payload[0] {
+		t.Fatal("websocket metadata should reuse the immutable client payload")
+	}
+	readBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	if !bytes.Equal(readBody, body) {
+		t.Fatalf("request body = %s, want %s", readBody, body)
+	}
+}
+
+func BenchmarkResponsesWebSocketNormalizeSubsequent(b *testing.B) {
+	state := responsesWebSocketSessionState{
+		initialized: true,
+		lastInput: []sonic.NoCopyRawMessage{
+			sonic.NoCopyRawMessage(`{"type":"message","role":"user","content":[{"type":"input_text","text":"` + strings.Repeat("x", 1<<20) + `"}]}`),
+		},
+		model: sonic.NoCopyRawMessage(`"gpt-test"`),
+	}
+	payload := []byte(`{"type":"response.create","previous_response_id":"resp_1","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		normalized, err := state.normalizeRequest(payload)
+		if err != nil || len(normalized.body) < 1<<20 {
+			b.Fatalf("normalizeRequest = %d bytes, %v", len(normalized.body), err)
+		}
 	}
 }
 

--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -1,0 +1,33 @@
+package jsonutil
+
+import (
+	"runtime"
+	"unsafe"
+
+	"github.com/bytedance/sonic"
+)
+
+// fast uses Sonic's fastest configuration for performance-critical internal
+// JSON paths. Callers must not rely on encoding/json's HTML escaping behavior.
+var fast = sonic.ConfigFastest
+
+func Marshal(value any) ([]byte, error) {
+	return fast.Marshal(value)
+}
+
+// Unmarshal decodes immutable JSON bytes without Sonic's default whole-buffer
+// []byte-to-string copy. Decoded string values may reference data, so callers
+// must not modify the input while the decoded value is still in use.
+func Unmarshal(data []byte, value any) error {
+	if len(data) == 0 {
+		return fast.UnmarshalFromString("", value)
+	}
+	source := unsafe.String(unsafe.SliceData(data), len(data))
+	err := fast.UnmarshalFromString(source, value)
+	runtime.KeepAlive(data)
+	return err
+}
+
+func UnmarshalString(data string, value any) error {
+	return fast.UnmarshalFromString(data, value)
+}

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -1,0 +1,68 @@
+package jsonutil
+
+import (
+	stdjson "encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshalRawMessageOwnsData(t *testing.T) {
+	input := []byte(`{"value":{"text":"one"}}`)
+	var object map[string]stdjson.RawMessage
+	if err := Unmarshal(input, &object); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	copy(input, []byte(`{"value":{"text":"two"}}`))
+	if got := string(object["value"]); got != `{"text":"one"}` {
+		t.Fatalf("raw message changed with input buffer: %s", got)
+	}
+}
+
+func TestUnmarshalString(t *testing.T) {
+	var value struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := UnmarshalString(`{"model":"gpt-test","stream":true}`, &value); err != nil {
+		t.Fatalf("UnmarshalString: %v", err)
+	}
+	if value.Model != "gpt-test" || !value.Stream {
+		t.Fatalf("decoded value = %+v", value)
+	}
+}
+
+func BenchmarkUnmarshalLargeRawMessage(b *testing.B) {
+	input := []byte(`{"model":"gpt-test","input":[{"content":"` + strings.Repeat("x", 1<<20) + `"}]}`)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	for i := 0; i < b.N; i++ {
+		var object map[string]stdjson.RawMessage
+		if err := Unmarshal(input, &object); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalLargeObject(b *testing.B) {
+	input := []byte(`{"type":"response.completed","response":{"model":"gpt-test","output":[{"content":"` + strings.Repeat("x", 1<<20) + `"}]}}`)
+	b.Run("Sonic", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(input)))
+		for i := 0; i < b.N; i++ {
+			var object map[string]interface{}
+			if err := Unmarshal(input, &object); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("EncodingJSON", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(input)))
+		for i := 0; i < b.N; i++ {
+			var object map[string]interface{}
+			if err := stdjson.Unmarshal(input, &object); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/usage/extractor.go
+++ b/internal/usage/extractor.go
@@ -3,10 +3,10 @@
 package usage
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/jsonutil"
 )
 
 // Metrics represents extracted usage information from an API response.
@@ -81,7 +81,7 @@ func ExtractFromResponseWithOptions(body string, opts ExtractOptions) *Metrics {
 // extractFromJSON tries to parse usage from a JSON response body.
 func extractFromJSON(body string, opts ExtractOptions) *Metrics {
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(body), &data); err != nil {
+	if err := jsonutil.UnmarshalString(body, &data); err != nil {
 		return nil
 	}
 
@@ -112,7 +112,7 @@ func extractFromSSE(body string, opts ExtractOptions) *Metrics {
 		}
 
 		var data map[string]interface{}
-		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+		if err := jsonutil.UnmarshalString(jsonStr, &data); err != nil {
 			continue
 		}
 
@@ -438,12 +438,30 @@ func (sc *StreamCollector) ProcessSSELine(line string) {
 	if jsonStr == "" || jsonStr == "[DONE]" {
 		return
 	}
-
 	var data map[string]interface{}
-	if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+	if err := jsonutil.UnmarshalString(jsonStr, &data); err != nil {
 		return
 	}
+	sc.ProcessParsedPayload(data)
+}
 
+// ProcessSSEPayload updates the collector from a raw SSE data payload without
+// forcing byte-oriented WebSocket callers through a temporary string.
+func (sc *StreamCollector) ProcessSSEPayload(payload []byte) {
+	var data map[string]interface{}
+	if err := jsonutil.Unmarshal(payload, &data); err != nil {
+		return
+	}
+	sc.ProcessParsedPayload(data)
+}
+
+// ProcessParsedPayload updates the collector from an already decoded SSE JSON
+// payload. Stream adapters that also inspect model/error fields can parse each
+// data event once and share the result instead of decoding it repeatedly.
+func (sc *StreamCollector) ProcessParsedPayload(data map[string]interface{}) {
+	if len(data) == 0 {
+		return
+	}
 	// Extract metrics
 	if metrics := extractUsageFromMap(data, sc.Options); metrics != nil && !metrics.IsEmpty() {
 		sc.Metrics = metrics


### PR DESCRIPTION
## Summary

- replace allocation-heavy JSON parsing in request metadata, CustomAdapter SSE handling, usage extraction, and Responses WebSocket handling with Sonic/gjson/sjson
- avoid full request decode/re-encode when model mapping is unchanged, and parse each SSE data payload only once
- cap CustomAdapter request snapshots and reuse immutable WebSocket request bodies through the internal HTTP bridge
- store WebSocket transcript fragments instead of retaining and repeatedly decoding complete merged requests

## Performance evidence

Local Windows/amd64 benchmarks with 1 MiB payloads:

- large object decode: ~24.9 us / 1,382 B / 13 allocs with Sonic versus ~4.35 ms / 1,050,000 B / 27 allocs with encoding/json
- unchanged model mapping: ~0.55 ms / 986 B / 1 alloc versus ~5.34 ms / 2,990,536 B / 47 allocs in the legacy full decode/re-encode path
- subsequent WebSocket transcript normalization: ~0.45-0.58 ms and ~1.11 MB allocated, approximately the required final HTTP body size without additional full-size transcript copies

## Validation

- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s ./internal/...`
- `go build ./cmd/maxx ./cmd/maxx-cli`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/maxx ./cmd/maxx-cli`
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/maxx ./cmd/maxx-cli`
- focused tests and benchmarks for JSON decoding, model rewriting, request metadata, and WebSocket body/session reuse

## Notes

The immutable-buffer contract is documented in the internal JSON and Responses WebSocket context helpers. Callers that mutate payloads continue to copy before modification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化请求与响应处理，减少大数据量场景下的内存占用与处理开销。
  * 提升模型识别、会话信息提取及流式用量统计效率。

* **Bug 修复**
  * 改善 WebSocket 流式响应的事件处理与内容合并。
  * 增强无效请求体、错误响应及流式错误的处理稳定性。
  * 修复请求体读取失败时的错误响应行为。

* **兼容性**
  * 优化自定义适配器对 JSON、SSE 和多部分表单请求的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->