### PR TITLE
fix(providers): prioritize runtime models in mappings

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -181,6 +181,10 @@ func (h *AdminHandler) handleProviders(w http.ResponseWriter, r *http.Request, i
 		h.handleBedrockDiscoveredModels(w, r, id)
 		return
 	}
+	if strings.HasSuffix(path, "/runtime-models/preview") {
+		h.handleProviderRuntimeModelsPreview(w, r)
+		return
+	}
 	if id > 0 && strings.HasSuffix(path, "/runtime-models") {
 		h.handleProviderRuntimeModels(w, r, id)
 		return
@@ -283,6 +287,23 @@ func (h *AdminHandler) handleProviderRuntimeModels(w http.ResponseWriter, r *htt
 	writeJSON(w, http.StatusOK, result)
 }
 
+func (h *AdminHandler) handleProviderRuntimeModelsPreview(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var provider domain.Provider
+	if err := json.NewDecoder(r.Body).Decode(&provider); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	result := h.fetchProviderRuntimeModels(r, &provider)
+	writeJSON(w, http.StatusOK, result)
+}
+
 func (h *AdminHandler) fetchProviderRuntimeModels(r *http.Request, provider *domain.Provider) providerRuntimeModelsResult {
 	if provider == nil || provider.Config == nil {
 		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "provider config unavailable"}
@@ -310,10 +331,10 @@ func (h *AdminHandler) fetchProviderRuntimeModels(r *http.Request, provider *dom
 		}
 		return fetchOpenAICompatibleModels(r, "https://openrouter.ai/api/v1/models", provider.Config.OpenRouter.APIKey, "openrouter")
 	case "custom":
-		if provider.Config.Custom == nil || strings.TrimSpace(provider.Config.Custom.BaseURL) == "" {
+		if provider.Config.Custom == nil || strings.TrimSpace(customRuntimeModelsBaseURL(provider.Config.Custom)) == "" {
 			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "custom provider base url unavailable"}
 		}
-		modelsURL, err := providerModelsURL(provider.Config.Custom.BaseURL)
+		modelsURL, err := providerModelsURL(customRuntimeModelsBaseURL(provider.Config.Custom))
 		if err != nil {
 			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: err.Error()}
 		}
@@ -321,6 +342,18 @@ func (h *AdminHandler) fetchProviderRuntimeModels(r *http.Request, provider *dom
 	default:
 		return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "provider runtime model discovery unsupported"}
 	}
+}
+
+func customRuntimeModelsBaseURL(custom *domain.ProviderConfigCustom) string {
+	if custom == nil {
+		return ""
+	}
+	if custom.ClientBaseURL != nil {
+		if baseURL := strings.TrimSpace(custom.ClientBaseURL[domain.ClientTypeOpenAI]); baseURL != "" {
+			return baseURL
+		}
+	}
+	return custom.BaseURL
 }
 
 func providerModelsURL(baseURL string) (string, error) {

--- a/internal/handler/admin_runtime_models_test.go
+++ b/internal/handler/admin_runtime_models_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestFetchProviderRuntimeModels_CustomUsesOpenAIClientOverride(t *testing.T) {
+	baseHit := false
+	base := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseHit = true
+		t.Fatalf("base URL should not be used when openai client override is set")
+	}))
+	defer base.Close()
+
+	openAI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %s, want /v1/models", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
+			t.Fatalf("Authorization = %q, want Bearer sk-test", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4o"},{"id":"gpt-4.1"}]}`))
+	}))
+	defer openAI.Close()
+
+	provider := &domain.Provider{
+		Type: "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: base.URL,
+			APIKey:  "sk-test",
+			ClientBaseURL: map[domain.ClientType]string{
+				domain.ClientTypeOpenAI: openAI.URL,
+			},
+		}},
+	}
+
+	result := (&AdminHandler{}).fetchProviderRuntimeModels(httptest.NewRequest(http.MethodPost, "/", nil), provider)
+	if baseHit {
+		t.Fatal("base URL was hit")
+	}
+	if !result.Available {
+		t.Fatalf("result not available: %#v", result)
+	}
+	if len(result.Models) != 2 || result.Models[0] != "gpt-4.1" || result.Models[1] != "gpt-4o" {
+		t.Fatalf("models = %#v", result.Models)
+	}
+}
+
+func TestFetchProviderRuntimeModels_CustomFallsBackToBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("path = %s, want /v1/models", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"base-model"}]}`))
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{
+		Type:   "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{BaseURL: server.URL}},
+	}
+
+	result := (&AdminHandler{}).fetchProviderRuntimeModels(httptest.NewRequest(http.MethodPost, "/", nil), provider)
+	if !result.Available {
+		t.Fatalf("result not available: %#v", result)
+	}
+	if len(result.Models) != 1 || result.Models[0] != "base-model" {
+		t.Fatalf("models = %#v", result.Models)
+	}
+}

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -8,6 +8,7 @@ export {
   useProviders,
   useProvider,
   useProviderRuntimeModels,
+  useProviderRuntimeModelsPreview,
   useCreateProvider,
   useUpdateProvider,
   useDeleteProvider,

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -3,7 +3,12 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTransport, type Provider, type CreateProviderData } from '@/lib/transport';
+import {
+  getTransport,
+  type Provider,
+  type CreateProviderData,
+  type ProviderRuntimeModelsPreviewRequest,
+} from '@/lib/transport';
 import { routeKeys } from './use-routes';
 
 // Query Keys
@@ -14,6 +19,8 @@ export const providerKeys = {
   details: () => [...providerKeys.all, 'detail'] as const,
   detail: (id: number) => [...providerKeys.details(), id] as const,
   runtimeModels: (id: number) => [...providerKeys.detail(id), 'runtime-models'] as const,
+  runtimeModelsPreview: (payload: ProviderRuntimeModelsPreviewRequest) =>
+    [...providerKeys.all, 'runtime-models-preview', payload] as const,
   stats: () => [...providerKeys.all, 'stats'] as const,
 };
 
@@ -41,6 +48,20 @@ export function useProviderRuntimeModels(providerId: number, enabled = true) {
     queryFn: () => getTransport().getProviderRuntimeModels(providerId),
     enabled: enabled && providerId > 0,
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useProviderRuntimeModelsPreview(
+  payload: ProviderRuntimeModelsPreviewRequest | undefined,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: payload
+      ? providerKeys.runtimeModelsPreview(payload)
+      : [...providerKeys.all, 'runtime-models-preview', 'disabled'],
+    queryFn: () => getTransport().previewProviderRuntimeModels(payload!),
+    enabled: enabled && !!payload,
+    staleTime: 60 * 1000,
   });
 }
 

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -38,6 +38,7 @@ import type {
   AntigravityQuotaData,
   BedrockDiscoveredModelsResult,
   ProviderRuntimeModelsResult,
+  ProviderRuntimeModelsPreviewRequest,
   ModelMapping,
   ModelMappingInput,
   ImportResult,
@@ -254,6 +255,19 @@ export class HttpTransport implements Transport {
     return this.expectObject<ProviderRuntimeModelsResult>(
       data,
       `/admin/providers/${providerId}/runtime-models`,
+    );
+  }
+
+  async previewProviderRuntimeModels(
+    payload: ProviderRuntimeModelsPreviewRequest,
+  ): Promise<ProviderRuntimeModelsResult> {
+    const { data } = await this.client.post<ProviderRuntimeModelsResult>(
+      '/admin/providers/runtime-models/preview',
+      payload,
+    );
+    return this.expectObject<ProviderRuntimeModelsResult>(
+      data,
+      '/admin/providers/runtime-models/preview',
     );
   }
 

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -7,6 +7,8 @@ export type {
   // 领域模型
   ClientType,
   Provider,
+  ProviderRuntimeModelsResult,
+  ProviderRuntimeModelsPreviewRequest,
   ProviderConfig,
   ProviderConfigCustom,
   ProviderConfigCustomDisguise,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -35,6 +35,7 @@ import type {
   AntigravityQuotaData,
   BedrockDiscoveredModelsResult,
   ProviderRuntimeModelsResult,
+  ProviderRuntimeModelsPreviewRequest,
   ModelMapping,
   ModelMappingInput,
   ImportResult,
@@ -99,6 +100,9 @@ export interface Transport {
   getProviders(): Promise<Provider[]>;
   getProvider(id: number): Promise<Provider>;
   getProviderRuntimeModels(providerId: number): Promise<ProviderRuntimeModelsResult>;
+  previewProviderRuntimeModels(
+    payload: ProviderRuntimeModelsPreviewRequest,
+  ): Promise<ProviderRuntimeModelsResult>;
   createProvider(data: CreateProviderData): Promise<Provider>;
   updateProvider(id: number, data: Partial<Provider>): Promise<Provider>;
   deleteProvider(id: number): Promise<void>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -166,6 +166,11 @@ export interface ProviderRuntimeModelsResult {
   error?: string;
 }
 
+export interface ProviderRuntimeModelsPreviewRequest {
+  type: string;
+  config: ProviderConfig;
+}
+
 export interface ProviderConfig {
   disableErrorCooldown?: boolean;
   custom?: ProviderConfigCustom;

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Globe,
   ChevronLeft,
@@ -11,8 +11,16 @@ import {
   EyeOff,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
-import type { ClientType, CreateProviderData } from '@/lib/transport';
+import {
+  useCreateProvider,
+  useCreateModelMapping,
+  useProviderRuntimeModelsPreview,
+} from '@/hooks/queries';
+import type {
+  ClientType,
+  CreateProviderData,
+  ProviderRuntimeModelsPreviewRequest,
+} from '@/lib/transport';
 import { ClientsConfigSection } from './clients-config-section';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -29,6 +37,7 @@ import { PageHeader } from '@/components/layout/page-header';
 import { useProviderForm } from '../context/provider-form-context';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import { buildDisguisePayload } from '../utils/disguise';
+import { buildProviderRuntimeModelOptions } from './provider-model-mappings';
 
 export function CustomConfigStep() {
   const [showApiKey, setShowApiKey] = useState(false);
@@ -46,6 +55,43 @@ export function CustomConfigStep() {
   const { goToSelectType, goToProviders } = useProviderNavigation();
   const createProvider = useCreateProvider();
   const createModelMapping = useCreateModelMapping();
+  const runtimeModelsPreview = useMemo<ProviderRuntimeModelsPreviewRequest | undefined>(() => {
+    const clientBaseURL: Partial<Record<ClientType, string>> = {};
+    formData.clients.forEach((client) => {
+      const url = client.urlOverride.trim();
+      if (client.enabled && url) {
+        clientBaseURL[client.id] = url;
+      }
+    });
+
+    const baseURL = formData.baseURL.trim();
+    if (!baseURL && !clientBaseURL.openai) return undefined;
+
+    return {
+      type: 'custom',
+      config: {
+        custom: {
+          baseURL,
+          backend: formData.backend === 'ollama' ? 'ollama' : undefined,
+          apiKey: formData.apiKey.trim(),
+          clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
+        },
+      },
+    };
+  }, [formData.apiKey, formData.backend, formData.baseURL, formData.clients]);
+  const { data: runtimeModels } = useProviderRuntimeModelsPreview(
+    runtimeModelsPreview,
+    !!runtimeModelsPreview,
+  );
+  const runtimeModelOptions = useMemo(
+    () =>
+      buildProviderRuntimeModelOptions(
+        runtimeModels?.models,
+        undefined,
+        t('modelInput.currentProviderModels'),
+      ),
+    [runtimeModels?.models, t],
+  );
 
   const handleSave = async () => {
     if (!isValid()) return;
@@ -398,6 +444,8 @@ export function CustomConfigStep() {
                           updateFormData({ modelMappings: newMappings });
                         }}
                         placeholder={t('modelInput.selectOrEnter')}
+                        extraModels={runtimeModelOptions}
+                        openSearchValue=""
                       />
                     </div>
                     <Button

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -30,7 +30,12 @@ import {
   useModelMappings,
   useCreateModelMapping,
 } from '@/hooks/queries';
-import type { Provider, ClientType, CreateProviderData } from '@/lib/transport';
+import type {
+  Provider,
+  ClientType,
+  CreateProviderData,
+  ProviderRuntimeModelsPreviewRequest,
+} from '@/lib/transport';
 import { defaultClients, type ClientConfig, type CustomBackend } from '../types';
 import { buildDisguisePayload } from '../utils/disguise';
 import { ClientsConfigSection } from './clients-config-section';
@@ -358,6 +363,31 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     };
   });
   const providerConfigIsWriteOnly = !!provider.excludeFromExport;
+  const runtimeModelsPreview = useMemo<ProviderRuntimeModelsPreviewRequest | undefined>(() => {
+    const clientBaseURL: Partial<Record<ClientType, string>> = {};
+    formData.clients.forEach((client) => {
+      const url = client.urlOverride.trim();
+      if (client.enabled && url) {
+        clientBaseURL[client.id] = url;
+      }
+    });
+
+    const baseURL = formData.baseURL.trim();
+    const apiKey = formData.apiKey.trim();
+    if (!baseURL && !clientBaseURL.openai) return undefined;
+
+    return {
+      type: provider.type || 'custom',
+      config: {
+        custom: {
+          baseURL,
+          backend: formData.backend === 'ollama' ? 'ollama' : undefined,
+          apiKey,
+          clientBaseURL: Object.keys(clientBaseURL).length > 0 ? clientBaseURL : undefined,
+        },
+      },
+    };
+  }, [formData.apiKey, formData.backend, formData.baseURL, formData.clients, provider.type]);
 
   const updateClient = (clientId: ClientType, updates: Partial<ClientConfig>) => {
     setFormData((prev) => ({
@@ -947,7 +977,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
             />
 
             {/* Provider Model Mappings */}
-            <ProviderModelMappings provider={provider} />
+            <ProviderModelMappings provider={provider} runtimeModelsPreview={runtimeModelsPreview} />
 
             <ResponseModelMappings
               mappings={formData.responseModelMapping}

--- a/web/src/pages/providers/components/provider-model-mappings.test.ts
+++ b/web/src/pages/providers/components/provider-model-mappings.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildProviderRuntimeModelOptions } from './provider-model-mappings';
+
+describe('buildProviderRuntimeModelOptions', () => {
+  it('puts provider interface models before configured support models', () => {
+    const options = buildProviderRuntimeModelOptions(
+      ['gpt-4o', 'gpt-4.1'],
+      ['configured-only', 'gpt-4o'],
+      'Current provider models',
+    );
+
+    expect(options.map((option) => option.id)).toEqual(['gpt-4o', 'gpt-4.1', 'configured-only']);
+  });
+});

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -19,6 +19,26 @@ import { ModelInput } from '@/components/ui/model-input';
  * it is the correct home for model mapping across every provider type, not the
  * inline config maps. Shared by the custom edit form and the OpenRouter view.
  */
+export function buildProviderRuntimeModelOptions(
+  providerModels: string[] | undefined,
+  configuredModels: string[] | undefined,
+  label: string,
+) {
+  const modelIDs = new Set<string>();
+  const options = [];
+  for (const model of [...(providerModels || []), ...(configuredModels || [])]) {
+    const id = model.trim();
+    if (!id || modelIDs.has(id)) continue;
+    modelIDs.add(id);
+    options.push({
+      id,
+      name: id,
+      provider: label,
+    });
+  }
+  return options;
+}
+
 export function ProviderModelMappings({ provider }: { provider: Provider }) {
   const { t } = useTranslation();
   const { data: allMappings } = useModelMappings();
@@ -37,21 +57,15 @@ export function ProviderModelMappings({ provider }: { provider: Provider }) {
   }, [allMappings, provider.id]);
 
   const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
-  const providerRuntimeModelOptions = useMemo(() => {
-    const modelIDs = new Set<string>();
-    const options = [];
-    for (const model of [...(provider.supportModels || []), ...(runtimeModels?.models || [])]) {
-      const id = model.trim();
-      if (!id || modelIDs.has(id)) continue;
-      modelIDs.add(id);
-      options.push({
-        id,
-        name: id,
-        provider: t('modelInput.currentProviderModels'),
-      });
-    }
-    return options;
-  }, [provider.supportModels, runtimeModels?.models, t]);
+  const providerRuntimeModelOptions = useMemo(
+    () =>
+      buildProviderRuntimeModelOptions(
+        runtimeModels?.models,
+        provider.supportModels,
+        t('modelInput.currentProviderModels'),
+      ),
+    [provider.supportModels, runtimeModels?.models, t],
+  );
 
   const handleAddMapping = async () => {
     if (!newPattern.trim() || !newTarget.trim()) return;

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -4,11 +4,17 @@ import { useTranslation } from 'react-i18next';
 import {
   useModelMappings,
   useProviderRuntimeModels,
+  useProviderRuntimeModelsPreview,
   useCreateModelMapping,
   useUpdateModelMapping,
   useDeleteModelMapping,
 } from '@/hooks/queries';
-import type { Provider, ModelMapping, ModelMappingInput } from '@/lib/transport';
+import type {
+  Provider,
+  ModelMapping,
+  ModelMappingInput,
+  ProviderRuntimeModelsPreviewRequest,
+} from '@/lib/transport';
 import { Button } from '@/components/ui/button';
 import { ModelInput } from '@/components/ui/model-input';
 
@@ -39,13 +45,25 @@ export function buildProviderRuntimeModelOptions(
   return options;
 }
 
-export function ProviderModelMappings({ provider }: { provider: Provider }) {
+export function ProviderModelMappings({
+  provider,
+  runtimeModelsPreview,
+}: {
+  provider: Provider;
+  runtimeModelsPreview?: ProviderRuntimeModelsPreviewRequest;
+}) {
   const { t } = useTranslation();
   const { data: allMappings } = useModelMappings();
   const createMapping = useCreateModelMapping();
   const updateMapping = useUpdateModelMapping();
   const deleteMapping = useDeleteModelMapping();
-  const { data: runtimeModels } = useProviderRuntimeModels(provider.id);
+  const hasPreviewConfig = !!runtimeModelsPreview;
+  const { data: savedRuntimeModels } = useProviderRuntimeModels(provider.id, !hasPreviewConfig);
+  const { data: previewRuntimeModels } = useProviderRuntimeModelsPreview(
+    runtimeModelsPreview,
+    hasPreviewConfig,
+  );
+  const runtimeModels = previewRuntimeModels ?? savedRuntimeModels;
   const [newPattern, setNewPattern] = useState('');
   const [newTarget, setNewTarget] = useState('');
 


### PR DESCRIPTION
## Summary
- add a draft runtime-model preview endpoint that discovers models from the currently filled provider config without saving it
- use the draft custom provider base URL/API key in create/edit mapping dropdowns; prefer the OpenAI client URL override when it is filled
- prioritize live provider interface models at the top of model mapping target dropdowns, then configured fallback models, then built-in presets
- add regression coverage for provider runtime model discovery and dropdown ordering

## Verification
- `go test ./internal/handler`
- `pnpm test -- --run provider-model-mappings model-input`
- `pnpm typecheck`
- `pnpm lint`

## Notes
- This is for display/selection only; the preview endpoint does not persist provider config.
- This PR does not inspect or act on CodeRabbit feedback unless explicitly requested.