### PR TITLE
fix(retry): add force upstream error retry setting

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -856,6 +856,7 @@ const (
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"
 	SettingKeyCodexReasoningGuard                  = "codex_reasoning_guard"                    // Codex reasoning guard 配置（JSON 对象）
 	SettingKeyPayloadOverrideRules                 = "payload_override_rules"                   // 请求 payload 覆盖规则（JSON 数组）
+	SettingKeyForceRetryUpstreamErrors             = "force_retry_upstream_errors"              // 是否强制上游/provider 错误按路由重试策略重试，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"      // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteOpenAIChatEnabled          = "proxy_route_openai_chat_enabled"          // 是否暴露 OpenAI Chat Completions 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteResponsesEnabled           = "proxy_route_responses_enabled"            // 是否暴露 Responses/Codex 代理路由，"true" 或 "false"，默认 "true"

--- a/internal/executor/force_retry_setting.go
+++ b/internal/executor/force_retry_setting.go
@@ -1,0 +1,67 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// forceRetryUpstreamErrorsEnabled reports whether the admin opted into
+// retrying upstream/provider failures that were previously classified as
+// non-retryable. It intentionally defaults to false: the normal per-error
+// retry classification remains the safe default.
+func (e *Executor) forceRetryUpstreamErrorsEnabled() bool {
+	if e == nil || e.settingsRepo == nil {
+		return false
+	}
+	value, err := e.settingsRepo.Get(domain.SettingKeyForceRetryUpstreamErrors)
+	return err == nil && strings.EqualFold(strings.TrimSpace(value), "true")
+}
+
+// forceRetryUpstreamErrorIfSafe upgrades only upstream/provider-side failures
+// to retryable when the admin setting is enabled. Hard safety boundaries stay
+// intact: request/client errors, auth/key errors, canceled request contexts,
+// committed responses that are not explicitly safe to retry, and exhausted
+// retry budgets are still handled by the dispatch loop.
+func forceRetryUpstreamErrorIfSafe(proxyErr *domain.ProxyError, ctx context.Context, responseCommitted bool, enabled bool) bool {
+	if !enabled || proxyErr == nil || proxyErr.Retryable {
+		return false
+	}
+	if ctx != nil && (errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+		return false
+	}
+	if responseCommitted && !shouldRetryCommittedResponseError(proxyErr) {
+		return false
+	}
+	if proxyErr.Scope == domain.ScopeRequest || proxyErr.Scope == domain.ScopeKey {
+		return false
+	}
+	if proxyErr.HTTPStatusCode >= http.StatusBadRequest && proxyErr.HTTPStatusCode < http.StatusInternalServerError && proxyErr.HTTPStatusCode != http.StatusTooManyRequests {
+		return false
+	}
+
+	switch proxyErr.Scope {
+	case domain.ScopeProvider, domain.ScopeEndpoint, domain.ScopeModel:
+		proxyErr.Retryable = true
+		return true
+	default:
+		return false
+	}
+}
+
+func proxyErrorScopeForLog(proxyErr *domain.ProxyError) domain.ErrorScope {
+	if proxyErr == nil {
+		return ""
+	}
+	return proxyErr.Scope
+}
+
+func proxyErrorReasonForLog(proxyErr *domain.ProxyError) domain.CooldownReason {
+	if proxyErr == nil {
+		return ""
+	}
+	return proxyErr.Reason
+}

--- a/internal/executor/force_retry_setting_test.go
+++ b/internal/executor/force_retry_setting_test.go
@@ -1,0 +1,227 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type forceRetrySettingsRepo struct {
+	values map[string]string
+}
+
+func (r *forceRetrySettingsRepo) Get(key string) (string, error) {
+	if r != nil && r.values != nil {
+		if value, ok := r.values[key]; ok {
+			return value, nil
+		}
+	}
+	return "", domain.ErrNotFound
+}
+
+func (r *forceRetrySettingsRepo) Set(key, value string) error {
+	if r.values == nil {
+		r.values = map[string]string{}
+	}
+	r.values[key] = value
+	return nil
+}
+
+func (r *forceRetrySettingsRepo) GetAll() ([]*domain.SystemSetting, error) { return nil, nil }
+func (r *forceRetrySettingsRepo) Delete(key string) error                  { return nil }
+
+type forceRetrySequenceAdapter struct {
+	errs  []error
+	calls int
+}
+
+func (a *forceRetrySequenceAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *forceRetrySequenceAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	if a.calls <= len(a.errs) && a.errs[a.calls-1] != nil {
+		return a.errs[a.calls-1]
+	}
+	_, _ = c.Writer.Write([]byte(`{"ok":true}`))
+	return nil
+}
+
+func TestDispatchForceRetryUpstreamErrorsSettingRetriesProviderError(t *testing.T) {
+	retryErr := domain.NewProxyErrorWithMessage(errors.New("upstream error"), false, "failed to connect to upstream")
+	retryErr.Scope = domain.ScopeProvider
+	retryErr.Reason = domain.CooldownReasonNetworkError
+
+	adapter, proxyReq, c, e := newForceRetryDispatchHarness(
+		t,
+		true,
+		&forceRetrySequenceAdapter{errs: []error{retryErr}},
+		&domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if proxyReq.Status != "COMPLETED" {
+		t.Fatalf("proxy request status = %q, want COMPLETED", proxyReq.Status)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 2 {
+		t.Fatalf("attempt count = %d, want 2", proxyReq.ProxyUpstreamAttemptCount)
+	}
+}
+
+func TestDispatchForceRetryUpstreamErrorsSettingOffPreservesNonRetryableProviderError(t *testing.T) {
+	retryErr := domain.NewProxyErrorWithMessage(errors.New("upstream error"), false, "failed to connect to upstream")
+	retryErr.Scope = domain.ScopeProvider
+	retryErr.Reason = domain.CooldownReasonNetworkError
+
+	adapter, proxyReq, c, e := newForceRetryDispatchHarness(
+		t,
+		false,
+		&forceRetrySequenceAdapter{errs: []error{retryErr, nil}},
+		&domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected non-retryable provider error")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if proxyReq.Status != "FAILED" {
+		t.Fatalf("proxy request status = %q, want FAILED", proxyReq.Status)
+	}
+}
+
+func TestDispatchForceRetryUpstreamErrorsDoesNotOverrideRequestScopedError(t *testing.T) {
+	requestErr := domain.NewProxyErrorWithMessage(errors.New("bad request"), false, "invalid request")
+	requestErr.Scope = domain.ScopeRequest
+	requestErr.HTTPStatusCode = http.StatusBadRequest
+
+	adapter, proxyReq, c, e := newForceRetryDispatchHarness(
+		t,
+		true,
+		&forceRetrySequenceAdapter{errs: []error{requestErr, nil}},
+		&domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected request-scoped error")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if proxyReq.Status != "FAILED" {
+		t.Fatalf("proxy request status = %q, want FAILED", proxyReq.Status)
+	}
+}
+
+func TestDispatchForceRetryUpstreamErrorsDoesNotOverrideCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	retryErr := domain.NewProxyErrorWithMessage(errors.New("upstream error"), false, "failed to connect to upstream")
+	retryErr.Scope = domain.ScopeProvider
+	retryErr.Reason = domain.CooldownReasonNetworkError
+
+	adapter, proxyReq, c, e := newForceRetryDispatchHarnessWithContext(
+		t,
+		ctx,
+		true,
+		&forceRetrySequenceAdapter{errs: []error{retryErr, nil}},
+		&domain.RetryConfig{MaxRetries: 1, InitialInterval: time.Hour, BackoffRate: 1, MaxInterval: time.Hour},
+	)
+
+	go func() {
+		for adapter.calls == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		cancel()
+	}()
+
+	e.dispatch(c)
+
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+	if !errors.Is(c.Err, context.Canceled) {
+		t.Fatalf("dispatch error = %v, want context.Canceled", c.Err)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 1 {
+		t.Fatalf("attempt count = %d, want 1", proxyReq.ProxyUpstreamAttemptCount)
+	}
+}
+
+func newForceRetryDispatchHarness(
+	t *testing.T,
+	forceRetry bool,
+	adapter *forceRetrySequenceAdapter,
+	retryConfig *domain.RetryConfig,
+) (*forceRetrySequenceAdapter, *domain.ProxyRequest, *flow.Ctx, *Executor) {
+	t.Helper()
+	return newForceRetryDispatchHarnessWithContext(t, context.Background(), forceRetry, adapter, retryConfig)
+}
+
+func newForceRetryDispatchHarnessWithContext(
+	t *testing.T,
+	ctx context.Context,
+	forceRetry bool,
+	adapter *forceRetrySequenceAdapter,
+	retryConfig *domain.RetryConfig,
+) (*forceRetrySequenceAdapter, *domain.ProxyRequest, *flow.Ctx, *Executor) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         303,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeOpenAI,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:          ctx,
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-4o",
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: 20, TenantID: domain.DefaultTenantID, Type: "custom", Name: "custom-force-retry"},
+				ProviderAdapter: adapter,
+				RetryConfig:     retryConfig,
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	e := &Executor{
+		proxyRequestRepo: &codexGuardProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		modelMappingRepo: &codexGuardModelMappingRepo{},
+		settingsRepo: &forceRetrySettingsRepo{values: map[string]string{
+			domain.SettingKeyForceRetryUpstreamErrors: map[bool]string{true: "true", false: "false"}[forceRetry],
+		}},
+		converter: converter.GetGlobalRegistry(),
+	}
+	return adapter, proxyReq, c, e
+}

--- a/internal/executor/force_retry_setting_test.go
+++ b/internal/executor/force_retry_setting_test.go
@@ -39,8 +39,9 @@ func (r *forceRetrySettingsRepo) GetAll() ([]*domain.SystemSetting, error) { ret
 func (r *forceRetrySettingsRepo) Delete(key string) error                  { return nil }
 
 type forceRetrySequenceAdapter struct {
-	errs  []error
-	calls int
+	errs   []error
+	calls  int
+	onCall func()
 }
 
 func (a *forceRetrySequenceAdapter) SupportedClientTypes() []domain.ClientType {
@@ -49,6 +50,9 @@ func (a *forceRetrySequenceAdapter) SupportedClientTypes() []domain.ClientType {
 
 func (a *forceRetrySequenceAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
 	a.calls++
+	if a.onCall != nil {
+		a.onCall()
+	}
 	if a.calls <= len(a.errs) && a.errs[a.calls-1] != nil {
 		return a.errs[a.calls-1]
 	}
@@ -140,21 +144,20 @@ func TestDispatchForceRetryUpstreamErrorsDoesNotOverrideCanceledContext(t *testi
 	retryErr := domain.NewProxyErrorWithMessage(errors.New("upstream error"), false, "failed to connect to upstream")
 	retryErr.Scope = domain.ScopeProvider
 	retryErr.Reason = domain.CooldownReasonNetworkError
+	sequence := &forceRetrySequenceAdapter{
+		errs: []error{retryErr, nil},
+		onCall: func() {
+			cancel()
+		},
+	}
 
 	adapter, proxyReq, c, e := newForceRetryDispatchHarnessWithContext(
 		t,
 		ctx,
 		true,
-		&forceRetrySequenceAdapter{errs: []error{retryErr, nil}},
+		sequence,
 		&domain.RetryConfig{MaxRetries: 1, InitialInterval: time.Hour, BackoffRate: 1, MaxInterval: time.Hour},
 	)
-
-	go func() {
-		for adapter.calls == 0 {
-			time.Sleep(time.Millisecond)
-		}
-		cancel()
-	}()
 
 	e.dispatch(c)
 

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -392,6 +392,10 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				return
 			}
 
+			if ok && forceRetryUpstreamErrorIfSafe(proxyErr, ctx, responseCapture.WroteToClient(), e.forceRetryUpstreamErrorsEnabled()) {
+				log.Printf("[Executor] Force retry upstream errors enabled; retrying provider-side error after provider %d: %v", matchedRoute.Provider.ID, err)
+			}
+
 			if ok && proxyErr.Scope == domain.ScopeRequest && !proxyErr.Retryable {
 				log.Printf("[Executor] Request-scoped non-retryable error; not failing over after provider %d: %v", matchedRoute.Provider.ID, err)
 				proxyReq.Status = "FAILED"
@@ -429,6 +433,18 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			}
 
 			if !ok || !proxyErr.Retryable {
+				log.Printf("[Executor] Not retrying provider %d error: proxyError=%v retryable=%v scope=%s reason=%s attempt=%d maxRetries=%d ctxErr=%v responseCommitted=%v err=%v",
+					matchedRoute.Provider.ID,
+					ok,
+					ok && proxyErr.Retryable,
+					proxyErrorScopeForLog(proxyErr),
+					proxyErrorReasonForLog(proxyErr),
+					attempt,
+					retryConfig.MaxRetries,
+					ctx.Err(),
+					responseCapture.WroteToClient(),
+					err,
+				)
 				break
 			}
 

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -16,10 +16,21 @@ func validateSystemSettingValue(key, value string) error {
 		return payloadoverride.ValidateRulesJSON(value)
 	case domain.SettingKeyCodexReasoningGuard:
 		return validateCodexReasoningGuardSetting(value)
+	case domain.SettingKeyForceRetryUpstreamErrors:
+		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)
 	default:
 		return nil
+	}
+}
+
+func validateBooleanSystemSetting(key, value string) error {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "true", "false":
+		return nil
+	default:
+		return fmt.Errorf("%w: %s must be true or false", domain.ErrInvalidInput, key)
 	}
 }
 

--- a/internal/service/system_setting_validation_test.go
+++ b/internal/service/system_setting_validation_test.go
@@ -140,6 +140,35 @@ func TestValidateSystemSettingValueCodexReasoningGuard(t *testing.T) {
 	}
 }
 
+func TestValidateSystemSettingValueForceRetryUpstreamErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "true", value: "true"},
+		{name: "false", value: "false"},
+		{name: "trimmed uppercase", value: " TRUE "},
+		{name: "empty", value: "", wantErr: true},
+		{name: "invalid", value: "yes", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSystemSettingValue(domain.SettingKeyForceRetryUpstreamErrors, tt.value)
+			if tt.wantErr {
+				if !errors.Is(err, domain.ErrInvalidInput) {
+					t.Fatalf("expected invalid input error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestBackupServiceImportSystemSettingsSkipsPayloadOverrideRules(t *testing.T) {
 	repo := &stubSystemSettingRepo{
 		values: map[string]string{},

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1424,7 +1424,12 @@
     },
     "themeDefault": "Default",
     "themeLuxury": "Luxury",
-    "proxyRouteExposureAtLeastOne": "At least one public route must stay enabled"
+    "proxyRouteExposureAtLeastOne": "At least one public route must stay enabled",
+    "retryBehavior": "Retry behavior",
+    "retryBehaviorDesc": "Controls how provider and upstream failures are retried.",
+    "forceRetryUpstreamErrors": "Force retry upstream errors",
+    "forceRetryUpstreamErrorsDesc": "When enabled, provider/upstream/network/server failures that were classified as non-retryable are still retried according to the matched route retry policy.",
+    "forceRetryUpstreamErrorsHint": "Request errors, invalid credentials, canceled request contexts, unsafe committed responses, and exhausted retry budgets are still not retried."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1421,7 +1421,12 @@
     },
     "themeDefault": "默认",
     "themeLuxury": "奢华",
-    "proxyRouteExposureAtLeastOne": "至少保留一个 public route 开启"
+    "proxyRouteExposureAtLeastOne": "至少保留一个 public route 开启",
+    "retryBehavior": "重试行为",
+    "retryBehaviorDesc": "控制 provider 与上游失败如何重试。",
+    "forceRetryUpstreamErrors": "强制重试上游错误",
+    "forceRetryUpstreamErrorsDesc": "开启后，被误分类为不可重试的 provider / 上游 / 网络 / 服务端错误仍会按命中的路由重试策略重试。",
+    "forceRetryUpstreamErrorsHint": "请求错误、无效凭据、请求上下文取消、不安全的已提交响应，以及已耗尽的重试预算仍不会被重试。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -71,6 +71,7 @@ function parseRetentionInteger(value: string): number | null {
 const PAYLOAD_OVERRIDE_SETTING_KEY = 'payload_override_rules';
 const PAYLOAD_OVERRIDE_RESERVED_ROOTS = new Set(['model', 'stream']);
 const CODEX_REASONING_GUARD_SETTING_KEY = 'codex_reasoning_guard';
+const FORCE_RETRY_UPSTREAM_ERRORS_SETTING_KEY = 'force_retry_upstream_errors';
 const DEFAULT_CODEX_REASONING_GUARD_SETTING = JSON.stringify(
   {
     enabled: false,
@@ -345,6 +346,7 @@ export function SettingsPage() {
               <ForceProjectSection />
               <PayloadOverrideSection />
               <CodexReasoningGuardSection />
+              <RetryBehaviorSection />
               <APITokenConcurrencySection />
               <ProxyRouteExposureSection />
               <AntigravitySection />
@@ -1459,6 +1461,64 @@ function CodexReasoningGuardSection() {
         />
 
         <p className="text-xs text-muted-foreground">{t('settings.codexReasoningGuard.hint')}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RetryBehaviorSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+
+  const forceRetryUpstreamErrors =
+    settings?.[FORCE_RETRY_UPSTREAM_ERRORS_SETTING_KEY] === 'true';
+
+  const handleToggle = async (checked: boolean) => {
+    await updateSetting.mutateAsync({
+      key: FORCE_RETRY_UPSTREAM_ERRORS_SETTING_KEY,
+      value: checked ? 'true' : 'false',
+    });
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-base font-medium flex items-center gap-2">
+              <Zap className="h-4 w-4 text-muted-foreground" />
+              {t('settings.retryBehavior')}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.retryBehaviorDesc')}
+            </p>
+          </div>
+          <Switch
+            aria-label={t('settings.forceRetryUpstreamErrors')}
+            checked={forceRetryUpstreamErrors}
+            onCheckedChange={handleToggle}
+            disabled={updateSetting.isPending}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="p-6 space-y-3">
+        <div>
+          <Label className="text-sm font-medium text-foreground">
+            {t('settings.forceRetryUpstreamErrors')}
+          </Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            {t('settings.forceRetryUpstreamErrorsDesc')}
+          </p>
+        </div>
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-3">
+          <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            {t('settings.forceRetryUpstreamErrorsHint')}
+          </p>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Add a default-off admin setting `force_retry_upstream_errors` for retrying upstream/provider-side failures according to the matched route retry policy.
- Keep hard safety boundaries: request/client errors, invalid auth/key errors, canceled/deadline request contexts, unsafe committed responses, and exhausted retry budgets are not force-retried.
- Add the Settings page switch, validation, localized copy, and retry decision tests for enabled/disabled and boundary cases.

## Validation
- `go test ./internal/executor -run 'TestDispatchForceRetryUpstreamErrors|TestExecuteProviderProxyRetriesSameProvider|TestDispatchDoesNotRetryAfterRequestContextCanceled' -count=1`
- `go test ./internal/service -run 'TestValidateSystemSetting|Test.*Setting' -count=1`
- `go test ./internal/executor ./internal/service -count=1`
- `pnpm --dir web typecheck`
- `go test ./...`
- `pnpm --dir web lint`

Closes #512