### PR TITLE
fix(providers): show configured models in mapping targets

### DIFF
--- a/web/src/components/ui/model-input.tsx
+++ b/web/src/components/ui/model-input.tsx
@@ -153,9 +153,10 @@ export function buildModelOptions(
   providers?: Provider[],
 ): ModelInputOption[] {
   const extraIDs = new Set(extraModels.map((model) => model.id));
-  const presets = (!providers || providers.length === 0
-    ? COMMON_MODELS
-    : COMMON_MODELS.filter((model) => providers.includes(model.provider))
+  const presets = (
+    !providers || providers.length === 0
+      ? COMMON_MODELS
+      : COMMON_MODELS.filter((model) => providers.includes(model.provider))
   ).filter((model) => !extraIDs.has(model.id));
 
   return [...extraModels, ...presets];
@@ -171,6 +172,8 @@ interface ModelInputProps {
   providers?: Provider[];
   /** Dynamic candidates prepended before the built-in presets. Presets themselves stay unchanged. */
   extraModels?: ModelInputOption[];
+  /** Search text to seed when opening the dropdown. Defaults to current value for existing behavior. */
+  openSearchValue?: string;
 }
 
 // 简单的模糊匹配函数
@@ -218,6 +221,7 @@ export function ModelInput({
   className,
   providers,
   extraModels,
+  openSearchValue,
 }: ModelInputProps) {
   const { t } = useTranslation();
   const actualPlaceholder = placeholder ?? t('modelInput.selectOrEnter');
@@ -273,7 +277,7 @@ export function ModelInput({
 
   const handleOpen = () => {
     if (!disabled) {
-      setSearch(value); // 初始化搜索框为当前值
+      setSearch(openSearchValue ?? value); // 初始化搜索框
       setIsOpen(true);
     }
   };

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -38,12 +38,20 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
 
   const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
   const providerRuntimeModelOptions = useMemo(() => {
-    return (runtimeModels?.models || []).map((model) => ({
-      id: model,
-      name: model,
-      provider: t('modelInput.currentProviderModels'),
-    }));
-  }, [runtimeModels?.models, t]);
+    const modelIDs = new Set<string>();
+    const options = [];
+    for (const model of [...(provider.supportModels || []), ...(runtimeModels?.models || [])]) {
+      const id = model.trim();
+      if (!id || modelIDs.has(id)) continue;
+      modelIDs.add(id);
+      options.push({
+        id,
+        name: id,
+        provider: t('modelInput.currentProviderModels'),
+      });
+    }
+    return options;
+  }, [provider.supportModels, runtimeModels?.models, t]);
 
   const handleAddMapping = async () => {
     if (!newPattern.trim() || !newTarget.trim()) return;
@@ -111,6 +119,7 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
                   placeholder={t('modelMappings.targetModel')}
                   disabled={isPending}
                   extraModels={providerRuntimeModelOptions}
+                  openSearchValue=""
                   className="flex-1 min-w-0 h-8 text-sm"
                 />
                 <Button
@@ -147,6 +156,7 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
             placeholder={t('modelMappings.targetModel')}
             disabled={isPending}
             extraModels={providerRuntimeModelOptions}
+            openSearchValue=""
             className="flex-1 min-w-0 h-8 text-sm"
           />
           <Button


### PR DESCRIPTION
## Summary
- include provider.supportModels in the mapping target dropdown dynamic model group
- keep runtime-discovered provider models as additional candidates after configured models
- open target dropdowns with an empty search seed so existing target values do not hide provider candidates

## Validation
- cd web && npm run typecheck
- cd web && npm run lint
- cd web && npm test
- cd web && npm run build
- local screenshot validation with isolated data and configured supportModels