### PR TITLE
fix(proxy): match provider proxy routes via router

### DIFF
--- a/internal/executor/provider_proxy.go
+++ b/internal/executor/provider_proxy.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
@@ -19,6 +20,39 @@ func (e *Executor) MapModelForProviderProxy(tenantID uint64, requestModel string
 	return e.mapModel(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
 }
 
+// MatchProviderProxyRoute applies the generic route matcher to direct
+// /provider/<id>/... requests, then constrains the result to the requested
+// provider. This preserves project/session/token route selection, cooldown,
+// model support checks and retry policy resolution without allowing provider
+// proxy requests to fail over to a different provider.
+func (e *Executor) MatchProviderProxyRoute(ctx context.Context, tenantID uint64, providerID uint64, clientType domain.ClientType, projectID uint64, requestModel string, apiTokenID uint64, sessionID string) (*router.MatchedRoute, error) {
+	if e == nil || e.router == nil || providerID == 0 || clientType == "" {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrInvalidInput, false, "provider proxy route match input missing")
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusInternalServerError
+		return nil, proxyErr
+	}
+
+	result, err := e.router.Match(&router.MatchContext{
+		Ctx:          ctx,
+		TenantID:     tenantID,
+		ClientType:   clientType,
+		ProjectID:    projectID,
+		RequestModel: requestModel,
+		APITokenID:   apiTokenID,
+		SessionID:    sessionID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, matched := range result.Routes {
+		if matched != nil && matched.Provider != nil && matched.Provider.ID == providerID {
+			return matched, nil
+		}
+	}
+	return nil, domain.ErrNoAvailableProviders
+}
+
 // ExecuteProviderProxy dispatches a direct /provider/<id>/... request through
 // the normal executor retry/attempt/billing path, constrained to the requested
 // provider. It intentionally does not route/fail over to other providers.
@@ -30,13 +64,6 @@ func (e *Executor) ExecuteProviderProxy(c *flow.Ctx, proxyReq *domain.ProxyReque
 		return proxyErr
 	}
 
-	ctx := c.Request.Context()
-	if v, ok := c.Get(flow.KeyProxyContext); ok {
-		if stored, ok := v.(context.Context); ok && stored != nil {
-			ctx = stored
-		}
-	}
-
 	retryConfig := (*domain.RetryConfig)(nil)
 	if route.RetryConfigID != 0 && e.retryConfigRepo != nil {
 		retryConfig, _ = e.retryConfigRepo.GetByID(proxyReq.TenantID, route.RetryConfigID)
@@ -45,15 +72,44 @@ func (e *Executor) ExecuteProviderProxy(c *flow.Ctx, proxyReq *domain.ProxyReque
 		retryConfig = e.getRetryConfig(proxyReq.TenantID, nil)
 	}
 
+	return e.ExecuteProviderProxyMatched(c, proxyReq, &router.MatchedRoute{
+		Route:           route,
+		Provider:        provider,
+		ProviderAdapter: adapter,
+		RetryConfig:     retryConfig,
+	})
+}
+
+// ExecuteProviderProxyMatched runs a direct provider proxy request through the
+// normal dispatch loop using an already matched, provider-constrained route.
+func (e *Executor) ExecuteProviderProxyMatched(c *flow.Ctx, proxyReq *domain.ProxyRequest, matched *router.MatchedRoute) error {
+	if e == nil || c == nil || proxyReq == nil || matched == nil || matched.Route == nil || matched.Provider == nil || matched.ProviderAdapter == nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrInvalidInput, false, "provider proxy matched executor input missing")
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = http.StatusInternalServerError
+		return proxyErr
+	}
+	if matched.RetryConfig == nil {
+		matched.RetryConfig = e.getRetryConfig(proxyReq.TenantID, nil)
+	}
+
+	ctx := c.Request.Context()
+	if v, ok := c.Get(flow.KeyProxyContext); ok {
+		if stored, ok := v.(context.Context); ok && stored != nil {
+			ctx = stored
+		}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return ctx.Err()
+	}
+
 	state := &execState{
 		ctx:      ctx,
 		proxyReq: proxyReq,
-		routes: []*router.MatchedRoute{{
-			Route:           route,
-			Provider:        provider,
-			ProviderAdapter: adapter,
-			RetryConfig:     retryConfig,
-		}},
+		routes:   []*router.MatchedRoute{matched},
 
 		tenantID:            proxyReq.TenantID,
 		clientType:          proxyReq.ClientType,

--- a/internal/executor/provider_proxy_match_test.go
+++ b/internal/executor/provider_proxy_match_test.go
@@ -1,0 +1,203 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+const providerProxyMatchTestType = "provider-proxy-route-match-test"
+
+func init() {
+	provideradapter.RegisterAdapterFactory(providerProxyMatchTestType, func(*domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return providerProxyMatchTestAdapter{}, nil
+	})
+}
+
+type providerProxyMatchTestAdapter struct{}
+
+func (providerProxyMatchTestAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (providerProxyMatchTestAdapter) Execute(*flow.Ctx, *domain.Provider) error { return nil }
+
+type providerProxyMatchRouteRepo struct{ routes []*domain.Route }
+
+func (r *providerProxyMatchRouteRepo) Create(route *domain.Route) error {
+	r.routes = append(r.routes, route)
+	return nil
+}
+func (r *providerProxyMatchRouteRepo) Update(route *domain.Route) error { return nil }
+func (r *providerProxyMatchRouteRepo) Delete(uint64, uint64) error      { return nil }
+func (r *providerProxyMatchRouteRepo) BulkDelete(uint64, domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	return &domain.RouteBulkDeleteResult{}, nil
+}
+func (r *providerProxyMatchRouteRepo) GetByID(tenantID uint64, id uint64) (*domain.Route, error) {
+	for _, route := range r.routes {
+		if route.TenantID == tenantID && route.ID == id {
+			return route, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *providerProxyMatchRouteRepo) FindByKey(tenantID uint64, projectID, providerID uint64, clientType domain.ClientType) (*domain.Route, error) {
+	for _, route := range r.routes {
+		if route.TenantID == tenantID && route.ProjectID == projectID && route.ProviderID == providerID && route.ClientType == clientType {
+			return route, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *providerProxyMatchRouteRepo) List(tenantID uint64) ([]*domain.Route, error) {
+	var out []*domain.Route
+	for _, route := range r.routes {
+		if tenantID == domain.TenantIDAll || route.TenantID == tenantID {
+			out = append(out, route)
+		}
+	}
+	return out, nil
+}
+func (r *providerProxyMatchRouteRepo) BatchUpdatePositions(uint64, []domain.RoutePositionUpdate) error {
+	return nil
+}
+
+type providerProxyMatchProviderRepo struct{ providers []*domain.Provider }
+
+func (r *providerProxyMatchProviderRepo) Create(provider *domain.Provider) error {
+	r.providers = append(r.providers, provider)
+	return nil
+}
+func (r *providerProxyMatchProviderRepo) Update(provider *domain.Provider) error { return nil }
+func (r *providerProxyMatchProviderRepo) Delete(uint64, uint64) error            { return nil }
+func (r *providerProxyMatchProviderRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
+	for _, provider := range r.providers {
+		if provider.TenantID == tenantID && provider.ID == id {
+			return provider, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *providerProxyMatchProviderRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	var out []*domain.Provider
+	for _, provider := range r.providers {
+		if tenantID == domain.TenantIDAll || provider.TenantID == tenantID {
+			out = append(out, provider)
+		}
+	}
+	return out, nil
+}
+
+type providerProxyMatchRetryRepo struct{ configs []*domain.RetryConfig }
+
+func (r *providerProxyMatchRetryRepo) Create(config *domain.RetryConfig) error {
+	r.configs = append(r.configs, config)
+	return nil
+}
+func (r *providerProxyMatchRetryRepo) Update(config *domain.RetryConfig) error { return nil }
+func (r *providerProxyMatchRetryRepo) Delete(uint64, uint64) error             { return nil }
+func (r *providerProxyMatchRetryRepo) GetByID(tenantID uint64, id uint64) (*domain.RetryConfig, error) {
+	for _, config := range r.configs {
+		if config.TenantID == tenantID && config.ID == id {
+			return config, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *providerProxyMatchRetryRepo) GetDefault(tenantID uint64) (*domain.RetryConfig, error) {
+	for _, config := range r.configs {
+		if config.TenantID == tenantID && config.IsDefault {
+			return config, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *providerProxyMatchRetryRepo) List(tenantID uint64) ([]*domain.RetryConfig, error) {
+	var out []*domain.RetryConfig
+	for _, config := range r.configs {
+		if tenantID == domain.TenantIDAll || config.TenantID == tenantID {
+			out = append(out, config)
+		}
+	}
+	return out, nil
+}
+
+type providerProxyMatchStrategyRepo struct{}
+
+func (providerProxyMatchStrategyRepo) Create(*domain.RoutingStrategy) error { return nil }
+func (providerProxyMatchStrategyRepo) Update(*domain.RoutingStrategy) error { return nil }
+func (providerProxyMatchStrategyRepo) Delete(uint64, uint64) error          { return nil }
+func (providerProxyMatchStrategyRepo) GetByID(uint64, uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (providerProxyMatchStrategyRepo) GetByProjectID(uint64, uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (providerProxyMatchStrategyRepo) List(uint64) ([]*domain.RoutingStrategy, error) {
+	return nil, nil
+}
+
+type providerProxyMatchProjectRepo struct{}
+
+func (providerProxyMatchProjectRepo) Create(*domain.Project) error { return nil }
+func (providerProxyMatchProjectRepo) Update(*domain.Project) error { return nil }
+func (providerProxyMatchProjectRepo) Delete(uint64, uint64) error  { return nil }
+func (providerProxyMatchProjectRepo) GetByID(tenantID uint64, id uint64) (*domain.Project, error) {
+	if tenantID == 1 && id == 123 {
+		return &domain.Project{ID: 123, TenantID: 1, EnabledCustomRoutes: []domain.ClientType{domain.ClientTypeOpenAI}}, nil
+	}
+	return nil, domain.ErrNotFound
+}
+func (providerProxyMatchProjectRepo) GetBySlug(uint64, string) (*domain.Project, error) {
+	return nil, domain.ErrNotFound
+}
+func (providerProxyMatchProjectRepo) List(uint64) ([]*domain.Project, error) { return nil, nil }
+
+func TestMatchProviderProxyRouteUsesProjectRouteRetryPolicy(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(&providerProxyMatchRouteRepo{routes: []*domain.Route{
+		{ID: 10, TenantID: 1, ProjectID: 0, ProviderID: 79007, ClientType: domain.ClientTypeOpenAI, IsEnabled: true},
+		{ID: 11, TenantID: 1, ProjectID: 123, ProviderID: 79007, ClientType: domain.ClientTypeOpenAI, RetryConfigID: 99, IsEnabled: true},
+	}})
+	providerRepo := cached.NewProviderRepository(&providerProxyMatchProviderRepo{providers: []*domain.Provider{
+		{ID: 79007, TenantID: 1, Type: providerProxyMatchTestType, Name: "provider", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}},
+	}})
+	retryRepo := cached.NewRetryConfigRepository(&providerProxyMatchRetryRepo{configs: []*domain.RetryConfig{
+		{ID: 1, TenantID: 1, IsDefault: true, MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+		{ID: 99, TenantID: 1, MaxRetries: 2, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	}})
+	strategyRepo := cached.NewRoutingStrategyRepository(providerProxyMatchStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(providerProxyMatchProjectRepo{})
+
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := router.NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("init adapters: %v", err)
+	}
+	e := &Executor{router: r}
+
+	matched, err := e.MatchProviderProxyRoute(context.Background(), 1, 79007, domain.ClientTypeOpenAI, 123, "minimaxai/minimax-m3", 46, "session-1")
+	if err != nil {
+		t.Fatalf("MatchProviderProxyRoute returned error: %v", err)
+	}
+	if matched.Route.ID != 11 {
+		t.Fatalf("matched route ID = %d, want project route 11", matched.Route.ID)
+	}
+	if matched.RetryConfig == nil || matched.RetryConfig.MaxRetries != 2 {
+		t.Fatalf("matched retry config = %+v, want project MaxRetries=2", matched.RetryConfig)
+	}
+}

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -102,40 +101,26 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 			return
 		}
 
-		route, err := h.routeRepo.FindByKey(tenantID, 0, provider.ID, clientType)
-		if err != nil || route == nil {
-			log.Printf("[ProviderProxy] route not found tenant=%d provider=%d clientType=%s: %v", tenantID, provider.ID, clientType, err)
+		requestModel := flow.GetRequestModel(c)
+		projectID := flow.GetProjectID(c)
+		apiTokenID := flow.GetAPITokenID(c)
+		sessionID := flow.GetSessionID(c)
+		if h.proxyHandler == nil || h.proxyHandler.executor == nil {
+			writeError(c.Writer, http.StatusInternalServerError, "provider proxy executor not configured")
+			c.Abort()
+			return
+		}
+		matchedRoute, err := h.proxyHandler.executor.MatchProviderProxyRoute(c.Request.Context(), tenantID, provider.ID, clientType, projectID, requestModel, apiTokenID, sessionID)
+		if err != nil || matchedRoute == nil || matchedRoute.Route == nil || matchedRoute.Provider == nil || matchedRoute.ProviderAdapter == nil {
+			log.Printf("[ProviderProxy] matched route not found tenant=%d project=%d provider=%d clientType=%s model=%s: %v", tenantID, projectID, provider.ID, clientType, requestModel, err)
 			writeError(c.Writer, http.StatusNotFound, "provider route not found")
 			c.Abort()
 			return
 		}
-
-		factory, ok := provideradapter.GetAdapterFactory(provider.Type)
-		if !ok {
-			writeError(c.Writer, http.StatusBadGateway, "provider adapter not found")
-			c.Abort()
-			return
-		}
-		adapter, err := factory(provider)
-		if err != nil {
-			log.Printf("[ProviderProxy] failed to create adapter provider=%d type=%s: %v", provider.ID, provider.Type, err)
-			writeError(c.Writer, http.StatusBadGateway, "provider adapter init failed")
-			c.Abort()
-			return
-		}
-		if !providerSupportsClientType(adapter.SupportedClientTypes(), clientType) {
-			writeError(c.Writer, http.StatusBadRequest, "provider does not support this client type")
-			c.Abort()
-			return
-		}
-
-		requestModel := flow.GetRequestModel(c)
-		projectID := flow.GetProjectID(c)
-		apiTokenID := flow.GetAPITokenID(c)
+		route := matchedRoute.Route
+		provider = matchedRoute.Provider
 		mappedModel := requestModel
-		if h.proxyHandler != nil && h.proxyHandler.executor != nil {
-			mappedModel = h.proxyHandler.executor.MapModelForProviderProxy(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
-		}
+		mappedModel = h.proxyHandler.executor.MapModelForProviderProxy(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
 		isStream := flow.GetIsStream(c)
 		clearDetail := h.proxyHandler != nil && h.proxyHandler.executor != nil && h.proxyHandler.executor.ShouldClearRequestDetailByConfig()
 		if getAPITokenDevMode(c) {
@@ -151,16 +136,8 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 		c.Set(flow.KeyProxyRequest, proxyReq)
 
 		// Route direct provider calls through the normal executor dispatch loop,
-		// constrained to this provider. This keeps the /provider/<id>/... contract
-		// one-to-one while preserving model mapping, retry, attempts and billing.
-		if h.proxyHandler == nil || h.proxyHandler.executor == nil {
-			err = &domain.ProxyError{
-				HTTPStatusCode: http.StatusInternalServerError,
-				Message:        "provider proxy executor not configured",
-			}
-		} else {
-			err = h.proxyHandler.executor.ExecuteProviderProxy(c, proxyReq, route, provider, adapter)
-		}
+		// constrained to the provider selected above by the generic matcher.
+		err = h.proxyHandler.executor.ExecuteProviderProxyMatched(c, proxyReq, matchedRoute)
 		if err == nil {
 			return
 		}


### PR DESCRIPTION
## Summary
- route direct `/provider/<id>/...` requests through the generic router matcher before dispatch
- constrain provider proxy dispatch to the requested provider while preserving project/session/token route selection
- reuse the matched route retry config so project-scoped provider proxy calls do not fall back to global `MaxRetries=0`
- add a regression test for project route retry-policy selection

## Tests
- `go test -count=1 ./internal/executor ./internal/handler`
- `go test -count=1 ./internal/...`

## Notes
- direct provider proxy still does not fail over to other providers; retries stay on the requested provider only
- CodeRabbit was not inspected or requested in this pass
