### PR TITLE
fix(providers): simplify template descriptions

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1848,7 +1848,7 @@
       },
       "freeduck": {
         "name": "Free Duck",
-        "description": "Free site · Claude Code only"
+        "description": "Free site · Claude"
       },
       "nvidia": {
         "name": "NVIDIA NIM",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1852,15 +1852,15 @@
       },
       "nvidia": {
         "name": "NVIDIA NIM",
-        "description": "NVIDIA NIM · OpenAI Compatible"
+        "description": "OpenAI Compatible"
       },
       "zhipu": {
         "name": "Zhipu AI",
-        "description": "GLM · Claude + OpenAI Compatible"
+        "description": "Claude + OpenAI Compatible"
       },
       "deepseek": {
         "name": "DeepSeek",
-        "description": "DeepSeek · Claude + OpenAI Compatible"
+        "description": "Claude + OpenAI Compatible"
       }
     },
     "grok": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1848,19 +1848,19 @@
       },
       "freeduck": {
         "name": "Free Duck",
-        "description": "Free site · Claude"
+        "description": "Claude"
       },
       "nvidia": {
         "name": "NVIDIA NIM",
-        "description": "OpenAI Compatible"
+        "description": "OpenAI"
       },
       "zhipu": {
         "name": "Zhipu AI",
-        "description": "Claude + OpenAI Compatible"
+        "description": "Claude + OpenAI"
       },
       "deepseek": {
         "name": "DeepSeek",
-        "description": "Claude + OpenAI Compatible"
+        "description": "Claude + OpenAI"
       }
     },
     "grok": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1844,7 +1844,7 @@
       },
       "freeduck": {
         "name": "Free Duck",
-        "description": "免费站点 · 只有 Claude Code"
+        "description": "免费站点 · Claude"
       },
       "nvidia": {
         "name": "NVIDIA NIM",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1848,15 +1848,15 @@
       },
       "nvidia": {
         "name": "NVIDIA NIM",
-        "description": "NVIDIA NIM · OpenAI 兼容"
+        "description": "OpenAI 兼容"
       },
       "zhipu": {
         "name": "智谱 AI",
-        "description": "GLM · Claude + OpenAI 兼容"
+        "description": "Claude + OpenAI 兼容"
       },
       "deepseek": {
         "name": "DeepSeek",
-        "description": "DeepSeek · Claude + OpenAI 兼容"
+        "description": "Claude + OpenAI 兼容"
       }
     },
     "grok": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1844,19 +1844,19 @@
       },
       "freeduck": {
         "name": "Free Duck",
-        "description": "免费站点 · Claude"
+        "description": "Claude"
       },
       "nvidia": {
         "name": "NVIDIA NIM",
-        "description": "OpenAI 兼容"
+        "description": "OpenAI"
       },
       "zhipu": {
         "name": "智谱 AI",
-        "description": "Claude + OpenAI 兼容"
+        "description": "Claude + OpenAI"
       },
       "deepseek": {
         "name": "DeepSeek",
-        "description": "Claude + OpenAI 兼容"
+        "description": "Claude + OpenAI"
       }
     },
     "grok": {

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -237,7 +237,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'nvidia',
     name: 'NVIDIA',
-    description: 'NVIDIA NIM · OpenAI 兼容',
+    description: 'OpenAI 兼容',
     nameKey: 'addProvider.templates.nvidia.name',
     descriptionKey: 'addProvider.templates.nvidia.description',
     icon: 'layers',
@@ -251,7 +251,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'zhipu',
     name: '智谱 AI',
-    description: 'GLM · Claude + OpenAI 兼容',
+    description: 'Claude + OpenAI 兼容',
     nameKey: 'addProvider.templates.zhipu.name',
     descriptionKey: 'addProvider.templates.zhipu.description',
     icon: 'grid',
@@ -265,7 +265,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'deepseek',
     name: 'DeepSeek',
-    description: 'DeepSeek · Claude + OpenAI 兼容',
+    description: 'Claude + OpenAI 兼容',
     nameKey: 'addProvider.templates.deepseek.name',
     descriptionKey: 'addProvider.templates.deepseek.description',
     icon: 'grid',

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -224,7 +224,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'freeduck',
     name: 'Free Duck',
-    description: '免费站点 · 只有 Claude Code',
+    description: '免费站点 · Claude',
     nameKey: 'addProvider.templates.freeduck.name',
     descriptionKey: 'addProvider.templates.freeduck.description',
     icon: 'grid',

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -224,7 +224,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'freeduck',
     name: 'Free Duck',
-    description: '免费站点 · Claude',
+    description: 'Claude',
     nameKey: 'addProvider.templates.freeduck.name',
     descriptionKey: 'addProvider.templates.freeduck.description',
     icon: 'grid',
@@ -237,7 +237,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'nvidia',
     name: 'NVIDIA',
-    description: 'OpenAI 兼容',
+    description: 'OpenAI',
     nameKey: 'addProvider.templates.nvidia.name',
     descriptionKey: 'addProvider.templates.nvidia.description',
     icon: 'layers',
@@ -251,7 +251,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'zhipu',
     name: '智谱 AI',
-    description: 'Claude + OpenAI 兼容',
+    description: 'Claude + OpenAI',
     nameKey: 'addProvider.templates.zhipu.name',
     descriptionKey: 'addProvider.templates.zhipu.description',
     icon: 'grid',
@@ -265,7 +265,7 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'deepseek',
     name: 'DeepSeek',
-    description: 'Claude + OpenAI 兼容',
+    description: 'Claude + OpenAI',
     nameKey: 'addProvider.templates.deepseek.name',
     descriptionKey: 'addProvider.templates.deepseek.description',
     icon: 'grid',


### PR DESCRIPTION
## Summary
- remove repeated provider brand names from NVIDIA, Zhipu, and DeepSeek quick template descriptions
- keep descriptions focused on supported client compatibility
- leave Free Duck as Claude Code only

## Validation
- node JSON parse check for web/src/locales/en.json and web/src/locales/zh.json
- npm test -- --run src/lib/proxy-route-exposure.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文案更新**
  * 优化“添加提供方”模板描述，统一展示 NVIDIA NIM、智谱 AI 和 DeepSeek 的兼容性信息。
  * 描述改为更简洁明确的“OpenAI 兼容”或“Claude + OpenAI 兼容”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->