### PR TITLE
feat(requests): show mapped model in request list and attempts

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -602,6 +602,7 @@ type ProxyRequest struct {
 	ClientType ClientType `json:"clientType"`
 
 	RequestModel    string `json:"requestModel"`
+	MappedModel     string `json:"mappedModel"`
 	ResponseModel   string `json:"responseModel"`
 	ReasoningEffort string `json:"reasoningEffort"`
 

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -281,6 +281,7 @@ type ProxyRequest struct {
 	SessionID                   string `gorm:"size:255;index"`
 	ClientType                  string `gorm:"size:64"`
 	RequestModel                string `gorm:"size:128"`
+	MappedModel                 string `gorm:"column:mapped_model;->;-:migration"`
 	ResponseModel               string `gorm:"size:128"`
 	ReasoningEffort             string `gorm:"size:32;-:migration"`
 	StartTime                   int64

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -13,9 +13,10 @@ import (
 )
 
 type ProxyRequestRepository struct {
-	db                       *DB
-	count                    int64 // 缓存的请求总数，使用原子操作
-	hasReasoningEffortColumn bool
+	db                            *DB
+	count                         int64 // 缓存的请求总数，使用原子操作
+	hasReasoningEffortColumn      bool
+	hasProxyUpstreamAttemptsTable bool
 }
 
 var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
@@ -33,9 +34,9 @@ func cloneProxyRequestFilter(filter *repository.ProxyRequestFilter) *repository.
 func applyProxyRequestErrorMode(query *gorm.DB, mode repository.ProxyRequestErrorMode) *gorm.DB {
 	switch mode {
 	case repository.ProxyRequestErrorModeOnly:
-		return query.Where("status IN ? OR status_code >= ?", proxyRequestErrorStatuses, 400)
+		return query.Where("proxy_requests.status IN ? OR proxy_requests.status_code >= ?", proxyRequestErrorStatuses, 400)
 	case repository.ProxyRequestErrorModeExclude:
-		return query.Where("status NOT IN ? AND status_code < ?", proxyRequestErrorStatuses, 400)
+		return query.Where("proxy_requests.status NOT IN ? AND proxy_requests.status_code < ?", proxyRequestErrorStatuses, 400)
 	default:
 		return query
 	}
@@ -54,22 +55,22 @@ func applyProxyRequestBaseFilter(query *gorm.DB, filter *repository.ProxyRequest
 		return query
 	}
 	if filter.ProviderID != nil {
-		query = query.Where("provider_id = ?", *filter.ProviderID)
+		query = query.Where("proxy_requests.provider_id = ?", *filter.ProviderID)
 	}
 	if filter.Status != nil {
-		query = query.Where("status = ?", *filter.Status)
+		query = query.Where("proxy_requests.status = ?", *filter.Status)
 	}
 	if filter.APITokenID != nil {
-		query = query.Where("api_token_id = ?", *filter.APITokenID)
+		query = query.Where("proxy_requests.api_token_id = ?", *filter.APITokenID)
 	}
 	if filter.ProjectID != nil {
-		query = query.Where("project_id = ?", *filter.ProjectID)
+		query = query.Where("proxy_requests.project_id = ?", *filter.ProjectID)
 	}
 	if filter.StartTime != nil {
-		query = query.Where("created_at >= ?", toTimestamp(*filter.StartTime))
+		query = query.Where("proxy_requests.created_at >= ?", toTimestamp(*filter.StartTime))
 	}
 	if filter.EndTime != nil {
-		query = query.Where("created_at <= ?", toTimestamp(*filter.EndTime))
+		query = query.Where("proxy_requests.created_at <= ?", toTimestamp(*filter.EndTime))
 	}
 	return query
 }
@@ -104,12 +105,36 @@ func proxyRequestTrendBucketSize(startMs, endMs int64) int64 {
 
 func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
 	r := &ProxyRequestRepository{
-		db:                       db,
-		hasReasoningEffortColumn: db.gorm.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort"),
+		db:                            db,
+		hasReasoningEffortColumn:      db.gorm.Migrator().HasColumn(&ProxyRequest{}, "reasoning_effort"),
+		hasProxyUpstreamAttemptsTable: db.gorm.Migrator().HasTable(&ProxyUpstreamAttempt{}),
 	}
 	// 初始化时从数据库加载计数
 	r.initCount()
 	return r
+}
+
+func (r *ProxyRequestRepository) proxyRequestListSelectColumns(includeTTFT bool) string {
+	mappedModelColumn := "'' AS mapped_model"
+	if r.hasProxyUpstreamAttemptsTable {
+		mappedModelColumn = "final_attempt.mapped_model AS mapped_model"
+	}
+	columns := "proxy_requests.id, proxy_requests.created_at, proxy_requests.updated_at, proxy_requests.instance_id, proxy_requests.request_id, proxy_requests.session_id, proxy_requests.client_type, proxy_requests.request_model, " + mappedModelColumn + ", proxy_requests.response_model, proxy_requests.start_time, proxy_requests.end_time, proxy_requests.duration_ms"
+	if includeTTFT {
+		columns += ", proxy_requests.ttft_ms"
+	}
+	columns += ", proxy_requests.is_stream, proxy_requests.status, proxy_requests.status_code, proxy_requests.error, proxy_requests.proxy_upstream_attempt_count, proxy_requests.final_proxy_upstream_attempt_id, proxy_requests.route_id, proxy_requests.provider_id, proxy_requests.project_id, proxy_requests.input_token_count, proxy_requests.output_token_count, proxy_requests.cache_read_count, proxy_requests.cache_write_count, proxy_requests.cache_5m_write_count, proxy_requests.cache_1h_write_count, proxy_requests.cost, proxy_requests.api_token_id"
+	if r.hasReasoningEffortColumn {
+		columns += ", proxy_requests.reasoning_effort"
+	}
+	return columns
+}
+
+func (r *ProxyRequestRepository) joinFinalProxyUpstreamAttempt(query *gorm.DB) *gorm.DB {
+	if !r.hasProxyUpstreamAttemptsTable {
+		return query
+	}
+	return query.Joins("LEFT JOIN proxy_upstream_attempts AS final_attempt ON final_attempt.id = proxy_requests.final_proxy_upstream_attempt_id")
 }
 
 // initCount 从数据库初始化计数缓存
@@ -191,25 +216,25 @@ func (r *ProxyRequestRepository) List(tenantID uint64, limit, offset int) ([]*do
 // 注意：列表查询不返回 request_info 和 response_info 大字段
 func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, after uint64, filter *repository.ProxyRequestFilter) ([]*domain.ProxyRequest, error) {
 	// 使用 Select 排除大字段
-	selectColumns := "id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, ttft_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id"
-	if r.hasReasoningEffortColumn {
-		selectColumns += ", reasoning_effort"
+	selectColumns := r.proxyRequestListSelectColumns(true)
+	baseQuery := r.joinFinalProxyUpstreamAttempt(r.db.gorm.Model(&ProxyRequest{}).
+		Select(selectColumns))
+	if tenantID != domain.TenantIDAll {
+		baseQuery = baseQuery.Where("proxy_requests.tenant_id = ?", tenantID)
 	}
-	baseQuery := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
-		Select(selectColumns)
 
 	if after > 0 {
-		baseQuery = baseQuery.Where("id > ?", after)
+		baseQuery = baseQuery.Where("proxy_requests.id > ?", after)
 	} else if before > 0 {
-		baseQuery = baseQuery.Where("id < ?", before)
+		baseQuery = baseQuery.Where("proxy_requests.id < ?", before)
 	}
 
 	// 应用过滤条件
 	baseQuery = applyProxyRequestFilter(baseQuery, filter)
 
-	orderBy := "id DESC"
+	orderBy := "proxy_requests.id DESC"
 	if after > 0 {
-		orderBy = "id ASC"
+		orderBy = "proxy_requests.id ASC"
 	}
 
 	// 游标分页必须保持全局单调 ID 顺序，活跃优先排序交给前端展示层处理。
@@ -222,15 +247,16 @@ func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, 
 
 // ListActive 获取所有活跃请求 (PENDING 或 IN_PROGRESS 状态)
 func (r *ProxyRequestRepository) ListActive(tenantID uint64) ([]*domain.ProxyRequest, error) {
-	selectColumns := "id, created_at, updated_at, instance_id, request_id, session_id, client_type, request_model, response_model, start_time, end_time, duration_ms, is_stream, status, status_code, error, proxy_upstream_attempt_count, final_proxy_upstream_attempt_id, route_id, provider_id, project_id, input_token_count, output_token_count, cache_read_count, cache_write_count, cache_5m_write_count, cache_1h_write_count, cost, api_token_id"
-	if r.hasReasoningEffortColumn {
-		selectColumns += ", reasoning_effort"
+	selectColumns := r.proxyRequestListSelectColumns(false)
+	query := r.joinFinalProxyUpstreamAttempt(r.db.gorm.Model(&ProxyRequest{}).
+		Select(selectColumns)).
+		Where("proxy_requests.status IN ?", activeProxyRequestStatuses)
+	if tenantID != domain.TenantIDAll {
+		query = query.Where("proxy_requests.tenant_id = ?", tenantID)
 	}
 	var models []ProxyRequest
-	if err := tenantScope(r.db.gorm.Model(&ProxyRequest{}), tenantID).
-		Select(selectColumns).
-		Where("status IN ?", activeProxyRequestStatuses).
-		Order("id DESC").
+	if err := query.
+		Order("proxy_requests.id DESC").
 		Find(&models).Error; err != nil {
 		return nil, err
 	}
@@ -1026,6 +1052,7 @@ func (r *ProxyRequestRepository) toDomain(m *ProxyRequest) *domain.ProxyRequest 
 		SessionID:                   m.SessionID,
 		ClientType:                  domain.ClientType(m.ClientType),
 		RequestModel:                m.RequestModel,
+		MappedModel:                 m.MappedModel,
 		ResponseModel:               m.ResponseModel,
 		ReasoningEffort:             m.ReasoningEffort,
 		StartTime:                   fromTimestamp(m.StartTime),

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -128,6 +128,49 @@ func TestProxyRequestListCursorReturnsNewestIDsFirst(t *testing.T) {
 	}
 }
 
+func TestProxyRequestListCursorIncludesFinalAttemptMappedModel(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	reqRepo := NewProxyRequestRepository(db)
+	attemptRepo := NewProxyUpstreamAttemptRepository(db)
+	req := buildTestProxyRequest("COMPLETED", 1)
+	req.RequestModel = "gpt-4.1"
+	if err := reqRepo.Create(req); err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	attempt := &domain.ProxyUpstreamAttempt{
+		TenantID:       req.TenantID,
+		ProxyRequestID: req.ID,
+		Status:         "COMPLETED",
+		RequestModel:   "gpt-4.1",
+		MappedModel:    "openrouter/gpt-4.1-mini",
+		ResponseModel:  "openrouter/gpt-4.1-mini",
+	}
+	if err := attemptRepo.Create(attempt); err != nil {
+		t.Fatalf("create attempt: %v", err)
+	}
+	req.FinalProxyUpstreamAttemptID = attempt.ID
+	if err := reqRepo.Update(req); err != nil {
+		t.Fatalf("update request: %v", err)
+	}
+
+	items, err := reqRepo.ListCursor(1, 10, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("ListCursor failed: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items length = %d, want 1", len(items))
+	}
+	if got := items[0].MappedModel; got != "openrouter/gpt-4.1-mini" {
+		t.Fatalf("MappedModel = %q, want openrouter/gpt-4.1-mini", got)
+	}
+}
+
 func TestProxyRequestReasoningEffortRoundTrip(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -474,6 +474,7 @@ export interface ProxyRequest {
   sessionID: string;
   clientType: ClientType;
   requestModel: string;
+  mappedModel: string;
   responseModel: string;
   reasoningEffort: string;
   startTime: string;

--- a/web/src/pages/requests/detail/RequestSidebar.tsx
+++ b/web/src/pages/requests/detail/RequestSidebar.tsx
@@ -32,6 +32,10 @@ function EmptyState({ message, icon }: { message: string; icon?: React.ReactNode
   );
 }
 
+function shouldShowMappedModel(attempt: ProxyUpstreamAttempt) {
+  return Boolean(attempt.mappedModel && attempt.requestModel && attempt.mappedModel !== attempt.requestModel);
+}
+
 interface RequestSidebarProps {
   request: ProxyRequest;
   attempts: ProxyUpstreamAttempt[] | undefined;
@@ -191,6 +195,16 @@ export function RequestSidebar({
                     {attempt.duration > 0 ? formatDuration(attempt.duration) : '-'}
                   </span>
                 </div>
+                {shouldShowMappedModel(attempt) && (
+                  <div
+                    className="mt-2 flex items-center gap-1.5 min-w-0 text-[11px] font-mono text-muted-foreground"
+                    title={`${t('requests.requestModel')}: ${attempt.requestModel}\n${t('requests.mappedModel')}: ${attempt.mappedModel}`}
+                  >
+                    <span className="truncate opacity-80">{attempt.requestModel}</span>
+                    <span className="shrink-0 opacity-60">→</span>
+                    <span className="truncate text-foreground">{attempt.mappedModel}</span>
+                  </div>
+                )}
               </button>
             ))}
           </div>

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -1089,6 +1089,17 @@ type LogRowProps = {
   onOpenRequest: (id: number) => void;
 };
 
+function getVisibleMappedModel(request: ProxyRequest) {
+  return request.mappedModel && request.mappedModel !== request.requestModel
+    ? request.mappedModel
+    : '';
+}
+
+function getVisibleResponseModel(request: ProxyRequest) {
+  const previousModel = getVisibleMappedModel(request) || request.requestModel;
+  return request.responseModel && request.responseModel !== previousModel ? request.responseModel : '';
+}
+
 function LogRow({
   request,
   providerName,
@@ -1122,6 +1133,8 @@ function LogRow({
   const startTimeMs = useMemo(() => new Date(request.startTime).getTime(), [request.startTime]);
   const liveDurationMs =
     isPending && Number.isFinite(startTimeMs) ? Math.max(0, nowMs - startTimeMs) : null;
+  const visibleMappedModel = getVisibleMappedModel(request);
+  const visibleResponseModel = getVisibleResponseModel(request);
 
   const formatDuration = (ns?: number | null) => {
     if (ns === undefined || ns === null) return '-';
@@ -1222,12 +1235,20 @@ function LogRow({
           >
             {request.requestModel || '-'}
           </span>
-          {request.responseModel && request.responseModel !== request.requestModel && (
+          {visibleMappedModel && (
             <span
               className="text-[10px] text-muted-foreground truncate"
-              title={request.responseModel}
+              title={`Mapped model: ${visibleMappedModel}`}
             >
-              → {request.responseModel}
+              → {visibleMappedModel}
+            </span>
+          )}
+          {visibleResponseModel && (
+            <span
+              className="text-[10px] text-muted-foreground truncate"
+              title={`Response model: ${visibleResponseModel}`}
+            >
+              ↳ {visibleResponseModel}
             </span>
           )}
         </div>
@@ -1410,6 +1431,8 @@ function MobileRequestCard({ request, providerName, onOpenRequest }: MobileReque
     request.endTime && new Date(request.endTime).getTime() > 0
       ? formatTime(request.endTime)
       : formatTime(request.startTime || request.createdAt);
+  const visibleMappedModel = getVisibleMappedModel(request);
+  const visibleResponseModel = getVisibleResponseModel(request);
 
   return (
     <div
@@ -1427,6 +1450,18 @@ function MobileRequestCard({ request, providerName, onOpenRequest }: MobileReque
         <ClientIcon type={request.clientType} size={14} className="shrink-0" />
         <span className="text-sm font-medium text-foreground truncate flex-1">
           {request.requestModel || '-'}
+          {visibleMappedModel && (
+            <span className="text-xs text-muted-foreground font-normal">
+              {' '}
+              → {visibleMappedModel}
+            </span>
+          )}
+          {visibleResponseModel && (
+            <span className="text-xs text-muted-foreground font-normal">
+              {' '}
+              ↳ {visibleResponseModel}
+            </span>
+          )}
         </span>
         {request.reasoningEffort && (
           <span className="text-[10px] font-mono text-muted-foreground">

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -694,7 +694,7 @@ export function RequestsPage() {
       <TableRow className="hover:bg-transparent border-none text-sm">
         <TableHead className="w-[180px] font-medium">{t('requests.time')}</TableHead>
         <TableHead className="w-[120px] pr-4 font-medium">{t('requests.client')}</TableHead>
-        <TableHead className="w-[160px] min-w-[160px] font-medium">{t('requests.model')}</TableHead>
+        <TableHead className="w-[200px] min-w-[200px] font-medium">{t('requests.model')}</TableHead>
         <TableHead className="w-[90px] min-w-[90px] text-center font-medium">
           {t('requests.reasoningEffort')}
         </TableHead>
@@ -1227,8 +1227,8 @@ function LogRow({
       </TableCell>
 
       {/* Model */}
-      <TableCell className="w-[160px] min-w-[160px] px-2 py-1">
-        <div className="flex items-center gap-2 min-w-0 max-w-[220px]">
+      <TableCell className="w-[200px] min-w-[200px] px-2 py-1">
+        <div className="flex items-center gap-2 min-w-0 max-w-[280px]">
           <span
             className="text-sm text-foreground font-medium truncate"
             title={request.requestModel}


### PR DESCRIPTION
## Summary
- show mapped model information in request attempt rows/details
- expose the final attempt mapped model on proxy request list responses
- show request list model flow as request → mapped, with response model shown separately only when it differs

## Verification
- `go test ./internal/repository/sqlite ./internal/handler ./internal/service`
- `npm run typecheck`
- `npm run lint`
- `npm test -- --run`
- `npm run build`
- local Playwright screenshot of the Requests tab list: `/tmp/maxx_mapped_model_request_list.png`

## Notes
- This PR does not inspect or act on CodeRabbit feedback unless explicitly requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 请求记录新增“映射模型”信息，展示请求模型实际映射到的模型名称。
  - 请求列表支持显示模型映射链路，并区分响应模型，桌面端与移动端体验保持一致。
  - 请求详情中会在映射模型与请求模型不一致时展示对应关系。

- **问题修复**
  - 优化请求记录查询，确保列表和详情优先显示最终上游尝试对应的映射模型。
  - 改进复杂查询场景下的数据筛选与排序稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->