### PR TITLE
fix(proxy): reuse dispatch for provider proxy

### DIFF
--- a/internal/executor/provider_proxy.go
+++ b/internal/executor/provider_proxy.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+// MapModelForProviderProxy applies the same model-mapping contract used by the
+// generic dispatch path to direct /provider/<id>/... requests.
+func (e *Executor) MapModelForProviderProxy(tenantID uint64, requestModel string, route *domain.Route, provider *domain.Provider, clientType domain.ClientType, projectID uint64, apiTokenID uint64) string {
+	if e == nil || e.modelMappingRepo == nil || route == nil || provider == nil {
+		return requestModel
+	}
+	return e.mapModel(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
+}
+
+// ExecuteProviderProxy dispatches a direct /provider/<id>/... request through
+// the normal executor retry/attempt/billing path, constrained to the requested
+// provider. It intentionally does not route/fail over to other providers.
+func (e *Executor) ExecuteProviderProxy(c *flow.Ctx, proxyReq *domain.ProxyRequest, route *domain.Route, provider *domain.Provider, adapter provideradapter.ProviderAdapter) error {
+	if e == nil || c == nil || proxyReq == nil || route == nil || provider == nil || adapter == nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrInvalidInput, false, "provider proxy executor input missing")
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusInternalServerError
+		return proxyErr
+	}
+
+	ctx := c.Request.Context()
+	if v, ok := c.Get(flow.KeyProxyContext); ok {
+		if stored, ok := v.(context.Context); ok && stored != nil {
+			ctx = stored
+		}
+	}
+
+	retryConfig := (*domain.RetryConfig)(nil)
+	if route.RetryConfigID != 0 && e.retryConfigRepo != nil {
+		retryConfig, _ = e.retryConfigRepo.GetByID(proxyReq.TenantID, route.RetryConfigID)
+	}
+	if retryConfig == nil {
+		retryConfig = e.getRetryConfig(proxyReq.TenantID, nil)
+	}
+
+	state := &execState{
+		ctx:      ctx,
+		proxyReq: proxyReq,
+		routes: []*router.MatchedRoute{{
+			Route:           route,
+			Provider:        provider,
+			ProviderAdapter: adapter,
+			RetryConfig:     retryConfig,
+		}},
+
+		tenantID:            proxyReq.TenantID,
+		clientType:          proxyReq.ClientType,
+		projectID:           proxyReq.ProjectID,
+		sessionID:           proxyReq.SessionID,
+		requestModel:        proxyReq.RequestModel,
+		isStream:            proxyReq.IsStream,
+		apiTokenID:          proxyReq.APITokenID,
+		apiTokenDevMode:     proxyReq.DevMode,
+		requestBody:         flow.GetRequestBody(c),
+		originalRequestBody: flow.GetOriginalRequestBody(c),
+		requestHeaders:      flow.GetRequestHeaders(c),
+		requestURI:          flow.GetRequestURI(c),
+	}
+	if len(state.originalRequestBody) == 0 {
+		state.originalRequestBody = state.requestBody
+	}
+	if state.requestHeaders == nil {
+		state.requestHeaders = http.Header{}
+	}
+
+	c.Set(flow.KeyExecutorState, state)
+	e.dispatch(c)
+	return state.lastErr
+}

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 )
@@ -301,5 +302,181 @@ func TestExecuteOnce_RecordsFailedAttemptWithoutMirroringCost(t *testing.T) {
 	}
 	if proxyReq.Cost != 0 {
 		t.Errorf("proxyReq.Cost = %d on failure path; should stay zero", proxyReq.Cost)
+	}
+}
+
+type staticRetryConfigRepo struct {
+	defaultConfig *domain.RetryConfig
+	configs       map[uint64]*domain.RetryConfig
+}
+
+func (r *staticRetryConfigRepo) Create(*domain.RetryConfig) error { return nil }
+func (r *staticRetryConfigRepo) Update(*domain.RetryConfig) error { return nil }
+func (r *staticRetryConfigRepo) Delete(uint64, uint64) error      { return nil }
+func (r *staticRetryConfigRepo) GetByID(_ uint64, id uint64) (*domain.RetryConfig, error) {
+	if r.configs == nil {
+		return nil, nil
+	}
+	return r.configs[id], nil
+}
+func (r *staticRetryConfigRepo) GetDefault(uint64) (*domain.RetryConfig, error) {
+	return r.defaultConfig, nil
+}
+func (r *staticRetryConfigRepo) List(uint64) ([]*domain.RetryConfig, error) { return nil, nil }
+
+type sequenceAdapter struct {
+	errs  []error
+	calls int
+}
+
+func (a *sequenceAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *sequenceAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	if ch := flow.GetEventChan(c); ch != nil {
+		ch.SendMetrics(&domain.AdapterMetrics{InputTokens: uint64(a.calls), OutputTokens: 10})
+	}
+	if a.calls <= len(a.errs) && a.errs[a.calls-1] != nil {
+		return a.errs[a.calls-1]
+	}
+	_, _ = c.Writer.Write([]byte(`{"ok":true}`))
+	return nil
+}
+
+func TestMapModelForProviderProxyHonorsModelMapping(t *testing.T) {
+	e := &Executor{modelMappingRepo: &staticModelMappingRepo{mappings: []*domain.ModelMapping{
+		{Pattern: "minimaxai/minimax-m3", Target: "minimax-m3-upstream"},
+	}}}
+	route := &domain.Route{ID: 11, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+
+	got := e.MapModelForProviderProxy(1, "minimaxai/minimax-m3", route, provider, domain.ClientTypeOpenAI, 0, 46)
+	if got != "minimax-m3-upstream" {
+		t.Fatalf("mapped model = %q, want minimax-m3-upstream", got)
+	}
+}
+
+func TestExecuteProviderProxyRetriesSameProvider(t *testing.T) {
+	proxyRepo := &codexGuardProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	retryErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
+	retryErr.Message = "failed to connect to upstream"
+	adapter := &sequenceAdapter{errs: []error{retryErr}}
+	e := &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      1,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{mappings: []*domain.ModelMapping{
+			{Pattern: "minimaxai/minimax-m3", Target: "minimax-m3-upstream"},
+		}},
+		converter: converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	c.Set(flow.KeyRequestBody, []byte(`{"model":"minimaxai/minimax-m3"}`))
+	c.Set(flow.KeyOriginalRequestBody, []byte(`{"model":"minimaxai/minimax-m3"}`))
+	c.Set(flow.KeyRequestHeaders, http.Header{"Content-Type": []string{"application/json"}})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:      1,
+		ID:            42,
+		ClientType:    domain.ClientTypeOpenAI,
+		RequestModel:  "minimaxai/minimax-m3",
+		ResponseModel: "minimax-m3-upstream",
+		IsStream:      false,
+		Status:        "IN_PROGRESS",
+		RouteID:       11,
+		ProviderID:    7,
+		APITokenID:    46,
+	}
+	route := &domain.Route{ID: 11, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+
+	if err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter); err != nil {
+		t.Fatalf("ExecuteProviderProxy returned error: %v", err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("attempts created = %d, want 2", len(attemptRepo.created))
+	}
+	if proxyReq.ProviderID != provider.ID {
+		t.Fatalf("provider changed to %d, want same provider %d", proxyReq.ProviderID, provider.ID)
+	}
+	if proxyReq.Status != "COMPLETED" {
+		t.Fatalf("proxy request status = %q, want COMPLETED", proxyReq.Status)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 2 {
+		t.Fatalf("attempt count = %d, want 2", proxyReq.ProxyUpstreamAttemptCount)
+	}
+	if proxyReq.ResponseModel != "minimax-m3-upstream" {
+		t.Fatalf("response model = %q, want minimax-m3-upstream", proxyReq.ResponseModel)
+	}
+	for _, created := range attemptRepo.created {
+		if created.ProviderID != provider.ID {
+			t.Fatalf("attempt provider = %d, want %d", created.ProviderID, provider.ID)
+		}
+		if created.MappedModel != "minimax-m3-upstream" {
+			t.Fatalf("attempt mapped model = %q, want minimax-m3-upstream", created.MappedModel)
+		}
+	}
+}
+
+func TestExecuteProviderProxyHonorsZeroMaxRetries(t *testing.T) {
+	retryErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
+	retryErr.Message = "failed to connect to upstream"
+	adapter := &sequenceAdapter{errs: []error{retryErr, nil}}
+	e := &Executor{
+		proxyRequestRepo: &codexGuardProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      0,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+	c.Set(flow.KeyRequestHeaders, http.Header{})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:     1,
+		ID:           42,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "minimaxai/minimax-m3",
+		IsStream:     false,
+		Status:       "IN_PROGRESS",
+		RouteID:      11,
+		ProviderID:   7,
+	}
+	route := &domain.Route{ID: 11, ProviderID: 7, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: 7, Type: "custom"}
+
+	if err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter); err == nil {
+		t.Fatal("expected first upstream error to be returned without retry")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1 when MaxRetries=0", adapter.calls)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 1 {
+		t.Fatalf("attempt count = %d, want 1", proxyReq.ProxyUpstreamAttemptCount)
 	}
 }

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -10,8 +10,6 @@ import (
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
-	"github.com/awsl-project/maxx/internal/executor"
-	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/repository"
 	"github.com/awsl-project/maxx/internal/requestmeta"
@@ -132,7 +130,12 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 		}
 
 		requestModel := flow.GetRequestModel(c)
+		projectID := flow.GetProjectID(c)
+		apiTokenID := flow.GetAPITokenID(c)
 		mappedModel := requestModel
+		if h.proxyHandler != nil && h.proxyHandler.executor != nil {
+			mappedModel = h.proxyHandler.executor.MapModelForProviderProxy(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
+		}
 		isStream := flow.GetIsStream(c)
 		clearDetail := h.proxyHandler != nil && h.proxyHandler.executor != nil && h.proxyHandler.executor.ShouldClearRequestDetailByConfig()
 		if getAPITokenDevMode(c) {
@@ -147,92 +150,30 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 		c.Set(flow.KeyOriginalClientType, clientType)
 		c.Set(flow.KeyProxyRequest, proxyReq)
 
-		clientWriter := http.ResponseWriter(c.Writer)
-		modifierWriter := responsemodifier.NewResponseModifierWriter(c.Writer, provider, clientType, isStream)
-		if modifierWriter != nil {
-			clientWriter = modifierWriter
-		}
-
-		responseCapture := executor.NewResponseCapture(clientWriter)
-		originalWriter := c.Writer
-		c.Writer = responseCapture
-		// Route through ExecuteOnce so this bypass path gets the same attempt-
-		// record + cost-finalization treatment as the retry-driven dispatch.
-		// Without this, /provider/<id>/... requests landed in the DB with 0
-		// attempts and cost=0 / multiplier=0 / modelPriceId=0 — silently
-		// zero-billing every direct-dispatch call.
-		//
-		// Fail fast if the executor isn't wired: silently falling back to a
-		// bare adapter call would reintroduce the exact "succeeded request
-		// with no attempt/billing" condition this PR fixes whenever production
-		// is misconfigured. The /v1beta/models pre-branch above already
-		// handles the only legitimately executor-less case (model-list reads).
+		// Route direct provider calls through the normal executor dispatch loop,
+		// constrained to this provider. This keeps the /provider/<id>/... contract
+		// one-to-one while preserving model mapping, retry, attempts and billing.
 		if h.proxyHandler == nil || h.proxyHandler.executor == nil {
 			err = &domain.ProxyError{
 				HTTPStatusCode: http.StatusInternalServerError,
 				Message:        "provider proxy executor not configured",
 			}
 		} else {
-			_, err = h.proxyHandler.executor.ExecuteOnce(
-				c, proxyReq, route, provider, adapter,
-				clientType, requestModel, mappedModel, isStream, clearDetail,
-			)
+			err = h.proxyHandler.executor.ExecuteProviderProxy(c, proxyReq, route, provider, adapter)
 		}
-		c.Writer = originalWriter
-
-		now := time.Now()
-		proxyReq.EndTime = now
-		proxyReq.Duration = now.Sub(proxyReq.StartTime)
-		proxyReq.StatusCode = responseCapture.StatusCode()
-		proxyReq.ResponseModel = mappedModel
-		if !clearDetail {
-			proxyReq.ResponseInfo = &domain.ResponseInfo{
-				Status:  responseCapture.StatusCode(),
-				Headers: responseCapture.CapturedHeaders(),
-				Body:    responseCapture.Body(),
-			}
-		}
-
 		if err == nil {
-			if modifierWriter != nil {
-				err = modifierWriter.Finalize()
-				if err != nil {
-					proxyReq.Status = "FAILED"
-					proxyReq.Error = err.Error()
-					clearProxyRequestDetail(proxyReq, clearDetail)
-					_ = h.proxyRequestRepo.Update(proxyReq)
-					c.Abort()
-					return
-				}
-			}
-			proxyReq.Status = "COMPLETED"
-			clearProxyRequestDetail(proxyReq, clearDetail)
-			_ = h.proxyRequestRepo.Update(proxyReq)
 			return
 		}
 
-		proxyReq.Status = "FAILED"
-		proxyReq.Error = err.Error()
 		if proxyErr, ok := err.(*domain.ProxyError); ok {
 			if isStream {
-				writeStreamError(responseCapture, proxyErr)
+				writeStreamError(c.Writer, proxyErr)
 			} else {
-				writeProxyError(responseCapture, proxyErr)
-			}
-			if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
-				proxyReq.StatusCode = proxyErr.HTTPStatusCode
+				writeProxyError(c.Writer, proxyErr)
 			}
 		} else {
-			writeError(responseCapture, http.StatusBadGateway, err.Error())
-			proxyReq.StatusCode = http.StatusBadGateway
+			writeError(c.Writer, http.StatusBadGateway, err.Error())
 		}
-		if modifierWriter != nil {
-			if finalizeErr := modifierWriter.Finalize(); finalizeErr != nil {
-				log.Printf("[ProviderProxy] failed to finalize response modifier: %v", finalizeErr)
-			}
-		}
-		clearProxyRequestDetail(proxyReq, clearDetail)
-		_ = h.proxyRequestRepo.Update(proxyReq)
 		c.Abort()
 	}
 }


### PR DESCRIPTION
## Summary
- route `/provider/<id>/...` direct calls through executor dispatch constrained to the requested provider
- apply normal model mapping before recording provider proxy requests
- preserve same-provider retry, attempts, billing and response model tracking for direct provider proxy calls

## Tests
- `go test ./internal/executor ./internal/handler`
- `go test ./internal/...`
- `go test -count=1 ./internal/executor ./internal/handler`
- `go test -count=1 ./internal/...`

## Notes
- direct provider proxy still does not fail over to other providers; retries stay on the requested provider only
- CodeRabbit was not inspected or requested in this pass