### PR TITLE
fix(proxy): retry committed stream EOF failures

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,3 +10,5 @@
 - Generated screenshot evidence for global, provider-scoped, project-scoped, and external mock/cooldown interaction nodes.
 - Converted the providers bulk delete/select toolbar from a normal top-of-list block to a sticky toolbar inside the providers scroll container.
 - Added a targeted layout regression test asserting sticky/top/z-index/wrapping/readable surface classes.
+- Decoupled committed stream read EOF retry from `DisableErrorCooldown` so provider/network stream EOFs can follow route retry policy without requiring cooldown opt-out.
+- Added regression coverage for committed stream EOF retry with cooldown enabled/disabled, zero retry budget, client cancellation, and custom adapter unexpected EOF classification after response start.

--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,6 @@
 - [x] Inspect providers bulk delete toolbar placement and scroll container.
 - [x] Make providers bulk actions toolbar sticky inside the providers scroll container.
 - [x] Validate layout with targeted tests, typecheck, build, and screenshots.
+- [x] Decouple committed stream read EOF retry from DisableErrorCooldown.
+- [x] Cover committed stream EOF retry budget and custom unexpected EOF classification with regression tests.
 - [ ] Open PR after verification.

--- a/internal/adapter/provider/custom/stream_eof_test.go
+++ b/internal/adapter/provider/custom/stream_eof_test.go
@@ -112,6 +112,40 @@ func TestCustomAdapterStreamDoesNotFlushPartialLineOnUnexpectedEOF(t *testing.T)
 	}
 }
 
+func TestCustomAdapterStreamClassifiesUnexpectedEOFAfterResponseStarted(t *testing.T) {
+	adapter := newTestCustomAdapter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: &terminalUnexpectedEOFReadCloser{data: []byte(
+			"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"partial",
+		)},
+	}
+
+	err := adapter.handleStreamResponse(ctx, resp, domain.ClientTypeOpenAI, false)
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("handleStreamResponse error = %T %v, want *domain.ProxyError", err, err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider || proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Fatalf("proxyErr scope/reason = %s/%s", proxyErr.Scope, proxyErr.Reason)
+	}
+	if proxyErr.Message != "upstream stream read error after response started" {
+		t.Fatalf("proxyErr message = %q", proxyErr.Message)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "content\":\"ok") {
+		t.Fatalf("completed line was not forwarded before EOF: %q", body)
+	}
+	if strings.Contains(rec.Body.String(), "partial") {
+		t.Fatalf("partial line was forwarded: %q", rec.Body.String())
+	}
+}
+
 func newTestCustomAdapter() *CustomAdapter {
 	return &CustomAdapter{provider: &domain.Provider{
 		Type: "custom",

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -70,8 +70,28 @@ func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownDisabled(t *tes
 	}
 }
 
-func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
+func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
 	c, adapter, _, proxyRepo := newDisabledCooldownStreamDispatchCtx(false)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
+		t.Fatalf("client body = %q", got)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchDoesNotRetryCommittedStreamReadErrorWithoutRetryBudget(t *testing.T) {
+	c, adapter, _, proxyRepo := newDisabledCooldownStreamDispatchCtx(false, 0)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
 
 	e.dispatch(c)
@@ -205,10 +225,14 @@ func newDisabledCooldownStreamTestExecutor(proxyRepo *codexGuardProxyRequestRepo
 	}
 }
 
-func newDisabledCooldownStreamDispatchCtx(disableErrorCooldown bool) (*flow.Ctx, *disabledCooldownStreamRetryAdapter, *recordingAttemptRepo, *codexGuardProxyRequestRepo) {
+func newDisabledCooldownStreamDispatchCtx(disableErrorCooldown bool, maxRetriesOverride ...int) (*flow.Ctx, *disabledCooldownStreamRetryAdapter, *recordingAttemptRepo, *codexGuardProxyRequestRepo) {
 	proxyRepo := &codexGuardProxyRequestRepo{}
 	attemptRepo := &recordingAttemptRepo{}
 	adapter := &disabledCooldownStreamRetryAdapter{}
+	maxRetries := 1
+	if len(maxRetriesOverride) > 0 {
+		maxRetries = maxRetriesOverride[0]
+	}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
 	c := flow.NewCtx(rec, req)
@@ -237,7 +261,7 @@ func newDisabledCooldownStreamDispatchCtx(disableErrorCooldown bool) (*flow.Ctx,
 					Config:   &domain.ProviderConfig{DisableErrorCooldown: disableErrorCooldown},
 				},
 				ProviderAdapter: adapter,
-				RetryConfig:     &domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+				RetryConfig:     &domain.RetryConfig{MaxRetries: maxRetries, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
 			},
 		},
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -345,18 +345,31 @@ func isDisabledErrorCooldownRetryableError(proxyErr *domain.ProxyError) bool {
 	if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
 		return true
 	}
+	return isCommittedStreamReadRetryableError(proxyErr)
+}
+
+func applyCommittedStreamReadRetryPolicy(proxyErr *domain.ProxyError) {
+	if isCommittedStreamReadRetryableError(proxyErr) {
+		proxyErr.Retryable = true
+	}
+}
+
+func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
+	if proxyErr == nil {
+		return false
+	}
 	if proxyErr.Scope != domain.ScopeProvider {
 		return false
 	}
-	if proxyErr.Reason == domain.CooldownReasonNetworkError {
-		return true
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		return false
 	}
-	msg := strings.ToLower(proxyErr.Message)
-	return strings.Contains(msg, "stream read error") || strings.Contains(msg, "upstream stream")
+	msg := strings.ToLower(proxyErr.Message + " " + proxyErr.Err.Error())
+	return strings.Contains(msg, "stream read error") || strings.Contains(msg, "upstream stream") || strings.Contains(msg, "unexpected eof")
 }
 
-func shouldRetryCommittedResponseError(provider *domain.Provider, proxyErr *domain.ProxyError) bool {
-	return shouldSkipErrorCooldown(provider) && proxyErr != nil && proxyErr.Retryable && isDisabledErrorCooldownRetryableError(proxyErr)
+func shouldRetryCommittedResponseError(proxyErr *domain.ProxyError) bool {
+	return proxyErr != nil && proxyErr.Retryable && isCommittedStreamReadRetryableError(proxyErr)
 }
 
 // handleAsyncCooldownUpdate listens for async cooldown updates from providers

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -364,7 +364,11 @@ func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
 	if proxyErr.Reason != domain.CooldownReasonNetworkError {
 		return false
 	}
-	msg := strings.ToLower(proxyErr.Message + " " + proxyErr.Err.Error())
+	msg := proxyErr.Message
+	if proxyErr.Err != nil {
+		msg += " " + proxyErr.Err.Error()
+	}
+	msg = strings.ToLower(msg)
 	return strings.Contains(msg, "stream read error") || strings.Contains(msg, "upstream stream") || strings.Contains(msg, "unexpected eof")
 }
 

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -353,8 +353,9 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			proxyErr, ok := err.(*domain.ProxyError)
 			if ok {
 				applyDisabledErrorCooldownRetryPolicy(matchedRoute.Provider, proxyErr)
+				applyCommittedStreamReadRetryPolicy(proxyErr)
 			}
-			if responseCapture.WroteToClient() && !shouldRetryCommittedResponseError(matchedRoute.Provider, proxyErr) {
+			if responseCapture.WroteToClient() && !shouldRetryCommittedResponseError(proxyErr) {
 				log.Printf("[Executor] Response already committed; not failing over after provider %d error: %v", matchedRoute.Provider.ID, err)
 				proxyReq.Status = "FAILED"
 				proxyReq.EndTime = time.Now()


### PR DESCRIPTION
## Summary
- decouple committed stream read EOF retry from `DisableErrorCooldown`
- let provider/network stream read failures after response start follow the route retry budget
- keep request-scope/client disconnect and zero retry budget paths non-retryable
- add regression coverage for custom adapter unexpected EOF classification after response start

## Validation
- `go test ./internal/executor -run 'TestDispatchRetriesCommittedStreamReadError|TestDispatchDoesNotRetryCommittedStreamReadErrorWithoutRetryBudget|TestDispatchDoesNotRetryAfterRequestContextCanceled'`
- `go test ./internal/executor ./internal/adapter/provider/custom -run 'TestDispatchRetriesCommittedStreamReadError|TestDispatchDoesNotRetryCommittedStreamReadErrorWithoutRetryBudget|TestDispatchDoesNotRetryAfterRequestContextCanceled|TestCustomAdapterStream'`
- `go test ./internal/executor ./internal/adapter/provider/custom ./internal/adapter/provider/claude ./internal/adapter/provider/codex ./internal/adapter/provider/bedrock`
- `cd web && pnpm install --frozen-lockfile && pnpm build`
- `go test ./...`

## Notes
`go test ./...` requires `web/dist` to exist because the root package embeds built frontend assets. The first broad run failed before the web build with `pattern all:web/dist: no matching files found`; after `pnpm build`, the full suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化流式响应已开始传输后发生读取异常时的重试策略。
  - 在错误冷却启用时，符合条件的流式读取错误现在可以按路由策略重试。
  - 无可用重试次数、客户端取消等场景将保持不重试。
  - 上游意外中断时，仅保留已完整传输的内容，避免转发不完整片段。
  - 重试成功后可返回完整的回退结果及结束标记。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->