### PR TITLE
fix(codex): filter Responses Lite internal header

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -1107,6 +1107,10 @@ var codexFilteredHeaders = map[string]bool{
 	// Explicitly controlled headers
 	"user-agent": true,
 
+	// Client-to-proxy hint consumed by Codex-compatible gateways. Forwarding it
+	// to the upstream Responses endpoint conflicts with parallel_tool_calls=true.
+	"x-openai-internal-codex-responses-lite": true,
+
 	// Proxy/forwarding headers (privacy protection)
 	"x-forwarded-for":    true,
 	"x-forwarded-host":   true,

--- a/internal/adapter/provider/codex/adapter_test.go
+++ b/internal/adapter/provider/codex/adapter_test.go
@@ -114,6 +114,7 @@ func TestApplyCodexHeadersFiltersSensitiveAndPreservesUA(t *testing.T) {
 	clientReq.Header.Set("X-Forwarded-For", "1.2.3.4")
 	clientReq.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")
 	clientReq.Header.Set("X-Request-Id", "rid-1")
+	clientReq.Header.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
 	clientReq.Header.Set("X-Custom", "ok")
 
 	a.applyCodexHeaders(upstreamReq, clientReq, "token-1", "acct-1", true, "")
@@ -126,6 +127,9 @@ func TestApplyCodexHeadersFiltersSensitiveAndPreservesUA(t *testing.T) {
 	}
 	if got := upstreamReq.Header.Get("X-Request-Id"); got != "" {
 		t.Fatalf("expected X-Request-Id filtered, got %q", got)
+	}
+	if got := upstreamReq.Header.Get("X-OpenAI-Internal-Codex-Responses-Lite"); got != "" {
+		t.Fatalf("expected Codex Responses Lite header filtered, got %q", got)
 	}
 	if got := upstreamReq.Header.Get("User-Agent"); got != "codex-cli/1.2.3" {
 		t.Fatalf("expected User-Agent passthrough, got %q", got)

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -129,6 +129,17 @@ func TestExecuteResponsesWebSocket_SkipsProtocolConversion(t *testing.T) {
 	}
 }
 
+func TestBuildCodexWebSocketHeadersFiltersResponsesLite(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	request.Header.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
+	c := flow.NewCtx(httptest.NewRecorder(), request)
+
+	headers := buildCodexWebSocketHeaders(c, "test-token", "", nil)
+	if got := headers.Get("X-OpenAI-Internal-Codex-Responses-Lite"); got != "" {
+		t.Fatalf("Codex Responses Lite header = %q, want filtered", got)
+	}
+}
+
 func newCodexWebSocketTestContext(t *testing.T, raw []byte, sessionID string) *flow.Ctx {
 	t.Helper()
 	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)


### PR DESCRIPTION
## Summary

- filter the client-only `X-OpenAI-Internal-Codex-Responses-Lite` header before forwarding Codex HTTP requests
- apply the same filter to Codex Responses WebSocket handshakes through the shared header policy
- preserve `parallel_tool_calls=true` instead of disabling parallel tool calls

## Root cause

MAXX's direct Codex adapter forwarded the internal Responses Lite hint to the upstream endpoint. When the request body retained `parallel_tool_calls=true`, upstream rejected the request with:

`X-OpenAI-Internal-Codex-Responses-Lite requires parallel_tool_calls to be false`

The bundled CPA path does not forward this internal header. This change aligns the direct adapter with that protocol boundary.

## Tests

- `go test ./internal/adapter/provider/codex`
- `go test ./internal/adapter/provider/...`
- `go test ./internal/converter`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化 Codex 请求头处理，避免内部提示头被转发至上游服务。
  * 提升并行工具调用场景下的请求兼容性与稳定性。

* **测试**
  * 增加对普通请求和 WebSocket 请求头过滤行为的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->