### PR TITLE
fix(routes): hide disabled routes from docs

### DIFF
--- a/tests/e2e/playwright/documentation-page.spec.ts
+++ b/tests/e2e/playwright/documentation-page.spec.ts
@@ -17,7 +17,10 @@ async function mockDocumentationApis(page: Page) {
     }
 
     if (pathname === '/api/admin/settings' || pathname === '/api/settings') {
-      return json({ api_token_auth_enabled: 'true' });
+      return json({
+        api_token_auth_enabled: 'true',
+        proxy_route_gemini_enabled: 'true',
+      });
     }
 
     if (pathname === '/api/admin/proxy-status' || pathname === '/api/proxy-status') {

--- a/web/e2e/route-exposure-docs-user-panel.spec.ts
+++ b/web/e2e/route-exposure-docs-user-panel.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+async function json(route: Route, body: unknown) {
+  await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+type RouteSettings = Record<string, string>;
+
+const now = new Date().toISOString();
+
+function mockApiToken() {
+  return {
+    apiToken: {
+      id: 1,
+      createdAt: now,
+      updatedAt: now,
+      token: '',
+      tokenPrefix: 'maxx_mock',
+      name: 'User panel token',
+      description: '',
+      projectID: 0,
+      isEnabled: true,
+      devMode: false,
+      useCount: 0,
+    },
+  };
+}
+
+async function installRouteExposureMocks(
+  page: Page,
+  settings: RouteSettings,
+  role: 'admin' | 'user' = 'admin',
+) {
+  const hits: Record<string, number> = {};
+  const track = async (route: Route, key: string, body: unknown) => {
+    hits[key] = (hits[key] || 0) + 1;
+    await json(route, body);
+  };
+
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+
+  // Playwright resolves the latest matching route first, so register the catch-all before
+  // specific routes. Otherwise the fallback masks /api/settings and produces false negatives.
+  await page.route('**/api/**', (route) => track(route, 'fallback', {}));
+  await page.route(/\/api\/admin\/streaming-requests\/counts(?:\?.*)?$/, (route) =>
+    track(route, 'streaming-counts', {}),
+  );
+  await page.route(/\/api\/admin\/requests\/count(?:\?.*)?$/, (route) =>
+    track(route, 'admin-requests-count', 0),
+  );
+  await page.route(/\/api\/admin\/requests(?:\?.*)?$/, (route) =>
+    track(route, 'admin-requests', { items: [], hasMore: false, firstId: null, lastId: null }),
+  );
+  await page.route('**/api/user-panel-token', (route) => track(route, 'user-panel-token', mockApiToken()));
+  await page.route('**/api/routes**', (route) => track(route, 'routes', []));
+  await page.route('**/api/providers**', (route) => track(route, 'providers', []));
+  await page.route('**/api/proxy-status', (route) =>
+    track(route, 'proxy-status', { running: true, address: '127.0.0.1', port: 9880, version: 'e2e' }),
+  );
+  await page.route('**/api/settings', (route) => track(route, 'public-settings', settings));
+  await page.route('**/api/admin/auth/status', (route) =>
+    track(route, 'auth-status', {
+      authEnabled: true,
+      user: { id: 1, username: role === 'admin' ? 'admin' : 'tenant-user', tenantID: 1, role },
+    }),
+  );
+
+  return hits;
+}
+
+async function attachMockEvidence(page: Page, title: string, settings: RouteSettings, hits: Record<string, number>) {
+  await page.evaluate(
+    ({ title, settings, hits }) => {
+      document.querySelector('[data-e2e-mock-evidence]')?.remove();
+      const el = document.createElement('div');
+      el.dataset.e2eMockEvidence = 'true';
+      el.style.cssText = [
+        'position:fixed',
+        'right:16px',
+        'bottom:16px',
+        'z-index:99999',
+        'max-width:430px',
+        'padding:12px',
+        'border-radius:12px',
+        'background:rgba(10,10,10,0.88)',
+        'color:white',
+        'font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace',
+        'box-shadow:0 12px 40px rgba(0,0,0,0.28)',
+        'white-space:pre-wrap',
+      ].join(';');
+      el.textContent = `${title}\nmock /api/settings = ${JSON.stringify(settings)}\nmock hits = ${JSON.stringify(hits)}`;
+      document.body.appendChild(el);
+    },
+    { title, settings, hits },
+  );
+}
+
+const defaultSettings: RouteSettings = {
+  api_token_auth_enabled: 'false',
+  force_project_binding: 'false',
+  ui_multitenant_enabled: 'false',
+  proxy_route_claude_messages_enabled: 'true',
+  proxy_route_openai_chat_enabled: 'true',
+  proxy_route_responses_enabled: 'true',
+  proxy_route_gemini_enabled: 'false',
+};
+
+const filteredSettings: RouteSettings = {
+  api_token_auth_enabled: 'false',
+  force_project_binding: 'false',
+  ui_multitenant_enabled: 'true',
+  ui_multitenant_layout: 'user_panel',
+  proxy_route_claude_messages_enabled: 'false',
+  proxy_route_openai_chat_enabled: 'true',
+  proxy_route_responses_enabled: 'false',
+  proxy_route_gemini_enabled: 'true',
+};
+
+const allOpenAiAndCodexDisabledSettings: RouteSettings = {
+  ...filteredSettings,
+  proxy_route_openai_chat_enabled: 'false',
+  proxy_route_responses_enabled: 'false',
+};
+
+test.use({
+  locale: 'zh-CN',
+  viewport: { width: 1440, height: 1000 },
+  launchOptions: { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || '/usr/bin/google-chrome' },
+});
+
+test.describe('route exposure follows public route settings', () => {
+  test('documentation quickstart tabs hide disabled client routes', async ({ page }, testInfo) => {
+    const defaultHits = await installRouteExposureMocks(page, defaultSettings, 'admin');
+    await page.goto('/documentation');
+    const tabs = page.getByTestId('documentation-quickstart-client-tabs');
+    await expect(tabs).toContainText('Claude');
+    await expect(tabs).toContainText('OpenAI');
+    await expect(tabs).toContainText('Codex');
+    await expect(tabs).not.toContainText('Gemini');
+    await attachMockEvidence(page, 'docs default route exposure', defaultSettings, defaultHits);
+    await page.screenshot({ path: testInfo.outputPath('01-docs-default-routes.png'), fullPage: true });
+
+    const filteredPage = await page.context().newPage();
+    const filteredHits = await installRouteExposureMocks(filteredPage, filteredSettings, 'admin');
+    await filteredPage.goto('/documentation');
+    const filteredTabs = filteredPage.getByTestId('documentation-quickstart-client-tabs');
+    await expect(filteredTabs).not.toContainText('Claude');
+    await expect(filteredTabs).toContainText('OpenAI');
+    await expect(filteredTabs).not.toContainText('Codex');
+    await expect(filteredTabs).toContainText('Gemini');
+    await attachMockEvidence(filteredPage, 'docs filtered route exposure', filteredSettings, filteredHits);
+    await filteredPage.screenshot({ path: testInfo.outputPath('02-docs-filtered-routes.png'), fullPage: true });
+  });
+
+  test('user panel endpoint hints and quickstart follow route exposure settings', async ({ page }, testInfo) => {
+    const hits = await installRouteExposureMocks(page, filteredSettings, 'user');
+    await page.goto('/');
+    await expect(page.getByText('OpenAI / Codex')).toBeVisible();
+    await expect(page.getByText('Gemini')).toBeVisible();
+    await expect(page.getByText('Claude')).not.toBeVisible();
+    await expect(page.getByText('/v1beta/models/{model}:generateContent')).toBeVisible();
+    await expect(page.getByText('/v1/chat/completions')).toBeVisible();
+    await attachMockEvidence(page, 'user panel filtered route exposure', filteredSettings, hits);
+    await page.screenshot({ path: testInfo.outputPath('03-user-panel-filtered-endpoints.png'), fullPage: true });
+
+    const disabledPage = await page.context().newPage();
+    const disabledHits = await installRouteExposureMocks(disabledPage, allOpenAiAndCodexDisabledSettings, 'user');
+    await disabledPage.goto('/');
+    await expect(disabledPage.getByText('OpenAI / Codex')).not.toBeVisible();
+    await expect(disabledPage.getByText('/v1/chat/completions')).not.toBeVisible();
+    await expect(disabledPage.getByText('Gemini')).toBeVisible();
+    await attachMockEvidence(
+      disabledPage,
+      'user panel OpenAI and Codex disabled',
+      allOpenAiAndCodexDisabledSettings,
+      disabledHits,
+    );
+    await disabledPage.screenshot({ path: testInfo.outputPath('04-user-panel-openai-codex-disabled.png'), fullPage: true });
+  });
+});

--- a/web/e2e/route-exposure-docs-user-panel.spec.ts
+++ b/web/e2e/route-exposure-docs-user-panel.spec.ts
@@ -125,6 +125,14 @@ const allOpenAiAndCodexDisabledSettings: RouteSettings = {
   proxy_route_responses_enabled: 'false',
 };
 
+const allRoutesDisabledSettings: RouteSettings = {
+  ...filteredSettings,
+  proxy_route_claude_messages_enabled: 'false',
+  proxy_route_openai_chat_enabled: 'false',
+  proxy_route_responses_enabled: 'false',
+  proxy_route_gemini_enabled: 'false',
+};
+
 test.use({
   locale: 'zh-CN',
   viewport: { width: 1440, height: 1000 },
@@ -153,6 +161,21 @@ test.describe('route exposure follows public route settings', () => {
     await expect(filteredTabs).toContainText('Gemini');
     await attachMockEvidence(filteredPage, 'docs filtered route exposure', filteredSettings, filteredHits);
     await filteredPage.screenshot({ path: testInfo.outputPath('02-docs-filtered-routes.png'), fullPage: true });
+
+    const disabledPage = await page.context().newPage();
+    const disabledHits = await installRouteExposureMocks(disabledPage, allRoutesDisabledSettings, 'admin');
+    await disabledPage.goto('/documentation');
+    const disabledTabs = disabledPage.getByTestId('documentation-quickstart-client-tabs');
+    await expect(disabledTabs).not.toContainText('Claude');
+    await expect(disabledTabs).not.toContainText('OpenAI');
+    await expect(disabledTabs).not.toContainText('Codex');
+    await expect(disabledTabs).not.toContainText('Gemini');
+    await expect(disabledPage.getByTestId('documentation-quickstart-no-clients')).toBeVisible();
+    await expect(disabledPage.getByTestId('documentation-quickstart-content')).not.toContainText(
+      'settings.json',
+    );
+    await attachMockEvidence(disabledPage, 'docs all routes disabled', allRoutesDisabledSettings, disabledHits);
+    await disabledPage.screenshot({ path: testInfo.outputPath('03-docs-all-routes-disabled.png'), fullPage: true });
   });
 
   test('user panel endpoint hints and quickstart follow route exposure settings', async ({ page }, testInfo) => {

--- a/web/src/components/layout/app-sidebar/client-routes-items.tsx
+++ b/web/src/components/layout/app-sidebar/client-routes-items.tsx
@@ -7,25 +7,8 @@ import {
 import { usePublicSettings } from '@/hooks/queries/use-settings';
 import { useStreamingRequests } from '@/hooks/use-streaming';
 import type { ClientType } from '@/lib/transport';
+import { getVisibleProxyRouteClients } from '@/lib/proxy-route-exposure';
 import { AnimatedNavItem } from './animated-nav-item';
-
-const clientRouteSettingKeys: Record<ClientType, string> = {
-  claude: 'proxy_route_claude_messages_enabled',
-  openai: 'proxy_route_openai_chat_enabled',
-  codex: 'proxy_route_responses_enabled',
-  gemini: 'proxy_route_gemini_enabled',
-};
-
-function isClientRouteVisible(
-  settings: Record<string, string> | undefined,
-  clientType: ClientType,
-) {
-  const settingValue = settings?.[clientRouteSettingKeys[clientType]];
-  if (settingValue === undefined) {
-    return clientType !== 'gemini';
-  }
-  return settingValue !== 'false';
-}
 
 function ClientNavItem({
   clientType,
@@ -56,9 +39,7 @@ function ClientNavItem({
 export function ClientRoutesItems() {
   const { countsByClient } = useStreamingRequests();
   const { data: publicSettings } = usePublicSettings();
-  const visibleClientTypes = allClientTypes.filter((clientType) =>
-    isClientRouteVisible(publicSettings, clientType),
-  );
+  const visibleClientTypes = getVisibleProxyRouteClients(publicSettings, allClientTypes);
 
   return (
     <>

--- a/web/src/lib/proxy-route-exposure.test.ts
+++ b/web/src/lib/proxy-route-exposure.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleProxyRouteClients, isProxyRouteVisible } from './proxy-route-exposure';
+
+describe('proxy route exposure visibility', () => {
+  it('uses production route defaults when settings are absent', () => {
+    expect(isProxyRouteVisible(undefined, 'claude')).toBe(true);
+    expect(isProxyRouteVisible(undefined, 'openai')).toBe(true);
+    expect(isProxyRouteVisible(undefined, 'codex')).toBe(true);
+    expect(isProxyRouteVisible(undefined, 'gemini')).toBe(false);
+  });
+
+  it('hides only routes explicitly set to false', () => {
+    const settings = {
+      proxy_route_claude_messages_enabled: 'false',
+      proxy_route_openai_chat_enabled: 'true',
+      proxy_route_responses_enabled: 'false',
+      proxy_route_gemini_enabled: 'true',
+    };
+
+    expect(isProxyRouteVisible(settings, 'claude')).toBe(false);
+    expect(isProxyRouteVisible(settings, 'openai')).toBe(true);
+    expect(isProxyRouteVisible(settings, 'codex')).toBe(false);
+    expect(isProxyRouteVisible(settings, 'gemini')).toBe(true);
+  });
+
+  it('filters client lists with the same visibility rules', () => {
+    expect(
+      getVisibleProxyRouteClients(
+        {
+          proxy_route_openai_chat_enabled: 'false',
+          proxy_route_gemini_enabled: 'true',
+        },
+        ['claude', 'openai', 'codex', 'gemini'],
+      ),
+    ).toEqual(['claude', 'codex', 'gemini']);
+  });
+});

--- a/web/src/lib/proxy-route-exposure.ts
+++ b/web/src/lib/proxy-route-exposure.ts
@@ -1,0 +1,26 @@
+import type { ClientType } from '@/lib/transport';
+
+export const proxyRouteExposureSettingKeys: Record<ClientType, string> = {
+  claude: 'proxy_route_claude_messages_enabled',
+  openai: 'proxy_route_openai_chat_enabled',
+  codex: 'proxy_route_responses_enabled',
+  gemini: 'proxy_route_gemini_enabled',
+};
+
+export function isProxyRouteVisible(
+  settings: Record<string, string> | undefined,
+  clientType: ClientType,
+): boolean {
+  const settingValue = settings?.[proxyRouteExposureSettingKeys[clientType]];
+  if (settingValue === undefined) {
+    return clientType !== 'gemini';
+  }
+  return settingValue !== 'false';
+}
+
+export function getVisibleProxyRouteClients(
+  settings: Record<string, string> | undefined,
+  clientTypes: readonly ClientType[],
+): ClientType[] {
+  return clientTypes.filter((clientType) => isProxyRouteVisible(settings, clientType));
+}

--- a/web/src/lib/user-panel-endpoints.test.ts
+++ b/web/src/lib/user-panel-endpoints.test.ts
@@ -12,10 +12,6 @@ describe('user panel endpoints', () => {
     expect(endpoints).toEqual([
       { id: 'openai-codex', url: 'https://maxx.example.com/v1' },
       { id: 'claude', url: 'https://maxx.example.com' },
-      {
-        id: 'gemini',
-        url: 'https://maxx.example.com/v1beta/models/{model}:generateContent',
-      },
     ]);
   });
 
@@ -29,5 +25,31 @@ describe('user panel endpoints', () => {
     expect(example).toContain('https://maxx.example.com/v1/chat/completions');
     expect(example).not.toContain('/project/');
     expect(example).not.toContain('Authorization: Bearer');
+  });
+
+  it('filters endpoint hints by public route exposure settings', () => {
+    expect(
+      buildUserPanelEndpointHints('https://maxx.example.com', {
+        proxy_route_claude_messages_enabled: 'false',
+        proxy_route_openai_chat_enabled: 'false',
+        proxy_route_responses_enabled: 'true',
+        proxy_route_gemini_enabled: 'true',
+      }),
+    ).toEqual([
+      { id: 'openai-codex', url: 'https://maxx.example.com/v1' },
+      {
+        id: 'gemini',
+        url: 'https://maxx.example.com/v1beta/models/{model}:generateContent',
+      },
+    ]);
+  });
+
+  it('hides the combined OpenAI / Codex endpoint only when both routes are disabled', () => {
+    expect(
+      buildUserPanelEndpointHints('https://maxx.example.com', {
+        proxy_route_openai_chat_enabled: 'false',
+        proxy_route_responses_enabled: 'false',
+      }).map((endpoint) => endpoint.id),
+    ).toEqual(['claude']);
   });
 });

--- a/web/src/lib/user-panel-endpoints.ts
+++ b/web/src/lib/user-panel-endpoints.ts
@@ -1,3 +1,5 @@
+import { isProxyRouteVisible } from '@/lib/proxy-route-exposure';
+
 export interface UserPanelEndpointHint {
   id: 'openai-codex' | 'claude' | 'gemini';
   url: string;
@@ -7,14 +9,24 @@ function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, '');
 }
 
-export function buildUserPanelEndpointHints(origin: string): UserPanelEndpointHint[] {
+export function buildUserPanelEndpointHints(
+  origin: string,
+  settings?: Record<string, string>,
+): UserPanelEndpointHint[] {
   const baseUrl = trimTrailingSlash(origin);
+  const endpoints: UserPanelEndpointHint[] = [];
 
-  return [
-    { id: 'openai-codex', url: `${baseUrl}/v1` },
-    { id: 'claude', url: baseUrl },
-    { id: 'gemini', url: `${baseUrl}/v1beta/models/{model}:generateContent` },
-  ];
+  if (isProxyRouteVisible(settings, 'openai') || isProxyRouteVisible(settings, 'codex')) {
+    endpoints.push({ id: 'openai-codex', url: `${baseUrl}/v1` });
+  }
+  if (isProxyRouteVisible(settings, 'claude')) {
+    endpoints.push({ id: 'claude', url: baseUrl });
+  }
+  if (isProxyRouteVisible(settings, 'gemini')) {
+    endpoints.push({ id: 'gemini', url: `${baseUrl}/v1beta/models/{model}:generateContent` });
+  }
+
+  return endpoints;
 }
 
 export function buildUserPanelChatCompletionsExample(params: { origin: string }): string {

--- a/web/src/pages/documentation/index.tsx
+++ b/web/src/pages/documentation/index.tsx
@@ -26,6 +26,8 @@ import { ClientIcon } from '@/components/icons/client-icons';
 import { PageHeader } from '@/components/layout/page-header';
 import { useProxyStatus, useProviders, usePublicSettings, useRoutes } from '@/hooks/queries';
 import { buildCodexConfigBundle, buildProxyBaseUrl } from '@/lib/codex-config';
+import { getVisibleProxyRouteClients } from '@/lib/proxy-route-exposure';
+import type { ClientType } from '@/lib/transport';
 
 interface CodeBlockProps {
   code: string;
@@ -54,8 +56,28 @@ function CodeBlock({ code, id, copiedCode, onCopy }: CodeBlockProps) {
   );
 }
 
-type QuickstartClient = 'claude' | 'openai' | 'codex' | 'gemini';
+type QuickstartClient = ClientType;
 type DocumentationPageTab = 'quickstart' | 'diagnostics';
+
+export const QUICKSTART_CLIENTS = [
+  'claude',
+  'openai',
+  'codex',
+  'gemini',
+] as const satisfies readonly QuickstartClient[];
+
+export function getVisibleQuickstartClients(
+  settings: Record<string, string> | undefined,
+): QuickstartClient[] {
+  return getVisibleProxyRouteClients(settings, QUICKSTART_CLIENTS);
+}
+
+export function resolveVisibleQuickstartClient(
+  current: QuickstartClient,
+  visibleClients: readonly QuickstartClient[],
+): QuickstartClient {
+  return visibleClients.includes(current) ? current : visibleClients[0] || 'claude';
+}
 
 interface QuickstartBundle {
   primaryLabel: string;
@@ -186,16 +208,27 @@ function DocumentationSection() {
   const { data: routes } = useRoutes();
   const baseUrl = buildProxyBaseUrl(proxyStatus);
   const tokenAuthEnabled = settings?.api_token_auth_enabled === 'true';
+  const visibleQuickstartClients = useMemo(() => getVisibleQuickstartClients(settings), [settings]);
+  const resolvedQuickstartClient = resolveVisibleQuickstartClient(
+    quickstartClient,
+    visibleQuickstartClients,
+  );
+
+  useEffect(() => {
+    if (resolvedQuickstartClient !== quickstartClient) {
+      setQuickstartClient(resolvedQuickstartClient);
+    }
+  }, [quickstartClient, resolvedQuickstartClient]);
 
   const quickstartBundle = useMemo(
     () =>
       buildQuickstartBundle({
-        client: quickstartClient,
+        client: resolvedQuickstartClient,
         token: quickstartToken.trim(),
         baseUrl,
         projectSlug: quickstartProjectSlug,
       }),
-    [quickstartClient, quickstartToken, baseUrl, quickstartProjectSlug],
+    [resolvedQuickstartClient, quickstartToken, baseUrl, quickstartProjectSlug],
   );
 
   const tokenFormatOk =
@@ -391,36 +424,33 @@ function DocumentationSection() {
             </div>
 
             <Tabs
-              value={quickstartClient}
+              value={resolvedQuickstartClient}
               onValueChange={handleQuickstartClientChange}
               data-testid="documentation-quickstart-client-tabs"
               className="w-full"
             >
-              <TabsList className="grid w-full grid-cols-4 h-12 p-1 bg-muted">
-                <TabsTrigger value="claude">
-                  <div className="flex items-center justify-center gap-2">
-                    <ClientIcon type="claude" size={16} className="shrink-0" />
-                    <span className="leading-none">Claude</span>
-                  </div>
-                </TabsTrigger>
-                <TabsTrigger value="openai">
-                  <div className="flex items-center justify-center gap-2">
-                    <ClientIcon type="openai" size={16} className="shrink-0" />
-                    <span className="leading-none">OpenAI</span>
-                  </div>
-                </TabsTrigger>
-                <TabsTrigger value="codex">
-                  <div className="flex items-center justify-center gap-2">
-                    <ClientIcon type="codex" size={16} className="shrink-0" />
-                    <span className="leading-none">Codex</span>
-                  </div>
-                </TabsTrigger>
-                <TabsTrigger value="gemini">
-                  <div className="flex items-center justify-center gap-2">
-                    <ClientIcon type="gemini" size={16} className="shrink-0" />
-                    <span className="leading-none">Gemini</span>
-                  </div>
-                </TabsTrigger>
+              <TabsList
+                className="grid w-full h-12 p-1 bg-muted"
+                style={{
+                  gridTemplateColumns: `repeat(${visibleQuickstartClients.length || 1}, minmax(0, 1fr))`,
+                }}
+              >
+                {visibleQuickstartClients.map((clientType) => (
+                  <TabsTrigger key={clientType} value={clientType}>
+                    <div className="flex items-center justify-center gap-2">
+                      <ClientIcon type={clientType} size={16} className="shrink-0" />
+                      <span className="leading-none">
+                        {clientType === 'openai'
+                          ? 'OpenAI'
+                          : clientType === 'codex'
+                            ? 'Codex'
+                            : clientType === 'claude'
+                              ? 'Claude'
+                              : 'Gemini'}
+                      </span>
+                    </div>
+                  </TabsTrigger>
+                ))}
               </TabsList>
             </Tabs>
 
@@ -462,7 +492,7 @@ function DocumentationSection() {
               </div>
               <CodeBlock
                 code={quickstartBundle.oneliner}
-                id={`quickstart-${quickstartClient}-oneliner`}
+                id={`quickstart-${resolvedQuickstartClient}-oneliner`}
                 copiedCode={copiedCode}
                 onCopy={copyToClipboard}
               />
@@ -473,17 +503,17 @@ function DocumentationSection() {
                 <h3 className="text-sm font-semibold">{t('documentation.wizardGenerated')}</h3>
                 <Badge variant="outline">{quickstartBundle.primaryLabel}</Badge>
               </div>
-              {quickstartClient === 'claude' && (
+              {resolvedQuickstartClient === 'claude' && (
                 <p className="text-xs text-muted-foreground">
                   {t('documentation.settingsJsonDesc')}
                 </p>
               )}
-              {quickstartClient === 'codex' && (
+              {resolvedQuickstartClient === 'codex' && (
                 <p className="text-xs text-muted-foreground">{t('documentation.configTomlDesc')}</p>
               )}
               <CodeBlock
                 code={quickstartBundle.primaryCode}
-                id={`quickstart-${quickstartClient}-primary`}
+                id={`quickstart-${resolvedQuickstartClient}-primary`}
                 copiedCode={copiedCode}
                 onCopy={copyToClipboard}
               />
@@ -495,12 +525,12 @@ function DocumentationSection() {
                   <h3 className="text-sm font-semibold">{t('documentation.wizardGenerated')}</h3>
                   <Badge variant="outline">{quickstartBundle.secondaryLabel}</Badge>
                 </div>
-                {quickstartClient === 'codex' && (
+                {resolvedQuickstartClient === 'codex' && (
                   <p className="text-xs text-muted-foreground">{t('documentation.authJsonDesc')}</p>
                 )}
                 <CodeBlock
                   code={quickstartBundle.secondaryCode}
-                  id={`quickstart-${quickstartClient}-secondary`}
+                  id={`quickstart-${resolvedQuickstartClient}-secondary`}
                   copiedCode={copiedCode}
                   onCopy={copyToClipboard}
                 />
@@ -508,7 +538,7 @@ function DocumentationSection() {
             )}
 
             {/* Claude: shell function alternative */}
-            {quickstartClient === 'claude' && (
+            {resolvedQuickstartClient === 'claude' && (
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
                   <Terminal className="h-4 w-4 text-muted-foreground" />
@@ -531,7 +561,7 @@ function DocumentationSection() {
             )}
 
             {/* OpenAI / Gemini: project proxy endpoint */}
-            {(quickstartClient === 'openai' || quickstartClient === 'gemini') && (
+            {(resolvedQuickstartClient === 'openai' || resolvedQuickstartClient === 'gemini') && (
               <div className="space-y-3">
                 <h3 className="text-sm font-semibold">{t('documentation.projectProxy')}</h3>
                 <p className="text-xs text-muted-foreground">
@@ -539,11 +569,11 @@ function DocumentationSection() {
                 </p>
                 <CodeBlock
                   code={
-                    quickstartClient === 'openai'
+                    resolvedQuickstartClient === 'openai'
                       ? `POST ${baseUrl}/project/{project-slug}/v1/chat/completions`
                       : `POST ${baseUrl}/project/{project-slug}/v1beta/models/{model}:generateContent`
                   }
-                  id={`quickstart-${quickstartClient}-project-proxy`}
+                  id={`quickstart-${resolvedQuickstartClient}-project-proxy`}
                   copiedCode={copiedCode}
                   onCopy={copyToClipboard}
                 />
@@ -554,7 +584,7 @@ function DocumentationSection() {
               <h3 className="text-sm font-semibold">{t('documentation.wizardVerify')}</h3>
               <CodeBlock
                 code={quickstartBundle.verifyCode}
-                id={`quickstart-${quickstartClient}-verify`}
+                id={`quickstart-${resolvedQuickstartClient}-verify`}
                 copiedCode={copiedCode}
                 onCopy={copyToClipboard}
               />

--- a/web/src/pages/documentation/index.tsx
+++ b/web/src/pages/documentation/index.tsx
@@ -454,7 +454,16 @@ function DocumentationSection() {
               </TabsList>
             </Tabs>
 
-            <div className="grid gap-3 md:grid-cols-2">
+            {visibleQuickstartClients.length === 0 ? (
+              <div
+                data-testid="documentation-quickstart-no-clients"
+                className="rounded-md border border-border/70 bg-muted/20 p-4 text-sm text-muted-foreground"
+              >
+                No enabled client routes are available for quick start.
+              </div>
+            ) : (
+              <>
+                <div className="grid gap-3 md:grid-cols-2">
               <div className="space-y-2">
                 <label className="text-xs font-semibold">
                   {t('documentation.tokenInputLabel')}
@@ -623,18 +632,20 @@ function DocumentationSection() {
               </div>
             </div>
 
-            <div className="flex flex-col gap-3 rounded-md border border-cyan-500/20 bg-cyan-500/5 p-4 md:flex-row md:items-center md:justify-between">
-              <p className="text-xs leading-5 text-cyan-700 dark:text-cyan-300">
-                {t('documentation.quickStartDiagnosticHint')}
-              </p>
-              <Button
-                variant="outline"
-                data-testid="documentation-open-diagnostics-button"
-                onClick={() => setActiveTab('diagnostics')}
-              >
-                {t('documentation.quickStartDiagnosticAction')}
-              </Button>
-            </div>
+                <div className="flex flex-col gap-3 rounded-md border border-cyan-500/20 bg-cyan-500/5 p-4 md:flex-row md:items-center md:justify-between">
+                  <p className="text-xs leading-5 text-cyan-700 dark:text-cyan-300">
+                    {t('documentation.quickStartDiagnosticHint')}
+                  </p>
+                  <Button
+                    variant="outline"
+                    data-testid="documentation-open-diagnostics-button"
+                    onClick={() => setActiveTab('diagnostics')}
+                  >
+                    {t('documentation.quickStartDiagnosticAction')}
+                  </Button>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
       </TabsContent>

--- a/web/src/pages/documentation/route-exposure.test.ts
+++ b/web/src/pages/documentation/route-exposure.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleQuickstartClients, resolveVisibleQuickstartClient } from '../documentation';
+
+describe('documentation quickstart route exposure', () => {
+  it('hides disabled quickstart client tabs using public route settings', () => {
+    expect(
+      getVisibleQuickstartClients({
+        proxy_route_claude_messages_enabled: 'false',
+        proxy_route_openai_chat_enabled: 'true',
+        proxy_route_responses_enabled: 'false',
+        proxy_route_gemini_enabled: 'true',
+      }),
+    ).toEqual(['openai', 'gemini']);
+  });
+
+  it('falls back when the active quickstart tab is no longer visible', () => {
+    expect(resolveVisibleQuickstartClient('claude', ['openai', 'codex'])).toBe('openai');
+    expect(resolveVisibleQuickstartClient('codex', ['openai', 'codex'])).toBe('codex');
+  });
+});

--- a/web/src/pages/documentation/route-exposure.test.ts
+++ b/web/src/pages/documentation/route-exposure.test.ts
@@ -18,4 +18,15 @@ describe('documentation quickstart route exposure', () => {
     expect(resolveVisibleQuickstartClient('claude', ['openai', 'codex'])).toBe('openai');
     expect(resolveVisibleQuickstartClient('codex', ['openai', 'codex'])).toBe('codex');
   });
+
+  it('supports the all-disabled route exposure state', () => {
+    expect(
+      getVisibleQuickstartClients({
+        proxy_route_claude_messages_enabled: 'false',
+        proxy_route_openai_chat_enabled: 'false',
+        proxy_route_responses_enabled: 'false',
+        proxy_route_gemini_enabled: 'false',
+      }),
+    ).toEqual([]);
+  });
 });

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -24,8 +24,10 @@ import {
   useRegenerateUserPanelAPIToken,
   useUserPanelAPIToken,
   useProxyRequestUpdates,
+  usePublicSettings,
 } from '@/hooks/queries';
 import type { APIToken, ProxyRequest } from '@/lib/transport';
+import { isProxyRouteVisible } from '@/lib/proxy-route-exposure';
 import {
   buildUserPanelChatCompletionsExample,
   buildUserPanelEndpointHints,
@@ -168,6 +170,7 @@ export function UserPanelPage() {
   const { logout, user } = useAuth();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
   const { data: userPanelRequests } = useProxyRequests({ limit: 25 });
+  const { data: publicSettings } = usePublicSettings();
   useProxyRequestUpdates();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
@@ -195,7 +198,7 @@ export function UserPanelPage() {
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const maskedUserPanelToken = userPanelToken?.tokenPrefix || 'maxx_••••';
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
-  const endpointHints = buildUserPanelEndpointHints(origin).map((endpoint) => ({
+  const endpointHints = buildUserPanelEndpointHints(origin, publicSettings).map((endpoint) => ({
     ...endpoint,
     label:
       endpoint.id === 'openai-codex'
@@ -204,7 +207,10 @@ export function UserPanelPage() {
           ? t('userPanel.routeClaude')
           : t('userPanel.routeGemini'),
   }));
-  const curlExample = buildUserPanelChatCompletionsExample({ origin });
+  const showChatCompletionsExample = isProxyRouteVisible(publicSettings, 'openai');
+  const curlExample = showChatCompletionsExample
+    ? buildUserPanelChatCompletionsExample({ origin })
+    : '';
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -448,25 +454,27 @@ export function UserPanelPage() {
                     ))}
                   </div>
                 </div>
-                <div className="rounded-xl border border-border bg-muted/25 p-4">
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {t('userPanel.quickStart')}
-                    </p>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-8 gap-2"
-                      onClick={handleCopyExample}
-                    >
-                      <Copy className="size-3.5" />
-                      {exampleCopied ? t('common.copied') : t('common.copy')}
-                    </Button>
+                {showChatCompletionsExample && (
+                  <div className="rounded-xl border border-border bg-muted/25 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {t('userPanel.quickStart')}
+                      </p>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8 gap-2"
+                        onClick={handleCopyExample}
+                      >
+                        <Copy className="size-3.5" />
+                        {exampleCopied ? t('common.copied') : t('common.copy')}
+                      </Button>
+                    </div>
+                    <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
+                      <code>{curlExample}</code>
+                    </pre>
                   </div>
-                  <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                    <code>{curlExample}</code>
-                  </pre>
-                </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- centralize proxy route exposure visibility for client route UI surfaces
- hide disabled client routes from Documentation quickstart tabs
- filter User Panel endpoint hints and quickstart example from the same public route settings
- add unit and Playwright E2E coverage for route exposure UI flows

## Validation
- `pnpm test` — 20 files / 92 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm build` — passed; existing chunk size warning only
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome pnpm exec playwright test e2e/route-exposure-docs-user-panel.spec.ts --project=chromium` — 2 tests passed

## E2E evidence
The Playwright route exposure test mocks auth, public settings, proxy status, providers, routes, user panel token, and request endpoints. Screenshots include an in-page mock evidence overlay with `/api/settings` payload and mock hit counts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 文档 Quickstart 标签页现在会根据公开路由设置动态显示可用客户端。
  - 用户面板会仅展示当前启用的模型入口和 API 端点提示。
  - 当已选客户端不可用时，页面会自动切换到可用选项。

- **问题修复**
  - 路由关闭后，相关 Quickstart 示例和入口不再继续显示。
  - 优化 OpenAI、Codex、Claude 与 Gemini 路由可见性的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->