### PR TITLE
fix(models): expose only currently available models

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,10 @@
+# DEVLOG
+
+## 2026-07-16
+
+- Implemented available-only model list semantics for maxx model-list endpoints.
+- `/v1/models` now filters collected candidates through the current routing scope instead of exposing historical/pricing/provider candidates directly.
+- `/project/{slug}/v1/models` respects project route scope.
+- `/provider/{id}/v1/models` constrains results to the requested provider.
+- Cooldown, disabled route, provider adapter availability, client type, project, and token context are covered by regression tests.
+- Generated screenshot evidence for global, provider-scoped, project-scoped, and external mock/cooldown interaction nodes.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,6 @@
+# TODO
+
+- [x] Implement model list availability filtering via current routing scope dry-run.
+- [x] Cover global/project/provider model list scopes with unit and integration regression tests.
+- [x] Add E2E-style mock evidence for visible model list behavior and capture screenshots.
+- [x] Run focused backend tests and frontend/mock evidence generation.

--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -517,7 +517,7 @@ func main() {
 	claudeHandler := handler.NewClaudeHandler(adminService, wsHub)
 
 	// Use already-created cached project repository for project proxy handler
-	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -460,6 +460,7 @@ func InitializeServerComponents(
 		repos.ResponseModelRepo,
 		repos.CachedProviderRepo,
 		repos.CachedModelMappingRepo,
+		r,
 	)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -3,11 +3,14 @@ package handler
 import (
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/pricing"
 	"github.com/awsl-project/maxx/internal/repository"
+	"github.com/awsl-project/maxx/internal/router"
 )
 
 // ModelsHandler serves model-list endpoints with a lightweight model list.
@@ -15,6 +18,7 @@ type ModelsHandler struct {
 	responseModelRepo repository.ResponseModelRepository
 	providerRepo      repository.ProviderRepository
 	modelMappingRepo  repository.ModelMappingRepository
+	router            *router.Router
 }
 
 // NewModelsHandler creates a new ModelsHandler.
@@ -22,11 +26,17 @@ func NewModelsHandler(
 	responseModelRepo repository.ResponseModelRepository,
 	providerRepo repository.ProviderRepository,
 	modelMappingRepo repository.ModelMappingRepository,
+	availabilityRouter ...*router.Router,
 ) *ModelsHandler {
+	var r *router.Router
+	if len(availabilityRouter) > 0 {
+		r = availabilityRouter[0]
+	}
 	return &ModelsHandler{
 		responseModelRepo: responseModelRepo,
 		providerRepo:      providerRepo,
 		modelMappingRepo:  modelMappingRepo,
+		router:            r,
 	}
 }
 
@@ -40,13 +50,17 @@ func (h *ModelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tenantID := maxxctx.GetTenantID(r.Context())
 	userAgent := r.Header.Get("User-Agent")
 	isGeminiModels := isGeminiModelsPath(r.URL.Path)
+	clientType := modelListClientType(r)
+	projectID := modelListProjectID(r)
+	providerID := modelListProviderID(r)
+	apiTokenID := maxxctx.GetAPITokenID(r.Context())
 
 	var names []string
 	var err error
 	if isGeminiModels {
-		names, err = h.collectModelNames(tenantID)
+		names, err = h.collectAvailableModelNames(tenantID, clientType, projectID, providerID, apiTokenID, "")
 	} else {
-		names, err = h.collectModelNamesForUserAgent(tenantID, userAgent)
+		names, err = h.collectAvailableModelNames(tenantID, clientType, projectID, providerID, apiTokenID, userAgent)
 	}
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -79,6 +93,32 @@ func (h *ModelsHandler) collectModelNames(tenantID uint64) ([]string, error) {
 }
 
 func (h *ModelsHandler) collectModelNamesForUserAgent(tenantID uint64, userAgent string) ([]string, error) {
+	candidates, err := h.collectCandidateModelNames(tenantID, userAgent)
+	if err != nil {
+		return nil, err
+	}
+	return sortedModelNames(candidates), nil
+}
+
+func (h *ModelsHandler) collectAvailableModelNames(tenantID uint64, clientType domain.ClientType, projectID, providerID, apiTokenID uint64, userAgent string) ([]string, error) {
+	candidates, err := h.collectCandidateModelNames(tenantID, userAgent)
+	if err != nil {
+		return nil, err
+	}
+	if h.router == nil {
+		return sortedModelNames(candidates), nil
+	}
+
+	available := make(map[string]struct{})
+	for name := range candidates {
+		if h.isModelAvailable(tenantID, clientType, projectID, providerID, apiTokenID, name) {
+			available[name] = struct{}{}
+		}
+	}
+	return sortedModelNames(available), nil
+}
+
+func (h *ModelsHandler) collectCandidateModelNames(tenantID uint64, userAgent string) (map[string]struct{}, error) {
 	result := make(map[string]struct{})
 
 	if h.responseModelRepo != nil {
@@ -115,13 +155,70 @@ func (h *ModelsHandler) collectModelNamesForUserAgent(tenantID uint64, userAgent
 	}
 
 	appendPricingModelNames(result, userAgent)
+	return result, nil
+}
 
+func (h *ModelsHandler) isModelAvailable(tenantID uint64, clientType domain.ClientType, projectID, providerID, apiTokenID uint64, model string) bool {
+	if h.router == nil || clientType == "" || model == "" {
+		return false
+	}
+	result, err := h.router.Match(&router.MatchContext{
+		TenantID:     tenantID,
+		ClientType:   clientType,
+		ProjectID:    projectID,
+		RequestModel: model,
+		APITokenID:   apiTokenID,
+	})
+	if err != nil || result == nil {
+		return false
+	}
+	for _, matched := range result.Routes {
+		if matched == nil || matched.Provider == nil {
+			continue
+		}
+		if providerID == 0 || matched.Provider.ID == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedModelNames(result map[string]struct{}) []string {
 	names := make([]string, 0, len(result))
 	for name := range result {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	return names, nil
+	return names
+}
+
+func modelListProjectID(r *http.Request) uint64 {
+	if r == nil {
+		return 0
+	}
+	return parseUintHeader(r, "X-Maxx-Project-ID")
+}
+
+func modelListProviderID(r *http.Request) uint64 {
+	if r == nil {
+		return 0
+	}
+	return parseUintHeader(r, "X-Maxx-Provider-ID")
+}
+
+func parseUintHeader(r *http.Request, name string) uint64 {
+	if r == nil {
+		return 0
+	}
+	value := strings.TrimSpace(r.Header.Get(name))
+	if value == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
 }
 
 func appendPricingModelNames(target map[string]struct{}, userAgent string) {

--- a/internal/handler/models_availability_test.go
+++ b/internal/handler/models_availability_test.go
@@ -1,0 +1,247 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type modelAvailabilityRouteRepo struct{ routes []*domain.Route }
+
+func (r *modelAvailabilityRouteRepo) Create(route *domain.Route) error        { return nil }
+func (r *modelAvailabilityRouteRepo) Update(route *domain.Route) error        { return nil }
+func (r *modelAvailabilityRouteRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *modelAvailabilityRouteRepo) BulkDelete(tenantID uint64, req domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	return nil, nil
+}
+func (r *modelAvailabilityRouteRepo) GetByID(tenantID uint64, id uint64) (*domain.Route, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityRouteRepo) FindByKey(tenantID uint64, projectID, providerID uint64, clientType domain.ClientType) (*domain.Route, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityRouteRepo) List(tenantID uint64) ([]*domain.Route, error) {
+	return append([]*domain.Route(nil), r.routes...), nil
+}
+func (r *modelAvailabilityRouteRepo) BatchUpdatePositions(tenantID uint64, updates []domain.RoutePositionUpdate) error {
+	return nil
+}
+
+type modelAvailabilityProviderRepo struct{ providers []*domain.Provider }
+
+func (r *modelAvailabilityProviderRepo) Create(provider *domain.Provider) error  { return nil }
+func (r *modelAvailabilityProviderRepo) Update(provider *domain.Provider) error  { return nil }
+func (r *modelAvailabilityProviderRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *modelAvailabilityProviderRepo) GetByID(tenantID uint64, id uint64) (*domain.Provider, error) {
+	for _, p := range r.providers {
+		if p.ID == id && (tenantID == domain.TenantIDAll || p.TenantID == tenantID) {
+			return p, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityProviderRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	return append([]*domain.Provider(nil), r.providers...), nil
+}
+
+type modelAvailabilityStrategyRepo struct{}
+
+func (r *modelAvailabilityStrategyRepo) Create(strategy *domain.RoutingStrategy) error { return nil }
+func (r *modelAvailabilityStrategyRepo) Update(strategy *domain.RoutingStrategy) error { return nil }
+func (r *modelAvailabilityStrategyRepo) Delete(tenantID uint64, id uint64) error       { return nil }
+func (r *modelAvailabilityStrategyRepo) GetByID(tenantID uint64, id uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityStrategyRepo) GetByProjectID(tenantID uint64, projectID uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityStrategyRepo) List(tenantID uint64) ([]*domain.RoutingStrategy, error) {
+	return nil, nil
+}
+
+type modelAvailabilityRetryRepo struct{}
+
+func (r *modelAvailabilityRetryRepo) Create(config *domain.RetryConfig) error { return nil }
+func (r *modelAvailabilityRetryRepo) Update(config *domain.RetryConfig) error { return nil }
+func (r *modelAvailabilityRetryRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *modelAvailabilityRetryRepo) GetByID(tenantID uint64, id uint64) (*domain.RetryConfig, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityRetryRepo) GetDefault(tenantID uint64) (*domain.RetryConfig, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityRetryRepo) List(tenantID uint64) ([]*domain.RetryConfig, error) {
+	return nil, nil
+}
+
+type modelAvailabilityProjectRepo struct{ projects []*domain.Project }
+
+func (r *modelAvailabilityProjectRepo) Create(project *domain.Project) error    { return nil }
+func (r *modelAvailabilityProjectRepo) Update(project *domain.Project) error    { return nil }
+func (r *modelAvailabilityProjectRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *modelAvailabilityProjectRepo) GetByID(tenantID uint64, id uint64) (*domain.Project, error) {
+	for _, p := range r.projects {
+		if p.ID == id && (tenantID == domain.TenantIDAll || p.TenantID == tenantID) {
+			return p, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityProjectRepo) GetBySlug(tenantID uint64, slug string) (*domain.Project, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelAvailabilityProjectRepo) List(tenantID uint64) ([]*domain.Project, error) {
+	return append([]*domain.Project(nil), r.projects...), nil
+}
+
+func newModelAvailabilityRouter(t *testing.T, providers []*domain.Provider, routes []*domain.Route, projects []*domain.Project) (*router.Router, *cached.ProviderRepository) {
+	t.Helper()
+	providerRepo := cached.NewProviderRepository(&modelAvailabilityProviderRepo{providers: providers})
+	routeRepo := cached.NewRouteRepository(&modelAvailabilityRouteRepo{routes: routes})
+	strategyRepo := cached.NewRoutingStrategyRepository(&modelAvailabilityStrategyRepo{})
+	retryRepo := cached.NewRetryConfigRepository(&modelAvailabilityRetryRepo{})
+	projectRepo := cached.NewProjectRepository(&modelAvailabilityProjectRepo{projects: projects})
+	for _, loader := range []struct {
+		name string
+		load func() error
+	}{
+		{"providers", providerRepo.Load},
+		{"routes", routeRepo.Load},
+		{"strategies", strategyRepo.Load},
+		{"retries", retryRepo.Load},
+		{"projects", projectRepo.Load},
+	} {
+		if err := loader.load(); err != nil {
+			t.Fatalf("load %s: %v", loader.name, err)
+		}
+	}
+	r := router.NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+	return r, providerRepo
+}
+
+func testCustomProvider(id uint64, name string, models []string) *domain.Provider {
+	return &domain.Provider{
+		ID:                   id,
+		TenantID:             1,
+		Name:                 name,
+		Type:                 "custom",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+		SupportModels:        models,
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://example.invalid/v1",
+			APIKey:  "test-key",
+		}},
+	}
+}
+
+func decodeOpenAIModelIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("invalid model list payload: %v", err)
+	}
+	ids := make([]string, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		ids = append(ids, item.ID)
+	}
+	return ids
+}
+
+func TestModelsHandlerFiltersUnavailableModelsByRouteMatch(t *testing.T) {
+	providers := []*domain.Provider{
+		testCustomProvider(10, "available", []string{"gpt-live", "gpt-cooldown"}),
+		testCustomProvider(11, "disabled", []string{"gpt-disabled"}),
+	}
+	routes := []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 10, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 1, Weight: 1},
+		{ID: 2, TenantID: 1, ProviderID: 11, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: false, Position: 2, Weight: 1},
+	}
+	r, providerRepo := newModelAvailabilityRouter(t, providers, routes, nil)
+	handler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-live", "gpt-cooldown", "gpt-disabled", "gpt-history-only"}}, providerRepo, nil, r)
+
+	cooldown.Default().SetCooldownUntil(10, string(domain.ClientTypeOpenAI), "gpt-cooldown", time.Now().Add(time.Minute))
+	defer cooldown.Default().ClearCooldown(10, string(domain.ClientTypeOpenAI), "gpt-cooldown")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("User-Agent", "codex_cli_rs/0.98.0")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	ids := decodeOpenAIModelIDs(t, rec.Body.Bytes())
+	if !containsModel(ids, "gpt-live") {
+		t.Fatalf("ids = %v, want gpt-live", ids)
+	}
+	for _, unavailable := range []string{"gpt-cooldown", "gpt-disabled", "gpt-history-only"} {
+		if containsModel(ids, unavailable) {
+			t.Fatalf("ids = %v, did not want %s", ids, unavailable)
+		}
+	}
+}
+
+func TestModelsHandlerFiltersProviderScopedModelList(t *testing.T) {
+	providers := []*domain.Provider{
+		testCustomProvider(10, "provider-a", []string{"gpt-a"}),
+		testCustomProvider(20, "provider-b", []string{"gpt-b"}),
+	}
+	routes := []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 10, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 1, Weight: 1},
+		{ID: 2, TenantID: 1, ProviderID: 20, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 2, Weight: 1},
+	}
+	r, providerRepo := newModelAvailabilityRouter(t, providers, routes, nil)
+	handler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-a", "gpt-b"}}, providerRepo, nil, r)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("X-Maxx-Provider-ID", "20")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	ids := decodeOpenAIModelIDs(t, rec.Body.Bytes())
+	if containsModel(ids, "gpt-a") || !containsModel(ids, "gpt-b") {
+		t.Fatalf("ids = %v, want only provider-b model", ids)
+	}
+}
+
+func TestModelsHandlerFiltersProjectScopedModelList(t *testing.T) {
+	providers := []*domain.Provider{
+		testCustomProvider(10, "global", []string{"gpt-global"}),
+		testCustomProvider(20, "project", []string{"gpt-project"}),
+	}
+	routes := []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 10, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 1, Weight: 1},
+		{ID: 2, TenantID: 1, ProviderID: 20, ClientType: domain.ClientTypeOpenAI, ProjectID: 42, IsEnabled: true, Position: 1, Weight: 1},
+	}
+	projects := []*domain.Project{{ID: 42, TenantID: 1, Name: "project", Slug: "project", EnabledCustomRoutes: []domain.ClientType{domain.ClientTypeOpenAI}}}
+	r, providerRepo := newModelAvailabilityRouter(t, providers, routes, projects)
+	handler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-global", "gpt-project"}}, providerRepo, nil, r)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("X-Maxx-Project-ID", "42")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	ids := decodeOpenAIModelIDs(t, rec.Body.Bytes())
+	if containsModel(ids, "gpt-global") || !containsModel(ids, "gpt-project") {
+		t.Fatalf("ids = %v, want only project model", ids)
+	}
+}

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -74,6 +74,7 @@ func (h *ProviderProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	if isModelListAPIPath(apiPath) {
 		r.URL.Path = apiPath
+		r.Header.Set("X-Maxx-Provider-ID", strconv.FormatUint(provider.ID, 10))
 		h.modelsHandler.ServeHTTP(w, r)
 		return
 	}

--- a/tests/e2e/models_test.go
+++ b/tests/e2e/models_test.go
@@ -1,8 +1,10 @@
 package e2e_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestGetModels(t *testing.T) {
@@ -250,5 +252,115 @@ func TestGetModels_ProjectAndProviderScopedRoutesRequireAPIToken(t *testing.T) {
 				t.Fatalf("Expected object 'list', got %v", result["object"])
 			}
 		})
+	}
+}
+
+func TestGetModels_OnlyCurrentAvailableModelsAcrossScopes(t *testing.T) {
+	env := NewProxyTestEnv(t)
+
+	globalProviderID := createModelListProvider(t, env, "models available global", []string{"gpt-models-global", "gpt-models-cold"})
+	disabledProviderID := createModelListProvider(t, env, "models unavailable disabled", []string{"gpt-models-disabled"})
+	projectProviderID := createModelListProvider(t, env, "models available project", []string{"gpt-models-project"})
+
+	createModelListRoute(t, env, globalProviderID, 0, true)
+	createModelListRoute(t, env, disabledProviderID, 0, false)
+
+	projectResp := env.AdminPost("/api/admin/projects", map[string]any{
+		"name":                "models availability project",
+		"slug":                "models-availability-project",
+		"enabledCustomRoutes": []string{"openai"},
+	})
+	AssertStatus(t, projectResp, http.StatusCreated)
+	var project map[string]any
+	DecodeJSON(t, projectResp, &project)
+	projectID := int(project["id"].(float64))
+	createModelListRoute(t, env, projectProviderID, projectID, true)
+
+	until := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	cooldownResp := env.AdminPut(fmt.Sprintf("/api/admin/cooldowns/%d", globalProviderID), map[string]any{
+		"untilTime":  until,
+		"clientType": "openai",
+		"model":      "gpt-models-cold",
+	})
+	AssertStatus(t, cooldownResp, http.StatusOK)
+	cooldownResp.Body.Close()
+
+	globalIDs := modelIDsFromResponse(t, env.doRequest(http.MethodGet, "/v1/models", nil, env.Token))
+	assertModelPresent(t, globalIDs, "gpt-models-global")
+	assertModelAbsent(t, globalIDs, "gpt-models-cold")
+	assertModelAbsent(t, globalIDs, "gpt-models-disabled")
+	assertModelAbsent(t, globalIDs, "gpt-models-project")
+
+	providerIDs := modelIDsFromResponse(t, env.doRequest(http.MethodGet, fmt.Sprintf("/provider/%d/v1/models", globalProviderID), nil, env.Token))
+	assertModelPresent(t, providerIDs, "gpt-models-global")
+	assertModelAbsent(t, providerIDs, "gpt-models-cold")
+	assertModelAbsent(t, providerIDs, "gpt-models-disabled")
+	assertModelAbsent(t, providerIDs, "gpt-models-project")
+
+	projectIDs := modelIDsFromResponse(t, env.doRequest(http.MethodGet, "/project/models-availability-project/v1/models", nil, env.Token))
+	assertModelPresent(t, projectIDs, "gpt-models-project")
+	assertModelAbsent(t, projectIDs, "gpt-models-global")
+	assertModelAbsent(t, projectIDs, "gpt-models-disabled")
+}
+
+func createModelListProvider(t *testing.T, env *ProxyTestEnv, name string, supportModels []string) int {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/providers", map[string]any{
+		"name": name,
+		"type": "custom",
+		"config": map[string]any{"custom": map[string]any{
+			"baseURL": "https://models-availability.example.test/v1",
+			"apiKey":  "sk-models-availability",
+		}},
+		"supportedClientTypes": []string{"openai"},
+		"supportModels":        supportModels,
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	var provider map[string]any
+	DecodeJSON(t, resp, &provider)
+	return int(provider["id"].(float64))
+}
+
+func createModelListRoute(t *testing.T, env *ProxyTestEnv, providerID int, projectID int, enabled bool) {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  enabled,
+		"isNative":   true,
+		"clientType": "openai",
+		"providerID": providerID,
+		"projectID":  projectID,
+		"position":   1,
+	})
+	AssertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+}
+
+func modelIDsFromResponse(t *testing.T, resp *http.Response) map[string]bool {
+	t.Helper()
+	AssertStatus(t, resp, http.StatusOK)
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	DecodeJSON(t, resp, &payload)
+	ids := make(map[string]bool, len(payload.Data))
+	for _, item := range payload.Data {
+		ids[item.ID] = true
+	}
+	return ids
+}
+
+func assertModelPresent(t *testing.T, ids map[string]bool, model string) {
+	t.Helper()
+	if !ids[model] {
+		t.Fatalf("expected model %q in %v", model, ids)
+	}
+}
+
+func assertModelAbsent(t *testing.T, ids map[string]bool, model string) {
+	t.Helper()
+	if ids[model] {
+		t.Fatalf("did not expect model %q in %v", model, ids)
 	}
 }

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -192,7 +192,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, inviteCodeRepo, inviteCodeUsageRepo, true)
 
 	// Create models handler
-	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)


### PR DESCRIPTION
## Summary
- filter `/v1/models` candidates through the current router scope so only currently reachable models are exposed
- constrain `/provider/{id}/v1/models` to the requested provider and preserve project-scoped `/models` routing semantics
- add unit and e2e coverage for disabled routes, cooldown-hidden models, provider scope, project scope, and token-protected model-list endpoints

## Validation
- `go test ./internal/handler ./internal/router ./internal/executor`
- `go test ./tests/e2e -run 'TestGetModels_OnlyCurrentAvailableModelsAcrossScopes|TestGetModels_ProjectAndProviderScopedRoutesRequireAPIToken|TestGetModels_APITokenAuthAndModelSources'`
- `cd web && pnpm install --frozen-lockfile && pnpm build`
- `go test ./...`

## Evidence notes
- Generated local screenshot evidence for global, provider-scoped, project-scoped, and external mock/cooldown interaction nodes under `tmp/model-list-evidence-*.png` during validation. These are local validation artifacts and are not committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 模型列表现在仅显示当前可用的模型。
  * 全局、Provider 和项目范围的模型列表会分别遵循对应的路由范围。
  * 自动排除冷却中、已禁用或路由不匹配的模型。

* **Bug 修复**
  * 修正 Provider 和项目上下文下模型列表返回范围不准确的问题。

* **测试**
  * 增加全局、Provider、项目范围及冷却状态下的模型可用性验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->