### PR TITLE
fix(requests): show mapped model during active requests

### DIFF
--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -117,7 +117,7 @@ func NewProxyRequestRepository(db *DB) *ProxyRequestRepository {
 func (r *ProxyRequestRepository) proxyRequestListSelectColumns(includeTTFT bool) string {
 	mappedModelColumn := "proxy_requests.response_model AS mapped_model"
 	if r.hasProxyUpstreamAttemptsTable {
-		mappedModelColumn = "COALESCE(NULLIF(final_attempt.mapped_model, ''), proxy_requests.response_model) AS mapped_model"
+		mappedModelColumn = "COALESCE(NULLIF(final_attempt.mapped_model, ''), NULLIF(latest_attempt.mapped_model, ''), proxy_requests.response_model) AS mapped_model"
 	}
 	columns := "proxy_requests.id, proxy_requests.created_at, proxy_requests.updated_at, proxy_requests.instance_id, proxy_requests.request_id, proxy_requests.session_id, proxy_requests.client_type, proxy_requests.request_model, " + mappedModelColumn + ", proxy_requests.response_model, proxy_requests.start_time, proxy_requests.end_time, proxy_requests.duration_ms"
 	if includeTTFT {
@@ -130,11 +130,13 @@ func (r *ProxyRequestRepository) proxyRequestListSelectColumns(includeTTFT bool)
 	return columns
 }
 
-func (r *ProxyRequestRepository) joinFinalProxyUpstreamAttempt(query *gorm.DB) *gorm.DB {
+func (r *ProxyRequestRepository) joinProxyUpstreamAttemptModels(query *gorm.DB) *gorm.DB {
 	if !r.hasProxyUpstreamAttemptsTable {
 		return query
 	}
-	return query.Joins("LEFT JOIN proxy_upstream_attempts AS final_attempt ON final_attempt.id = proxy_requests.final_proxy_upstream_attempt_id")
+	return query.
+		Joins("LEFT JOIN proxy_upstream_attempts AS final_attempt ON final_attempt.id = proxy_requests.final_proxy_upstream_attempt_id").
+		Joins("LEFT JOIN proxy_upstream_attempts AS latest_attempt ON latest_attempt.id = (SELECT MAX(id) FROM proxy_upstream_attempts WHERE proxy_request_id = proxy_requests.id)")
 }
 
 // initCount 从数据库初始化计数缓存
@@ -217,7 +219,7 @@ func (r *ProxyRequestRepository) List(tenantID uint64, limit, offset int) ([]*do
 func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, after uint64, filter *repository.ProxyRequestFilter) ([]*domain.ProxyRequest, error) {
 	// 使用 Select 排除大字段
 	selectColumns := r.proxyRequestListSelectColumns(true)
-	baseQuery := r.joinFinalProxyUpstreamAttempt(r.db.gorm.Model(&ProxyRequest{}).
+	baseQuery := r.joinProxyUpstreamAttemptModels(r.db.gorm.Model(&ProxyRequest{}).
 		Select(selectColumns))
 	if tenantID != domain.TenantIDAll {
 		baseQuery = baseQuery.Where("proxy_requests.tenant_id = ?", tenantID)
@@ -248,7 +250,7 @@ func (r *ProxyRequestRepository) ListCursor(tenantID uint64, limit int, before, 
 // ListActive 获取所有活跃请求 (PENDING 或 IN_PROGRESS 状态)
 func (r *ProxyRequestRepository) ListActive(tenantID uint64) ([]*domain.ProxyRequest, error) {
 	selectColumns := r.proxyRequestListSelectColumns(false)
-	query := r.joinFinalProxyUpstreamAttempt(r.db.gorm.Model(&ProxyRequest{}).
+	query := r.joinProxyUpstreamAttemptModels(r.db.gorm.Model(&ProxyRequest{}).
 		Select(selectColumns)).
 		Where("proxy_requests.status IN ?", activeProxyRequestStatuses)
 	if tenantID != domain.TenantIDAll {

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -172,7 +172,7 @@ func TestProxyRequestListCursorIncludesFinalAttemptMappedModel(t *testing.T) {
 	}
 }
 
-func TestProxyRequestListActiveFallsBackToResponseModelBeforeFinalAttempt(t *testing.T) {
+func TestProxyRequestListActiveUsesLatestAttemptMappedModelBeforeFinalAttempt(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {
 		t.Fatalf("Failed to create DB: %v", err)
@@ -180,11 +180,23 @@ func TestProxyRequestListActiveFallsBackToResponseModelBeforeFinalAttempt(t *tes
 	defer db.Close()
 
 	reqRepo := NewProxyRequestRepository(db)
+	attemptRepo := NewProxyUpstreamAttemptRepository(db)
 	req := buildTestProxyRequest("IN_PROGRESS", 1)
 	req.RequestModel = "claude-3-5-sonnet"
-	req.ResponseModel = "openrouter/anthropic/claude-3.5-sonnet"
+	req.ResponseModel = ""
 	if err := reqRepo.Create(req); err != nil {
 		t.Fatalf("create request: %v", err)
+	}
+
+	attempt := &domain.ProxyUpstreamAttempt{
+		TenantID:       req.TenantID,
+		ProxyRequestID: req.ID,
+		Status:         "IN_PROGRESS",
+		RequestModel:   "claude-3-5-sonnet",
+		MappedModel:    "openrouter/anthropic/claude-3.5-sonnet",
+	}
+	if err := attemptRepo.Create(attempt); err != nil {
+		t.Fatalf("create attempt: %v", err)
 	}
 
 	items, err := reqRepo.ListActive(1)

--- a/web/src/pages/requests/detail/RequestDetailView.tsx
+++ b/web/src/pages/requests/detail/RequestDetailView.tsx
@@ -403,6 +403,19 @@ export function RequestDetailView({
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-center">
                   <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                    {t('requests.mappedModel')}
+                  </dt>
+                  <dd className="sm:col-span-2 font-mono text-xs text-foreground bg-muted px-2 py-1 rounded">
+                    {request.mappedModel || '-'}
+                    {request.mappedModel && request.requestModel !== request.mappedModel && (
+                      <span className="ml-2 text-muted-foreground text-[10px]">
+                        {t('requests.converted')}
+                      </span>
+                    )}
+                  </dd>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-center">
+                  <dt className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
                     {t('requests.responseModel')}
                   </dt>
                   <dd className="sm:col-span-2 font-mono text-xs text-foreground bg-muted px-2 py-1 rounded">


### PR DESCRIPTION
## Summary
- show mapped model for active requests before final upstream attempt is selected
- add mapped model to the main request detail metadata panel
- cover active request mapped-model visibility with a SQLite repository regression test

## Validation
- `go test ./internal/repository/sqlite -run 'TestProxyRequestList(CursorIncludesFinalAttemptMappedModel|ActiveUsesLatestAttemptMappedModelBeforeFinalAttempt)'`
- `git diff --check`
- `pnpm test -- --run src/hooks/queries/use-requests.test.ts`
- `pnpm exec tsc -b --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 请求详情的 Metadata 页签新增“映射模型”信息。
  * 当请求模型被转换时，页面会显示相应标识。

* **问题修复**
  * 请求列表和活动请求现在可正确显示最新上游尝试使用的映射模型。
  * 优化映射模型的回退逻辑，提升请求信息展示准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->