### PR TITLE
fix(routes): add TTFT-based route sorting

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -786,6 +786,8 @@
     "routesConfigured_other": "{{count}} routes configured for this project",
     "sortAntigravity": "Sort Antigravity",
     "sortCodex": "Sort Codex",
+    "sortByTtft": "Sort by TTFT",
+    "sortByTtftHint": "Sort current routes by average TTFT from the last 24 hours. Routes with fewer than 3 successful requests keep their slot.",
     "clientRoutesTitle": "{{client}} Routes",
     "configureRoutingFor": "Configure routing for {{client}}",
     "usingProjectRoutes": "Using project-specific routes",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -783,6 +783,8 @@
     "routesConfigured_other": "为该项目配置了 {{count}} 条路由",
     "sortAntigravity": "一键排序 Antigravity",
     "sortCodex": "一键排序 Codex",
+    "sortByTtft": "按 TTFT 排序",
+    "sortByTtftHint": "按最近 24 小时平均 TTFT 排序当前路由；成功请求少于 3 次的路由保留原槽位。",
     "clientRoutesTitle": "{{client}} 路由",
     "configureRoutingFor": "为 {{client}} 配置路由",
     "usingProjectRoutes": "使用项目专属路由",

--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -285,6 +285,53 @@ export function ClientRoutesPage() {
     });
   };
 
+  const sortButtons = (
+    <div className="flex items-center gap-2">
+      {currentScopeRoutes.length > 1 && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSortByTtft}
+          disabled={isSorting || isLoadingTtftStats || ttftSortUpdates.length === 0}
+          title={t('routes.sortByTtftHint')}
+          className="h-8 text-xs"
+        >
+          <Gauge className="h-3.5 w-3.5 mr-1.5" />
+          {t('routes.sortByTtft')}
+          {(isSorting || isLoadingTtftStats) && (
+            <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />
+          )}
+        </Button>
+      )}
+      {selectedProjectId === '0' && hasAntigravityRoutes && isClaudePage && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSortAntigravity}
+          disabled={isSorting}
+          className="h-8 text-xs"
+        >
+          <Zap className="h-3.5 w-3.5 mr-1.5" />
+          {t('routes.sortAntigravity')}
+          {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
+        </Button>
+      )}
+      {selectedProjectId === '0' && hasCodexRoutes && isCodexPage && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleSortCodex}
+          disabled={isSorting}
+          className="h-8 text-xs"
+        >
+          <Code2 className="h-3.5 w-3.5 mr-1.5" />
+          {t('routes.sortCodex')}
+          {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
+        </Button>
+      )}
+    </div>
+  );
+
   return (
     <div className="flex flex-col h-full">
       <PageHeader
@@ -340,50 +387,7 @@ export function ClientRoutesPage() {
               </div>
 
               {/* Sort Buttons */}
-              <div className="flex items-center gap-2">
-                {currentScopeRoutes.length > 1 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSortByTtft}
-                    disabled={isSorting || isLoadingTtftStats || ttftSortUpdates.length === 0}
-                    title={t('routes.sortByTtftHint')}
-                    className="h-8 text-xs"
-                  >
-                    <Gauge className="h-3.5 w-3.5 mr-1.5" />
-                    {t('routes.sortByTtft')}
-                    {(isSorting || isLoadingTtftStats) && (
-                      <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />
-                    )}
-                  </Button>
-                )}
-                {selectedProjectId === '0' && hasAntigravityRoutes && isClaudePage && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSortAntigravity}
-                    disabled={isSorting}
-                    className="h-8 text-xs"
-                  >
-                    <Zap className="h-3.5 w-3.5 mr-1.5" />
-                    {t('routes.sortAntigravity')}
-                    {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
-                  </Button>
-                )}
-                {selectedProjectId === '0' && hasCodexRoutes && isCodexPage && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleSortCodex}
-                    disabled={isSorting}
-                    className="h-8 text-xs"
-                  >
-                    <Code2 className="h-3.5 w-3.5 mr-1.5" />
-                    {t('routes.sortCodex')}
-                    {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
-                  </Button>
-                )}
-              </div>
+              {sortButtons}
             </div>
 
             {/* Full-width hover panel: all projects */}
@@ -414,6 +418,11 @@ export function ClientRoutesPage() {
                 </div>
               </div>
             )}
+          </div>
+        )}
+        {sortedProjects.length === 0 && (
+          <div className="px-6 py-3 border-b border-border bg-card">
+            <div className="mx-auto max-w-[1400px] flex justify-end">{sortButtons}</div>
           </div>
         )}
 

--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -15,6 +15,7 @@ import {
   Code2,
   ChevronLeft,
   ChevronRight,
+  Gauge,
 } from 'lucide-react';
 import { ClientIcon, getClientName } from '@/components/icons/client-icons';
 import { PageHeader } from '@/components/layout/page-header';
@@ -22,10 +23,19 @@ import type { ClientType } from '@/lib/transport';
 import { ClientTypeRoutesContent } from '@/components/routes/ClientTypeRoutesContent';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger, TabsContent, Switch, Button } from '@/components/ui';
-import { useProjects, useUpdateProject, useRoutes, useProviders, routeKeys } from '@/hooks/queries';
+import {
+  useProjects,
+  useUpdateProject,
+  useRoutes,
+  useProviders,
+  routeKeys,
+  useUsageStats,
+  getTimeRange,
+} from '@/hooks/queries';
 import { useTransport } from '@/lib/transport/context';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
+import { buildTtftRoutePositionUpdates } from './utils/ttft-sort';
 
 const SCROLL_STEP = 200;
 
@@ -154,6 +164,28 @@ export function ClientRoutesPage() {
   const updateProject = useUpdateProject();
   const { transport } = useTransport();
   const queryClient = useQueryClient();
+  const selectedProjectIDNumber = Number(selectedProjectId);
+  const ttftUsageStatsFilter = useMemo(() => {
+    const { start, end, granularity } = getTimeRange('last_24_hours');
+    return {
+      granularity,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      clientType: activeClientType,
+      projectId: selectedProjectIDNumber,
+    };
+  }, [activeClientType, selectedProjectIDNumber]);
+  const { data: ttftUsageStats, isFetching: isLoadingTtftStats } =
+    useUsageStats(ttftUsageStatsFilter);
+
+  const currentScopeRoutes = useMemo(
+    () =>
+      (allRoutes ?? []).filter(
+        (route) =>
+          route.clientType === activeClientType && route.projectID === selectedProjectIDNumber,
+      ),
+    [activeClientType, allRoutes, selectedProjectIDNumber],
+  );
 
   const handleProjectHoverStart = useCallback(() => {
     if (!window.matchMedia('(hover: hover)').matches) return;
@@ -210,6 +242,25 @@ export function ClientRoutesPage() {
       queryClient.invalidateQueries({ queryKey: routeKeys.list() });
     } catch (error) {
       console.error('Failed to sort Codex routes:', error);
+    } finally {
+      setIsSorting(false);
+    }
+  };
+
+  const ttftSortUpdates = useMemo(
+    () => buildTtftRoutePositionUpdates(currentScopeRoutes, ttftUsageStats),
+    [currentScopeRoutes, ttftUsageStats],
+  );
+
+  const handleSortByTtft = async () => {
+    if (ttftSortUpdates.length === 0) return;
+
+    setIsSorting(true);
+    try {
+      await transport.batchUpdateRoutePositions(ttftSortUpdates);
+      queryClient.invalidateQueries({ queryKey: routeKeys.list() });
+    } catch (error) {
+      console.error('Failed to sort routes by TTFT:', error);
     } finally {
       setIsSorting(false);
     }
@@ -288,40 +339,51 @@ export function ClientRoutesPage() {
                 />
               </div>
 
-              {/* Sort Buttons - Only show when viewing Global routes and on appropriate pages */}
-              {selectedProjectId === '0' &&
-                ((hasAntigravityRoutes && isClaudePage) || (hasCodexRoutes && isCodexPage)) && (
-                  <div className="flex items-center gap-2">
-                    {/* Only show Antigravity sort button for Claude page */}
-                    {hasAntigravityRoutes && isClaudePage && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleSortAntigravity}
-                        disabled={isSorting}
-                        className="h-8 text-xs"
-                      >
-                        <Zap className="h-3.5 w-3.5 mr-1.5" />
-                        {t('routes.sortAntigravity')}
-                        {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
-                      </Button>
+              {/* Sort Buttons */}
+              <div className="flex items-center gap-2">
+                {currentScopeRoutes.length > 1 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSortByTtft}
+                    disabled={isSorting || isLoadingTtftStats || ttftSortUpdates.length === 0}
+                    title={t('routes.sortByTtftHint')}
+                    className="h-8 text-xs"
+                  >
+                    <Gauge className="h-3.5 w-3.5 mr-1.5" />
+                    {t('routes.sortByTtft')}
+                    {(isSorting || isLoadingTtftStats) && (
+                      <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />
                     )}
-                    {/* Only show Codex sort button for Codex page */}
-                    {hasCodexRoutes && isCodexPage && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleSortCodex}
-                        disabled={isSorting}
-                        className="h-8 text-xs"
-                      >
-                        <Code2 className="h-3.5 w-3.5 mr-1.5" />
-                        {t('routes.sortCodex')}
-                        {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
-                      </Button>
-                    )}
-                  </div>
+                  </Button>
                 )}
+                {selectedProjectId === '0' && hasAntigravityRoutes && isClaudePage && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSortAntigravity}
+                    disabled={isSorting}
+                    className="h-8 text-xs"
+                  >
+                    <Zap className="h-3.5 w-3.5 mr-1.5" />
+                    {t('routes.sortAntigravity')}
+                    {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
+                  </Button>
+                )}
+                {selectedProjectId === '0' && hasCodexRoutes && isCodexPage && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleSortCodex}
+                    disabled={isSorting}
+                    className="h-8 text-xs"
+                  >
+                    <Code2 className="h-3.5 w-3.5 mr-1.5" />
+                    {t('routes.sortCodex')}
+                    {isSorting && <ArrowUpDown className="h-3.5 w-3.5 ml-1.5 animate-pulse" />}
+                  </Button>
+                )}
+              </div>
             </div>
 
             {/* Full-width hover panel: all projects */}

--- a/web/src/pages/client-routes/utils/ttft-sort.test.ts
+++ b/web/src/pages/client-routes/utils/ttft-sort.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTtftRoutePositionUpdates, summarizeRouteTtft } from './ttft-sort';
+
+describe('TTFT route sorting helpers', () => {
+  it('aggregates average TTFT by route using successful requests', () => {
+    const summaries = summarizeRouteTtft([
+      { routeID: 1, successfulRequests: 2, totalTtftMs: 400 },
+      { routeID: 1, successfulRequests: 2, totalTtftMs: 200 },
+      { routeID: 2, successfulRequests: 0, totalTtftMs: 100 },
+    ]);
+
+    expect(summaries.get(1)).toEqual({
+      routeID: 1,
+      successfulRequests: 4,
+      avgTtftMs: 150,
+    });
+    expect(summaries.has(2)).toBe(false);
+  });
+
+  it('moves sufficiently sampled faster routes earlier while leaving low-sample routes in place', () => {
+    const updates = buildTtftRoutePositionUpdates(
+      [
+        { id: 1, position: 1 },
+        { id: 2, position: 2 },
+        { id: 3, position: 3 },
+        { id: 4, position: 4 },
+      ],
+      [
+        { routeID: 1, successfulRequests: 10, totalTtftMs: 10000 },
+        { routeID: 2, successfulRequests: 2, totalTtftMs: 20 },
+        { routeID: 3, successfulRequests: 10, totalTtftMs: 1000 },
+        { routeID: 4, successfulRequests: 10, totalTtftMs: 5000 },
+      ],
+    );
+
+    expect(updates).toEqual([
+      { id: 3, position: 1 },
+      { id: 4, position: 3 },
+      { id: 1, position: 4 },
+    ]);
+  });
+
+  it('keeps the current order when no route has enough TTFT samples', () => {
+    expect(
+      buildTtftRoutePositionUpdates(
+        [
+          { id: 1, position: 1 },
+          { id: 2, position: 2 },
+        ],
+        [
+          { routeID: 1, successfulRequests: 1, totalTtftMs: 20 },
+          { routeID: 2, successfulRequests: 0, totalTtftMs: 0 },
+        ],
+      ),
+    ).toEqual([]);
+  });
+});

--- a/web/src/pages/client-routes/utils/ttft-sort.ts
+++ b/web/src/pages/client-routes/utils/ttft-sort.ts
@@ -1,0 +1,94 @@
+import type { Route, UsageStats } from '@/lib/transport';
+
+const MIN_SUCCESSFUL_REQUESTS_FOR_TTFT_SORT = 3;
+
+type RouteLike = Pick<Route, 'id' | 'position'>;
+
+type UsageStatsLike = Pick<UsageStats, 'routeID' | 'successfulRequests' | 'totalTtftMs'>;
+
+export interface RouteTtftSummary {
+  routeID: number;
+  successfulRequests: number;
+  avgTtftMs: number;
+}
+
+export interface TtftRoutePositionUpdate {
+  id: number;
+  position: number;
+}
+
+export function summarizeRouteTtft(stats: UsageStatsLike[] | undefined): Map<number, RouteTtftSummary> {
+  const summaries = new Map<number, RouteTtftSummary>();
+
+  for (const stat of stats ?? []) {
+    if (stat.routeID === 0 || stat.successfulRequests <= 0 || stat.totalTtftMs <= 0) continue;
+
+    const existing = summaries.get(stat.routeID);
+    if (existing) {
+      const totalTtftMs = existing.avgTtftMs * existing.successfulRequests + stat.totalTtftMs;
+      const successfulRequests = existing.successfulRequests + stat.successfulRequests;
+      summaries.set(stat.routeID, {
+        routeID: stat.routeID,
+        successfulRequests,
+        avgTtftMs: totalTtftMs / successfulRequests,
+      });
+      continue;
+    }
+
+    summaries.set(stat.routeID, {
+      routeID: stat.routeID,
+      successfulRequests: stat.successfulRequests,
+      avgTtftMs: stat.totalTtftMs / stat.successfulRequests,
+    });
+  }
+
+  return summaries;
+}
+
+export function buildTtftRoutePositionUpdates(
+  routes: RouteLike[],
+  stats: UsageStatsLike[] | undefined,
+  minSuccessfulRequests = MIN_SUCCESSFUL_REQUESTS_FOR_TTFT_SORT,
+): TtftRoutePositionUpdate[] {
+  const summaries = summarizeRouteTtft(stats);
+  const originalOrder = routes.slice().sort((a, b) => {
+    const posDiff = (a.position ?? 0) - (b.position ?? 0);
+    if (posDiff !== 0) return posDiff;
+    return a.id - b.id;
+  });
+  const originalIndexByRouteId = new Map(originalOrder.map((route, index) => [route.id, index]));
+
+  const sortableRoutes = originalOrder.filter((route) => {
+    const summary = summaries.get(route.id);
+    return summary && summary.successfulRequests >= minSuccessfulRequests;
+  });
+
+  const unsortedRoutes = originalOrder.filter((route) => !sortableRoutes.includes(route));
+
+  sortableRoutes.sort((a, b) => {
+    const aSummary = summaries.get(a.id)!;
+    const bSummary = summaries.get(b.id)!;
+    const ttftDiff = aSummary.avgTtftMs - bSummary.avgTtftMs;
+    if (ttftDiff !== 0) return ttftDiff;
+    const requestDiff = bSummary.successfulRequests - aSummary.successfulRequests;
+    if (requestDiff !== 0) return requestDiff;
+    return (originalIndexByRouteId.get(a.id) ?? 0) - (originalIndexByRouteId.get(b.id) ?? 0);
+  });
+
+  const sortedQueue = [...sortableRoutes];
+  const stableQueue = [...unsortedRoutes];
+  const reordered = originalOrder.map((route) => {
+    const summary = summaries.get(route.id);
+    if (summary && summary.successfulRequests >= minSuccessfulRequests) {
+      return sortedQueue.shift()!;
+    }
+    return stableQueue.shift()!;
+  });
+
+  return reordered
+    .map((route, index) => ({ id: route.id, position: index + 1 }))
+    .filter((update) => {
+      const route = routes.find((candidate) => candidate.id === update.id);
+      return route?.position !== update.position;
+    });
+}


### PR DESCRIPTION
## Summary
- add a TTFT sort button to the client routes tab
- sort the current client/project route scope by the last 24h average TTFT
- keep low-sample routes in their current slot when they have fewer than 3 successful requests
- add helper coverage for TTFT aggregation and route position updates

## Validation
- `pnpm test -- --run ttft-sort`
- `pnpm typecheck`
- `pnpm lint`

## Notes
- This is the lightweight implementation: the frontend uses existing usage stats and existing batch route position updates.
- No CodeRabbit check was performed because this run was not authorized to inspect CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 客户端路由页面新增按 TTFT（首字节时间）排序功能。
  * 排序基于最近 24 小时的平均 TTFT，成功请求不足 3 次的路由保留原有位置。
  * 支持全局及项目范围，并提供中英文界面文案。
* **改进**
  * 排序完成后自动刷新路由列表，并在无可调整路由时禁用排序操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->