### PR TITLE
fix(requests): show active mapped model in list

### DIFF
--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -115,9 +115,9 @@ func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
 }
 
 func (r *ProxyRequestRepository) proxyRequestListSelectColumns(includeTTFT bool) string {
-	mappedModelColumn := "'' AS mapped_model"
+	mappedModelColumn := "proxy_requests.response_model AS mapped_model"
 	if r.hasProxyUpstreamAttemptsTable {
-		mappedModelColumn = "final_attempt.mapped_model AS mapped_model"
+		mappedModelColumn = "COALESCE(NULLIF(final_attempt.mapped_model, ''), proxy_requests.response_model) AS mapped_model"
 	}
 	columns := "proxy_requests.id, proxy_requests.created_at, proxy_requests.updated_at, proxy_requests.instance_id, proxy_requests.request_id, proxy_requests.session_id, proxy_requests.client_type, proxy_requests.request_model, " + mappedModelColumn + ", proxy_requests.response_model, proxy_requests.start_time, proxy_requests.end_time, proxy_requests.duration_ms"
 	if includeTTFT {

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -139,6 +139,7 @@ func TestProxyRequestListCursorIncludesFinalAttemptMappedModel(t *testing.T) {
 	attemptRepo := NewProxyUpstreamAttemptRepository(db)
 	req := buildTestProxyRequest("COMPLETED", 1)
 	req.RequestModel = "gpt-4.1"
+	req.ResponseModel = "fallback-from-request"
 	if err := reqRepo.Create(req); err != nil {
 		t.Fatalf("create request: %v", err)
 	}
@@ -168,6 +169,33 @@ func TestProxyRequestListCursorIncludesFinalAttemptMappedModel(t *testing.T) {
 	}
 	if got := items[0].MappedModel; got != "openrouter/gpt-4.1-mini" {
 		t.Fatalf("MappedModel = %q, want openrouter/gpt-4.1-mini", got)
+	}
+}
+
+func TestProxyRequestListActiveFallsBackToResponseModelBeforeFinalAttempt(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("Failed to create DB: %v", err)
+	}
+	defer db.Close()
+
+	reqRepo := NewProxyRequestRepository(db)
+	req := buildTestProxyRequest("IN_PROGRESS", 1)
+	req.RequestModel = "claude-3-5-sonnet"
+	req.ResponseModel = "openrouter/anthropic/claude-3.5-sonnet"
+	if err := reqRepo.Create(req); err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	items, err := reqRepo.ListActive(1)
+	if err != nil {
+		t.Fatalf("ListActive failed: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items length = %d, want 1", len(items))
+	}
+	if got := items[0].MappedModel; got != "openrouter/anthropic/claude-3.5-sonnet" {
+		t.Fatalf("MappedModel = %q, want openrouter/anthropic/claude-3.5-sonnet", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- show mapped model for active/in-progress requests in the Requests tab list
- fall back to the request-level response model while `final_proxy_upstream_attempt_id` is not available yet
- keep final upstream attempt `mapped_model` as the preferred historical value once it exists

## Verification
- `go test ./internal/repository/sqlite ./internal/handler ./internal/service`

## Notes
- This fixes the in-flight request gap after #704: active requests may not have a final attempt yet, so joining only the final attempt cannot populate `mappedModel` during the request.
- This PR does not inspect or act on CodeRabbit feedback unless explicitly requested.
