### PR TITLE
feat(providers): prepend runtime models to mapping targets

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1,10 +1,14 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -177,6 +181,10 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 		h.handleBedrockDiscoveredModels(w, r, id)
 		return
 	}
+	if id > 0 && strings.HasSuffix(path, "/runtime-models") {
+		h.handleProviderRuntimeModels(w, r, id)
+		return
+	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
 
@@ -248,6 +256,155 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+type providerRuntimeModelsResult struct {
+	Available bool     `json:"available"`
+	Models    []string `json:"models"`
+	Source    string   `json:"source,omitempty"`
+	Error     string   `json:"error,omitempty"`
+}
+
+func (h *AdminHandler) handleProviderRuntimeModels(w http.ResponseWriter, r *http.Request, id uint64) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	provider, err := h.svc.GetProvider(tenantID, id)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "provider not found"})
+		return
+	}
+
+	result := h.fetchProviderRuntimeModels(r, provider)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (h *AdminHandler) fetchProviderRuntimeModels(r *http.Request, provider *domain.Provider) providerRuntimeModelsResult {
+	if provider == nil || provider.Config == nil {
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "provider config unavailable"}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(provider.Type)) {
+	case "bedrock":
+		adapter, ok := h.svc.GetProviderAdapter(provider.ID)
+		if !ok {
+			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "bedrock adapter unavailable"}
+		}
+		bedrockA, ok := adapter.(*bedrock.BedrockAdapter)
+		if !ok {
+			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "bedrock adapter unavailable"}
+		}
+		discovered := bedrockA.DiscoveredModels(r.Context(), true)
+		models := make([]string, 0, len(discovered.Models))
+		for _, model := range discovered.Models {
+			models = append(models, model.ShortName)
+		}
+		return providerRuntimeModelsResult{Available: discovered.Available, Models: uniqueSortedStrings(models), Source: "bedrock"}
+	case "openrouter":
+		if provider.Config.OpenRouter == nil || strings.TrimSpace(provider.Config.OpenRouter.APIKey) == "" {
+			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "openrouter api key unavailable"}
+		}
+		return fetchOpenAICompatibleModels(r, "https://openrouter.ai/api/v1/models", provider.Config.OpenRouter.APIKey, "openrouter")
+	case "custom":
+		if provider.Config.Custom == nil || strings.TrimSpace(provider.Config.Custom.BaseURL) == "" {
+			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "custom provider base url unavailable"}
+		}
+		modelsURL, err := providerModelsURL(provider.Config.Custom.BaseURL)
+		if err != nil {
+			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: err.Error()}
+		}
+		return fetchOpenAICompatibleModels(r, modelsURL, provider.Config.Custom.APIKey, "custom")
+	default:
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "provider runtime model discovery unsupported"}
+	}
+}
+
+func providerModelsURL(baseURL string) (string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return "", fmt.Errorf("provider base url unavailable")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid provider base url")
+	}
+	if strings.HasSuffix(parsed.Path, "/v1") {
+		return baseURL + "/models", nil
+	}
+	return baseURL + "/v1/models", nil
+}
+
+func fetchOpenAICompatibleModels(r *http.Request, modelsURL string, apiKey string, source string) providerRuntimeModelsResult {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "build models request failed"}
+	}
+	if strings.TrimSpace(apiKey) != "" {
+		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "fetch provider models failed: " + err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: fmt.Sprintf("fetch provider models failed: upstream status %d", resp.StatusCode)}
+	}
+
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+		Models []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "decode provider models failed"}
+	}
+
+	models := make([]string, 0, len(payload.Data)+len(payload.Models))
+	for _, model := range payload.Data {
+		models = append(models, model.ID)
+	}
+	for _, model := range payload.Models {
+		if model.ID != "" {
+			models = append(models, model.ID)
+		} else {
+			models = append(models, model.Name)
+		}
+	}
+	models = uniqueSortedStrings(models)
+	return providerRuntimeModelsResult{Available: len(models) > 0, Models: models, Source: source}
+}
+
+func uniqueSortedStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func bulkDeleteErrorStatus(err error) int {

--- a/web/src/components/ui/model-input.test.ts
+++ b/web/src/components/ui/model-input.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildModelOptions } from './model-input';
+
+describe('buildModelOptions', () => {
+  it('prepends runtime provider models before built-in presets', () => {
+    const options = buildModelOptions([
+      { id: 'provider-live-alpha', name: 'provider-live-alpha', provider: 'Current provider models' },
+      { id: 'provider-live-beta', name: 'provider-live-beta', provider: 'Current provider models' },
+    ]);
+
+    expect(options.slice(0, 2).map((model) => model.id)).toEqual([
+      'provider-live-alpha',
+      'provider-live-beta',
+    ]);
+    expect(options[2].id).toBe('*claude*');
+  });
+
+  it('does not duplicate a preset when a runtime provider model has the same id', () => {
+    const options = buildModelOptions([
+      { id: 'gpt-4o', name: 'Runtime GPT-4o', provider: 'Current provider models' },
+    ]);
+
+    expect(options[0]).toMatchObject({ id: 'gpt-4o', provider: 'Current provider models' });
+    expect(options.filter((model) => model.id === 'gpt-4o')).toHaveLength(1);
+  });
+});

--- a/web/src/components/ui/model-input.tsx
+++ b/web/src/components/ui/model-input.tsx
@@ -142,6 +142,25 @@ const COMMON_MODELS = [
 type Model = (typeof COMMON_MODELS)[number];
 type Provider = Model['provider'];
 
+export interface ModelInputOption {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+export function buildModelOptions(
+  extraModels: ModelInputOption[] = [],
+  providers?: Provider[],
+): ModelInputOption[] {
+  const extraIDs = new Set(extraModels.map((model) => model.id));
+  const presets = (!providers || providers.length === 0
+    ? COMMON_MODELS
+    : COMMON_MODELS.filter((model) => providers.includes(model.provider))
+  ).filter((model) => !extraIDs.has(model.id));
+
+  return [...extraModels, ...presets];
+}
+
 interface ModelInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -150,6 +169,8 @@ interface ModelInputProps {
   className?: string;
   /** Filter to only show models from specific providers */
   providers?: Provider[];
+  /** Dynamic candidates prepended before the built-in presets. Presets themselves stay unchanged. */
+  extraModels?: ModelInputOption[];
 }
 
 // 简单的模糊匹配函数
@@ -171,7 +192,7 @@ function fuzzyMatch(text: string, pattern: string): boolean {
 }
 
 // 计算匹配分数（用于排序）
-function matchScore(model: Model, pattern: string): number {
+function matchScore(model: ModelInputOption, pattern: string): number {
   const lowerPattern = pattern.toLowerCase();
   const lowerId = model.id.toLowerCase();
   const lowerName = model.name.toLowerCase();
@@ -196,6 +217,7 @@ export function ModelInput({
   disabled = false,
   className,
   providers,
+  extraModels,
 }: ModelInputProps) {
   const { t } = useTranslation();
   const actualPlaceholder = placeholder ?? t('modelInput.selectOrEnter');
@@ -206,9 +228,8 @@ export function ModelInput({
 
   // Base models filtered by providers prop
   const baseModels = useMemo(() => {
-    if (!providers || providers.length === 0) return [...COMMON_MODELS];
-    return COMMON_MODELS.filter((model) => providers.includes(model.provider));
-  }, [providers]);
+    return buildModelOptions(extraModels, providers);
+  }, [providers, extraModels]);
 
   // 过滤和排序模型（支持模糊匹配）
   const filteredModels = useMemo(() => {
@@ -246,7 +267,7 @@ export function ModelInput({
         acc[model.provider].push(model);
         return acc;
       },
-      {} as Record<string, Model[]>,
+      {} as Record<string, ModelInputOption[]>,
     );
   }, [filteredModels]);
 

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -7,6 +7,7 @@ export {
   providerKeys,
   useProviders,
   useProvider,
+  useProviderRuntimeModels,
   useCreateProvider,
   useUpdateProvider,
   useDeleteProvider,

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -13,6 +13,7 @@ export const providerKeys = {
   list: () => [...providerKeys.lists()] as const,
   details: () => [...providerKeys.all, 'detail'] as const,
   detail: (id: number) => [...providerKeys.details(), id] as const,
+  runtimeModels: (id: number) => [...providerKeys.detail(id), 'runtime-models'] as const,
   stats: () => [...providerKeys.all, 'stats'] as const,
 };
 
@@ -30,6 +31,16 @@ export function useProvider(id: number) {
     queryKey: providerKeys.detail(id),
     queryFn: () => getTransport().getProvider(id),
     enabled: id > 0,
+  });
+}
+
+// 获取 Provider 上游模型接口返回的模型列表
+export function useProviderRuntimeModels(providerId: number, enabled = true) {
+  return useQuery({
+    queryKey: providerKeys.runtimeModels(providerId),
+    queryFn: () => getTransport().getProviderRuntimeModels(providerId),
+    enabled: enabled && providerId > 0,
+    staleTime: 5 * 60 * 1000,
   });
 }
 

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -37,6 +37,7 @@ import type {
   AntigravityBatchValidationResult,
   AntigravityQuotaData,
   BedrockDiscoveredModelsResult,
+  ProviderRuntimeModelsResult,
   ModelMapping,
   ModelMappingInput,
   ImportResult,
@@ -244,6 +245,16 @@ export class HttpTransport implements Transport {
   async getProvider(id: number): Promise<Provider> {
     const { data } = await this.client.get<Provider>(`/providers/${id}`);
     return this.expectObject<Provider>(data, `/providers/${id}`);
+  }
+
+  async getProviderRuntimeModels(providerId: number): Promise<ProviderRuntimeModelsResult> {
+    const { data } = await this.client.get<ProviderRuntimeModelsResult>(
+      `/admin/providers/${providerId}/runtime-models`,
+    );
+    return this.expectObject<ProviderRuntimeModelsResult>(
+      data,
+      `/admin/providers/${providerId}/runtime-models`,
+    );
   }
 
   async createProvider(payload: CreateProviderData): Promise<Provider> {

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -34,6 +34,7 @@ import type {
   AntigravityBatchValidationResult,
   AntigravityQuotaData,
   BedrockDiscoveredModelsResult,
+  ProviderRuntimeModelsResult,
   ModelMapping,
   ModelMappingInput,
   ImportResult,
@@ -97,6 +98,7 @@ export interface Transport {
   // ===== Provider API =====
   getProviders(): Promise<Provider[]>;
   getProvider(id: number): Promise<Provider>;
+  getProviderRuntimeModels(providerId: number): Promise<ProviderRuntimeModelsResult>;
   createProvider(data: CreateProviderData): Promise<Provider>;
   updateProvider(id: number, data: Partial<Provider>): Promise<Provider>;
   deleteProvider(id: number): Promise<void>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -159,6 +159,13 @@ export interface BedrockDiscoveredModelsResult {
   refreshError?: string;
 }
 
+export interface ProviderRuntimeModelsResult {
+  available: boolean;
+  models: string[];
+  source?: string;
+  error?: string;
+}
+
 export interface ProviderConfig {
   disableErrorCooldown?: boolean;
   custom?: ProviderConfigCustom;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1702,6 +1702,7 @@
     "selectOrEnter": "Select or enter model...",
     "searchOrEnter": "Search or enter custom model...",
     "selectModel": "Select Model",
+    "currentProviderModels": "Current provider models",
     "noMatchingModels": "No matching models found.",
     "useCustom": "Use custom:",
     "noModelsAvailable": "No models available",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1699,6 +1699,7 @@
     "selectOrEnter": "选择或输入模型...",
     "searchOrEnter": "搜索或输入自定义模型...",
     "selectModel": "选择模型",
+    "currentProviderModels": "当前提供商模型",
     "noMatchingModels": "未找到匹配的模型。",
     "useCustom": "使用自定义：",
     "noModelsAvailable": "无可用模型",

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, Plus, Trash2, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   useModelMappings,
+  useProviderRuntimeModels,
   useCreateModelMapping,
   useUpdateModelMapping,
   useDeleteModelMapping,
@@ -24,6 +25,7 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
   const createMapping = useCreateModelMapping();
   const updateMapping = useUpdateModelMapping();
   const deleteMapping = useDeleteModelMapping();
+  const { data: runtimeModels } = useProviderRuntimeModels(provider.id);
   const [newPattern, setNewPattern] = useState('');
   const [newTarget, setNewTarget] = useState('');
 
@@ -35,6 +37,13 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
   }, [allMappings, provider.id]);
 
   const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
+  const providerRuntimeModelOptions = useMemo(() => {
+    return (runtimeModels?.models || []).map((model) => ({
+      id: model,
+      name: model,
+      provider: t('modelInput.currentProviderModels'),
+    }));
+  }, [runtimeModels?.models, t]);
 
   const handleAddMapping = async () => {
     if (!newPattern.trim() || !newTarget.trim()) return;
@@ -101,6 +110,7 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
                   onChange={(target) => handleUpdateMapping(mapping, { target })}
                   placeholder={t('modelMappings.targetModel')}
                   disabled={isPending}
+                  extraModels={providerRuntimeModelOptions}
                   className="flex-1 min-w-0 h-8 text-sm"
                 />
                 <Button
@@ -136,6 +146,7 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
             onChange={setNewTarget}
             placeholder={t('modelMappings.targetModel')}
             disabled={isPending}
+            extraModels={providerRuntimeModelOptions}
             className="flex-1 min-w-0 h-8 text-sm"
           />
           <Button


### PR DESCRIPTION
## Summary
- add a provider runtime-models admin endpoint that fetches model IDs from the selected provider without exposing provider credentials to the frontend
- prepend runtime provider models to the right-side model mapping target dropdown while keeping the built-in preset list unchanged
- add a regression test that locks dynamic options ahead of presets and avoids duplicate preset IDs

## Validation
- `go test ./internal/handler ./internal/adapter/provider/custom ./internal/core`
- `cd web && npm run typecheck`
- `cd web && npm run lint`
- `cd web && npm test`
- `cd web && npm run build`
- local screenshot validation with isolated maxx data dir and a fake `/v1/models` upstream returning `provider-live-alpha` / `provider-live-beta`

## Notes
- Existing preset models are not modified; runtime provider models are only prepended as dynamic candidates.
- The source model/request pattern input remains unchanged; only mapping targets receive runtime provider candidates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持动态发现 Provider 当前可用的运行时模型。
  * 在模型映射输入框中展示当前 Provider 的模型，并置于内置模型之前。
  * 自动去除重复模型，提升模型选择体验。
  * 支持从多种 Provider 服务获取模型列表，并显示加载可用性及错误状态。

* **测试**
  * 新增运行时模型排序及重复项处理测试。

* **本地化**
  * 新增中英文“当前提供商模型”相关提示文本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->