### PR TITLE
fix(providers): keep bulk actions visible while scrolling

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -8,3 +8,5 @@
 - `/provider/{id}/v1/models` constrains results to the requested provider.
 - Cooldown, disabled route, provider adapter availability, client type, project, and token context are covered by regression tests.
 - Generated screenshot evidence for global, provider-scoped, project-scoped, and external mock/cooldown interaction nodes.
+- Converted the providers bulk delete/select toolbar from a normal top-of-list block to a sticky toolbar inside the providers scroll container.
+- Added a targeted layout regression test asserting sticky/top/z-index/wrapping/readable surface classes.

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,7 @@
 - [x] Cover global/project/provider model list scopes with unit and integration regression tests.
 - [x] Add E2E-style mock evidence for visible model list behavior and capture screenshots.
 - [x] Run focused backend tests and frontend/mock evidence generation.
+- [x] Inspect providers bulk delete toolbar placement and scroll container.
+- [x] Make providers bulk actions toolbar sticky inside the providers scroll container.
+- [x] Validate layout with targeted tests, typecheck, build, and screenshots.
+- [ ] Open PR after verification.

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -133,6 +133,9 @@ type ProviderBulkDeletePreviewItem = {
   streamingCount: number;
 };
 
+export const PROVIDER_BULK_ACTIONS_STICKY_CLASS =
+  'sticky top-0 z-20 mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border bg-background/95 p-3 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/80';
+
 export function ProvidersPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -664,7 +667,7 @@ export function ProvidersPage() {
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto p-4 md:p-6">
         <div className="mx-auto max-w-7xl">
           {canManageProviderSettings && providers.length > 0 && (
-            <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card/80 p-3 shadow-sm">
+            <div className={PROVIDER_BULK_ACTIONS_STICKY_CLASS}>
               <Button
                 type="button"
                 variant="outline"

--- a/web/src/pages/providers/providers-bulk-actions-layout.test.ts
+++ b/web/src/pages/providers/providers-bulk-actions-layout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { PROVIDER_BULK_ACTIONS_STICKY_CLASS } from './index';
+
+describe('provider bulk actions toolbar layout', () => {
+  it('stays available inside the providers scroll container', () => {
+    expect(PROVIDER_BULK_ACTIONS_STICKY_CLASS.split(' ')).toEqual(
+      expect.arrayContaining(['sticky', 'top-0', 'z-20', 'flex', 'flex-wrap']),
+    );
+  });
+
+  it('keeps an opaque readable surface while provider rows scroll under it', () => {
+    expect(PROVIDER_BULK_ACTIONS_STICKY_CLASS).toContain('bg-background/95');
+    expect(PROVIDER_BULK_ACTIONS_STICKY_CLASS).toContain('backdrop-blur');
+    expect(PROVIDER_BULK_ACTIONS_STICKY_CLASS).toContain('shadow-sm');
+  });
+});


### PR DESCRIPTION
## Summary
- keep the Providers bulk select/delete toolbar sticky inside the providers scroll container
- preserve the existing select visible / invert visible / selected count / cancel / delete flow without changing bulk delete API behavior
- add a targeted layout regression test for sticky positioning, wrapping, and readable toolbar surface

## Validation
- `cd web && pnpm test -- providers-bulk-actions-layout.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm build`
- generated local UI evidence screenshots for top scroll, bottom scroll, delete dialog reachability, and mobile narrow viewport

## Evidence notes
- Screenshot evidence was generated locally under `tmp/providers-sticky-toolbar-*.png` and sent in the chat. These screenshots are validation artifacts and are not committed.
