### PR TITLE
feat(openrouter): image aspect ratio across protocols + generated-image passthrough

### DIFF
--- a/internal/adapter/provider/openrouter/adapter.go
+++ b/internal/adapter/provider/openrouter/adapter.go
@@ -92,7 +92,15 @@ func (a *Adapter) SupportedClientTypes() []domain.ClientType {
 }
 
 // Execute delegates to the custom core, passing the synthesized provider so the
-// custom config drives base URL and auth.
+// custom config drives base URL and auth. Before delegating it normalizes any
+// image sizing into the form the target OpenRouter endpoint honors (see
+// normalizeImageConfigBody), so each protocol can express sizing its own standard
+// way and still reach the upstream image model correctly.
 func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	if body := flow.GetRequestBody(c); len(body) > 0 {
+		if nb := normalizeImageConfigBody(body, flow.GetRequestURI(c)); len(nb) > 0 {
+			c.Set(flow.KeyRequestBody, nb)
+		}
+	}
 	return a.inner.Execute(c, a.synth)
 }

--- a/internal/adapter/provider/openrouter/image_config.go
+++ b/internal/adapter/provider/openrouter/image_config.go
@@ -29,8 +29,9 @@ import (
 // unchanged) body; never nil.
 func normalizeImageConfigBody(body []byte, requestURI string) []byte {
 	aspect := gjson.GetBytes(body, "image_config.aspect_ratio").String()
+	imageSize := gjson.GetBytes(body, "image_config.image_size").String()
 	size := gjson.GetBytes(body, "size").String()
-	if aspect == "" && size == "" {
+	if aspect == "" && imageSize == "" && size == "" {
 		return body // no image sizing intent
 	}
 
@@ -64,14 +65,23 @@ func isImagesEndpoint(requestURI string) bool {
 }
 
 // ensureImageModalities makes sure a chat request asks for image output, which
-// OpenRouter requires via modalities:["image","text"]. No-op when already present.
+// OpenRouter requires via modalities:["image","text"]. When modalities already
+// exist without "image", it prepends "image" and preserves the rest rather than
+// clobbering them (e.g. ["audio","text"] → ["image","audio","text"]).
 func ensureImageModalities(body []byte) []byte {
 	if mods := gjson.GetBytes(body, "modalities"); mods.IsArray() {
+		values := make([]string, 0, len(mods.Array())+1)
 		for _, m := range mods.Array() {
 			if strings.EqualFold(m.String(), "image") {
-				return body
+				return body // already requests image
 			}
+			values = append(values, m.String())
 		}
+		values = append([]string{"image"}, values...)
+		if out, err := sjson.SetBytes(body, "modalities", values); err == nil {
+			return out
+		}
+		return body
 	}
 	if out, err := sjson.SetBytes(body, "modalities", []string{"image", "text"}); err == nil {
 		return out

--- a/internal/adapter/provider/openrouter/image_config.go
+++ b/internal/adapter/provider/openrouter/image_config.go
@@ -1,0 +1,144 @@
+package openrouter
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// normalizeImageConfigBody rewrites an outbound OpenRouter request so an image
+// aspect ratio is expressed in the form the target endpoint actually honors.
+//
+// This is the provider-owned half of the "each protocol sends its own standard,
+// the provider converts" design. By the time a request reaches here it is in
+// OpenRouter-native OpenAI shape (an OpenAI client's own body, or a Gemini client
+// converted upstream), carrying the aspect ratio as either the OpenAI pixel
+// `size` or the `image_config.aspect_ratio` object. Which one the upstream model
+// reads depends entirely on the endpoint (verified against live OpenRouter):
+//
+//   - chat/completions: Gemini image models read image_config.aspect_ratio and
+//     ignore size; image output also requires modalities:["image","text"].
+//     (GPT image models cannot control size on chat at all — an upstream limit.)
+//   - images (generations): both Gemini and GPT image models read the pixel
+//     `size`; image_config is not consulted.
+//
+// So we fill in whichever representation the endpoint needs from whichever the
+// client sent, leaving the original field intact. Returns the (possibly
+// unchanged) body; never nil.
+func normalizeImageConfigBody(body []byte, requestURI string) []byte {
+	aspect := gjson.GetBytes(body, "image_config.aspect_ratio").String()
+	size := gjson.GetBytes(body, "size").String()
+	if aspect == "" && size == "" {
+		return body // no image sizing intent
+	}
+
+	if isImagesEndpoint(requestURI) {
+		// The images endpoint honors pixel size; derive it from the aspect ratio
+		// when the client only expressed image_config.
+		if size == "" && aspect != "" {
+			if s := sizeFromAspect(aspect); s != "" {
+				if out, err := sjson.SetBytes(body, "size", s); err == nil {
+					body = out
+				}
+			}
+		}
+		return body
+	}
+
+	// chat/completions: honor image_config.aspect_ratio, and ensure the request
+	// actually asks for image output.
+	if aspect == "" && size != "" {
+		if a := aspectFromSize(size); a != "" {
+			if out, err := sjson.SetBytes(body, "image_config.aspect_ratio", a); err == nil {
+				body = out
+			}
+		}
+	}
+	return ensureImageModalities(body)
+}
+
+func isImagesEndpoint(requestURI string) bool {
+	return strings.Contains(requestURI, "/images")
+}
+
+// ensureImageModalities makes sure a chat request asks for image output, which
+// OpenRouter requires via modalities:["image","text"]. No-op when already present.
+func ensureImageModalities(body []byte) []byte {
+	if mods := gjson.GetBytes(body, "modalities"); mods.IsArray() {
+		for _, m := range mods.Array() {
+			if strings.EqualFold(m.String(), "image") {
+				return body
+			}
+		}
+	}
+	if out, err := sjson.SetBytes(body, "modalities", []string{"image", "text"}); err == nil {
+		return out
+	}
+	return body
+}
+
+// sizeFromAspect maps an aspect ratio ("16:9") to a standard OpenAI pixel size
+// bucket. These are the sizes GPT image models accept, and OpenRouter maps them
+// to the nearest native aspect for Gemini image models. Landscape/portrait/square
+// is the best fidelity achievable with the standard buckets.
+func sizeFromAspect(aspect string) string {
+	r := ratioOfAspect(aspect)
+	switch {
+	case r == 0:
+		return ""
+	case r >= 1.15:
+		return "1536x1024"
+	case r <= 0.87:
+		return "1024x1536"
+	default:
+		return "1024x1024"
+	}
+}
+
+// aspectFromSize maps a pixel size ("1536x1024") to a coarse aspect ratio bucket
+// that Gemini image models honor on the chat endpoint.
+func aspectFromSize(size string) string {
+	w, h := parsePixelSize(size)
+	if w == 0 || h == 0 {
+		return ""
+	}
+	r := float64(w) / float64(h)
+	switch {
+	case r >= 1.15:
+		return "3:2"
+	case r <= 0.87:
+		return "2:3"
+	default:
+		return "1:1"
+	}
+}
+
+// ratioOfAspect parses "W:H" into a width/height ratio, or 0 when unparseable.
+func ratioOfAspect(aspect string) float64 {
+	parts := strings.SplitN(strings.TrimSpace(aspect), ":", 2)
+	if len(parts) != 2 {
+		return 0
+	}
+	w, err1 := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	h, err2 := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err1 != nil || err2 != nil || h == 0 {
+		return 0
+	}
+	return w / h
+}
+
+// parsePixelSize parses "WxH" (e.g. "1536x1024") into width and height.
+func parsePixelSize(size string) (int, int) {
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(size)), "x", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil {
+		return 0, 0
+	}
+	return w, h
+}

--- a/internal/adapter/provider/openrouter/image_config_test.go
+++ b/internal/adapter/provider/openrouter/image_config_test.go
@@ -65,6 +65,42 @@ func TestNormalizeImageConfig_ImagesKeepsExplicitSize(t *testing.T) {
 	}
 }
 
+func TestNormalizeImageConfig_ChatImageSizeOnlyAddsModalities(t *testing.T) {
+	// A Gemini request converted upstream may carry only image_config.image_size
+	// (no aspect_ratio, no size). On chat it must still get the image modality
+	// rather than being treated as a non-image request.
+	body := []byte(`{"model":"google/gemini-3-pro-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"image_size":"2K"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	mods := gjson.GetBytes(out, "modalities").Array()
+	hasImage := false
+	for _, m := range mods {
+		if m.String() == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Fatalf("image modality not added for image_size-only request: %s", out)
+	}
+	if gjson.GetBytes(out, "image_config.image_size").String() != "2K" {
+		t.Fatalf("image_size should be preserved: %s", out)
+	}
+}
+
+func TestEnsureImageModalities_PreservesExisting(t *testing.T) {
+	// Existing modalities must be kept, with image prepended — not clobbered.
+	body := []byte(`{"model":"x","messages":[],"image_config":{"aspect_ratio":"1:1"},"modalities":["audio","text"]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	got := gjson.GetBytes(out, "modalities").Array()
+	var vals []string
+	for _, m := range got {
+		vals = append(vals, m.String())
+	}
+	if len(vals) != 3 || vals[0] != "image" || vals[1] != "audio" || vals[2] != "text" {
+		t.Fatalf("modalities = %v, want [image audio text]", vals)
+	}
+}
+
 func TestNormalizeImageConfig_NoImageIntentUntouched(t *testing.T) {
 	// A plain chat request with no sizing must not gain modalities/image_config.
 	body := []byte(`{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}`)

--- a/internal/adapter/provider/openrouter/image_config_test.go
+++ b/internal/adapter/provider/openrouter/image_config_test.go
@@ -1,0 +1,102 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeImageConfig_ChatDerivesAspectAndModalities(t *testing.T) {
+	// OpenAI-ish chat request expressing sizing only via pixel size → on the chat
+	// endpoint we derive image_config.aspect_ratio (Gemini honors it) and ensure
+	// image output modality.
+	body := []byte(`{"model":"google/gemini-2.5-flash-image","messages":[{"role":"user","content":"a cat"}],"size":"1536x1024"}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "image_config.aspect_ratio").String(); got != "3:2" {
+		t.Fatalf("aspect_ratio = %q, want 3:2\n%s", got, out)
+	}
+	mods := gjson.GetBytes(out, "modalities").Array()
+	if len(mods) != 2 || mods[0].String() != "image" {
+		t.Fatalf("modalities = %v, want [image text]\n%s", mods, out)
+	}
+	// Original size is left intact.
+	if gjson.GetBytes(out, "size").String() != "1536x1024" {
+		t.Fatalf("size should be preserved: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ChatKeepsAspectAddsModalities(t *testing.T) {
+	// Gemini client converted upstream → chat body already carries
+	// image_config.aspect_ratio; we only need to guarantee modalities.
+	body := []byte(`{"model":"google/gemini-3-pro-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"aspect_ratio":"16:9"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "image_config.aspect_ratio").String(); got != "16:9" {
+		t.Fatalf("aspect_ratio mangled: %s", out)
+	}
+	if !gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("modalities not added: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ImagesDerivesSize(t *testing.T) {
+	// On the images endpoint the model reads pixel size; derive it from an
+	// aspect ratio the client expressed as image_config.
+	body := []byte(`{"model":"openai/gpt-5-image","prompt":"a cat","image_config":{"aspect_ratio":"9:16"}}`)
+	out := normalizeImageConfigBody(body, "/v1/images/generations")
+
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1536" {
+		t.Fatalf("size = %q, want 1024x1536\n%s", got, out)
+	}
+	// Images endpoint must NOT get modalities (different schema).
+	if gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("modalities must not be added on images endpoint: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ImagesKeepsExplicitSize(t *testing.T) {
+	// Standard OpenAI client already sent pixel size on the images endpoint —
+	// pass through untouched (OpenRouter maps it to the model's aspect).
+	body := []byte(`{"model":"openai/gpt-5-image","prompt":"a cat","size":"1024x1536"}`)
+	out := normalizeImageConfigBody(body, "/v1/images/generations")
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1536" {
+		t.Fatalf("size should be preserved verbatim: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_NoImageIntentUntouched(t *testing.T) {
+	// A plain chat request with no sizing must not gain modalities/image_config.
+	body := []byte(`{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	if gjson.GetBytes(out, "modalities").Exists() || gjson.GetBytes(out, "image_config").Exists() {
+		t.Fatalf("non-image request must be left untouched: %s", out)
+	}
+}
+
+func TestSizeAspectHelpers(t *testing.T) {
+	cases := []struct {
+		aspect string
+		size   string
+	}{
+		{"16:9", "1536x1024"},
+		{"21:9", "1536x1024"},
+		{"1:1", "1024x1024"},
+		{"9:16", "1024x1536"},
+		{"2:3", "1024x1536"},
+	}
+	for _, c := range cases {
+		if got := sizeFromAspect(c.aspect); got != c.size {
+			t.Errorf("sizeFromAspect(%q) = %q, want %q", c.aspect, got, c.size)
+		}
+	}
+	if got := sizeFromAspect("garbage"); got != "" {
+		t.Errorf("sizeFromAspect(garbage) = %q, want empty", got)
+	}
+	if got := aspectFromSize("1536x1024"); got != "3:2" {
+		t.Errorf("aspectFromSize landscape = %q, want 3:2", got)
+	}
+	if got := aspectFromSize("1024x1024"); got != "1:1" {
+		t.Errorf("aspectFromSize square = %q, want 1:1", got)
+	}
+}

--- a/internal/converter/gemini_to_openai.go
+++ b/internal/converter/gemini_to_openai.go
@@ -45,6 +45,31 @@ func (c *geminiToOpenAIRequest) Transform(body []byte, model string, stream bool
 				openaiReq.ReasoningEffort = mapBudgetToEffort(req.GenerationConfig.ThinkingConfig.ThinkingBudget)
 			}
 		}
+
+		// Image generation: mirror of openai_to_gemini_request.go so a Gemini
+		// image request keeps its output modality and sizing when converted to
+		// OpenAI (e.g. a Gemini client routed to an OpenAI-speaking provider like
+		// OpenRouter). Without this the aspect ratio / image output are dropped.
+		if len(req.GenerationConfig.ResponseModalities) > 0 {
+			var mods []string
+			for _, m := range req.GenerationConfig.ResponseModalities {
+				switch strings.ToUpper(strings.TrimSpace(m)) {
+				case "TEXT":
+					mods = append(mods, "text")
+				case "IMAGE":
+					mods = append(mods, "image")
+				}
+			}
+			if len(mods) > 0 {
+				openaiReq.Modalities = mods
+			}
+		}
+		if req.GenerationConfig.ImageConfig != nil {
+			openaiReq.ImageConfig = &OpenAIImageConfig{
+				AspectRatio: req.GenerationConfig.ImageConfig.AspectRatio,
+				ImageSize:   req.GenerationConfig.ImageConfig.ImageSize,
+			}
+		}
 	}
 
 	// Convert systemInstruction

--- a/internal/converter/gemini_to_openai_image_test.go
+++ b/internal/converter/gemini_to_openai_image_test.go
@@ -1,0 +1,39 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A Gemini image request converted to OpenAI (e.g. a Gemini client routed to an
+// OpenAI-speaking provider like OpenRouter) must keep its output modality and
+// image sizing, mirroring the openai->gemini direction.
+func TestGeminiToOpenAIRequest_ImageConfigAndModalities(t *testing.T) {
+	gReq := GeminiRequest{
+		Contents: []GeminiContent{{
+			Role:  "user",
+			Parts: []GeminiPart{{Text: "a cat"}},
+		}},
+		GenerationConfig: &GeminiGenerationConfig{
+			ResponseModalities: []string{"TEXT", "IMAGE"},
+			ImageConfig:        &GeminiImageConfig{AspectRatio: "16:9", ImageSize: "2K"},
+		},
+	}
+	body, _ := json.Marshal(gReq)
+
+	out, err := (&geminiToOpenAIRequest{}).Transform(body, "google/gemini-3-pro-image", false)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+	var got OpenAIRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.ImageConfig == nil || got.ImageConfig.AspectRatio != "16:9" || got.ImageConfig.ImageSize != "2K" {
+		t.Fatalf("image_config not carried: %#v", got.ImageConfig)
+	}
+	if len(got.Modalities) != 2 || got.Modalities[0] != "text" || got.Modalities[1] != "image" {
+		t.Fatalf("modalities = %v, want [text image]", got.Modalities)
+	}
+}

--- a/internal/converter/openai_to_gemini_image_response_test.go
+++ b/internal/converter/openai_to_gemini_image_response_test.go
@@ -1,0 +1,97 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const tinyPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+// A generated image in the OpenAI response's non-standard message.images[] array
+// must convert to a Gemini inlineData part so a Gemini client receives it.
+func TestOpenAIToGeminiResponse_CarriesGeneratedImage(t *testing.T) {
+	body := []byte(`{
+		"id":"gen","object":"chat.completion","model":"google/gemini-2.5-flash-image",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"here",
+			"images":[{"type":"image_url","image_url":{"url":"` + tinyPNGDataURL + `"}}]},
+			"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":3,"completion_tokens":1290,"total_tokens":1293}
+	}`)
+
+	out, err := (&openaiToGeminiResponse{}).Transform(body)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+
+	mime := gjson.GetBytes(out, "candidates.0.content.parts.#(inlineData.mimeType!=).inlineData.mimeType").String()
+	data := gjson.GetBytes(out, "candidates.0.content.parts.#(inlineData.data!=).inlineData.data").String()
+	if mime != "image/png" {
+		t.Errorf("inlineData.mimeType = %q, want image/png\n%s", mime, out)
+	}
+	if data == "" {
+		t.Errorf("generated image dropped; body=%s", out)
+	}
+	// The text part is still present.
+	if !gjson.GetBytes(out, `candidates.0.content.parts.#(text=="here")`).Exists() {
+		t.Errorf("text part lost: %s", out)
+	}
+}
+
+// The streaming variant must emit the image delta as a Gemini inlineData part.
+func TestOpenAIToGeminiStream_CarriesGeneratedImage(t *testing.T) {
+	chunk := []byte("data: " + `{"id":"gen","object":"chat.completion.chunk","model":"google/gemini-2.5-flash-image","choices":[{"index":0,"delta":{"role":"assistant","images":[{"type":"image_url","image_url":{"url":"` + tinyPNGDataURL + `"}}]}}]}` + "\n\n")
+
+	state := NewTransformState()
+	out, err := (&openaiToGeminiResponse{}).TransformChunk(chunk, state)
+	if err != nil {
+		t.Fatalf("transform chunk: %v", err)
+	}
+	// The emitted SSE frame must carry the inlineData image.
+	if !gjson.ValidBytes(extractSSEData(t, out)) {
+		t.Fatalf("no valid gemini frame emitted: %s", out)
+	}
+	frame := extractSSEData(t, out)
+	if got := gjson.GetBytes(frame, "candidates.0.content.parts.0.inlineData.data").String(); got == "" {
+		t.Fatalf("stream dropped generated image; frame=%s", frame)
+	}
+	if got := gjson.GetBytes(frame, "candidates.0.content.parts.0.inlineData.mimeType").String(); got != "image/png" {
+		t.Fatalf("stream inlineData.mimeType = %q, want image/png", got)
+	}
+}
+
+// extractSSEData returns the JSON payload of the first "data:" SSE line.
+func extractSSEData(t *testing.T, sse []byte) []byte {
+	t.Helper()
+	for _, line := range splitLines(string(sse)) {
+		if len(line) > 5 && line[:5] == "data:" {
+			var js json.RawMessage
+			payload := []byte(line[5:])
+			if json.Unmarshal(payload, &js) == nil {
+				return payload
+			}
+		}
+	}
+	return nil
+}
+
+func splitLines(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		if r == '\r' {
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/converter/openai_to_gemini_response.go
+++ b/internal/converter/openai_to_gemini_response.go
@@ -51,6 +51,17 @@ func (c *openaiToGeminiResponse) Transform(body []byte) ([]byte, error) {
 					}
 				}
 			}
+			// Generated images (OpenRouter/Gemini image models return them in the
+			// non-standard message.images[] array) → Gemini inlineData parts, so a
+			// Gemini client actually receives the image it asked for.
+			for _, img := range choice.Message.Images {
+				if img.ImageURL == nil {
+					continue
+				}
+				if inline := parseInlineImage(img.ImageURL.URL); inline != nil {
+					candidate.Content.Parts = append(candidate.Content.Parts, GeminiPart{InlineData: inline})
+				}
+			}
 			for _, tc := range choice.Message.ToolCalls {
 				var args map[string]interface{}
 				if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {

--- a/internal/converter/openai_to_gemini_stream.go
+++ b/internal/converter/openai_to_gemini_stream.go
@@ -51,6 +51,26 @@ func (c *openaiToGeminiResponse) TransformChunk(chunk []byte, state *TransformSt
 					output = append(output, FormatSSE("", geminiChunk)...)
 				}
 
+				// Generated images arrive in the delta's non-standard images[]
+				// array → emit them as Gemini inlineData parts.
+				for _, img := range choice.Delta.Images {
+					if img.ImageURL == nil {
+						continue
+					}
+					if inline := parseInlineImage(img.ImageURL.URL); inline != nil {
+						geminiChunk := GeminiStreamChunk{
+							Candidates: []GeminiCandidate{{
+								Content: GeminiContent{
+									Role:  "model",
+									Parts: []GeminiPart{{InlineData: inline}},
+								},
+								Index: 0,
+							}},
+						}
+						output = append(output, FormatSSE("", geminiChunk)...)
+					}
+				}
+
 				if len(choice.Delta.ToolCalls) > 0 {
 					if state.ToolCalls == nil {
 						state.ToolCalls = make(map[int]*ToolCallState)

--- a/internal/converter/types_openai.go
+++ b/internal/converter/types_openai.go
@@ -32,6 +32,10 @@ type OpenAIMessage struct {
 	Name             string           `json:"name,omitempty"`
 	ToolCalls        []OpenAIToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string           `json:"tool_call_id,omitempty"`
+	// Images carries generated images on a response message. It is the
+	// non-standard array OpenRouter/Gemini image models return, each element
+	// {type:"image_url", image_url:{url:"data:...base64,..."}}.
+	Images []OpenAIContentPart `json:"images,omitempty"`
 }
 
 type OpenAIContentPart struct {

--- a/tests/e2e/openrouter_image_config_test.go
+++ b/tests/e2e/openrouter_image_config_test.go
@@ -1,0 +1,150 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// newORImageConfigMock captures the upstream request and returns a minimal valid
+// response per endpoint (data[] for /images, a plain chat completion otherwise),
+// so these tests can assert how maxx shapes the OUTBOUND image sizing.
+func newORImageConfigMock(t *testing.T, captured *capturedRequest, calls *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(calls, 1)
+		reqBody, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(reqBody))
+		captured.Set(r)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/images") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"created": 1700000000,
+				"data":    []map[string]any{{"b64_json": "aGVsbG8=", "media_type": "image/png"}},
+				"usage":   map[string]any{"cost": 0.01},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl_or", "object": "chat.completion",
+			"model": "google/gemini-2.5-flash-image", "created": 1700000000,
+			"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]any{"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+		})
+	}))
+}
+
+// On the chat endpoint, an OpenAI client that expresses sizing only via the
+// standard pixel `size` must reach OpenRouter as image_config.aspect_ratio (the
+// form Gemini image models honor on chat) plus modalities:["image"].
+func TestOpenRouterImageConfig_ChatSizeToAspect(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-imgcfg-chat", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	req := map[string]any{
+		"model":    "google/gemini-2.5-flash-image",
+		"messages": []map[string]any{{"role": "user", "content": "a cat"}},
+		"size":     "1536x1024",
+	}
+	resp := env.ProxyPost("/v1/chat/completions", req, map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, _, up := captured.Get()
+	if got := gjson.GetBytes(up, "image_config.aspect_ratio").String(); got != "3:2" {
+		t.Errorf("upstream image_config.aspect_ratio = %q, want 3:2; body=%s", got, up)
+	}
+	if !gjson.GetBytes(up, "modalities").Exists() {
+		t.Errorf("upstream lost modalities; body=%s", up)
+	}
+}
+
+// On the images endpoint, an aspect ratio expressed as image_config must reach
+// OpenRouter as a pixel `size` (the form both Gemini and GPT image models honor
+// there).
+func TestOpenRouterImageConfig_ImagesAspectToSize(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-imgcfg-images", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	req := map[string]any{
+		"model":        "openai/gpt-5-image",
+		"prompt":       "a cat",
+		"image_config": map[string]any{"aspect_ratio": "9:16"},
+	}
+	resp := env.ProxyPost("/v1/images/generations", req, map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, _, up := captured.Get()
+	if got := gjson.GetBytes(up, "size").String(); got != "1024x1536" {
+		t.Errorf("upstream size = %q, want 1024x1536; body=%s", got, up)
+	}
+}
+
+// Full pipeline: a native Gemini client (generationConfig.imageConfig) routed to
+// the OpenAI-speaking OpenRouter provider. The forced Gemini->OpenAI conversion
+// (layer 1) must carry the aspect ratio into image_config, and the provider
+// (layer 2) must guarantee modalities — so the image request survives end to end.
+func TestOpenRouterImageConfig_GeminiClientToOpenRouter(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
+	// openai-only support forces the gemini request to be converted to OpenAI.
+	pid := createORProvider(t, env, "or-imgcfg-gem", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "gemini", pid, 1)
+
+	req := map[string]any{
+		"contents": []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "a cat"}}}},
+		"generationConfig": map[string]any{
+			"responseModalities": []string{"TEXT", "IMAGE"},
+			"imageConfig":        map[string]any{"aspectRatio": "16:9"},
+		},
+	}
+	resp := env.ProxyPost("/v1beta/models/gemini-2.0-flash:generateContent", req, nil)
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, path, _, up := captured.Get()
+	if !strings.Contains(path, "/chat/completions") {
+		t.Fatalf("expected conversion to chat/completions, upstream path=%s", path)
+	}
+	if got := gjson.GetBytes(up, "image_config.aspect_ratio").String(); got != "16:9" {
+		t.Errorf("aspect ratio lost across gemini->openai; got %q, body=%s", got, up)
+	}
+	mods := gjson.GetBytes(up, "modalities").Array()
+	hasImage := false
+	for _, m := range mods {
+		if m.String() == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Errorf("upstream lost image modality; body=%s", up)
+	}
+}


### PR DESCRIPTION
## Problem

Image generation config (aspect ratio / size) was lost when a request crossed protocols to reach an OpenAI-speaking upstream (e.g. OpenRouter), and generated images were dropped when converting the response back to a Gemini client. Each API protocol expresses image sizing its own standard way — OpenAI uses a pixel `size`, Gemini uses `generationConfig.imageConfig` — and these weren't preserved across conversion.

## What this does

Each protocol sends its own standard; conversion is handled transparently so the same client request works regardless of which upstream serves it.

**Request side** (`feat(openrouter): preserve image aspect ratio across protocols`)
- Converter (gemini→openai): carry `imageConfig`/`responseModalities` into OpenAI `image_config`/`modalities` so a Gemini client's aspect ratio survives the forced Gemini→OpenAI conversion. Generic — benefits any OpenAI-speaking upstream.
- OpenRouter provider: endpoint-aware normalization before forwarding — chat honors `image_config.aspect_ratio` (+`modalities`), the images endpoint honors pixel `size`; fill in whichever the endpoint needs from what the client sent.

**Response side** (`fix(converter): carry generated images openai->gemini response`)
- Map the non-standard `message.images[]` array (how OpenRouter/Gemini image models return generated images) to Gemini `parts[].inlineData`, in both the non-stream and streaming response converters — so a Gemini client actually receives the image.

## Testing

- Unit tests for both converters and the provider normalization.
- e2e integration tests through the full proxy pipeline against a mock upstream (CI-safe): OpenAI chat size→aspect, images aspect→size, and a full Gemini-client→OpenRouter round trip.
- Verified end-to-end against live OpenRouter (decoding returned image dimensions): OpenAI client `size=1536x1024` → 3:2, Gemini client `aspectRatio=9:16` → 9:16 with the image returned. Also verified the same request fails over correctly across upstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持 Gemini 图像生成参数转换为 OpenAI/OpenRouter 格式，包括图像尺寸、长宽比及响应模态。
  - 自动兼容不同接口的图像尺寸与长宽比参数。
  - 支持将 OpenAI/OpenRouter 返回的生成图片转换为 Gemini 可识别的图片内容，覆盖普通和流式响应。

- **Bug 修复**
  - 改善图像生成请求在不同接口间的参数兼容性，确保图像模态信息正确传递。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->