### PR TITLE
feat(proxy): add public route exposure controls

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -546,6 +546,7 @@ func main() {
 		ProxyHandler:         proxyHandler,
 		ModelsHandler:        protectedModelsHandler,
 		ProviderProxyHandler: providerProxyHandler,
+		SettingRepo:          settingRepo,
 	})
 
 	// Health check

--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -1,6 +1,11 @@
 package core
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
+)
 
 // ProxyRouteHandlers groups the public AI API handlers that must stay in sync
 // across CLI, desktop, and test route registration.
@@ -8,6 +13,7 @@ type ProxyRouteHandlers struct {
 	ProxyHandler         http.Handler
 	ModelsHandler        http.Handler
 	ProviderProxyHandler http.Handler
+	SettingRepo          repository.SystemSettingRepository
 }
 
 // RegisterProxyRoutes registers the shared public AI API routes.
@@ -17,12 +23,17 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 	}
 
 	if handlers.ProxyHandler != nil {
+		claudeMessagesHandler := routeGate(handlers.ProxyHandler, handlers.SettingRepo, domain.SettingKeyProxyRouteClaudeMessagesEnabled)
+		openAIChatHandler := routeGate(handlers.ProxyHandler, handlers.SettingRepo, domain.SettingKeyProxyRouteOpenAIChatEnabled)
+		responsesHandler := routeGate(handlers.ProxyHandler, handlers.SettingRepo, domain.SettingKeyProxyRouteResponsesEnabled)
+		geminiHandler := routeGate(handlers.ProxyHandler, handlers.SettingRepo, domain.SettingKeyProxyRouteGeminiEnabled)
+
 		// Claude API
-		mux.Handle("/v1/messages", handlers.ProxyHandler)
-		mux.Handle("/v1/messages/", handlers.ProxyHandler)
+		mux.Handle("/v1/messages", claudeMessagesHandler)
+		mux.Handle("/v1/messages/", claudeMessagesHandler)
 		// OpenAI API
-		mux.Handle("/v1/chat/completions", handlers.ProxyHandler)
-		mux.Handle("/chat/completions", handlers.ProxyHandler)
+		mux.Handle("/v1/chat/completions", openAIChatHandler)
+		mux.Handle("/chat/completions", openAIChatHandler)
 		// OpenAI Images API (gpt-image-* generation + edits)
 		mux.Handle("/v1/images/generations", handlers.ProxyHandler)
 		mux.Handle("/v1/images/edits", handlers.ProxyHandler)
@@ -32,12 +43,12 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 		mux.Handle("/v1/images", handlers.ProxyHandler)
 		mux.Handle("/images", handlers.ProxyHandler)
 		// Codex API
-		mux.Handle("/responses", handlers.ProxyHandler)
-		mux.Handle("/responses/", handlers.ProxyHandler)
-		mux.Handle("/v1/responses", handlers.ProxyHandler)
-		mux.Handle("/v1/responses/", handlers.ProxyHandler)
+		mux.Handle("/responses", responsesHandler)
+		mux.Handle("/responses/", responsesHandler)
+		mux.Handle("/v1/responses", responsesHandler)
+		mux.Handle("/v1/responses/", responsesHandler)
 		// Gemini API (Google AI Studio style generation endpoints)
-		mux.Handle("/v1beta/models/", handlers.ProxyHandler)
+		mux.Handle("/v1beta/models/", geminiHandler)
 	}
 
 	if handlers.ModelsHandler != nil {
@@ -49,4 +60,36 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 	if handlers.ProviderProxyHandler != nil {
 		mux.Handle("/provider/", handlers.ProviderProxyHandler)
 	}
+}
+
+func routeGate(next http.Handler, settings repository.SystemSettingRepository, key string) http.Handler {
+	if next == nil {
+		return nil
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !proxyRouteEnabled(settings, key) {
+			http.NotFound(w, r)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func proxyRouteEnabled(settings repository.SystemSettingRepository, key string) bool {
+	if settings == nil {
+		return proxyRouteEnabledByDefault(key)
+	}
+
+	value, err := settings.Get(key)
+	if err != nil || value == "" {
+		return proxyRouteEnabledByDefault(key)
+	}
+
+	return value != "false"
+}
+
+func proxyRouteEnabledByDefault(key string) bool {
+	return key != domain.SettingKeyProxyRouteGeminiEnabled
 }

--- a/internal/core/proxy_routes_test.go
+++ b/internal/core/proxy_routes_test.go
@@ -4,7 +4,27 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
 )
+
+type proxyRouteSettingsRepo struct {
+	values map[string]string
+	err    error
+}
+
+func (r proxyRouteSettingsRepo) Get(key string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.values[key], nil
+}
+
+func (r proxyRouteSettingsRepo) Set(key, value string) error { return nil }
+
+func (r proxyRouteSettingsRepo) GetAll() ([]*domain.SystemSetting, error) { return nil, nil }
+
+func (r proxyRouteSettingsRepo) Delete(key string) error { return nil }
 
 func TestRegisterProxyRoutes_RegistersModelsRoute(t *testing.T) {
 	mux := http.NewServeMux()
@@ -51,6 +71,9 @@ func TestRegisterProxyRoutes_RoutesGeminiGenerationToProxy(t *testing.T) {
 		ModelsHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Fatalf("did not expect Gemini generation path to hit ModelsHandler")
 		}),
+		SettingRepo: proxyRouteSettingsRepo{values: map[string]string{
+			domain.SettingKeyProxyRouteGeminiEnabled: "true",
+		}},
 	})
 
 	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", nil)
@@ -64,3 +87,110 @@ func TestRegisterProxyRoutes_RoutesGeminiGenerationToProxy(t *testing.T) {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
 	}
 }
+
+func TestRegisterProxyRoutes_GeminiGenerationDisabledByDefault(t *testing.T) {
+	mux := http.NewServeMux()
+
+	RegisterProxyRoutes(mux, ProxyRouteHandlers{
+		ProxyHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("did not expect default-disabled Gemini path to hit ProxyHandler")
+		}),
+		SettingRepo: proxyRouteSettingsRepo{values: map[string]string{}},
+	})
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestRegisterProxyRoutes_DisablesConfiguredProxyRouteGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		settingKey  string
+		disabledURL string
+		allowedURL  string
+	}{
+		{
+			name:        "claude messages",
+			settingKey:  domain.SettingKeyProxyRouteClaudeMessagesEnabled,
+			disabledURL: "/v1/messages",
+			allowedURL:  "/v1/chat/completions",
+		},
+		{
+			name:        "openai chat completions",
+			settingKey:  domain.SettingKeyProxyRouteOpenAIChatEnabled,
+			disabledURL: "/v1/chat/completions",
+			allowedURL:  "/v1/messages",
+		},
+		{
+			name:        "responses",
+			settingKey:  domain.SettingKeyProxyRouteResponsesEnabled,
+			disabledURL: "/v1/responses",
+			allowedURL:  "/v1/messages",
+		},
+		{
+			name:        "gemini",
+			settingKey:  domain.SettingKeyProxyRouteGeminiEnabled,
+			disabledURL: "/v1beta/models/gemini-2.5-pro:generateContent",
+			allowedURL:  "/v1/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			proxyCalls := 0
+
+			RegisterProxyRoutes(mux, ProxyRouteHandlers{
+				ProxyHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					proxyCalls++
+					w.WriteHeader(http.StatusNoContent)
+				}),
+				SettingRepo: proxyRouteSettingsRepo{values: map[string]string{tt.settingKey: "false"}},
+			})
+
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, tt.disabledURL, nil))
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("disabled route status = %d, want %d", rec.Code, http.StatusNotFound)
+			}
+
+			rec = httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, tt.allowedURL, nil))
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("allowed route status = %d, want %d", rec.Code, http.StatusNoContent)
+			}
+			if proxyCalls != 1 {
+				t.Fatalf("proxyCalls = %d, want 1", proxyCalls)
+			}
+		})
+	}
+}
+
+func TestRegisterProxyRoutes_ProxyRouteGateDefaultsOpen(t *testing.T) {
+	for _, settings := range []proxyRouteSettingsRepo{
+		{values: map[string]string{}},
+		{err: assertAnError{}},
+	} {
+		mux := http.NewServeMux()
+		RegisterProxyRoutes(mux, ProxyRouteHandlers{
+			ProxyHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			}),
+			SettingRepo: settings,
+		})
+
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/messages", nil))
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("default-open route status = %d, want %d", rec.Code, http.StatusNoContent)
+		}
+	}
+}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string { return "assertion error" }

--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -107,6 +107,7 @@ func (s *ManagedServer) setupRoutes() *http.ServeMux {
 		ProxyHandler:         components.ProxyHandler,
 		ModelsHandler:        modelsHandler,
 		ProviderProxyHandler: components.ProviderProxyHandler,
+		SettingRepo:          s.config.SettingRepo,
 	})
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -856,6 +856,10 @@ const (
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"
 	SettingKeyCodexReasoningGuard                  = "codex_reasoning_guard"                    // Codex reasoning guard 配置（JSON 对象）
 	SettingKeyPayloadOverrideRules                 = "payload_override_rules"                   // 请求 payload 覆盖规则（JSON 数组）
+	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"      // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"
+	SettingKeyProxyRouteOpenAIChatEnabled          = "proxy_route_openai_chat_enabled"          // 是否暴露 OpenAI Chat Completions 代理路由，"true" 或 "false"，默认 "true"
+	SettingKeyProxyRouteResponsesEnabled           = "proxy_route_responses_enabled"            // 是否暴露 Responses/Codex 代理路由，"true" 或 "false"，默认 "true"
+	SettingKeyProxyRouteGeminiEnabled              = "proxy_route_gemini_enabled"               // 是否暴露 Gemini 代理路由，"true" 或 "false"，默认 "false"
 	SettingKeyEnablePprof                          = "enable_pprof"                             // 是否启用 pprof 性能分析，"true" 或 "false"，默认 "false"
 	SettingKeyPprofPort                            = "pprof_port"                               // pprof 服务端口，默认 6060
 	SettingKeyPprofPassword                        = "pprof_password"                           // pprof 访问密码，为空表示不需要密码

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1424,7 +1424,11 @@ func (h *AdminHandler) handleSettings(w http.ResponseWriter, r *http.Request, pa
 			return
 		}
 		if err := h.svc.DeleteSetting(key); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			status := http.StatusInternalServerError
+			if errors.Is(err, domain.ErrInvalidInput) {
+				status = http.StatusBadRequest
+			}
+			writeJSON(w, status, map[string]string{"error": err.Error()})
 			return
 		}
 		writeJSON(w, http.StatusNoContent, nil)

--- a/internal/handler/admin_settings_test.go
+++ b/internal/handler/admin_settings_test.go
@@ -77,3 +77,51 @@ func TestHandleSettingsReturnsBadRequestForInvalidPayloadOverrideRules(t *testin
 		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
 	}
 }
+
+func TestHandleSettingsDeleteReturnsBadRequestWhenDeletingLastPublicProxyRoute(t *testing.T) {
+	repo := &settingsTestRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+	}}
+	svc := service.NewAdminService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		repo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+	handler := NewAdminHandler(svc, nil, "")
+
+	req := httptest.NewRequest(
+		http.MethodDelete,
+		"/admin/settings/"+domain.SettingKeyProxyRouteGeminiEnabled,
+		nil,
+	)
+	rec := httptest.NewRecorder()
+
+	handler.handleSettings(rec, req, []string{"admin", "settings", domain.SettingKeyProxyRouteGeminiEnabled})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "true" {
+		t.Fatalf("gemini setting = %q, want unchanged true", got)
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -17,13 +17,17 @@ import (
 )
 
 var publicSettingsAllowlist = map[string]struct{}{
-	"api_token_auth_enabled": {},
-	"force_project_binding":  {},
-	"force_project_timeout":  {},
-	"auto_sort_antigravity":  {},
-	"auto_sort_codex":        {},
-	"ui_multitenant_enabled": {},
-	"ui_multitenant_layout":  {},
+	"api_token_auth_enabled":                         {},
+	"force_project_binding":                          {},
+	"force_project_timeout":                          {},
+	"auto_sort_antigravity":                          {},
+	"auto_sort_codex":                                {},
+	"ui_multitenant_enabled":                         {},
+	"ui_multitenant_layout":                          {},
+	domain.SettingKeyProxyRouteClaudeMessagesEnabled: {},
+	domain.SettingKeyProxyRouteOpenAIChatEnabled:     {},
+	domain.SettingKeyProxyRouteResponsesEnabled:      {},
+	domain.SettingKeyProxyRouteGeminiEnabled:         {},
 }
 
 const userPanelAPITokenDescriptionPrefix = "managed-by=maxx-user-panel;user-id="

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1186,6 +1186,9 @@ func (s *AdminService) UpdateSetting(key, value string) error {
 	if err := validateSystemSettingValue(key, value); err != nil {
 		return err
 	}
+	if err := s.validatePublicProxyRouteExposureUpdate(key, value); err != nil {
+		return err
+	}
 	if err := s.settingRepo.Set(key, value); err != nil {
 		return err
 	}
@@ -1206,7 +1209,55 @@ func (s *AdminService) UpdateSetting(key, value string) error {
 	return nil
 }
 
+var publicProxyRouteExposureSettingKeys = []string{
+	domain.SettingKeyProxyRouteClaudeMessagesEnabled,
+	domain.SettingKeyProxyRouteOpenAIChatEnabled,
+	domain.SettingKeyProxyRouteResponsesEnabled,
+	domain.SettingKeyProxyRouteGeminiEnabled,
+}
+
+func isPublicProxyRouteExposureSetting(key string) bool {
+	for _, routeKey := range publicProxyRouteExposureSettingKeys {
+		if key == routeKey {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *AdminService) validatePublicProxyRouteExposureUpdate(key, value string) error {
+	if !isPublicProxyRouteExposureSetting(key) || value != "false" {
+		return nil
+	}
+
+	for _, routeKey := range publicProxyRouteExposureSettingKeys {
+		routeValue := value
+		if routeKey != key {
+			storedValue, err := s.settingRepo.Get(routeKey)
+			if err != nil {
+				return err
+			}
+			routeValue = storedValue
+		}
+		if publicProxyRouteSettingEnabled(routeKey, routeValue) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: at least one public proxy route must be enabled", domain.ErrInvalidInput)
+}
+
+func publicProxyRouteSettingEnabled(key, value string) bool {
+	if value == "" {
+		return key != domain.SettingKeyProxyRouteGeminiEnabled
+	}
+	return value != "false"
+}
+
 func (s *AdminService) DeleteSetting(key string) error {
+	if err := s.validatePublicProxyRouteExposureDelete(key); err != nil {
+		return err
+	}
 	if err := s.settingRepo.Delete(key); err != nil {
 		return err
 	}
@@ -1225,6 +1276,28 @@ func (s *AdminService) DeleteSetting(key string) error {
 	}
 
 	return nil
+}
+
+func (s *AdminService) validatePublicProxyRouteExposureDelete(key string) error {
+	if !isPublicProxyRouteExposureSetting(key) {
+		return nil
+	}
+
+	for _, routeKey := range publicProxyRouteExposureSettingKeys {
+		routeValue := ""
+		if routeKey != key {
+			storedValue, err := s.settingRepo.Get(routeKey)
+			if err != nil {
+				return err
+			}
+			routeValue = storedValue
+		}
+		if publicProxyRouteSettingEnabled(routeKey, routeValue) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: at least one public proxy route must be enabled", domain.ErrInvalidInput)
 }
 
 // ===== Proxy Status API =====

--- a/internal/service/public_proxy_route_settings_test.go
+++ b/internal/service/public_proxy_route_settings_test.go
@@ -1,0 +1,163 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type publicProxyRouteSettingRepo struct {
+	values map[string]string
+}
+
+func (r *publicProxyRouteSettingRepo) Get(key string) (string, error) {
+	if r.values == nil {
+		return "", nil
+	}
+	return r.values[key], nil
+}
+
+func (r *publicProxyRouteSettingRepo) Set(key, value string) error {
+	if r.values == nil {
+		r.values = map[string]string{}
+	}
+	r.values[key] = value
+	return nil
+}
+
+func (r *publicProxyRouteSettingRepo) GetAll() ([]*domain.SystemSetting, error) {
+	return nil, nil
+}
+
+func (r *publicProxyRouteSettingRepo) Delete(key string) error {
+	delete(r.values, key)
+	return nil
+}
+
+func newPublicProxyRouteSettingsService(repo *publicProxyRouteSettingRepo) *AdminService {
+	return NewAdminService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		repo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		"",
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func TestUpdateSettingRejectsDisablingLastPublicProxyRoute(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	err := svc.UpdateSetting(domain.SettingKeyProxyRouteGeminiEnabled, "false")
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "true" {
+		t.Fatalf("gemini setting = %q, want unchanged true", got)
+	}
+}
+
+func TestUpdateSettingTreatsUnsetGeminiAsDisabledByDefault(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "true",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	err := svc.UpdateSetting(domain.SettingKeyProxyRouteResponsesEnabled, "false")
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteResponsesEnabled]; got != "true" {
+		t.Fatalf("responses setting = %q, want unchanged true", got)
+	}
+}
+
+func TestDeleteSettingRejectsDeletingExplicitLastEnabledGemini(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	err := svc.DeleteSetting(domain.SettingKeyProxyRouteGeminiEnabled)
+	if !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "true" {
+		t.Fatalf("gemini setting = %q, want unchanged true", got)
+	}
+}
+
+func TestDeleteSettingAllowsDeletingDisabledRouteWhenDefaultsKeepAnotherEnabled(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "false",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	if err := svc.DeleteSetting(domain.SettingKeyProxyRouteClaudeMessagesEnabled); err != nil {
+		t.Fatalf("DeleteSetting returned error: %v", err)
+	}
+	if _, ok := repo.values[domain.SettingKeyProxyRouteClaudeMessagesEnabled]; ok {
+		t.Fatalf("claude setting still exists after delete")
+	}
+}
+
+func TestUpdateSettingAllowsDisablingPublicProxyRouteWhenAnotherRemainsEnabled(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "true",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	if err := svc.UpdateSetting(domain.SettingKeyProxyRouteGeminiEnabled, "false"); err != nil {
+		t.Fatalf("UpdateSetting returned error: %v", err)
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "false" {
+		t.Fatalf("gemini setting = %q, want false", got)
+	}
+}
+
+func TestUpdateSettingAllowsRestoringPublicProxyRoute(t *testing.T) {
+	repo := &publicProxyRouteSettingRepo{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
+		domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+	}}
+	svc := newPublicProxyRouteSettingsService(repo)
+
+	if err := svc.UpdateSetting(domain.SettingKeyProxyRouteClaudeMessagesEnabled, "true"); err != nil {
+		t.Fatalf("UpdateSetting returned error: %v", err)
+	}
+	if got := repo.values[domain.SettingKeyProxyRouteClaudeMessagesEnabled]; got != "true" {
+		t.Fatalf("claude setting = %q, want true", got)
+	}
+}

--- a/tests/e2e/playwright/routes-multitenant-ui-toggle.spec.ts
+++ b/tests/e2e/playwright/routes-multitenant-ui-toggle.spec.ts
@@ -17,7 +17,13 @@ async function mockRouteApis(page: Page) {
     }
 
     if (pathname === '/api/settings' || pathname === '/api/admin/settings') {
-      return json({ ui_multitenant_enabled: 'false' });
+      return json({
+        ui_multitenant_enabled: 'false',
+        proxy_route_claude_messages_enabled: 'true',
+        proxy_route_openai_chat_enabled: 'true',
+        proxy_route_responses_enabled: 'true',
+        proxy_route_gemini_enabled: 'true',
+      });
     }
 
     if (

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -622,6 +622,7 @@ func TestProxyGeminiPassthrough(t *testing.T) {
 	defer mock.Close()
 
 	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
 	providerID := createProvider(t, env, "mock-gemini", mock.URL, []string{"gemini"})
 	createRoute(t, env, "gemini", providerID)
 
@@ -1053,6 +1054,9 @@ func TestProxyCrossProtocolConversions(t *testing.T) {
 			defer mock.Close()
 
 			env := NewProxyTestEnv(t)
+			if tc.clientType == "gemini" {
+				enableGeminiPublicProxyRoute(t, env)
+			}
 			providerID := createProvider(t, env, fmt.Sprintf("mock-%s", tc.upstreamType), mock.URL, []string{tc.upstreamType})
 			createRoute(t, env, tc.clientType, providerID)
 
@@ -1436,6 +1440,7 @@ func TestProxyGeminiToCodexStreamingSSE(t *testing.T) {
 	defer mock.Close()
 
 	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
 	providerID := createProvider(t, env, "mock-codex-stream", mock.URL, []string{"codex"})
 	createRoute(t, env, "gemini", providerID)
 
@@ -1496,6 +1501,7 @@ func TestProxyAllProtocolsCoexist(t *testing.T) {
 	defer mockGemini.Close()
 
 	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
 
 	// Create 4 providers, one for each protocol
 	claudeProviderID := createProvider(t, env, "mock-claude", mockClaude.URL, []string{"claude"})
@@ -1591,6 +1597,13 @@ func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 			runTokenConcurrencyLimitRecordsRejectedRequest(t, tc.configureRetention)
 		})
 	}
+}
+
+func enableGeminiPublicProxyRoute(t *testing.T, env *ProxyTestEnv) {
+	t.Helper()
+	resp := env.AdminPut("/api/admin/settings/proxy_route_gemini_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
 }
 
 func setRequestDetailRetentionSetting(t *testing.T, env *ProxyTestEnv, key, value string) {
@@ -1888,6 +1901,7 @@ func TestCooldown_200ClearsCooldown(t *testing.T) {
 
 func TestCooldown_GeminiProtocol(t *testing.T) {
 	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
 	srv := mockserver.New()
 	defer srv.Close()
 

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -210,6 +210,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 		ProxyHandler:         proxyHandler,
 		ModelsHandler:        protectedModelsHandler,
 		ProviderProxyHandler: providerProxyHandler,
+		SettingRepo:          settingRepo,
 	})
 	mux.Handle("/project/", projectProxyHandler)
 

--- a/web/src/components/layout/app-sidebar/client-routes-items.tsx
+++ b/web/src/components/layout/app-sidebar/client-routes-items.tsx
@@ -4,9 +4,28 @@ import {
   getClientName,
   getClientColor,
 } from '@/components/icons/client-icons';
+import { usePublicSettings } from '@/hooks/queries/use-settings';
 import { useStreamingRequests } from '@/hooks/use-streaming';
 import type { ClientType } from '@/lib/transport';
 import { AnimatedNavItem } from './animated-nav-item';
+
+const clientRouteSettingKeys: Record<ClientType, string> = {
+  claude: 'proxy_route_claude_messages_enabled',
+  openai: 'proxy_route_openai_chat_enabled',
+  codex: 'proxy_route_responses_enabled',
+  gemini: 'proxy_route_gemini_enabled',
+};
+
+function isClientRouteVisible(
+  settings: Record<string, string> | undefined,
+  clientType: ClientType,
+) {
+  const settingValue = settings?.[clientRouteSettingKeys[clientType]];
+  if (settingValue === undefined) {
+    return clientType !== 'gemini';
+  }
+  return settingValue !== 'false';
+}
 
 function ClientNavItem({
   clientType,
@@ -36,10 +55,14 @@ function ClientNavItem({
  */
 export function ClientRoutesItems() {
   const { countsByClient } = useStreamingRequests();
+  const { data: publicSettings } = usePublicSettings();
+  const visibleClientTypes = allClientTypes.filter((clientType) =>
+    isClientRouteVisible(publicSettings, clientType),
+  );
 
   return (
     <>
-      {allClientTypes.map((clientType) => (
+      {visibleClientTypes.map((clientType) => (
         <ClientNavItem
           key={clientType}
           clientType={clientType}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1336,6 +1336,17 @@
     "defaultValue": "default {{value}}",
     "minutes": "minutes",
     "routesSortNote": "Auto-sort settings can be configured in the Routes page for each client type",
+    "proxyRouteExposure": "Public Proxy Routes",
+    "proxyRouteExposureDesc": "Control whether public proxy protocol entrypoints are exposed. Disabled routes return 404 and behave as missing routes.",
+    "proxyRouteClaudeMessages": "Claude Messages",
+    "proxyRouteClaudeMessagesDesc": "Controls the Claude / Anthropic Messages compatible entrypoint.",
+    "proxyRouteOpenAIChat": "OpenAI Chat Completions",
+    "proxyRouteOpenAIChatDesc": "Controls the OpenAI Chat Completions compatible entrypoints.",
+    "proxyRouteResponses": "Responses / Codex",
+    "proxyRouteResponsesDesc": "Controls the Responses and Codex compatible entrypoints.",
+    "proxyRouteGemini": "Gemini",
+    "proxyRouteGeminiDesc": "Controls the Google AI Studio style Gemini generation entrypoint. Disabled by default.",
+    "proxyRouteExposureHint": "These toggles only affect public proxy entrypoints, not model list routes, image routes, or provider-specific URLs.",
     "autoSortSettings": "Auto-Sort Settings",
     "autoSortAntigravity": "Auto-Sort Antigravity",
     "autoSortAntigravityDesc": "Automatically sort Antigravity routes by Claude model reset time (earliest first) after quota refresh",
@@ -1412,7 +1423,8 @@
       }
     },
     "themeDefault": "Default",
-    "themeLuxury": "Luxury"
+    "themeLuxury": "Luxury",
+    "proxyRouteExposureAtLeastOne": "At least one public route must stay enabled"
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1333,6 +1333,17 @@
     "defaultValue": "默认 {{value}}",
     "minutes": "分钟",
     "routesSortNote": "自动排序设置可以在各个客户端类型的路由页面中配置",
+    "proxyRouteExposure": "公开代理路由",
+    "proxyRouteExposureDesc": "控制公开代理协议入口是否暴露。关闭后对应路径返回 404，表现为路由不存在。",
+    "proxyRouteClaudeMessages": "Claude Messages",
+    "proxyRouteClaudeMessagesDesc": "控制 Claude / Anthropic Messages 兼容入口。",
+    "proxyRouteOpenAIChat": "OpenAI Chat Completions",
+    "proxyRouteOpenAIChatDesc": "控制 OpenAI Chat Completions 兼容入口。",
+    "proxyRouteResponses": "Responses / Codex",
+    "proxyRouteResponsesDesc": "控制 Responses 与 Codex 兼容入口。",
+    "proxyRouteGemini": "Gemini",
+    "proxyRouteGeminiDesc": "控制 Google AI Studio 风格的 Gemini 生成入口。默认关闭。",
+    "proxyRouteExposureHint": "这些开关只影响公开代理入口，不影响模型列表、图片接口或提供商专属 URL。",
     "autoSortSettings": "自动排序设置",
     "autoSortAntigravity": "自动排序 Antigravity",
     "autoSortAntigravityDesc": "配额刷新后自动按 Claude 模型重置时间排序 Antigravity 路由（最早重置的优先）",
@@ -1409,7 +1420,8 @@
       }
     },
     "themeDefault": "默认",
-    "themeLuxury": "奢华"
+    "themeLuxury": "奢华",
+    "proxyRouteExposureAtLeastOne": "至少保留一个 public route 开启"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -86,6 +86,45 @@ const DEFAULT_CODEX_REASONING_GUARD_SETTING = JSON.stringify(
 const MULTITENANT_UI_LAYOUT_SETTING_KEY = 'ui_multitenant_layout';
 type MultiTenantUILayout = 'current' | 'user_panel';
 
+interface ProxyRouteExposureSetting {
+  key: string;
+  titleKey: string;
+  descKey: string;
+  paths: string[];
+  defaultEnabled: boolean;
+}
+
+const PROXY_ROUTE_EXPOSURE_SETTINGS: ProxyRouteExposureSetting[] = [
+  {
+    key: 'proxy_route_claude_messages_enabled',
+    titleKey: 'settings.proxyRouteClaudeMessages',
+    descKey: 'settings.proxyRouteClaudeMessagesDesc',
+    paths: ['/v1/messages'],
+    defaultEnabled: true,
+  },
+  {
+    key: 'proxy_route_openai_chat_enabled',
+    titleKey: 'settings.proxyRouteOpenAIChat',
+    descKey: 'settings.proxyRouteOpenAIChatDesc',
+    paths: ['/v1/chat/completions', '/chat/completions'],
+    defaultEnabled: true,
+  },
+  {
+    key: 'proxy_route_responses_enabled',
+    titleKey: 'settings.proxyRouteResponses',
+    descKey: 'settings.proxyRouteResponsesDesc',
+    paths: ['/v1/responses', '/responses'],
+    defaultEnabled: true,
+  },
+  {
+    key: 'proxy_route_gemini_enabled',
+    titleKey: 'settings.proxyRouteGemini',
+    descKey: 'settings.proxyRouteGeminiDesc',
+    paths: ['/v1beta/models/*'],
+    defaultEnabled: false,
+  },
+];
+
 type PayloadOverrideProtocol = 'codex';
 
 interface PayloadOverrideFormRule {
@@ -307,6 +346,7 @@ export function SettingsPage() {
               <PayloadOverrideSection />
               <CodexReasoningGuardSection />
               <APITokenConcurrencySection />
+              <ProxyRouteExposureSection />
               <AntigravitySection />
               <PprofSection />
               <BackupSection />
@@ -1558,6 +1598,94 @@ function APITokenConcurrencySection() {
               {t('settings.rateLimitCooldownDefaultSecondsInvalid')}
             </p>
           )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProxyRouteExposureSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+
+  const enabledCount = PROXY_ROUTE_EXPOSURE_SETTINGS.filter((route) => {
+    const value = settings?.[route.key];
+    return value === undefined ? route.defaultEnabled : value !== 'false';
+  }).length;
+
+  const handleToggle = async (key: string, checked: boolean) => {
+    if (!checked && enabledCount <= 1) return;
+
+    await updateSetting.mutateAsync({
+      key,
+      value: checked ? 'true' : 'false',
+    });
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div>
+          <CardTitle className="text-base font-medium flex items-center gap-2">
+            <Globe className="h-4 w-4 text-muted-foreground" />
+            {t('settings.proxyRouteExposure')}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">
+            {t('settings.proxyRouteExposureDesc')}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        {PROXY_ROUTE_EXPOSURE_SETTINGS.map((route) => {
+          const value = settings?.[route.key];
+          const enabled = value === undefined ? route.defaultEnabled : value !== 'false';
+          const disableLastEnabledRoute = enabled && enabledCount <= 1;
+
+          return (
+            <div
+              key={route.key}
+              className="flex flex-col gap-3 rounded-lg border border-border bg-muted/20 p-4 sm:flex-row sm:items-start sm:justify-between"
+            >
+              <div className="min-w-0 space-y-2">
+                <div>
+                  <Label className="text-sm font-medium text-foreground">{t(route.titleKey)}</Label>
+                  <p className="text-xs text-muted-foreground mt-1">{t(route.descKey)}</p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {route.paths.map((path) => (
+                    <code
+                      key={path}
+                      className="rounded border border-border bg-background px-2 py-1 text-xs text-muted-foreground"
+                    >
+                      {path}
+                    </code>
+                  ))}
+                </div>
+              </div>
+              <div className="flex flex-col items-end gap-1">
+                <Switch
+                  aria-label={t(route.titleKey)}
+                  checked={enabled}
+                  onCheckedChange={(checked) => handleToggle(route.key, checked)}
+                  disabled={updateSetting.isPending || disableLastEnabledRoute}
+                />
+                {disableLastEnabledRoute && (
+                  <span className="max-w-40 text-right text-[11px] text-muted-foreground">
+                    {t('settings.proxyRouteExposureAtLeastOne')}
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div className="flex items-start gap-2 p-3 rounded-md bg-blue-500/10 border border-blue-500/20">
+          <AlertTriangle className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-blue-600 dark:text-blue-400">
+            {t('settings.proxyRouteExposureHint')}
+          </p>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- add admin settings to enable/disable public Claude/OpenAI/Codex/Gemini proxy route groups
- expose the route settings through public settings so the sidebar hides disabled route tabs
- keep Gemini disabled by default while Claude/OpenAI/Codex remain enabled by default
- enforce that at least one public proxy route remains enabled, including API bypass and delete paths

## Validation
- `go test ./internal/service ./internal/core ./internal/handler`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- E2E with real Maxx backend `127.0.0.1:9880` and real Web UI `localhost:3000`: default Gemini off, enabling Gemini restores tab/endpoint, UI locks the last enabled route, PUT/DELETE API bypass attempts to disable the last route return 400, `/v1/models` stays unaffected.

E2E summary: `/home/moltbot/clawd-wechat/tmp/maxx-premerge-public-routes-e2e/summary.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 管理员可分别控制 Claude、OpenAI、Responses/Codex 和 Gemini 公开代理入口的启用状态。
  * 关闭的代理入口将返回 404；Gemini 入口默认关闭。
  * 侧边栏仅显示已启用的客户端入口。
  * 设置页新增各入口说明、路径展示及开关操作，并支持中英文文案。

* **限制与修复**
  * 至少保留一个公开代理入口启用，避免误关闭全部入口。
  * 删除无效设置时返回更准确的请求错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->