### PR TITLE
fix(proxy): honor route exposure for scoped proxies

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -519,8 +519,8 @@ func main() {
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo)
-	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)
 
 	// Setup routes
 	mux := http.NewServeMux()

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -474,7 +474,7 @@ func InitializeServerComponents(
 	claudeHandler := handler.NewClaudeHandler(adminService, wailsBroadcaster)
 	claudeOAuthServer := NewClaudeOAuthServer(claudeHandler)
 	claudeHandler.SetOAuthServer(claudeOAuthServer)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProjectRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProjectRepo, repos.SettingRepo)
 
 	log.Printf("[Core] Creating request tracker for graceful shutdown")
 	requestTracker := NewRequestTracker()
@@ -499,7 +499,7 @@ func InitializeServerComponents(
 		ClaudeHandler:          claudeHandler,
 		ClaudeOAuthServer:      claudeOAuthServer,
 		ProjectProxyHandler:    projectProxyHandler,
-		ProviderProxyHandler:   handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo),
+		ProviderProxyHandler:   handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, repos.CachedProviderRepo, repos.CachedRouteRepo, repos.ProxyRequestRepo, repos.SettingRepo),
 		RequestTracker:         requestTracker,
 		PprofManager:           pprofMgr,
 		AuthMiddleware:         authMiddleware,

--- a/internal/handler/project_proxy.go
+++ b/internal/handler/project_proxy.go
@@ -15,6 +15,7 @@ type ProjectProxyHandler struct {
 	proxyHandler  *ProxyHandler
 	modelsHandler http.Handler
 	projectRepo   repository.ProjectRepository
+	settingsRepo  repository.SystemSettingRepository
 }
 
 // NewProjectProxyHandler creates a new project proxy handler
@@ -22,11 +23,13 @@ func NewProjectProxyHandler(
 	proxyHandler *ProxyHandler,
 	modelsHandler http.Handler,
 	projectRepo repository.ProjectRepository,
+	settingsRepo repository.SystemSettingRepository,
 ) *ProjectProxyHandler {
 	return &ProjectProxyHandler{
 		proxyHandler:  proxyHandler,
 		modelsHandler: modelsHandler,
 		projectRepo:   projectRepo,
+		settingsRepo:  settingsRepo,
 	}
 }
 
@@ -60,6 +63,10 @@ func (h *ProjectProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	// Forward to the appropriate handler
 	if isModelListAPIPath(apiPath) {
 		h.modelsHandler.ServeHTTP(w, r)
+		return
+	}
+	if !proxyRouteExposureEnabled(h.settingsRepo, apiPath) {
+		http.NotFound(w, r)
 		return
 	}
 	h.proxyHandler.ServeHTTP(w, r)

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -26,6 +26,7 @@ type ProviderProxyHandler struct {
 	providerRepo     repository.ProviderRepository
 	routeRepo        repository.RouteRepository
 	proxyRequestRepo repository.ProxyRequestRepository
+	settingsRepo     repository.SystemSettingRepository
 }
 
 // NewProviderProxyHandler creates a new provider proxy handler.
@@ -35,6 +36,7 @@ func NewProviderProxyHandler(
 	providerRepo repository.ProviderRepository,
 	routeRepo repository.RouteRepository,
 	proxyRequestRepo repository.ProxyRequestRepository,
+	settingsRepo repository.SystemSettingRepository,
 ) *ProviderProxyHandler {
 	return &ProviderProxyHandler{
 		proxyHandler:     proxyHandler,
@@ -42,6 +44,7 @@ func NewProviderProxyHandler(
 		providerRepo:     providerRepo,
 		routeRepo:        routeRepo,
 		proxyRequestRepo: proxyRequestRepo,
+		settingsRepo:     settingsRepo,
 	}
 }
 
@@ -75,6 +78,10 @@ func (h *ProviderProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	if isModelListAPIPath(apiPath) {
 		r.URL.Path = apiPath
 		h.modelsHandler.ServeHTTP(w, r)
+		return
+	}
+	if !proxyRouteExposureEnabled(h.settingsRepo, apiPath) {
+		http.NotFound(w, r)
 		return
 	}
 

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -46,6 +46,17 @@ func (f *fakeProviderByIDRepo) List(tenantID uint64) ([]*domain.Provider, error)
 	return []*domain.Provider{f.provider}, nil
 }
 
+type fakeProxyRouteExposureSettings struct {
+	values map[string]string
+}
+
+func (f fakeProxyRouteExposureSettings) Get(key string) (string, error) {
+	return f.values[key], nil
+}
+func (f fakeProxyRouteExposureSettings) Set(key, value string) error              { return nil }
+func (f fakeProxyRouteExposureSettings) GetAll() ([]*domain.SystemSetting, error) { return nil, nil }
+func (f fakeProxyRouteExposureSettings) Delete(key string) error                  { return nil }
+
 func assertGeminiModelsPayload(t *testing.T, body []byte) {
 	t.Helper()
 	var payload struct {
@@ -236,7 +247,7 @@ func TestProjectProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
 	handler := NewProjectProxyHandler(nil, modelsHandler, &fakeProjectRepo{
 		project: &domain.Project{ID: 42, Name: "Demo", Slug: "demo"},
-	})
+	}, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/project/demo/v1beta/models", nil)
 	req.Header.Set("User-Agent", "claude-cli/2.0")
@@ -253,7 +264,7 @@ func TestProviderProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-1"}}, nil, nil)
 	handler := NewProviderProxyHandler(nil, modelsHandler, &fakeProviderByIDRepo{
 		provider: &domain.Provider{ID: 1, Name: "Provider"},
-	}, nil, nil)
+	}, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/provider/1/v1beta/models", nil)
 	req.Header.Set("User-Agent", "claude-cli/2.0")
@@ -264,4 +275,34 @@ func TestProviderProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 	assertGeminiModelsPayload(t, rec.Body.Bytes())
+}
+
+func TestProjectProxyHonorsDisabledProxyRouteExposure(t *testing.T) {
+	handler := NewProjectProxyHandler(nil, nil, &fakeProjectRepo{
+		project: &domain.Project{ID: 42, Name: "Demo", Slug: "demo"},
+	}, fakeProxyRouteExposureSettings{values: map[string]string{
+		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+	}})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/project/demo/v1/messages", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestProviderProxyHonorsDisabledProxyRouteExposureBeforeRecording(t *testing.T) {
+	handler := NewProviderProxyHandler(nil, nil, &fakeProviderByIDRepo{
+		provider: &domain.Provider{ID: 1, Name: "Provider"},
+	}, nil, nil, fakeProxyRouteExposureSettings{values: map[string]string{
+		domain.SettingKeyProxyRouteOpenAIChatEnabled: "false",
+	}})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/provider/1/v1/chat/completions", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
 }

--- a/internal/handler/proxy_api_paths.go
+++ b/internal/handler/proxy_api_paths.go
@@ -1,6 +1,11 @@
 package handler
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
+)
 
 // proxyAPIEndpoint is one public AI API path family accepted under the
 // /project/<slug>/ and /provider/<id>/ prefixes.
@@ -53,4 +58,38 @@ func isValidProxyAPIPath(path string) bool {
 		}
 	}
 	return false
+}
+
+func proxyRouteExposureSettingKey(path string) (string, bool) {
+	switch {
+	case path == "/v1/messages" || strings.HasPrefix(path, "/v1/messages/"):
+		return domain.SettingKeyProxyRouteClaudeMessagesEnabled, true
+	case path == "/v1/chat/completions" || strings.HasPrefix(path, "/v1/chat/completions/"):
+		return domain.SettingKeyProxyRouteOpenAIChatEnabled, true
+	case path == "/responses" || strings.HasPrefix(path, "/responses/") || path == "/v1/responses" || strings.HasPrefix(path, "/v1/responses/"):
+		return domain.SettingKeyProxyRouteResponsesEnabled, true
+	case path == "/v1beta/models" || strings.HasPrefix(path, "/v1beta/models/"):
+		return domain.SettingKeyProxyRouteGeminiEnabled, true
+	default:
+		return "", false
+	}
+}
+
+func proxyRouteExposureEnabled(settings repository.SystemSettingRepository, path string) bool {
+	key, ok := proxyRouteExposureSettingKey(path)
+	if !ok {
+		return true
+	}
+	if settings == nil {
+		return proxyRouteExposureEnabledByDefault(key)
+	}
+	value, err := settings.Get(key)
+	if err != nil || value == "" {
+		return proxyRouteExposureEnabledByDefault(key)
+	}
+	return value != "false"
+}
+
+func proxyRouteExposureEnabledByDefault(key string) bool {
+	return key != domain.SettingKeyProxyRouteGeminiEnabled
 }

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -194,8 +194,8 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
-	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo)
-	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo)
+	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
+	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)
 
 	// Setup routes (mirroring main.go)
 	mux := http.NewServeMux()

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -210,7 +210,7 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 	// end-to-end. The project proxy safely 404s on non-project paths, so a nil
 	// proxy handler is fine for the routes these tests exercise.
 	if opts.mountRoot {
-		projectProxyHandler := handler.NewProjectProxyHandler(nil, protectedModelsHandler, cachedProjectRepo)
+		projectProxyHandler := handler.NewProjectProxyHandler(nil, protectedModelsHandler, cachedProjectRepo, settingRepo)
 		if opts.serveStatic {
 			staticHandler := handler.NewStaticHandler()
 			mux.Handle("/", handler.NewCombinedHandler(projectProxyHandler, staticHandler))


### PR DESCRIPTION
## Summary
- apply proxy route exposure settings to project-scoped proxy paths before they enter the generic proxy handler
- apply the same exposure settings to provider-scoped proxy paths before direct dispatch creates proxy telemetry
- add regression coverage for disabled project/provider scoped proxy routes returning 404 without continuing into the proxy path

## Validation
- `go test ./internal/handler ./internal/core`
- `go test ./internal/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增代理路由暴露控制，可按 API 路径启用或禁用项目与服务商代理接口。
  - 未启用的代理接口将返回 404，避免继续转发请求。
  - Gemini 相关代理路由默认关闭，其余路由默认启用。

- **测试**
  - 增加代理路由开关关闭时的请求处理验证，覆盖录制前生效的场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->