### PR TITLE
feat(requests): display reasoning effort in request logs

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -578,8 +578,9 @@ type ProxyRequest struct {
 	SessionID  string     `json:"sessionID"`
 	ClientType ClientType `json:"clientType"`
 
-	RequestModel  string `json:"requestModel"`
-	ResponseModel string `json:"responseModel"`
+	RequestModel    string `json:"requestModel"`
+	ResponseModel   string `json:"responseModel"`
+	ReasoningEffort string `json:"reasoningEffort"`
 
 	StartTime time.Time     `json:"startTime"`
 	EndTime   time.Time     `json:"endTime"`

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/awsl-project/maxx/internal/event"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/repository"
+	"github.com/awsl-project/maxx/internal/requestmeta"
 	"github.com/awsl-project/maxx/internal/router"
 	"github.com/awsl-project/maxx/internal/waiter"
 )
@@ -194,23 +195,28 @@ func (e *Executor) RecordRejectedProxyRequest(c *flow.Ctx, apiToken *domain.APIT
 	}
 
 	now := time.Now()
+	reasoningBody := flow.GetOriginalRequestBody(c)
+	if len(reasoningBody) == 0 {
+		reasoningBody = flow.GetRequestBody(c)
+	}
 	proxyReq := &domain.ProxyRequest{
-		TenantID:     tenantID,
-		InstanceID:   e.instanceID,
-		RequestID:    generateRequestID(),
-		SessionID:    flow.GetSessionID(c),
-		ClientType:   flow.GetClientType(c),
-		ProjectID:    projectID,
-		RequestModel: flow.GetRequestModel(c),
-		StartTime:    now,
-		EndTime:      now,
-		Duration:     0,
-		IsStream:     flow.GetIsStream(c),
-		Status:       "REJECTED",
-		StatusCode:   statusCode,
-		Error:        errMsg,
-		APITokenID:   apiTokenID,
-		DevMode:      devMode,
+		TenantID:        tenantID,
+		InstanceID:      e.instanceID,
+		RequestID:       generateRequestID(),
+		SessionID:       flow.GetSessionID(c),
+		ClientType:      flow.GetClientType(c),
+		ProjectID:       projectID,
+		RequestModel:    flow.GetRequestModel(c),
+		ReasoningEffort: requestmeta.ReasoningEffort(reasoningBody),
+		StartTime:       now,
+		EndTime:         now,
+		Duration:        0,
+		IsStream:        flow.GetIsStream(c),
+		Status:          "REJECTED",
+		StatusCode:      statusCode,
+		Error:           errMsg,
+		APITokenID:      apiTokenID,
+		DevMode:         devMode,
 	}
 
 	clearDetail := e.shouldClearFailedRequestDetailFor(&execState{apiTokenDevMode: devMode})

--- a/internal/executor/middleware_ingress.go
+++ b/internal/executor/middleware_ingress.go
@@ -10,6 +10,7 @@ import (
 	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/requestmeta"
 )
 
 func (e *Executor) ingress(c *flow.Ctx) {
@@ -135,19 +136,24 @@ func (e *Executor) ingress(c *flow.Ctx) {
 }
 
 func (e *Executor) newProxyRequest(c *flow.Ctx, state *execState, status string) *domain.ProxyRequest {
+	reasoningBody := state.originalRequestBody
+	if len(reasoningBody) == 0 {
+		reasoningBody = state.requestBody
+	}
 	proxyReq := &domain.ProxyRequest{
-		TenantID:     state.tenantID,
-		InstanceID:   e.instanceID,
-		RequestID:    generateRequestID(),
-		SessionID:    state.sessionID,
-		ClientType:   state.clientType,
-		ProjectID:    state.projectID,
-		RequestModel: state.requestModel,
-		StartTime:    time.Now(),
-		IsStream:     state.isStream,
-		Status:       status,
-		APITokenID:   state.apiTokenID,
-		DevMode:      state.apiTokenDevMode,
+		TenantID:        state.tenantID,
+		InstanceID:      e.instanceID,
+		RequestID:       generateRequestID(),
+		SessionID:       state.sessionID,
+		ClientType:      state.clientType,
+		ProjectID:       state.projectID,
+		RequestModel:    state.requestModel,
+		ReasoningEffort: requestmeta.ReasoningEffort(reasoningBody),
+		StartTime:       time.Now(),
+		IsStream:        state.isStream,
+		Status:          status,
+		APITokenID:      state.apiTokenID,
+		DevMode:         state.apiTokenDevMode,
 	}
 
 	clearDetail := e.shouldClearRequestDetailFor(state)

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/repository"
+	"github.com/awsl-project/maxx/internal/requestmeta"
 )
 
 // ProviderProxyHandler handles provider-prefixed proxy requests like /provider/{id}/v1/messages.
@@ -233,27 +234,32 @@ func (h *ProviderProxyHandler) newProxyRequest(c *flow.Ctx, route *domain.Route,
 	requestHeaders := flow.GetRequestHeaders(c)
 	requestURI := flow.GetRequestURI(c)
 	requestBody := flow.GetRequestBody(c)
+	reasoningBody := flow.GetOriginalRequestBody(c)
+	if len(reasoningBody) == 0 {
+		reasoningBody = requestBody
+	}
 	apiTokenID := flow.GetAPITokenID(c)
 	projectID := flow.GetProjectID(c)
 	tenantID := maxxctx.GetTenantID(c.Request.Context())
 	devMode := getAPITokenDevMode(c)
 
 	proxyReq := &domain.ProxyRequest{
-		TenantID:      tenantID,
-		RequestID:     generateProxyRequestID(),
-		SessionID:     flow.GetSessionID(c),
-		ClientType:    flow.GetClientType(c),
-		RequestModel:  requestModel,
-		ResponseModel: mappedModel,
-		StartTime:     time.Now(),
-		IsStream:      isStream,
-		Status:        "IN_PROGRESS",
-		StatusCode:    http.StatusOK,
-		RouteID:       route.ID,
-		ProviderID:    provider.ID,
-		ProjectID:     projectID,
-		APITokenID:    apiTokenID,
-		DevMode:       devMode,
+		TenantID:        tenantID,
+		RequestID:       generateProxyRequestID(),
+		SessionID:       flow.GetSessionID(c),
+		ClientType:      flow.GetClientType(c),
+		RequestModel:    requestModel,
+		ResponseModel:   mappedModel,
+		ReasoningEffort: requestmeta.ReasoningEffort(reasoningBody),
+		StartTime:       time.Now(),
+		IsStream:        isStream,
+		Status:          "IN_PROGRESS",
+		StatusCode:      http.StatusOK,
+		RouteID:         route.ID,
+		ProviderID:      provider.ID,
+		ProjectID:       projectID,
+		APITokenID:      apiTokenID,
+		DevMode:         devMode,
 	}
 	if !clearDetail {
 		proxyReq.RequestInfo = &domain.RequestInfo{

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -539,6 +540,91 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     18,
+		Description: "Add reasoning effort metadata to proxy requests",
+		Up: func(db *gorm.DB) error {
+			return runReasoningEffortColumnMigration(db)
+		},
+		Down: func(db *gorm.DB) error {
+			// Keep the column on rollback: dropping a column can rebuild large
+			// MySQL tables and the older application safely ignores it.
+			return nil
+		},
+	},
+}
+
+func runReasoningEffortColumnMigration(db *gorm.DB) error {
+	if db.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort") {
+		return nil
+	}
+
+	const ddl = "ALTER TABLE proxy_requests ADD COLUMN reasoning_effort VARCHAR(32) NULL"
+	if db.Dialector.Name() != "mysql" {
+		if err := db.Exec(ddl).Error; err != nil {
+			lower := strings.ToLower(err.Error())
+			if strings.Contains(lower, "duplicate column") || strings.Contains(lower, "already exists") {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+
+	var version string
+	if err := db.Raw("SELECT VERSION()").Scan(&version).Error; err == nil && mysqlSupportsInstantAddColumn(version) {
+		if err := db.Exec(ddl + ", ALGORITHM=INSTANT").Error; err == nil {
+			return nil
+		} else {
+			lower := strings.ToLower(err.Error())
+			if strings.Contains(lower, "duplicate column") || strings.Contains(lower, "already exists") {
+				return nil
+			}
+			log.Printf("[Migration v18] MySQL instant ADD COLUMN unavailable (%v); evaluating safe fallback", err)
+		}
+	}
+
+	var rowCount int64
+	if err := db.Raw("SELECT COUNT(*) FROM proxy_requests").Scan(&rowCount).Error; err != nil {
+		log.Printf("[Migration v18] could not count proxy_requests (%v); skipping column add. Apply manually if needed: %s;", err, ddl)
+		return nil
+	}
+	if rowCount > detailCleanupIndexRowThreshold {
+		log.Printf("[Migration v18] SKIPPING reasoning_effort ADD COLUMN: proxy_requests has %d rows (> %d threshold). "+
+			"Apply manually during a maintenance window: %s;",
+			rowCount, detailCleanupIndexRowThreshold, ddl)
+		return nil
+	}
+
+	if err := db.Exec(ddl).Error; err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "duplicate column") || strings.Contains(lower, "already exists") {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func mysqlSupportsInstantAddColumn(version string) bool {
+	if strings.Contains(strings.ToLower(version), "mariadb") {
+		return false
+	}
+	version = strings.SplitN(version, "-", 2)[0]
+	parts := strings.Split(version, ".")
+	if len(parts) < 3 {
+		return false
+	}
+	major, errMajor := strconv.Atoi(parts[0])
+	minor, errMinor := strconv.Atoi(parts[1])
+	patch, errPatch := strconv.Atoi(parts[2])
+	if errMajor != nil || errMinor != nil || errPatch != nil {
+		return false
+	}
+	if major > 8 {
+		return true
+	}
+	return major == 8 && (minor > 0 || patch >= 12)
 }
 
 // runDetailClearedColumnMigration 显式添加 detail_cleared 列到两张大表,带 threshold-skip。

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -40,6 +40,36 @@ func TestIsMySQLMissingIndexError(t *testing.T) {
 	}
 }
 
+func TestMySQLSupportsInstantAddColumn(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "8.0.11", want: false},
+		{version: "8.0.12", want: true},
+		{version: "8.4.1", want: true},
+		{version: "5.7.44-log", want: false},
+		{version: "10.11.6-MariaDB", want: false},
+		{version: "invalid", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := mysqlSupportsInstantAddColumn(tt.version); got != tt.want {
+			t.Errorf("mysqlSupportsInstantAddColumn(%q) = %v, want %v", tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestReasoningEffortColumnIsExcludedFromAutoMigrate(t *testing.T) {
+	db := openRawSQLiteDB(t)
+	if err := db.AutoMigrate(&ProxyRequest{}); err != nil {
+		t.Fatalf("AutoMigrate ProxyRequest: %v", err)
+	}
+	if db.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort") {
+		t.Fatal("reasoning_effort must be added by guarded migration v18, not AutoMigrate")
+	}
+}
+
 func TestDedupeCodexQuotaIdentityRows(t *testing.T) {
 	gormDB := openRawSQLiteDB(t)
 	prepareCodexQuotaDedupeFixture(t, gormDB)

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -282,6 +282,7 @@ type ProxyRequest struct {
 	ClientType                  string `gorm:"size:64"`
 	RequestModel                string `gorm:"size:128"`
 	ResponseModel               string `gorm:"size:128"`
+	ReasoningEffort             string `gorm:"size:32;-:migration"`
 	StartTime                   int64
 	EndTime                     int64 `gorm:"index;index:idx_requests_status_endtime"`
 	DurationMs                  int64

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -13,8 +13,9 @@ import (
 )
 
 type ProxyRequestRepository struct {
-	db    *DB
-	count int64 // 缓存的请求总数，使用原子操作
+	db                       *DB
+	count                    int64 // 缓存的请求总数，使用原子操作
+	hasReasoningEffortColumn bool
 }
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
@@ -102,7 +103,10 @@ func proxyRequestTrendBucketSize(startMs, endMs int64) int64 {
 }
 
 func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
-	r := &ProxyRequestRepository{db: db}
+	r := &ProxyRequestRepository{
+		db:                       db,
+		hasReasoningEffortColumn: db.gorm.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort"),
+	}
 	// 初始化时从数据库加载计数
 	r.initCount()
 	return r
@@ -122,7 +126,11 @@ func (r *ProxyRequestRepository) Create(p *domain.ProxyRequest) error {
 	p.UpdatedAt = now
 
 	model := r.toModel(p)
-	if err := r.db.gorm.Create(model).Error; err != nil {
+	query := r.db.gorm
+	if !r.hasReasoningEffortColumn {
+		query = query.Omit("reasoning_effort")
+	}
+	if err := query.Create(model).Error; err != nil {
 		return err
 	}
 	p.ID = model.ID
@@ -150,6 +158,9 @@ func (r *ProxyRequestRepository) Update(p *domain.ProxyRequest) error {
 		model.ResponseInfo = LongText(toJSON(p.ResponseInfo))
 	} else {
 		omit = append(omit, "response_info")
+	}
+	if !r.hasReasoningEffortColumn {
+		omit = append(omit, "reasoning_effort")
 	}
 	return r.db.gorm.Omit(omit...).Save(model).Error
 }
@@ -180,8 +191,12 @@ func (r *ProxyRequestRepository) List(tenantID uint64, limit, offset int) ([]*do
 // 注意：列表查询不返回 request_info 和 response_info 大字段
 func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, after uint64, filter *repository.ProxyRequestFilter) ([]*domain.ProxyRequest, error) {
 	// 使用 Select 排除大字段
+	selectColumns := "id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, ttft_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id"
+	if r.hasReasoningEffortColumn {
+		selectColumns += ", reasoning_effort"
+	}
 	baseQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
-		Select("id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, ttft_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id")
+		Select(selectColumns)
 
 	if after > 0 {
 		baseQuery = baseQuery.Where("id > ?", after)
@@ -207,9 +222,13 @@ func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, 
 
 // ListActive 获取所有活跃请求 (PENDING 或 IN_PROGRESS 状态)
 func (r *ProxyRequestRepository) ListActive(tenantID uint64) ([]*domain.ProxyRequest, error) {
+	selectColumns := "id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id"
+	if r.hasReasoningEffortColumn {
+		selectColumns += ", reasoning_effort"
+	}
 	var models []ProxyRequest
 	if err := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
-		Select("id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id").
+		Select(selectColumns).
 		Where("status IN ?", activeProxyRequestStatuses).
 		Order("id DESC").
 		Find(&models).Error; err != nil {
@@ -968,6 +987,7 @@ func (r *ProxyRequestRepository) toModelMeta(p *domain.ProxyRequest) *ProxyReque
 		ClientType:                  string(p.ClientType),
 		RequestModel:                p.RequestModel,
 		ResponseModel:               p.ResponseModel,
+		ReasoningEffort:             p.ReasoningEffort,
 		StartTime:                   toTimestamp(p.StartTime),
 		EndTime:                     toTimestamp(p.EndTime),
 		DurationMs:                  p.Duration.Milliseconds(),
@@ -1007,6 +1027,7 @@ func (r *ProxyRequestRepository) toDomain(m *ProxyRequest) *domain.ProxyRequest 
 		ClientType:                  domain.ClientType(m.ClientType),
 		RequestModel:                m.RequestModel,
 		ResponseModel:               m.ResponseModel,
+		ReasoningEffort:             m.ReasoningEffort,
 		StartTime:                   fromTimestamp(m.StartTime),
 		EndTime:                     fromTimestamp(m.EndTime),
 		Duration:                    time.Duration(m.DurationMs) * time.Millisecond,

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -128,6 +128,62 @@ func TestProxyRequestListCursorReturnsNewestIDsFirst(t *testing.T) {
 	}
 }
 
+func TestProxyRequestReasoningEffortRoundTrip(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	if !db.gorm.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort") {
+		t.Fatal("reasoning_effort column was not migrated")
+	}
+
+	repo := NewProxyRequestRepository(db)
+	request := buildTestProxyRequest("COMPLETED", 1)
+	request.ReasoningEffort = "high"
+	if err := repo.Create(request); err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	items, err := repo.ListCursor(1, 10, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("ListCursor failed: %v", err)
+	}
+	if len(items) != 1 || items[0].ReasoningEffort != "high" {
+		t.Fatalf("reasoning effort round trip = %#v, want high", items)
+	}
+}
+
+func TestProxyRequestRepositoryWorksWithoutReasoningEffortColumn(t *testing.T) {
+	gormDB := openRawSQLiteDB(t)
+	if err := gormDB.AutoMigrate(&ProxyRequest{}); err != nil {
+		t.Fatalf("AutoMigrate ProxyRequest: %v", err)
+	}
+	db := &DB{gorm: gormDB, dialector: "sqlite"}
+	repo := NewProxyRequestRepository(db)
+	if repo.hasReasoningEffortColumn {
+		t.Fatal("expected guarded migration fallback to detect the missing column")
+	}
+
+	request := buildTestProxyRequest("IN_PROGRESS", 1)
+	request.ReasoningEffort = "high"
+	if err := repo.Create(request); err != nil {
+		t.Fatalf("Create without reasoning_effort column: %v", err)
+	}
+	request.Status = "COMPLETED"
+	if err := repo.Update(request); err != nil {
+		t.Fatalf("Update without reasoning_effort column: %v", err)
+	}
+	items, err := repo.ListCursor(1, 10, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("ListCursor without reasoning_effort column: %v", err)
+	}
+	if len(items) != 1 || items[0].ReasoningEffort != "" {
+		t.Fatalf("fallback list = %#v, want one item without reasoning effort", items)
+	}
+}
+
 func TestProxyRequestListCursorBeforeCursorDoesNotRepeatOrSkipRecords(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/internal/requestmeta/reasoning.go
+++ b/internal/requestmeta/reasoning.go
@@ -1,0 +1,73 @@
+package requestmeta
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/tidwall/gjson"
+)
+
+// ReasoningEffort extracts the client-requested reasoning depth from the
+// request formats accepted by MAXX. It intentionally reads the original
+// client payload so converted requests keep the user's requested depth.
+func ReasoningEffort(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	for _, path := range []string{
+		"reasoning.effort",                              // OpenAI Responses / Codex
+		"reasoning_effort",                              // OpenAI Chat Completions
+		"output_config.effort",                          // Claude adaptive thinking
+		"generationConfig.thinkingConfig.thinkingLevel", // Gemini
+		"generation_config.thinking_config.thinking_level",
+	} {
+		if effort := normalizeEffort(gjson.GetBytes(body, path).String()); effort != "" {
+			return effort
+		}
+	}
+
+	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
+	switch thinkingType {
+	case "adaptive":
+		return "auto"
+	case "disabled":
+		return "none"
+	case "enabled":
+		budget := gjson.GetBytes(body, "thinking.budget_tokens")
+		if !budget.Exists() || budget.Type != gjson.Number {
+			return "auto"
+		}
+		return effortForThinkingBudget(budget.Int())
+	default:
+		return ""
+	}
+}
+
+func effortForThinkingBudget(budget int64) string {
+	switch {
+	case budget == -1:
+		return "auto"
+	case budget <= 0:
+		return "none"
+	case budget <= 1024:
+		return "low"
+	case budget <= 8192:
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
+func normalizeEffort(effort string) string {
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "" || len(effort) > 32 {
+		return ""
+	}
+	for _, r := range effort {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
+			return ""
+		}
+	}
+	return effort
+}

--- a/internal/requestmeta/reasoning_test.go
+++ b/internal/requestmeta/reasoning_test.go
@@ -1,0 +1,31 @@
+package requestmeta
+
+import "testing"
+
+func TestReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "codex responses", body: `{"reasoning":{"effort":"high"}}`, want: "high"},
+		{name: "openai chat", body: `{"reasoning_effort":"xhigh"}`, want: "xhigh"},
+		{name: "claude adaptive", body: `{"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"}}`, want: "medium"},
+		{name: "claude adaptive default", body: `{"thinking":{"type":"adaptive"}}`, want: "auto"},
+		{name: "claude classic low", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: "low"},
+		{name: "claude classic medium", body: `{"thinking":{"type":"enabled","budget_tokens":8192}}`, want: "medium"},
+		{name: "claude classic high", body: `{"thinking":{"type":"enabled","budget_tokens":16000}}`, want: "high"},
+		{name: "claude disabled", body: `{"thinking":{"type":"disabled"}}`, want: "none"},
+		{name: "gemini", body: `{"generationConfig":{"thinkingConfig":{"thinkingLevel":"HIGH"}}}`, want: "high"},
+		{name: "invalid value", body: `{"reasoning":{"effort":"high effort"}}`, want: ""},
+		{name: "missing", body: `{"model":"gpt-5"}`, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReasoningEffort([]byte(tt.body)); got != tt.want {
+				t.Fatalf("ReasoningEffort() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/web/e2e/requests-reasoning-effort.spec.ts
+++ b/web/e2e/requests-reasoning-effort.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+async function json(route: Route, body: unknown) {
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+async function installRequestPageMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+
+  const now = new Date().toISOString();
+  const request = {
+    id: 1,
+    createdAt: now,
+    updatedAt: now,
+    instanceID: 'e2e',
+    requestID: 'request-reasoning-e2e',
+    sessionID: 'session-reasoning-e2e',
+    clientType: 'codex',
+    requestModel: 'gpt-5.6-sol',
+    responseModel: 'gpt-5.6-sol',
+    reasoningEffort: 'high',
+    startTime: now,
+    endTime: now,
+    duration: 3_310_000_000,
+    ttft: 1_020_000_000,
+    isStream: true,
+    status: 'COMPLETED',
+    statusCode: 200,
+    requestInfo: null,
+    responseInfo: null,
+    error: '',
+    proxyUpstreamAttemptCount: 1,
+    finalProxyUpstreamAttemptID: 1,
+    routeID: 1,
+    providerID: 0,
+    projectID: 0,
+    inputTokenCount: 493,
+    outputTokenCount: 43,
+    cacheReadCount: 72_200,
+    cacheWriteCount: 0,
+    cache5mWriteCount: 0,
+    cache1hWriteCount: 0,
+    modelPriceId: 0,
+    multiplier: 10_000,
+    cost: 0,
+    apiTokenID: 0,
+  };
+
+  await page.route('**/api/admin/auth/status', (route) =>
+    json(route, {
+      authEnabled: true,
+      user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
+    }),
+  );
+  await page.route('**/api/settings', (route) =>
+    json(route, {
+      api_token_auth_enabled: 'false',
+      force_project_binding: 'false',
+      ui_multitenant_enabled: 'false',
+    }),
+  );
+  await page.route('**/api/providers', (route) => json(route, []));
+  await page.route('**/api/projects', (route) => json(route, []));
+  await page.route('**/api/api-tokens', (route) => json(route, []));
+  await page.route(/\/api\/admin\/requests\/cleanup-failed-count(?:\?.*)?$/, (route) =>
+    json(route, 0),
+  );
+  await page.route(/\/api\/admin\/requests\/count(?:\?.*)?$/, (route) => json(route, 1));
+  await page.route(/\/api\/admin\/requests(?:\?.*)?$/, (route) =>
+    json(route, { items: [request], hasMore: false, firstId: 1, lastId: 1 }),
+  );
+}
+
+test.use({ viewport: { width: 1548, height: 1018 }, locale: 'zh-CN' });
+
+test('request table shows reasoning effort beside a compact model column', async ({
+  page,
+}, testInfo) => {
+  await installRequestPageMocks(page);
+  await page.goto('/requests');
+
+  const modelHeader = page.getByRole('columnheader', { name: '模型', exact: true });
+  const reasoningHeader = page.getByRole('columnheader', { name: '思考深度', exact: true });
+  const row = page.locator('[data-request-row="true"]');
+
+  await expect(modelHeader).toBeVisible();
+  await expect(reasoningHeader).toBeVisible();
+  await expect(row.getByText('gpt-5.6-sol', { exact: true })).toBeVisible();
+  await expect(row.getByText('high', { exact: true })).toBeVisible();
+
+  const modelBox = await modelHeader.boundingBox();
+  const reasoningBox = await reasoningHeader.boundingBox();
+  expect(modelBox).not.toBeNull();
+  expect(reasoningBox).not.toBeNull();
+  expect(modelBox!.width).toBeLessThan(220);
+  expect(Math.abs(reasoningBox!.x - (modelBox!.x + modelBox!.width))).toBeLessThan(2);
+
+  await page.screenshot({ path: testInfo.outputPath('requests-reasoning-effort.png') });
+});

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -468,6 +468,7 @@ export interface ProxyRequest {
   clientType: ClientType;
   requestModel: string;
   responseModel: string;
+  reasoningEffort: string;
   startTime: string;
   endTime: string;
   duration: number; // nanoseconds

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -251,6 +251,7 @@
     "time": "Time",
     "client": "Client",
     "model": "Model",
+    "reasoningEffort": "Reasoning",
     "project": "Project",
     "token": "Token",
     "provider": "Provider",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -250,6 +250,7 @@
     "time": "时间",
     "client": "客户端",
     "model": "模型",
+    "reasoningEffort": "思考深度",
     "project": "项目",
     "token": "令牌",
     "provider": "提供商",

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -424,7 +424,7 @@ export function RequestsPage() {
   // 高频实时更新时，仅保留可视区域附近的桌面行，减少表格重排和重绘成本。
   const shouldVirtualizeDesktop =
     !isMobile && allRequests.length >= REQUESTS_VIRTUALIZE_THRESHOLD && viewportHeight > 0;
-  const desktopColumnCount = 14 + (hasProjects ? 1 : 0) + (apiTokenAuthEnabled ? 1 : 0);
+  const desktopColumnCount = 15 + (hasProjects ? 1 : 0) + (apiTokenAuthEnabled ? 1 : 0);
   const desktopVirtualRange = useMemo(() => {
     if (!shouldVirtualizeDesktop) {
       return {
@@ -694,7 +694,10 @@ export function RequestsPage() {
       <TableRow className="hover:bg-transparent border-none text-sm">
         <TableHead className="w-[180px] font-medium">{t('requests.time')}</TableHead>
         <TableHead className="w-[120px] pr-4 font-medium">{t('requests.client')}</TableHead>
-        <TableHead className="min-w-[250px] font-medium">{t('requests.model')}</TableHead>
+        <TableHead className="w-[160px] min-w-[160px] font-medium">{t('requests.model')}</TableHead>
+        <TableHead className="w-[90px] min-w-[90px] text-center font-medium">
+          {t('requests.reasoningEffort')}
+        </TableHead>
         {hasProjects && (
           <TableHead className="w-[100px] font-medium">{t('requests.project')}</TableHead>
         )}
@@ -1211,17 +1214,30 @@ function LogRow({
       </TableCell>
 
       {/* Model */}
-      <TableCell className="min-w-[250px] px-2 py-1">
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-foreground font-medium" title={request.requestModel}>
+      <TableCell className="w-[160px] min-w-[160px] px-2 py-1">
+        <div className="flex items-center gap-2 min-w-0 max-w-[220px]">
+          <span
+            className="text-sm text-foreground font-medium truncate"
+            title={request.requestModel}
+          >
             {request.requestModel || '-'}
           </span>
           {request.responseModel && request.responseModel !== request.requestModel && (
-            <span className="text-[10px] text-muted-foreground shrink-0">
+            <span
+              className="text-[10px] text-muted-foreground truncate"
+              title={request.responseModel}
+            >
               → {request.responseModel}
             </span>
           )}
         </div>
+      </TableCell>
+
+      {/* Reasoning effort */}
+      <TableCell className="w-[90px] min-w-[90px] px-2 py-1 text-center">
+        <span className="text-xs font-mono text-foreground/80">
+          {request.reasoningEffort || '-'}
+        </span>
       </TableCell>
 
       {/* Project */}
@@ -1412,6 +1428,11 @@ function MobileRequestCard({ request, providerName, onOpenRequest }: MobileReque
         <span className="text-sm font-medium text-foreground truncate flex-1">
           {request.requestModel || '-'}
         </span>
+        {request.reasoningEffort && (
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {request.reasoningEffort}
+          </span>
+        )}
         <RequestStatusBadge status={request.status} />
       </div>
       {/* Row 2: Time + Duration + Cost */}


### PR DESCRIPTION
## Summary

- capture the client-requested reasoning effort from the original Codex/OpenAI, Claude, and Gemini payload before any protocol conversion
- persist the normalized value on proxy requests and expose it through cursor/active request queries
- replace the oversized 250px model column with a compact model column plus a new reasoning-effort column on `/requests`; also show the value in mobile cards
- add backend extraction/migration/fallback coverage and a Playwright regression that checks both the displayed `high` value and the compact adjacent column layout

## Database safety

- migration v18 adds a nullable `reasoning_effort VARCHAR(32)` column
- MySQL 8.0.12+ uses `ALGORITHM=INSTANT` when available
- legacy MySQL tables above the existing 500k-row safety threshold skip startup DDL and log the manual maintenance-window SQL
- repository reads/writes safely omit the column when it is unavailable, so a skipped migration does not break request logging
- historical request rows are intentionally not backfilled; they display `-` to avoid parsing large stored request bodies during upgrade

## Verification

- `go test ./internal/requestmeta ./internal/repository/sqlite ./internal/executor ./internal/handler`
- `pnpm typecheck`
- `pnpm exec eslint e2e/requests-reasoning-effort.spec.ts src/pages/requests/index.tsx src/lib/transport/types.ts`
- `pnpm test` (83 tests)
- `pnpm build`
- `pnpm exec playwright test e2e/requests-reasoning-effort.spec.ts` (1 passed; desktop screenshot inspected at 1548x1018)