### PR TITLE
fix(proxy): avoid false cancelled status

### DIFF
--- a/internal/executor/cancel_status.go
+++ b/internal/executor/cancel_status.go
@@ -39,8 +39,14 @@ func isClientDisconnectError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
 
 	if proxyErr, ok := err.(*domain.ProxyError); ok {
+		if errors.Is(proxyErr.Err, context.Canceled) || errors.Is(proxyErr.Err, context.DeadlineExceeded) {
+			return false
+		}
 		if isClientDisconnectText(proxyErr.Message) || isClientDisconnectText(proxyErr.Code) || isClientDisconnectText(proxyErr.Err) {
 			return true
 		}

--- a/internal/executor/cancel_status.go
+++ b/internal/executor/cancel_status.go
@@ -1,0 +1,70 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func requestFailureStatusAndError(ctx context.Context, err error) (string, string) {
+	if ctx == nil || ctx.Err() == nil {
+		if err != nil {
+			return "FAILED", err.Error()
+		}
+		return "FAILED", "request did not complete"
+	}
+
+	if errors.Is(ctx.Err(), context.Canceled) && isClientDisconnectError(err) {
+		return "CANCELLED", "client disconnected"
+	}
+
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "FAILED", "request timeout"
+	}
+
+	if err != nil {
+		return "FAILED", err.Error()
+	}
+	return "FAILED", ctx.Err().Error()
+}
+
+func attemptFailureStatus(ctx context.Context, err error) string {
+	status, _ := requestFailureStatusAndError(ctx, err)
+	return status
+}
+
+func isClientDisconnectError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if proxyErr, ok := err.(*domain.ProxyError); ok {
+		if isClientDisconnectText(proxyErr.Message) || isClientDisconnectText(proxyErr.Code) || isClientDisconnectText(proxyErr.Err) {
+			return true
+		}
+	}
+
+	return isClientDisconnectText(err)
+}
+
+func isClientDisconnectText(v interface{}) bool {
+	var text string
+	switch x := v.(type) {
+	case nil:
+		return false
+	case string:
+		text = x
+	case error:
+		text = x.Error()
+	default:
+		return false
+	}
+	text = strings.ToLower(text)
+	return strings.Contains(text, "client disconnected") ||
+		strings.Contains(text, "client cancelled") ||
+		strings.Contains(text, "client canceled") ||
+		strings.Contains(text, "broken pipe") ||
+		strings.Contains(text, "connection reset by peer")
+}

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -152,11 +152,36 @@ func TestDispatchDoesNotRetryAfterRequestContextCanceled(t *testing.T) {
 	if !errors.Is(c.Err, context.Canceled) {
 		t.Fatalf("dispatch error = %v, want context.Canceled", c.Err)
 	}
-	if proxyReq.Status != "CANCELLED" {
-		t.Fatalf("proxy request status = %q, want CANCELLED", proxyReq.Status)
+	if proxyReq.Status != "FAILED" {
+		t.Fatalf("proxy request status = %q, want FAILED", proxyReq.Status)
 	}
-	if proxyReq.Error != "client disconnected" && proxyReq.Error != "client disconnected during retry wait" {
-		t.Fatalf("proxy request error = %q, want client disconnected cancellation", proxyReq.Error)
+	if proxyReq.Error != "upstream retryable error: upstream retryable error" {
+		t.Fatalf("proxy request error = %q, want upstream error", proxyReq.Error)
+	}
+}
+
+func TestRequestFailureStatusOnlyCancelsForClientDisconnectEvidence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	upstreamErr := domain.NewProxyErrorWithMessage(errors.New("upstream retryable error"), true, "upstream retryable error")
+	upstreamErr.Scope = domain.ScopeProvider
+	status, msg := requestFailureStatusAndError(ctx, upstreamErr)
+	if status != "FAILED" {
+		t.Fatalf("status without disconnect evidence = %q, want FAILED", status)
+	}
+	if msg != "upstream retryable error: upstream retryable error" {
+		t.Fatalf("message without disconnect evidence = %q", msg)
+	}
+
+	disconnectErr := domain.NewProxyErrorWithMessage(errors.New("write tcp: broken pipe"), false, "client disconnected")
+	disconnectErr.Scope = domain.ScopeRequest
+	status, msg = requestFailureStatusAndError(ctx, disconnectErr)
+	if status != "CANCELLED" {
+		t.Fatalf("status with disconnect evidence = %q, want CANCELLED", status)
+	}
+	if msg != "client disconnected" {
+		t.Fatalf("message with disconnect evidence = %q", msg)
 	}
 }
 

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -174,6 +174,16 @@ func TestRequestFailureStatusOnlyCancelsForClientDisconnectEvidence(t *testing.T
 		t.Fatalf("message without disconnect evidence = %q", msg)
 	}
 
+	mislabelledContextErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
+	mislabelledContextErr.Scope = domain.ScopeRequest
+	status, msg = requestFailureStatusAndError(ctx, mislabelledContextErr)
+	if status != "FAILED" {
+		t.Fatalf("status for context cancellation labelled client disconnected = %q, want FAILED", status)
+	}
+	if msg != "client disconnected: context canceled" {
+		t.Fatalf("message for context cancellation labelled client disconnected = %q", msg)
+	}
+
 	disconnectErr := domain.NewProxyErrorWithMessage(errors.New("write tcp: broken pipe"), false, "client disconnected")
 	disconnectErr.Scope = domain.ScopeRequest
 	status, msg = requestFailureStatusAndError(ctx, disconnectErr)

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -304,11 +304,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			attemptRecord.Duration = attemptRecord.EndTime.Sub(attemptRecord.StartTime)
 			state.lastErr = err
 
-			if ctx.Err() != nil {
-				attemptRecord.Status = "CANCELLED"
-			} else {
-				attemptRecord.Status = "FAILED"
-			}
+			attemptRecord.Status = attemptFailureStatus(ctx, err)
 
 			pricing.FinalizeAttemptCost(attemptRecord, multiplier)
 
@@ -382,16 +378,9 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				return
 			}
 			if ok && ctx.Err() != nil {
-				proxyReq.Status = "CANCELLED"
+				proxyReq.Status, proxyReq.Error = requestFailureStatusAndError(ctx, err)
 				proxyReq.EndTime = time.Now()
 				proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-				if ctx.Err() == context.Canceled {
-					proxyReq.Error = "client disconnected"
-				} else if ctx.Err() == context.DeadlineExceeded {
-					proxyReq.Error = "request timeout"
-				} else {
-					proxyReq.Error = ctx.Err().Error()
-				}
 				clearProxyRequestDetail(proxyReq, clearDetail)
 				_ = e.proxyRequestRepo.Update(proxyReq)
 				if e.broadcaster != nil {
@@ -449,16 +438,14 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				}
 				select {
 				case <-ctx.Done():
-					proxyReq.Status = "CANCELLED"
-					proxyReq.EndTime = time.Now()
-					proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-					if ctx.Err() == context.Canceled {
+					proxyReq.Status, proxyReq.Error = requestFailureStatusAndError(ctx, err)
+					if proxyReq.Status == "CANCELLED" {
 						proxyReq.Error = "client disconnected during retry wait"
 					} else if ctx.Err() == context.DeadlineExceeded {
 						proxyReq.Error = "request timeout during retry wait"
-					} else {
-						proxyReq.Error = ctx.Err().Error()
 					}
+					proxyReq.EndTime = time.Now()
+					proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
 					clearProxyRequestDetail(proxyReq, clearDetail)
 					_ = e.proxyRequestRepo.Update(proxyReq)
 					if e.broadcaster != nil {

--- a/internal/executor/middleware_egress.go
+++ b/internal/executor/middleware_egress.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"context"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/flow"
@@ -20,18 +19,7 @@ func (e *Executor) egress(c *flow.Ctx) {
 	if proxyReq != nil && proxyReq.Status == "IN_PROGRESS" {
 		proxyReq.EndTime = time.Now()
 		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-		if state.ctx != nil && state.ctx.Err() != nil {
-			proxyReq.Status = "CANCELLED"
-			if state.ctx.Err() == context.Canceled {
-				proxyReq.Error = "client disconnected"
-			} else if state.ctx.Err() == context.DeadlineExceeded {
-				proxyReq.Error = "request timeout"
-			} else {
-				proxyReq.Error = state.ctx.Err().Error()
-			}
-		} else {
-			proxyReq.Status = "FAILED"
-		}
+		proxyReq.Status, proxyReq.Error = requestFailureStatusAndError(state.ctx, state.lastErr)
 		_ = e.proxyRequestRepo.Update(proxyReq)
 		if e.broadcaster != nil {
 			e.broadcaster.BroadcastProxyRequest(proxyReq)
@@ -41,11 +29,7 @@ func (e *Executor) egress(c *flow.Ctx) {
 	if state.currentAttempt != nil && state.currentAttempt.Status == "IN_PROGRESS" {
 		state.currentAttempt.EndTime = time.Now()
 		state.currentAttempt.Duration = state.currentAttempt.EndTime.Sub(state.currentAttempt.StartTime)
-		if state.ctx != nil && state.ctx.Err() != nil {
-			state.currentAttempt.Status = "CANCELLED"
-		} else {
-			state.currentAttempt.Status = "FAILED"
-		}
+		state.currentAttempt.Status = attemptFailureStatus(state.ctx, state.lastErr)
 		_ = e.attemptRepo.Update(state.currentAttempt)
 		if e.broadcaster != nil {
 			e.broadcaster.BroadcastProxyUpstreamAttempt(state.currentAttempt)

--- a/internal/executor/single_attempt.go
+++ b/internal/executor/single_attempt.go
@@ -105,10 +105,8 @@ func (e *Executor) ExecuteOnce(
 	switch {
 	case err == nil:
 		attempt.Status = "COMPLETED"
-	case c.Request.Context().Err() != nil:
-		attempt.Status = "CANCELLED"
 	default:
-		attempt.Status = "FAILED"
+		attempt.Status = attemptFailureStatus(c.Request.Context(), err)
 	}
 
 	multiplier := getProviderMultiplier(provider, clientType)


### PR DESCRIPTION
## Summary

- stop classifying request records as `CANCELLED` from `ctx.Err()` alone
- add executor status classification that only emits `CANCELLED` when there is explicit client-disconnect/write-failure evidence
- keep upstream/provider failures as `FAILED` even if the downstream request context is already done
- add regression coverage for cancelled contexts without disconnect evidence vs real client disconnect evidence

## Context

> awsl confirmed the issue has code evidence: requests that take longer than roughly 300ms can appear as cancelled even while the client is still waiting. `>300ms` is not the backend cancellation threshold; the request list batches websocket updates around 250ms, making backend intermediate/final states more visible. The backend currently writes `CANCELLED` when `state.ctx.Err()!=nil` in `internal/executor/middleware_egress.go` and when adapter errors combine with `ctx.Err()!=nil` in `internal/executor/middleware_dispatch.go`. The fix should not stamp `CANCELLED` from context cancellation alone; write/flush failure or explicit client-disconnect evidence should be required.

## Validation

- `go test ./internal/executor`
- `go test ./internal/...`
- `go test ./...` partially: all listed packages including `tests/e2e` and `tests/multiinstance` passed, but the root package failed in this checkout because `web/dist` is absent: `main.go:26:12: pattern all:web/dist: no matching files found`

## Changed files

- `internal/executor/cancel_status.go`
- `internal/executor/middleware_dispatch.go`
- `internal/executor/middleware_egress.go`
- `internal/executor/disabled_error_cooldown_test.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 统一请求失败状态与错误信息的展示。
  * 更准确地区分客户端断开、请求取消、请求超时及其他上游错误。
  * 改善重试等待期间的失败提示，提供更明确的错误原因。
  * 修正请求取消但缺少客户端断开证据时的状态判断，避免误标记为已取消。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->