### PR TITLE
feat(providers): first-class newapi and ollama provider types

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -21,6 +21,8 @@ import (
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"     // Register custom adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/grok"       // Register grok adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"       // Register kiro adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/newapi"     // Register newapi adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/ollama"     // Register ollama adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/openrouter" // Register openrouter adapter
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"

--- a/internal/adapter/provider/newapi/adapter.go
+++ b/internal/adapter/provider/newapi/adapter.go
@@ -1,0 +1,67 @@
+// Package newapi implements a first-class provider adapter for new-api / one-api
+// style relay gateways (e.g. code0), a widely self-hosted aggregation gateway that
+// speaks the OpenAI Chat Completions API and proxies Gemini through Google's
+// OpenAI-compatibility layer. Like the openrouter adapter it is a thin wrapper over
+// the proven `custom` proxy core: everything about forwarding, streaming, auth and
+// error handling is identical to a custom OpenAI-compatible upstream. The only
+// new-api-specific behavior is translating a client's image sizing into new-api's
+// dialect (extra_body.google.image_config) before delegating — the exact mirror of
+// what the openrouter adapter does for OpenRouter's own dialect.
+//
+// Making new-api a dedicated type (rather than a `custom` provider with a discriminator
+// flag) keeps each relay product's quirks in its own adapter and lets `custom` stay a
+// truly generic passthrough. See the deprecated ProviderConfigCustom.Backend field.
+package newapi
+
+import (
+	"fmt"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+func init() {
+	provider.RegisterAdapterFactory("newapi", NewAdapter)
+}
+
+// Adapter is a first-class new-api provider that delegates to the custom adapter,
+// translating image sizing into new-api's dialect on the way out.
+type Adapter struct {
+	inner    provider.ProviderAdapter
+	provider *domain.Provider
+}
+
+// NewAdapter builds a new-api adapter around the custom proxy core. new-api providers
+// reuse the custom config (BaseURL, APIKey, model mapping, etc.) — no separate config
+// shape is needed, since a new-api upstream is configured exactly like any OpenAI-
+// compatible relay.
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	if p.Config == nil || p.Config.Custom == nil {
+		return nil, fmt.Errorf("provider %s missing custom config", p.Name)
+	}
+	inner, err := custom.NewAdapter(p)
+	if err != nil {
+		return nil, err
+	}
+	return &Adapter{inner: inner, provider: p}, nil
+}
+
+// SupportedClientTypes reports the client types this new-api provider serves.
+func (a *Adapter) SupportedClientTypes() []domain.ClientType {
+	return a.provider.SupportedClientTypes
+}
+
+// Execute normalizes any image sizing into new-api's extra_body.google.image_config
+// form (so an OpenAI- or Gemini-origin client can express sizing its own standard
+// way and still reach the upstream image model correctly), then delegates to the
+// custom core.
+func (a *Adapter) Execute(c *flow.Ctx, prov *domain.Provider) error {
+	if body := flow.GetRequestBody(c); len(body) > 0 {
+		if nb := normalizeImageConfigBody(body, flow.GetRequestURI(c)); len(nb) > 0 {
+			c.Set(flow.KeyRequestBody, nb)
+		}
+	}
+	return a.inner.Execute(c, prov)
+}

--- a/internal/adapter/provider/newapi/adapter_test.go
+++ b/internal/adapter/provider/newapi/adapter_test.go
@@ -1,0 +1,34 @@
+package newapi
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestNewAdapter_RequiresCustomConfig(t *testing.T) {
+	if _, err := NewAdapter(&domain.Provider{Name: "x", Type: "newapi", Config: &domain.ProviderConfig{}}); err == nil {
+		t.Fatal("expected error for missing custom config")
+	}
+
+	p := &domain.Provider{
+		Name:                 "code0",
+		Type:                 "newapi",
+		Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{BaseURL: "https://example.com"}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+	}
+	a, err := NewAdapter(p)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	if len(a.SupportedClientTypes()) != 1 || a.SupportedClientTypes()[0] != domain.ClientTypeOpenAI {
+		t.Fatalf("SupportedClientTypes = %v", a.SupportedClientTypes())
+	}
+}
+
+func TestNewAPIFactoryRegistered(t *testing.T) {
+	if _, ok := provider.GetAdapterFactory("newapi"); !ok {
+		t.Fatal("newapi adapter factory not registered")
+	}
+}

--- a/internal/adapter/provider/newapi/image_config.go
+++ b/internal/adapter/provider/newapi/image_config.go
@@ -1,0 +1,164 @@
+package newapi
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// normalizeImageConfigBody rewrites an outbound new-api request so an image
+// aspect ratio is expressed in the form a new-api / Google-OpenAI-compat upstream
+// actually honors.
+//
+// This is the new-api half of the "each protocol sends its own standard, the
+// provider converts" design — the exact mirror of the openrouter adapter, but
+// aimed at a different upstream dialect. By the time a request reaches here it is
+// in OpenAI shape (an OpenAI client's own body, or a Gemini client converted
+// upstream), carrying the aspect ratio as either the OpenAI pixel `size` or the
+// top-level `image_config` object. new-api (which proxies Gemini through Google's
+// OpenAI-compatibility layer) reads neither of those on chat: it wants the aspect
+// under `extra_body.google.image_config`, plus modalities:["image","text"] to ask
+// for image output. Verified live against a new-api instance:
+//
+//	{"modalities":["image","text"],
+//	 "extra_body":{"google":{"image_config":{"aspect_ratio":"16:9"}}}}  → 1344x768
+//
+// So we translate whichever representation the client sent into the new-api form,
+// leaving the original fields intact (new-api ignores unknown keys). On the images
+// endpoint new-api reads the pixel `size` like plain OpenAI, so we only derive that.
+// Returns the (possibly unchanged) body; never nil.
+//
+// NOTE: the small aspect/size math helpers below intentionally mirror the ones in
+// the openrouter package rather than sharing a module, to keep each first-class
+// provider adapter self-contained and avoid touching the merged openrouter path.
+func normalizeImageConfigBody(body []byte, requestURI string) []byte {
+	aspect := gjson.GetBytes(body, "image_config.aspect_ratio").String()
+	imageSize := gjson.GetBytes(body, "image_config.image_size").String()
+	size := gjson.GetBytes(body, "size").String()
+	if aspect == "" && imageSize == "" && size == "" {
+		return body // no image sizing intent
+	}
+
+	if isImagesEndpoint(requestURI) {
+		// The images endpoint honors pixel size; derive it from the aspect ratio
+		// when the client only expressed image_config.
+		if size == "" && aspect != "" {
+			if s := sizeFromAspect(aspect); s != "" {
+				if out, err := sjson.SetBytes(body, "size", s); err == nil {
+					body = out
+				}
+			}
+		}
+		return body
+	}
+
+	// chat/completions: new-api reads the aspect ratio from
+	// extra_body.google.image_config, and needs modalities to emit an image.
+	if aspect == "" && size != "" {
+		aspect = aspectFromSize(size)
+	}
+	if aspect != "" {
+		if out, err := sjson.SetBytes(body, "extra_body.google.image_config.aspect_ratio", aspect); err == nil {
+			body = out
+		}
+	}
+	if imageSize != "" {
+		if out, err := sjson.SetBytes(body, "extra_body.google.image_config.image_size", imageSize); err == nil {
+			body = out
+		}
+	}
+	return ensureImageModalities(body)
+}
+
+func isImagesEndpoint(requestURI string) bool {
+	return strings.Contains(requestURI, "/images")
+}
+
+// ensureImageModalities makes sure a chat request asks for image output. When
+// modalities already exist without "image", it prepends "image" and preserves the
+// rest rather than clobbering them (e.g. ["audio","text"] → ["image","audio","text"]).
+func ensureImageModalities(body []byte) []byte {
+	if mods := gjson.GetBytes(body, "modalities"); mods.IsArray() {
+		values := make([]string, 0, len(mods.Array())+1)
+		for _, m := range mods.Array() {
+			if strings.EqualFold(m.String(), "image") {
+				return body // already requests image
+			}
+			values = append(values, m.String())
+		}
+		values = append([]string{"image"}, values...)
+		if out, err := sjson.SetBytes(body, "modalities", values); err == nil {
+			return out
+		}
+		return body
+	}
+	if out, err := sjson.SetBytes(body, "modalities", []string{"image", "text"}); err == nil {
+		return out
+	}
+	return body
+}
+
+// sizeFromAspect maps an aspect ratio ("16:9") to a standard OpenAI pixel size
+// bucket for the images endpoint. Landscape/portrait/square is the best fidelity
+// achievable with the standard buckets.
+func sizeFromAspect(aspect string) string {
+	r := ratioOfAspect(aspect)
+	switch {
+	case r == 0:
+		return ""
+	case r >= 1.15:
+		return "1536x1024"
+	case r <= 0.87:
+		return "1024x1536"
+	default:
+		return "1024x1024"
+	}
+}
+
+// aspectFromSize maps a pixel size ("1536x1024") to a coarse aspect ratio bucket
+// that Gemini image models honor.
+func aspectFromSize(size string) string {
+	w, h := parsePixelSize(size)
+	if w == 0 || h == 0 {
+		return ""
+	}
+	r := float64(w) / float64(h)
+	switch {
+	case r >= 1.15:
+		return "3:2"
+	case r <= 0.87:
+		return "2:3"
+	default:
+		return "1:1"
+	}
+}
+
+// ratioOfAspect parses "W:H" into a width/height ratio, or 0 when unparseable.
+func ratioOfAspect(aspect string) float64 {
+	parts := strings.SplitN(strings.TrimSpace(aspect), ":", 2)
+	if len(parts) != 2 {
+		return 0
+	}
+	w, err1 := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	h, err2 := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err1 != nil || err2 != nil || h == 0 {
+		return 0
+	}
+	return w / h
+}
+
+// parsePixelSize parses "WxH" (e.g. "1536x1024") into width and height.
+func parsePixelSize(size string) (int, int) {
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(size)), "x", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil {
+		return 0, 0
+	}
+	return w, h
+}

--- a/internal/adapter/provider/newapi/image_config_test.go
+++ b/internal/adapter/provider/newapi/image_config_test.go
@@ -1,0 +1,124 @@
+package newapi
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeImageConfig_ChatTopLevelToExtraBodyGoogle(t *testing.T) {
+	// A client (OpenAI- or Gemini-origin) expressing aspect via the top-level
+	// image_config → new-api needs it under extra_body.google.image_config plus
+	// image output modalities.
+	body := []byte(`{"model":"gemini-2.5-flash-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"aspect_ratio":"16:9"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "extra_body.google.image_config.aspect_ratio").String(); got != "16:9" {
+		t.Fatalf("extra_body.google.image_config.aspect_ratio = %q, want 16:9\n%s", got, out)
+	}
+	mods := gjson.GetBytes(out, "modalities").Array()
+	if len(mods) != 2 || mods[0].String() != "image" {
+		t.Fatalf("modalities = %v, want [image text]\n%s", mods, out)
+	}
+}
+
+func TestNormalizeImageConfig_ChatSizeDerivesAspect(t *testing.T) {
+	// Standard OpenAI client only sent pixel size → derive a coarse aspect ratio
+	// and emit it in new-api's dialect.
+	body := []byte(`{"model":"gemini-2.5-flash-image","messages":[{"role":"user","content":"a cat"}],"size":"1536x1024"}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "extra_body.google.image_config.aspect_ratio").String(); got != "3:2" {
+		t.Fatalf("aspect_ratio = %q, want 3:2\n%s", got, out)
+	}
+	// Original size stays intact (new-api ignores unknown top-level keys).
+	if gjson.GetBytes(out, "size").String() != "1536x1024" {
+		t.Fatalf("size should be preserved: %s", out)
+	}
+	if !gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("modalities not added: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ChatImageSizeOnly(t *testing.T) {
+	// A request carrying only image_config.image_size still gets translated and
+	// gains the image modality (not treated as a non-image request).
+	body := []byte(`{"model":"gemini-3-pro-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"image_size":"2K"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "extra_body.google.image_config.image_size").String(); got != "2K" {
+		t.Fatalf("image_size = %q, want 2K\n%s", got, out)
+	}
+	mods := gjson.GetBytes(out, "modalities").Array()
+	hasImage := false
+	for _, m := range mods {
+		if m.String() == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Fatalf("image modality not added for image_size-only request: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_PreservesExistingModalities(t *testing.T) {
+	// Existing modalities must be kept, with image prepended — not clobbered.
+	body := []byte(`{"model":"x","messages":[],"image_config":{"aspect_ratio":"1:1"},"modalities":["audio","text"]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	got := gjson.GetBytes(out, "modalities").Array()
+	var vals []string
+	for _, m := range got {
+		vals = append(vals, m.String())
+	}
+	if len(vals) != 3 || vals[0] != "image" || vals[1] != "audio" || vals[2] != "text" {
+		t.Fatalf("modalities = %v, want [image audio text]", vals)
+	}
+}
+
+func TestNormalizeImageConfig_ImagesDerivesSize(t *testing.T) {
+	// On the images endpoint new-api reads pixel size like plain OpenAI; derive it
+	// from an aspect ratio the client expressed as image_config, and do NOT add
+	// extra_body.google or modalities (different schema).
+	body := []byte(`{"model":"gpt-image-1","prompt":"a cat","image_config":{"aspect_ratio":"9:16"}}`)
+	out := normalizeImageConfigBody(body, "/v1/images/generations")
+
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1536" {
+		t.Fatalf("size = %q, want 1024x1536\n%s", got, out)
+	}
+	if gjson.GetBytes(out, "extra_body").Exists() {
+		t.Fatalf("images endpoint must not get extra_body.google: %s", out)
+	}
+	if gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("images endpoint must not get modalities: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_NoImageIntentUntouched(t *testing.T) {
+	// A plain chat request with no sizing must not gain modalities/extra_body.
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	if gjson.GetBytes(out, "modalities").Exists() || gjson.GetBytes(out, "extra_body").Exists() {
+		t.Fatalf("non-image request must be left untouched: %s", out)
+	}
+}
+
+func TestSizeAspectHelpers(t *testing.T) {
+	if got := sizeFromAspect("16:9"); got != "1536x1024" {
+		t.Errorf("sizeFromAspect(16:9) = %q, want 1536x1024", got)
+	}
+	if got := sizeFromAspect("9:16"); got != "1024x1536" {
+		t.Errorf("sizeFromAspect(9:16) = %q, want 1024x1536", got)
+	}
+	if got := sizeFromAspect("1:1"); got != "1024x1024" {
+		t.Errorf("sizeFromAspect(1:1) = %q, want 1024x1024", got)
+	}
+	if got := sizeFromAspect("garbage"); got != "" {
+		t.Errorf("sizeFromAspect(garbage) = %q, want empty", got)
+	}
+	if got := aspectFromSize("1536x1024"); got != "3:2" {
+		t.Errorf("aspectFromSize landscape = %q, want 3:2", got)
+	}
+	if got := aspectFromSize("1024x1024"); got != "1:1" {
+		t.Errorf("aspectFromSize square = %q, want 1:1", got)
+	}
+}

--- a/internal/adapter/provider/ollama/adapter.go
+++ b/internal/adapter/provider/ollama/adapter.go
@@ -1,0 +1,73 @@
+// Package ollama implements a first-class provider adapter for Ollama
+// (https://ollama.com), a local/self-hosted model server that speaks its own
+// /api/chat protocol. Like the openrouter and newapi adapters it is a thin wrapper
+// over the `custom` proxy core, which already contains the full Claude<->Ollama
+// translation (see custom/ollama.go). This adapter simply guarantees the custom
+// core takes its Ollama code path.
+//
+// Historically Ollama was reached via a `custom` provider with Backend:"ollama".
+// That still works (the field is retained for backward compatibility) but is
+// deprecated in favor of this dedicated type, so `custom` can stay a generic
+// passthrough and each upstream product owns its own adapter.
+package ollama
+
+import (
+	"fmt"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// ollamaBackend is the custom-core backend selector that routes to the
+// Claude<->Ollama translation. Kept in sync with custom.customBackendOllama.
+const ollamaBackend = "ollama"
+
+func init() {
+	provider.RegisterAdapterFactory("ollama", NewAdapter)
+}
+
+// Adapter is a first-class Ollama provider that delegates to the custom core with
+// the Ollama backend forced on.
+type Adapter struct {
+	inner provider.ProviderAdapter
+	synth *domain.Provider
+}
+
+// NewAdapter builds an Ollama adapter by synthesizing a custom config with the
+// Ollama backend selected, then wrapping a custom adapter around it. Ollama
+// providers reuse the custom config (BaseURL, APIKey, model mapping); the caller
+// need not set the deprecated Backend field — this type implies it.
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	if p.Config == nil || p.Config.Custom == nil {
+		return nil, fmt.Errorf("provider %s missing custom config", p.Name)
+	}
+
+	// Shallow-copy the provider and its custom config so forcing the backend never
+	// mutates the shared, cached provider entity.
+	synth := *p
+	customCfg := *p.Config.Custom
+	customCfg.Backend = ollamaBackend
+	cfg := *p.Config
+	cfg.Custom = &customCfg
+	synth.Config = &cfg
+
+	inner, err := custom.NewAdapter(&synth)
+	if err != nil {
+		return nil, err
+	}
+	return &Adapter{inner: inner, synth: &synth}, nil
+}
+
+// SupportedClientTypes reports the client types this Ollama provider serves. The
+// custom Ollama path only supports Claude-compatible requests.
+func (a *Adapter) SupportedClientTypes() []domain.ClientType {
+	return a.synth.SupportedClientTypes
+}
+
+// Execute delegates to the custom core, passing the synthesized provider so the
+// Ollama backend and its config drive the request.
+func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	return a.inner.Execute(c, a.synth)
+}

--- a/internal/adapter/provider/ollama/adapter_test.go
+++ b/internal/adapter/provider/ollama/adapter_test.go
@@ -1,0 +1,52 @@
+package ollama
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestNewAdapter_ForcesBackendWithoutMutatingOriginal(t *testing.T) {
+	p := &domain.Provider{
+		Name: "local-ollama",
+		Type: "ollama",
+		Config: &domain.ProviderConfig{
+			Custom: &domain.ProviderConfigCustom{
+				BaseURL: "http://localhost:11434",
+			},
+		},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+
+	a, err := NewAdapter(p)
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+
+	// The original provider entity must be untouched (it may be shared/cached).
+	if p.Config.Custom.Backend != "" {
+		t.Fatalf("original provider backend mutated: %q", p.Config.Custom.Backend)
+	}
+
+	// The synthesized provider drives the custom core with backend=ollama.
+	got := a.(*Adapter)
+	if got.synth.Config.Custom.Backend != ollamaBackend {
+		t.Fatalf("synth backend = %q, want %q", got.synth.Config.Custom.Backend, ollamaBackend)
+	}
+	if got.synth.Config.Custom == p.Config.Custom {
+		t.Fatalf("synth custom config must be a copy, not the shared pointer")
+	}
+}
+
+func TestNewAdapter_MissingCustomConfig(t *testing.T) {
+	if _, err := NewAdapter(&domain.Provider{Name: "x", Type: "ollama", Config: &domain.ProviderConfig{}}); err == nil {
+		t.Fatal("expected error for missing custom config")
+	}
+}
+
+func TestOllamaFactoryRegistered(t *testing.T) {
+	if _, ok := provider.GetAdapterFactory("ollama"); !ok {
+		t.Fatal("ollama adapter factory not registered")
+	}
+}

--- a/internal/adapter/provider/openrouter/adapter.go
+++ b/internal/adapter/provider/openrouter/adapter.go
@@ -92,7 +92,15 @@ func (a *Adapter) SupportedClientTypes() []domain.ClientType {
 }
 
 // Execute delegates to the custom core, passing the synthesized provider so the
-// custom config drives base URL and auth.
+// custom config drives base URL and auth. Before delegating it normalizes any
+// image sizing into the form the target OpenRouter endpoint honors (see
+// normalizeImageConfigBody), so each protocol can express sizing its own standard
+// way and still reach the upstream image model correctly.
 func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	if body := flow.GetRequestBody(c); len(body) > 0 {
+		if nb := normalizeImageConfigBody(body, flow.GetRequestURI(c)); len(nb) > 0 {
+			c.Set(flow.KeyRequestBody, nb)
+		}
+	}
 	return a.inner.Execute(c, a.synth)
 }

--- a/internal/adapter/provider/openrouter/image_config.go
+++ b/internal/adapter/provider/openrouter/image_config.go
@@ -29,8 +29,9 @@ import (
 // unchanged) body; never nil.
 func normalizeImageConfigBody(body []byte, requestURI string) []byte {
 	aspect := gjson.GetBytes(body, "image_config.aspect_ratio").String()
+	imageSize := gjson.GetBytes(body, "image_config.image_size").String()
 	size := gjson.GetBytes(body, "size").String()
-	if aspect == "" && size == "" {
+	if aspect == "" && imageSize == "" && size == "" {
 		return body // no image sizing intent
 	}
 
@@ -64,14 +65,23 @@ func isImagesEndpoint(requestURI string) bool {
 }
 
 // ensureImageModalities makes sure a chat request asks for image output, which
-// OpenRouter requires via modalities:["image","text"]. No-op when already present.
+// OpenRouter requires via modalities:["image","text"]. When modalities already
+// exist without "image", it prepends "image" and preserves the rest rather than
+// clobbering them (e.g. ["audio","text"] → ["image","audio","text"]).
 func ensureImageModalities(body []byte) []byte {
 	if mods := gjson.GetBytes(body, "modalities"); mods.IsArray() {
+		values := make([]string, 0, len(mods.Array())+1)
 		for _, m := range mods.Array() {
 			if strings.EqualFold(m.String(), "image") {
-				return body
+				return body // already requests image
 			}
+			values = append(values, m.String())
 		}
+		values = append([]string{"image"}, values...)
+		if out, err := sjson.SetBytes(body, "modalities", values); err == nil {
+			return out
+		}
+		return body
 	}
 	if out, err := sjson.SetBytes(body, "modalities", []string{"image", "text"}); err == nil {
 		return out

--- a/internal/adapter/provider/openrouter/image_config.go
+++ b/internal/adapter/provider/openrouter/image_config.go
@@ -1,0 +1,144 @@
+package openrouter
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// normalizeImageConfigBody rewrites an outbound OpenRouter request so an image
+// aspect ratio is expressed in the form the target endpoint actually honors.
+//
+// This is the provider-owned half of the "each protocol sends its own standard,
+// the provider converts" design. By the time a request reaches here it is in
+// OpenRouter-native OpenAI shape (an OpenAI client's own body, or a Gemini client
+// converted upstream), carrying the aspect ratio as either the OpenAI pixel
+// `size` or the `image_config.aspect_ratio` object. Which one the upstream model
+// reads depends entirely on the endpoint (verified against live OpenRouter):
+//
+//   - chat/completions: Gemini image models read image_config.aspect_ratio and
+//     ignore size; image output also requires modalities:["image","text"].
+//     (GPT image models cannot control size on chat at all — an upstream limit.)
+//   - images (generations): both Gemini and GPT image models read the pixel
+//     `size`; image_config is not consulted.
+//
+// So we fill in whichever representation the endpoint needs from whichever the
+// client sent, leaving the original field intact. Returns the (possibly
+// unchanged) body; never nil.
+func normalizeImageConfigBody(body []byte, requestURI string) []byte {
+	aspect := gjson.GetBytes(body, "image_config.aspect_ratio").String()
+	size := gjson.GetBytes(body, "size").String()
+	if aspect == "" && size == "" {
+		return body // no image sizing intent
+	}
+
+	if isImagesEndpoint(requestURI) {
+		// The images endpoint honors pixel size; derive it from the aspect ratio
+		// when the client only expressed image_config.
+		if size == "" && aspect != "" {
+			if s := sizeFromAspect(aspect); s != "" {
+				if out, err := sjson.SetBytes(body, "size", s); err == nil {
+					body = out
+				}
+			}
+		}
+		return body
+	}
+
+	// chat/completions: honor image_config.aspect_ratio, and ensure the request
+	// actually asks for image output.
+	if aspect == "" && size != "" {
+		if a := aspectFromSize(size); a != "" {
+			if out, err := sjson.SetBytes(body, "image_config.aspect_ratio", a); err == nil {
+				body = out
+			}
+		}
+	}
+	return ensureImageModalities(body)
+}
+
+func isImagesEndpoint(requestURI string) bool {
+	return strings.Contains(requestURI, "/images")
+}
+
+// ensureImageModalities makes sure a chat request asks for image output, which
+// OpenRouter requires via modalities:["image","text"]. No-op when already present.
+func ensureImageModalities(body []byte) []byte {
+	if mods := gjson.GetBytes(body, "modalities"); mods.IsArray() {
+		for _, m := range mods.Array() {
+			if strings.EqualFold(m.String(), "image") {
+				return body
+			}
+		}
+	}
+	if out, err := sjson.SetBytes(body, "modalities", []string{"image", "text"}); err == nil {
+		return out
+	}
+	return body
+}
+
+// sizeFromAspect maps an aspect ratio ("16:9") to a standard OpenAI pixel size
+// bucket. These are the sizes GPT image models accept, and OpenRouter maps them
+// to the nearest native aspect for Gemini image models. Landscape/portrait/square
+// is the best fidelity achievable with the standard buckets.
+func sizeFromAspect(aspect string) string {
+	r := ratioOfAspect(aspect)
+	switch {
+	case r == 0:
+		return ""
+	case r >= 1.15:
+		return "1536x1024"
+	case r <= 0.87:
+		return "1024x1536"
+	default:
+		return "1024x1024"
+	}
+}
+
+// aspectFromSize maps a pixel size ("1536x1024") to a coarse aspect ratio bucket
+// that Gemini image models honor on the chat endpoint.
+func aspectFromSize(size string) string {
+	w, h := parsePixelSize(size)
+	if w == 0 || h == 0 {
+		return ""
+	}
+	r := float64(w) / float64(h)
+	switch {
+	case r >= 1.15:
+		return "3:2"
+	case r <= 0.87:
+		return "2:3"
+	default:
+		return "1:1"
+	}
+}
+
+// ratioOfAspect parses "W:H" into a width/height ratio, or 0 when unparseable.
+func ratioOfAspect(aspect string) float64 {
+	parts := strings.SplitN(strings.TrimSpace(aspect), ":", 2)
+	if len(parts) != 2 {
+		return 0
+	}
+	w, err1 := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	h, err2 := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err1 != nil || err2 != nil || h == 0 {
+		return 0
+	}
+	return w / h
+}
+
+// parsePixelSize parses "WxH" (e.g. "1536x1024") into width and height.
+func parsePixelSize(size string) (int, int) {
+	parts := strings.SplitN(strings.ToLower(strings.TrimSpace(size)), "x", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil {
+		return 0, 0
+	}
+	return w, h
+}

--- a/internal/adapter/provider/openrouter/image_config_test.go
+++ b/internal/adapter/provider/openrouter/image_config_test.go
@@ -65,6 +65,42 @@ func TestNormalizeImageConfig_ImagesKeepsExplicitSize(t *testing.T) {
 	}
 }
 
+func TestNormalizeImageConfig_ChatImageSizeOnlyAddsModalities(t *testing.T) {
+	// A Gemini request converted upstream may carry only image_config.image_size
+	// (no aspect_ratio, no size). On chat it must still get the image modality
+	// rather than being treated as a non-image request.
+	body := []byte(`{"model":"google/gemini-3-pro-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"image_size":"2K"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	mods := gjson.GetBytes(out, "modalities").Array()
+	hasImage := false
+	for _, m := range mods {
+		if m.String() == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Fatalf("image modality not added for image_size-only request: %s", out)
+	}
+	if gjson.GetBytes(out, "image_config.image_size").String() != "2K" {
+		t.Fatalf("image_size should be preserved: %s", out)
+	}
+}
+
+func TestEnsureImageModalities_PreservesExisting(t *testing.T) {
+	// Existing modalities must be kept, with image prepended — not clobbered.
+	body := []byte(`{"model":"x","messages":[],"image_config":{"aspect_ratio":"1:1"},"modalities":["audio","text"]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	got := gjson.GetBytes(out, "modalities").Array()
+	var vals []string
+	for _, m := range got {
+		vals = append(vals, m.String())
+	}
+	if len(vals) != 3 || vals[0] != "image" || vals[1] != "audio" || vals[2] != "text" {
+		t.Fatalf("modalities = %v, want [image audio text]", vals)
+	}
+}
+
 func TestNormalizeImageConfig_NoImageIntentUntouched(t *testing.T) {
 	// A plain chat request with no sizing must not gain modalities/image_config.
 	body := []byte(`{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}`)

--- a/internal/adapter/provider/openrouter/image_config_test.go
+++ b/internal/adapter/provider/openrouter/image_config_test.go
@@ -1,0 +1,102 @@
+package openrouter
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeImageConfig_ChatDerivesAspectAndModalities(t *testing.T) {
+	// OpenAI-ish chat request expressing sizing only via pixel size → on the chat
+	// endpoint we derive image_config.aspect_ratio (Gemini honors it) and ensure
+	// image output modality.
+	body := []byte(`{"model":"google/gemini-2.5-flash-image","messages":[{"role":"user","content":"a cat"}],"size":"1536x1024"}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "image_config.aspect_ratio").String(); got != "3:2" {
+		t.Fatalf("aspect_ratio = %q, want 3:2\n%s", got, out)
+	}
+	mods := gjson.GetBytes(out, "modalities").Array()
+	if len(mods) != 2 || mods[0].String() != "image" {
+		t.Fatalf("modalities = %v, want [image text]\n%s", mods, out)
+	}
+	// Original size is left intact.
+	if gjson.GetBytes(out, "size").String() != "1536x1024" {
+		t.Fatalf("size should be preserved: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ChatKeepsAspectAddsModalities(t *testing.T) {
+	// Gemini client converted upstream → chat body already carries
+	// image_config.aspect_ratio; we only need to guarantee modalities.
+	body := []byte(`{"model":"google/gemini-3-pro-image","messages":[{"role":"user","content":"a cat"}],"image_config":{"aspect_ratio":"16:9"}}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+
+	if got := gjson.GetBytes(out, "image_config.aspect_ratio").String(); got != "16:9" {
+		t.Fatalf("aspect_ratio mangled: %s", out)
+	}
+	if !gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("modalities not added: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ImagesDerivesSize(t *testing.T) {
+	// On the images endpoint the model reads pixel size; derive it from an
+	// aspect ratio the client expressed as image_config.
+	body := []byte(`{"model":"openai/gpt-5-image","prompt":"a cat","image_config":{"aspect_ratio":"9:16"}}`)
+	out := normalizeImageConfigBody(body, "/v1/images/generations")
+
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1536" {
+		t.Fatalf("size = %q, want 1024x1536\n%s", got, out)
+	}
+	// Images endpoint must NOT get modalities (different schema).
+	if gjson.GetBytes(out, "modalities").Exists() {
+		t.Fatalf("modalities must not be added on images endpoint: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_ImagesKeepsExplicitSize(t *testing.T) {
+	// Standard OpenAI client already sent pixel size on the images endpoint —
+	// pass through untouched (OpenRouter maps it to the model's aspect).
+	body := []byte(`{"model":"openai/gpt-5-image","prompt":"a cat","size":"1024x1536"}`)
+	out := normalizeImageConfigBody(body, "/v1/images/generations")
+	if got := gjson.GetBytes(out, "size").String(); got != "1024x1536" {
+		t.Fatalf("size should be preserved verbatim: %s", out)
+	}
+}
+
+func TestNormalizeImageConfig_NoImageIntentUntouched(t *testing.T) {
+	// A plain chat request with no sizing must not gain modalities/image_config.
+	body := []byte(`{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	out := normalizeImageConfigBody(body, "/v1/chat/completions")
+	if gjson.GetBytes(out, "modalities").Exists() || gjson.GetBytes(out, "image_config").Exists() {
+		t.Fatalf("non-image request must be left untouched: %s", out)
+	}
+}
+
+func TestSizeAspectHelpers(t *testing.T) {
+	cases := []struct {
+		aspect string
+		size   string
+	}{
+		{"16:9", "1536x1024"},
+		{"21:9", "1536x1024"},
+		{"1:1", "1024x1024"},
+		{"9:16", "1024x1536"},
+		{"2:3", "1024x1536"},
+	}
+	for _, c := range cases {
+		if got := sizeFromAspect(c.aspect); got != c.size {
+			t.Errorf("sizeFromAspect(%q) = %q, want %q", c.aspect, got, c.size)
+		}
+	}
+	if got := sizeFromAspect("garbage"); got != "" {
+		t.Errorf("sizeFromAspect(garbage) = %q, want empty", got)
+	}
+	if got := aspectFromSize("1536x1024"); got != "3:2" {
+		t.Errorf("aspectFromSize landscape = %q, want 3:2", got)
+	}
+	if got := aspectFromSize("1024x1024"); got != "1:1" {
+		t.Errorf("aspectFromSize square = %q, want 1:1", got)
+	}
+}

--- a/internal/converter/gemini_to_openai.go
+++ b/internal/converter/gemini_to_openai.go
@@ -45,6 +45,31 @@ func (c *geminiToOpenAIRequest) Transform(body []byte, model string, stream bool
 				openaiReq.ReasoningEffort = mapBudgetToEffort(req.GenerationConfig.ThinkingConfig.ThinkingBudget)
 			}
 		}
+
+		// Image generation: mirror of openai_to_gemini_request.go so a Gemini
+		// image request keeps its output modality and sizing when converted to
+		// OpenAI (e.g. a Gemini client routed to an OpenAI-speaking provider like
+		// OpenRouter). Without this the aspect ratio / image output are dropped.
+		if len(req.GenerationConfig.ResponseModalities) > 0 {
+			var mods []string
+			for _, m := range req.GenerationConfig.ResponseModalities {
+				switch strings.ToUpper(strings.TrimSpace(m)) {
+				case "TEXT":
+					mods = append(mods, "text")
+				case "IMAGE":
+					mods = append(mods, "image")
+				}
+			}
+			if len(mods) > 0 {
+				openaiReq.Modalities = mods
+			}
+		}
+		if req.GenerationConfig.ImageConfig != nil {
+			openaiReq.ImageConfig = &OpenAIImageConfig{
+				AspectRatio: req.GenerationConfig.ImageConfig.AspectRatio,
+				ImageSize:   req.GenerationConfig.ImageConfig.ImageSize,
+			}
+		}
 	}
 
 	// Convert systemInstruction

--- a/internal/converter/gemini_to_openai_image_test.go
+++ b/internal/converter/gemini_to_openai_image_test.go
@@ -1,0 +1,39 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// A Gemini image request converted to OpenAI (e.g. a Gemini client routed to an
+// OpenAI-speaking provider like OpenRouter) must keep its output modality and
+// image sizing, mirroring the openai->gemini direction.
+func TestGeminiToOpenAIRequest_ImageConfigAndModalities(t *testing.T) {
+	gReq := GeminiRequest{
+		Contents: []GeminiContent{{
+			Role:  "user",
+			Parts: []GeminiPart{{Text: "a cat"}},
+		}},
+		GenerationConfig: &GeminiGenerationConfig{
+			ResponseModalities: []string{"TEXT", "IMAGE"},
+			ImageConfig:        &GeminiImageConfig{AspectRatio: "16:9", ImageSize: "2K"},
+		},
+	}
+	body, _ := json.Marshal(gReq)
+
+	out, err := (&geminiToOpenAIRequest{}).Transform(body, "google/gemini-3-pro-image", false)
+	if err != nil {
+		t.Fatalf("transform failed: %v", err)
+	}
+	var got OpenAIRequest
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.ImageConfig == nil || got.ImageConfig.AspectRatio != "16:9" || got.ImageConfig.ImageSize != "2K" {
+		t.Fatalf("image_config not carried: %#v", got.ImageConfig)
+	}
+	if len(got.Modalities) != 2 || got.Modalities[0] != "text" || got.Modalities[1] != "image" {
+		t.Fatalf("modalities = %v, want [text image]", got.Modalities)
+	}
+}

--- a/internal/converter/openai_to_gemini_image_response_test.go
+++ b/internal/converter/openai_to_gemini_image_response_test.go
@@ -1,0 +1,97 @@
+package converter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const tinyPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+// A generated image in the OpenAI response's non-standard message.images[] array
+// must convert to a Gemini inlineData part so a Gemini client receives it.
+func TestOpenAIToGeminiResponse_CarriesGeneratedImage(t *testing.T) {
+	body := []byte(`{
+		"id":"gen","object":"chat.completion","model":"google/gemini-2.5-flash-image",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"here",
+			"images":[{"type":"image_url","image_url":{"url":"` + tinyPNGDataURL + `"}}]},
+			"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":3,"completion_tokens":1290,"total_tokens":1293}
+	}`)
+
+	out, err := (&openaiToGeminiResponse{}).Transform(body)
+	if err != nil {
+		t.Fatalf("transform: %v", err)
+	}
+
+	mime := gjson.GetBytes(out, "candidates.0.content.parts.#(inlineData.mimeType!=).inlineData.mimeType").String()
+	data := gjson.GetBytes(out, "candidates.0.content.parts.#(inlineData.data!=).inlineData.data").String()
+	if mime != "image/png" {
+		t.Errorf("inlineData.mimeType = %q, want image/png\n%s", mime, out)
+	}
+	if data == "" {
+		t.Errorf("generated image dropped; body=%s", out)
+	}
+	// The text part is still present.
+	if !gjson.GetBytes(out, `candidates.0.content.parts.#(text=="here")`).Exists() {
+		t.Errorf("text part lost: %s", out)
+	}
+}
+
+// The streaming variant must emit the image delta as a Gemini inlineData part.
+func TestOpenAIToGeminiStream_CarriesGeneratedImage(t *testing.T) {
+	chunk := []byte("data: " + `{"id":"gen","object":"chat.completion.chunk","model":"google/gemini-2.5-flash-image","choices":[{"index":0,"delta":{"role":"assistant","images":[{"type":"image_url","image_url":{"url":"` + tinyPNGDataURL + `"}}]}}]}` + "\n\n")
+
+	state := NewTransformState()
+	out, err := (&openaiToGeminiResponse{}).TransformChunk(chunk, state)
+	if err != nil {
+		t.Fatalf("transform chunk: %v", err)
+	}
+	// The emitted SSE frame must carry the inlineData image.
+	if !gjson.ValidBytes(extractSSEData(t, out)) {
+		t.Fatalf("no valid gemini frame emitted: %s", out)
+	}
+	frame := extractSSEData(t, out)
+	if got := gjson.GetBytes(frame, "candidates.0.content.parts.0.inlineData.data").String(); got == "" {
+		t.Fatalf("stream dropped generated image; frame=%s", frame)
+	}
+	if got := gjson.GetBytes(frame, "candidates.0.content.parts.0.inlineData.mimeType").String(); got != "image/png" {
+		t.Fatalf("stream inlineData.mimeType = %q, want image/png", got)
+	}
+}
+
+// extractSSEData returns the JSON payload of the first "data:" SSE line.
+func extractSSEData(t *testing.T, sse []byte) []byte {
+	t.Helper()
+	for _, line := range splitLines(string(sse)) {
+		if len(line) > 5 && line[:5] == "data:" {
+			var js json.RawMessage
+			payload := []byte(line[5:])
+			if json.Unmarshal(payload, &js) == nil {
+				return payload
+			}
+		}
+	}
+	return nil
+}
+
+func splitLines(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		if r == '\r' {
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/converter/openai_to_gemini_response.go
+++ b/internal/converter/openai_to_gemini_response.go
@@ -51,6 +51,17 @@ func (c *openaiToGeminiResponse) Transform(body []byte) ([]byte, error) {
 					}
 				}
 			}
+			// Generated images (OpenRouter/Gemini image models return them in the
+			// non-standard message.images[] array) → Gemini inlineData parts, so a
+			// Gemini client actually receives the image it asked for.
+			for _, img := range choice.Message.Images {
+				if img.ImageURL == nil {
+					continue
+				}
+				if inline := parseInlineImage(img.ImageURL.URL); inline != nil {
+					candidate.Content.Parts = append(candidate.Content.Parts, GeminiPart{InlineData: inline})
+				}
+			}
 			for _, tc := range choice.Message.ToolCalls {
 				var args map[string]interface{}
 				if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {

--- a/internal/converter/openai_to_gemini_stream.go
+++ b/internal/converter/openai_to_gemini_stream.go
@@ -51,6 +51,26 @@ func (c *openaiToGeminiResponse) TransformChunk(chunk []byte, state *TransformSt
 					output = append(output, FormatSSE("", geminiChunk)...)
 				}
 
+				// Generated images arrive in the delta's non-standard images[]
+				// array → emit them as Gemini inlineData parts.
+				for _, img := range choice.Delta.Images {
+					if img.ImageURL == nil {
+						continue
+					}
+					if inline := parseInlineImage(img.ImageURL.URL); inline != nil {
+						geminiChunk := GeminiStreamChunk{
+							Candidates: []GeminiCandidate{{
+								Content: GeminiContent{
+									Role:  "model",
+									Parts: []GeminiPart{{InlineData: inline}},
+								},
+								Index: 0,
+							}},
+						}
+						output = append(output, FormatSSE("", geminiChunk)...)
+					}
+				}
+
 				if len(choice.Delta.ToolCalls) > 0 {
 					if state.ToolCalls == nil {
 						state.ToolCalls = make(map[int]*ToolCallState)

--- a/internal/converter/types_openai.go
+++ b/internal/converter/types_openai.go
@@ -32,6 +32,10 @@ type OpenAIMessage struct {
 	Name             string           `json:"name,omitempty"`
 	ToolCalls        []OpenAIToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string           `json:"tool_call_id,omitempty"`
+	// Images carries generated images on a response message. It is the
+	// non-standard array OpenRouter/Gemini image models return, each element
+	// {type:"image_url", image_url:{url:"data:...base64,..."}}.
+	Images []OpenAIContentPart `json:"images,omitempty"`
 }
 
 type OpenAIContentPart struct {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -15,6 +15,8 @@ import (
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/codex"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/grok"
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/newapi"
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/ollama"
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/coordinator"

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -22,6 +22,11 @@ type ProviderConfigCustom struct {
 	// Backend selects the custom provider's upstream protocol implementation.
 	// Empty means legacy HTTP passthrough. "ollama" converts Claude-compatible
 	// requests to Ollama /api/chat and wraps responses back to Claude format.
+	//
+	// Deprecated: use a dedicated provider type instead (e.g. type "ollama").
+	// Retained for backward compatibility with existing custom+backend:ollama
+	// providers, which keep working unchanged. New setups should pick the matching
+	// first-class provider type so each upstream's quirks live in its own adapter.
 	Backend string `json:"backend,omitempty"`
 
 	// API Key

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -330,7 +330,8 @@ func (h *AdminHandler) fetchProviderRuntimeModels(r *http.Request, provider *dom
 			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "openrouter api key unavailable"}
 		}
 		return fetchOpenAICompatibleModels(r, "https://openrouter.ai/api/v1/models", provider.Config.OpenRouter.APIKey, "openrouter")
-	case "custom":
+	case "custom", "newapi":
+		// new-api is OpenAI-compatible, so /v1/models discovery works the same way.
 		if provider.Config.Custom == nil || strings.TrimSpace(customRuntimeModelsBaseURL(provider.Config.Custom)) == "" {
 			return providerRuntimeModelsResult{Available: false, Models: []string{}, Error: "custom provider base url unavailable"}
 		}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -379,6 +379,19 @@ func preserveExcludedProviderWriteOnlyMode(existing, incoming *domain.Provider) 
 	preserveEmptyExcludedProviderURLs(existing, incoming)
 }
 
+// providerUsesCustomConfig reports whether a provider type stores its
+// configuration under Config.Custom. The generic "custom" relay and the
+// first-class relay types built on the custom core (newapi, ollama) all share
+// that config shape, so config-preservation logic treats them alike.
+func providerUsesCustomConfig(providerType string) bool {
+	switch providerType {
+	case "custom", "newapi", "ollama":
+		return true
+	default:
+		return false
+	}
+}
+
 func preserveEmptyExcludedProviderURLs(existing, incoming *domain.Provider) {
 	if existing == nil || incoming == nil || existing.Config == nil || existing.Config.Custom == nil {
 		return
@@ -387,7 +400,7 @@ func preserveEmptyExcludedProviderURLs(existing, incoming *domain.Provider) {
 	if effectiveType == "" {
 		effectiveType = existing.Type
 	}
-	if effectiveType != "custom" || existing.Type != "custom" {
+	if !providerUsesCustomConfig(effectiveType) || !providerUsesCustomConfig(existing.Type) {
 		return
 	}
 	if incoming.Config == nil {
@@ -434,7 +447,8 @@ func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
 	}
 
 	switch effectiveType {
-	case "custom":
+	case "custom", "newapi", "ollama":
+		// newapi/ollama are first-class relay types that reuse the custom config.
 		if existing.Config.Custom != nil {
 			if incoming.Config.Custom == nil {
 				custom := *existing.Config.Custom
@@ -1387,11 +1401,16 @@ func (s *AdminService) autoSetSupportedClientTypes(provider *domain.Provider) {
 		provider.SupportedClientTypes = []domain.ClientType{
 			domain.ClientTypeClaude,
 		}
-	case "custom":
-		// Custom providers use their configured SupportedClientTypes
-		// If not set, default to OpenAI
+	case "custom", "newapi":
+		// Custom and new-api providers use their configured SupportedClientTypes.
+		// If not set, default to OpenAI (both are OpenAI-compatible relays).
 		if len(provider.SupportedClientTypes) == 0 {
 			provider.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
+		}
+	case "ollama":
+		// Ollama's custom-core path only supports Claude-compatible requests.
+		provider.SupportedClientTypes = []domain.ClientType{
+			domain.ClientTypeClaude,
 		}
 	case "openrouter":
 		// OpenRouter natively serves both the OpenAI and Anthropic protocols, so

--- a/tests/e2e/openrouter_image_config_test.go
+++ b/tests/e2e/openrouter_image_config_test.go
@@ -1,0 +1,150 @@
+package e2e_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// newORImageConfigMock captures the upstream request and returns a minimal valid
+// response per endpoint (data[] for /images, a plain chat completion otherwise),
+// so these tests can assert how maxx shapes the OUTBOUND image sizing.
+func newORImageConfigMock(t *testing.T, captured *capturedRequest, calls *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(calls, 1)
+		reqBody, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(reqBody))
+		captured.Set(r)
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/images") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"created": 1700000000,
+				"data":    []map[string]any{{"b64_json": "aGVsbG8=", "media_type": "image/png"}},
+				"usage":   map[string]any{"cost": 0.01},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "chatcmpl_or", "object": "chat.completion",
+			"model": "google/gemini-2.5-flash-image", "created": 1700000000,
+			"choices": []map[string]any{{"index": 0, "message": map[string]any{"role": "assistant", "content": "ok"}, "finish_reason": "stop"}},
+			"usage":   map[string]any{"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+		})
+	}))
+}
+
+// On the chat endpoint, an OpenAI client that expresses sizing only via the
+// standard pixel `size` must reach OpenRouter as image_config.aspect_ratio (the
+// form Gemini image models honor on chat) plus modalities:["image"].
+func TestOpenRouterImageConfig_ChatSizeToAspect(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-imgcfg-chat", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	req := map[string]any{
+		"model":    "google/gemini-2.5-flash-image",
+		"messages": []map[string]any{{"role": "user", "content": "a cat"}},
+		"size":     "1536x1024",
+	}
+	resp := env.ProxyPost("/v1/chat/completions", req, map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, _, up := captured.Get()
+	if got := gjson.GetBytes(up, "image_config.aspect_ratio").String(); got != "3:2" {
+		t.Errorf("upstream image_config.aspect_ratio = %q, want 3:2; body=%s", got, up)
+	}
+	if !gjson.GetBytes(up, "modalities").Exists() {
+		t.Errorf("upstream lost modalities; body=%s", up)
+	}
+}
+
+// On the images endpoint, an aspect ratio expressed as image_config must reach
+// OpenRouter as a pixel `size` (the form both Gemini and GPT image models honor
+// there).
+func TestOpenRouterImageConfig_ImagesAspectToSize(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-imgcfg-images", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "openai", pid, 1)
+
+	req := map[string]any{
+		"model":        "openai/gpt-5-image",
+		"prompt":       "a cat",
+		"image_config": map[string]any{"aspect_ratio": "9:16"},
+	}
+	resp := env.ProxyPost("/v1/images/generations", req, map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, _, _, up := captured.Get()
+	if got := gjson.GetBytes(up, "size").String(); got != "1024x1536" {
+		t.Errorf("upstream size = %q, want 1024x1536; body=%s", got, up)
+	}
+}
+
+// Full pipeline: a native Gemini client (generationConfig.imageConfig) routed to
+// the OpenAI-speaking OpenRouter provider. The forced Gemini->OpenAI conversion
+// (layer 1) must carry the aspect ratio into image_config, and the provider
+// (layer 2) must guarantee modalities — so the image request survives end to end.
+func TestOpenRouterImageConfig_GeminiClientToOpenRouter(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newORImageConfigMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	enableGeminiPublicProxyRoute(t, env)
+	// openai-only support forces the gemini request to be converted to OpenAI.
+	pid := createORProvider(t, env, "or-imgcfg-gem", "sk-test-key", []string{"openai"})
+	createRouteAt(t, env, "gemini", pid, 1)
+
+	req := map[string]any{
+		"contents": []map[string]any{{"role": "user", "parts": []map[string]any{{"text": "a cat"}}}},
+		"generationConfig": map[string]any{
+			"responseModalities": []string{"TEXT", "IMAGE"},
+			"imageConfig":        map[string]any{"aspectRatio": "16:9"},
+		},
+	}
+	resp := env.ProxyPost("/v1beta/models/gemini-2.0-flash:generateContent", req, nil)
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	_, path, _, up := captured.Get()
+	if !strings.Contains(path, "/chat/completions") {
+		t.Fatalf("expected conversion to chat/completions, upstream path=%s", path)
+	}
+	if got := gjson.GetBytes(up, "image_config.aspect_ratio").String(); got != "16:9" {
+		t.Errorf("aspect ratio lost across gemini->openai; got %q, body=%s", got, up)
+	}
+	mods := gjson.GetBytes(up, "modalities").Array()
+	hasImage := false
+	for _, m := range mods {
+		if m.String() == "image" {
+			hasImage = true
+		}
+	}
+	if !hasImage {
+		t.Errorf("upstream lost image modality; body=%s", up)
+	}
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -98,6 +98,8 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --provider-claude: oklch(0.65 0.15 28); /* Anthropic 橙色/珊瑚色 */
   --provider-openrouter: oklch(0.58 0.19 277); /* #6366F1 靛蓝色 */
   --provider-grok: oklch(0.62 0.18 285); /* xAI/Grok 紫色 */
+  --provider-newapi: oklch(0.62 0.17 230); /* new-api/one-api 蓝色 */
+  --provider-ollama: oklch(0.55 0.02 260); /* Ollama 石墨灰 */
 
   /* Client 品牌色 (引用 Provider 颜色) */
   --client-claude: var(--provider-anthropic);
@@ -385,6 +387,8 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --color-provider-claude: var(--provider-claude);
   --color-provider-openrouter: var(--provider-openrouter);
   --color-provider-grok: var(--provider-grok);
+  --color-provider-newapi: var(--provider-newapi);
+  --color-provider-ollama: var(--provider-ollama);
 
   /* Client 颜色映射 (Tailwind 可用) */
   --color-client-claude: var(--client-claude);

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -22,7 +22,9 @@ export type ProviderType =
   | 'codex'
   | 'claude'
   | 'openrouter'
-  | 'grok';
+  | 'grok'
+  | 'newapi'
+  | 'ollama';
 
 /**
  * Client 类型定义

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1818,6 +1818,24 @@
       "name": "Custom Provider",
       "description": "Configure your own API endpoint"
     },
+    "newapi": {
+      "name": "New API",
+      "description": "new-api / one-api relay · OpenAI & Gemini compatible",
+      "baseURL": "Base URL",
+      "baseURLHint": "Root URL of your new-api / one-api instance (without the /v1 path).",
+      "apiKey": "API Key",
+      "clientsTitle": "Client Types",
+      "clientsDesc": "Which protocols this relay serves. Defaults to OpenAI; image sizing is translated to extra_body.google automatically."
+    },
+    "ollama": {
+      "name": "Ollama",
+      "description": "Local model server · Claude-compatible",
+      "baseURL": "Base URL",
+      "baseURLHint": "Ollama server address, e.g. http://localhost:11434.",
+      "apiKey": "API Key",
+      "apiKeyHint": "Optional — only needed if your Ollama endpoint is protected.",
+      "apiKeyPlaceholder": "Optional"
+    },
     "openrouter": {
       "name": "OpenRouter",
       "description": "Aggregation gateway · OpenAI & Anthropic compatible",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1814,6 +1814,24 @@
       "name": "自定义提供商",
       "description": "配置您自己的 API 端点"
     },
+    "newapi": {
+      "name": "New API",
+      "description": "new-api / one-api 中转 · 兼容 OpenAI 与 Gemini",
+      "baseURL": "Base URL",
+      "baseURLHint": "你的 new-api / one-api 实例根地址（不含 /v1 路径）。",
+      "apiKey": "API Key",
+      "clientsTitle": "客户端协议",
+      "clientsDesc": "该中转对外提供哪些协议。默认 OpenAI；图片尺寸会自动翻译成 extra_body.google。"
+    },
+    "ollama": {
+      "name": "Ollama",
+      "description": "本地模型服务 · 兼容 Claude",
+      "baseURL": "Base URL",
+      "baseURLHint": "Ollama 服务地址，例如 http://localhost:11434。",
+      "apiKey": "API Key",
+      "apiKeyHint": "可选 —— 仅当你的 Ollama 端点需要鉴权时填写。",
+      "apiKeyPlaceholder": "可选"
+    },
     "openrouter": {
       "name": "OpenRouter",
       "description": "聚合网关 · 兼容 OpenAI 与 Anthropic",

--- a/web/src/pages/providers/components/newapi-config-step.tsx
+++ b/web/src/pages/providers/components/newapi-config-step.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
+import type { ClientType, CreateProviderData } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { OpenRouterModelMappings } from './openrouter-model-mappings';
+
+// new-api / one-api style relays serve multiple client protocols under a single
+// base URL. Default to OpenAI (the image-generation path this type is built for);
+// claude/gemini are opt-in.
+const NEWAPI_CLIENT_TYPES = ['openai', 'claude', 'gemini'] as const;
+
+export function NewApiConfigStep() {
+  const { t } = useTranslation();
+  const { goToSelectType, goToProviders } = useProviderNavigation();
+  const createProvider = useCreateProvider();
+  const createModelMapping = useCreateModelMapping();
+
+  const [name, setName] = useState('New API');
+  const [baseURL, setBaseURL] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [clients, setClients] = useState<Record<ClientType, boolean>>({
+    claude: false,
+    openai: true,
+    codex: false,
+    gemini: false,
+  });
+  const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [blackBox, setBlackBox] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const enabledClients = NEWAPI_CLIENT_TYPES.filter((c) => clients[c]);
+  const isValid = () =>
+    name.trim() !== '' && baseURL.trim() !== '' && enabledClients.length > 0;
+
+  const toggleClient = (client: ClientType) =>
+    setClients((prev) => ({ ...prev, [client]: !prev[client] }));
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: CreateProviderData = {
+        type: 'newapi',
+        name: name.trim(),
+        config: {
+          disableErrorCooldown,
+          custom: {
+            baseURL: baseURL.trim(),
+            apiKey: apiKey.trim(),
+          },
+        },
+        supportedClientTypes: enabledClients,
+        excludeFromExport: blackBox,
+        blackBox,
+      };
+
+      const provider = await createProvider.mutateAsync(data);
+
+      // Persist model mappings as provider-scoped ModelMapping entities — the
+      // mechanism executor.mapModel actually consults at request time.
+      for (const [pattern, target] of Object.entries(modelMapping)) {
+        await createModelMapping.mutateAsync({
+          scope: 'provider',
+          providerID: provider.id,
+          pattern,
+          target,
+        });
+      }
+
+      setSaveStatus('success');
+      goToProviders();
+    } catch (error) {
+      console.error('Failed to create provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={goToSelectType} />}
+        title={t('addProvider.newapi.name')}
+        description={t('addProvider.newapi.description')}
+      >
+        <Button onClick={goToProviders} variant="secondary">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.create')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="New API"
+                  className="w-full"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Globe size={14} />
+                    <span>{t('addProvider.newapi.baseURL')}</span>
+                  </div>
+                </label>
+                <Input
+                  type="text"
+                  value={baseURL}
+                  onChange={(e) => setBaseURL(e.target.value)}
+                  placeholder="https://your-new-api.example.com"
+                  className="w-full font-mono"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('addProvider.newapi.baseURLHint')}
+                </p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('addProvider.newapi.apiKey')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="sk-..."
+                    className="w-full pr-10 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                  >
+                    {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Client Types */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('addProvider.newapi.clientsTitle')}
+            </h3>
+            <p className="text-xs text-muted-foreground">{t('addProvider.newapi.clientsDesc')}</p>
+            <div className="grid gap-3">
+              {NEWAPI_CLIENT_TYPES.map((client) => (
+                <div
+                  key={client}
+                  className="flex items-center justify-between p-4 bg-card border border-border rounded-xl"
+                >
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground capitalize">{client}</div>
+                  </div>
+                  <Switch checked={clients[client]} onCheckedChange={() => toggleClient(client)} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Model Mappings */}
+          <OpenRouterModelMappings mappings={modelMapping} onChange={setModelMapping} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {/* Visibility */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.visibilityAndExport')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">{t('provider.blackBox')}</div>
+                <p className="text-xs text-muted-foreground mt-1">{t('provider.blackBoxDesc')}</p>
+              </div>
+              <Switch checked={blackBox} onCheckedChange={setBlackBox} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.createError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/newapi-provider-view.tsx
+++ b/web/src/pages/providers/components/newapi-provider-view.tsx
@@ -1,0 +1,246 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Trash2, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUpdateProvider } from '@/hooks/queries';
+import type { ClientType, CreateProviderData, Provider } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import { ProviderModelMappings } from './provider-model-mappings';
+
+const NEWAPI_CLIENT_TYPES = ['openai', 'claude', 'gemini'] as const;
+
+interface NewApiProviderViewProps {
+  provider: Provider;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProviderViewProps) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+
+  // Secrets (and base URL) are redacted on read for export-excluded providers;
+  // a blank submit preserves the stored value (backend keeps the existing one).
+  const secretsAreWriteOnly = !!provider.excludeFromExport;
+
+  const [name, setName] = useState(provider.name);
+  const [baseURL, setBaseURL] = useState(
+    secretsAreWriteOnly ? '' : provider.config?.custom?.baseURL || '',
+  );
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [clients, setClients] = useState<Record<ClientType, boolean>>(() => {
+    const supported = provider.supportedClientTypes || [];
+    return {
+      claude: supported.includes('claude'),
+      openai: supported.includes('openai'),
+      codex: false,
+      gemini: supported.includes('gemini'),
+    };
+  });
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(
+    !!provider.config?.disableErrorCooldown,
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const enabledClients = NEWAPI_CLIENT_TYPES.filter((c) => clients[c]);
+  const isValid = () => name.trim() !== '' && enabledClients.length > 0;
+
+  const toggleClient = (client: ClientType) =>
+    setClients((prev) => ({ ...prev, [client]: !prev[client] }));
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: Partial<CreateProviderData> = {
+        name: name.trim(),
+        type: 'newapi',
+        config: {
+          disableErrorCooldown,
+          custom: {
+            // Blank preserves the stored values for export-excluded providers.
+            baseURL: baseURL.trim(),
+            apiKey: apiKey.trim(),
+          },
+        },
+        supportedClientTypes: enabledClients,
+      };
+
+      await updateProvider.mutateAsync({ id: Number(provider.id), data });
+      setSaveStatus('success');
+      setTimeout(() => onClose(), 500);
+    } catch (error) {
+      console.error('Failed to update provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={onClose} />}
+        title={t('provider.edit')}
+        description={t('addProvider.newapi.description')}
+      >
+        <Button onClick={onDelete} variant="destructive">
+          <Trash2 size={14} />
+          {t('provider.delete')}
+        </Button>
+        <Button onClick={onClose} variant="secondary">
+          {t('provider.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.saveChanges')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="New API"
+                  className="w-full"
+                />
+              </div>
+
+              {!secretsAreWriteOnly && (
+                <div>
+                  <label className="text-sm font-medium text-foreground block mb-2">
+                    <div className="flex items-center gap-2">
+                      <Globe size={14} />
+                      <span>{t('addProvider.newapi.baseURL')}</span>
+                    </div>
+                  </label>
+                  <Input
+                    type="text"
+                    value={baseURL}
+                    onChange={(e) => setBaseURL(e.target.value)}
+                    placeholder="https://your-new-api.example.com"
+                    className="w-full font-mono"
+                  />
+                </div>
+              )}
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('provider.apiKeyEdit')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={
+                      secretsAreWriteOnly
+                        ? t('provider.keyPlaceholderWriteOnly')
+                        : t('provider.keyPlaceholder')
+                    }
+                    className="w-full pr-10 font-mono"
+                  />
+                  {!secretsAreWriteOnly && (
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  )}
+                </div>
+                {secretsAreWriteOnly && (
+                  <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
+                    {t('provider.apiKeyExcludedHint')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Client Types */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('addProvider.newapi.clientsTitle')}
+            </h3>
+            <div className="grid gap-3">
+              {NEWAPI_CLIENT_TYPES.map((client) => (
+                <div
+                  key={client}
+                  className="flex items-center justify-between p-4 bg-card border border-border rounded-xl"
+                >
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground capitalize">{client}</div>
+                  </div>
+                  <Switch checked={clients[client]} onCheckedChange={() => toggleClient(client)} />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Model Mappings (provider-scoped ModelMapping entities) */}
+          <ProviderModelMappings provider={provider} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.updateError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/ollama-config-step.tsx
+++ b/web/src/pages/providers/components/ollama-config-step.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useCreateProvider, useCreateModelMapping } from '@/hooks/queries';
+import type { CreateProviderData } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { OpenRouterModelMappings } from './openrouter-model-mappings';
+
+export function OllamaConfigStep() {
+  const { t } = useTranslation();
+  const { goToSelectType, goToProviders } = useProviderNavigation();
+  const createProvider = useCreateProvider();
+  const createModelMapping = useCreateModelMapping();
+
+  const [name, setName] = useState('Ollama');
+  const [baseURL, setBaseURL] = useState('http://localhost:11434');
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const isValid = () => name.trim() !== '' && baseURL.trim() !== '';
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: CreateProviderData = {
+        type: 'ollama',
+        name: name.trim(),
+        config: {
+          disableErrorCooldown,
+          custom: {
+            baseURL: baseURL.trim(),
+            apiKey: apiKey.trim(),
+          },
+        },
+        // Ollama's Claude<->Ollama translation path only serves Claude requests.
+        supportedClientTypes: ['claude'],
+      };
+
+      const provider = await createProvider.mutateAsync(data);
+
+      for (const [pattern, target] of Object.entries(modelMapping)) {
+        await createModelMapping.mutateAsync({
+          scope: 'provider',
+          providerID: provider.id,
+          pattern,
+          target,
+        });
+      }
+
+      setSaveStatus('success');
+      goToProviders();
+    } catch (error) {
+      console.error('Failed to create provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={goToSelectType} />}
+        title={t('addProvider.ollama.name')}
+        description={t('addProvider.ollama.description')}
+      >
+        <Button onClick={goToProviders} variant="secondary">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.create')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Ollama"
+                  className="w-full"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Globe size={14} />
+                    <span>{t('addProvider.ollama.baseURL')}</span>
+                  </div>
+                </label>
+                <Input
+                  type="text"
+                  value={baseURL}
+                  onChange={(e) => setBaseURL(e.target.value)}
+                  placeholder="http://localhost:11434"
+                  className="w-full font-mono"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('addProvider.ollama.baseURLHint')}
+                </p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('addProvider.ollama.apiKey')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={t('addProvider.ollama.apiKeyPlaceholder')}
+                    className="w-full pr-10 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                  >
+                    {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('addProvider.ollama.apiKeyHint')}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Model Mappings */}
+          <OpenRouterModelMappings mappings={modelMapping} onChange={setModelMapping} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.createError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/ollama-provider-view.tsx
+++ b/web/src/pages/providers/components/ollama-provider-view.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Trash2, Globe } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUpdateProvider } from '@/hooks/queries';
+import type { CreateProviderData, Provider } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import { ProviderModelMappings } from './provider-model-mappings';
+
+interface OllamaProviderViewProps {
+  provider: Provider;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProviderViewProps) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+
+  const secretsAreWriteOnly = !!provider.excludeFromExport;
+
+  const [name, setName] = useState(provider.name);
+  const [baseURL, setBaseURL] = useState(
+    secretsAreWriteOnly ? '' : provider.config?.custom?.baseURL || '',
+  );
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(
+    !!provider.config?.disableErrorCooldown,
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const isValid = () => name.trim() !== '';
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+
+    setSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const data: Partial<CreateProviderData> = {
+        name: name.trim(),
+        type: 'ollama',
+        config: {
+          disableErrorCooldown,
+          custom: {
+            baseURL: baseURL.trim(),
+            apiKey: apiKey.trim(),
+          },
+        },
+        supportedClientTypes: ['claude'],
+      };
+
+      await updateProvider.mutateAsync({ id: Number(provider.id), data });
+      setSaveStatus('success');
+      setTimeout(() => onClose(), 500);
+    } catch (error) {
+      console.error('Failed to update provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={onClose} />}
+        title={t('provider.edit')}
+        description={t('addProvider.ollama.description')}
+      >
+        <Button onClick={onDelete} variant="destructive">
+          <Trash2 size={14} />
+          {t('provider.delete')}
+        </Button>
+        <Button onClick={onClose} variant="secondary">
+          {t('provider.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.saveChanges')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Ollama"
+                  className="w-full"
+                />
+              </div>
+
+              {!secretsAreWriteOnly && (
+                <div>
+                  <label className="text-sm font-medium text-foreground block mb-2">
+                    <div className="flex items-center gap-2">
+                      <Globe size={14} />
+                      <span>{t('addProvider.ollama.baseURL')}</span>
+                    </div>
+                  </label>
+                  <Input
+                    type="text"
+                    value={baseURL}
+                    onChange={(e) => setBaseURL(e.target.value)}
+                    placeholder="http://localhost:11434"
+                    className="w-full font-mono"
+                  />
+                </div>
+              )}
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('provider.apiKeyEdit')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={
+                      secretsAreWriteOnly
+                        ? t('provider.keyPlaceholderWriteOnly')
+                        : t('provider.keyPlaceholder')
+                    }
+                    className="w-full pr-10 font-mono"
+                  />
+                  {!secretsAreWriteOnly && (
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  )}
+                </div>
+                {secretsAreWriteOnly && (
+                  <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
+                    {t('provider.apiKeyExcludedHint')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Model Mappings (provider-scoped ModelMapping entities) */}
+          <ProviderModelMappings provider={provider} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.updateError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -45,6 +45,8 @@ import { KiroProviderView } from './kiro-provider-view';
 import { CodexProviderView } from './codex-provider-view';
 import { ClaudeProviderView } from './claude-provider-view';
 import { OpenRouterProviderView } from './openrouter-provider-view';
+import { NewApiProviderView } from './newapi-provider-view';
+import { OllamaProviderView } from './ollama-provider-view';
 import { GrokProviderView } from './grok-provider-view';
 import { ProviderModelMappings } from './provider-model-mappings';
 import { Button } from '@/components/ui/button';
@@ -683,6 +685,46 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     return (
       <>
         <OpenRouterProviderView
+          provider={provider}
+          onDelete={() => setShowDeleteConfirm(true)}
+          onClose={onClose}
+        />
+        <DeleteConfirmModal
+          providerName={provider.name}
+          deleting={deleting}
+          open={showDeleteConfirm}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      </>
+    );
+  }
+
+  // New API provider
+  if (provider.type === 'newapi') {
+    return (
+      <>
+        <NewApiProviderView
+          provider={provider}
+          onDelete={() => setShowDeleteConfirm(true)}
+          onClose={onClose}
+        />
+        <DeleteConfirmModal
+          providerName={provider.name}
+          deleting={deleting}
+          open={showDeleteConfirm}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      </>
+    );
+  }
+
+  // Ollama provider
+  if (provider.type === 'ollama') {
+    return (
+      <>
+        <OllamaProviderView
           provider={provider}
           onDelete={() => setShowDeleteConfirm(true)}
           onClose={onClose}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -10,8 +10,10 @@ import {
   Sparkles,
   ChevronLeft,
   Bot,
+  Network,
+  Boxes,
 } from 'lucide-react';
-import { quickTemplates, PROVIDER_TYPE_CONFIGS } from '../types';
+import { quickTemplates, PROVIDER_TYPE_CONFIGS, type ProviderFormData } from '../types';
 import openrouterLogo from '@/assets/icons/openrouter.svg';
 import { Button } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
@@ -29,14 +31,14 @@ export function SelectTypeStep() {
     goToClaude,
     goToBedrock,
     goToOpenRouter,
+    goToNewApi,
+    goToOllama,
     goToGrok,
     goToProviders,
   } = useProviderNavigation();
   const { t } = useTranslation();
 
-  const handleSelectType = (
-    type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok',
-  ) => {
+  const handleSelectType = (type: ProviderFormData['type']) => {
     updateFormData({ type });
     if (type === 'antigravity') {
       goToAntigravity();
@@ -52,6 +54,10 @@ export function SelectTypeStep() {
       goToCodex();
     } else if (type === 'claude') {
       goToClaude();
+    } else if (type === 'newapi') {
+      goToNewApi();
+    } else if (type === 'ollama') {
+      goToOllama();
     }
   };
 
@@ -345,6 +351,64 @@ export function SelectTypeStep() {
 
                   {formData.type === 'custom' && (
                     <CheckCircle2 className="size-5 text-provider-custom shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                  )}
+                </div>
+              </Button>
+
+              <Button
+                onClick={() => handleSelectType('newapi')}
+                variant="ghost"
+                className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                  formData.type === 'newapi'
+                    ? 'border-provider-newapi bg-provider-newapi/10 shadow-sm'
+                    : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                }`}
+              >
+                <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                  <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-newapi/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                    <Network className="size-5 md:size-6 text-provider-newapi" />
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                      {t('addProvider.newapi.name')}
+                    </h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                      {t('addProvider.newapi.description')}
+                    </p>
+                  </div>
+
+                  {formData.type === 'newapi' && (
+                    <CheckCircle2 className="size-5 text-provider-newapi shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                  )}
+                </div>
+              </Button>
+
+              <Button
+                onClick={() => handleSelectType('ollama')}
+                variant="ghost"
+                className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                  formData.type === 'ollama'
+                    ? 'border-provider-ollama bg-provider-ollama/10 shadow-sm'
+                    : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                }`}
+              >
+                <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                  <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-ollama/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                    <Boxes className="size-5 md:size-6 text-provider-ollama" />
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                      {t('addProvider.ollama.name')}
+                    </h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                      {t('addProvider.ollama.description')}
+                    </p>
+                  </div>
+
+                  {formData.type === 'ollama' && (
+                    <CheckCircle2 className="size-5 text-provider-ollama shrink-0 self-center animate-in zoom-in-50 duration-200" />
                   )}
                 </div>
               </Button>

--- a/web/src/pages/providers/create-layout.tsx
+++ b/web/src/pages/providers/create-layout.tsx
@@ -9,6 +9,8 @@ import { ClaudeTokenImport } from './components/claude-token-import';
 import { CustomConfigStep } from './components/custom-config-step';
 import { BedrockConfigStep } from './components/bedrock-config-step';
 import { OpenRouterConfigStep } from './components/openrouter-config-step';
+import { NewApiConfigStep } from './components/newapi-config-step';
+import { OllamaConfigStep } from './components/ollama-config-step';
 
 export function ProviderCreateLayout() {
   return (
@@ -18,6 +20,8 @@ export function ProviderCreateLayout() {
         <Route path="custom" element={<CustomConfigStep />} />
         <Route path="bedrock" element={<BedrockConfigStep />} />
         <Route path="openrouter" element={<OpenRouterConfigStep />} />
+        <Route path="newapi" element={<NewApiConfigStep />} />
+        <Route path="ollama" element={<OllamaConfigStep />} />
         <Route path="antigravity" element={<AntigravityTokenImport />} />
         <Route path="kiro" element={<KiroTokenImport />} />
         <Route path="codex" element={<CodexTokenImport />} />

--- a/web/src/pages/providers/hooks/use-provider-navigation.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.ts
@@ -12,6 +12,8 @@ export function useProviderNavigation() {
     goToClaude: () => navigate('/providers/create/claude'),
     goToBedrock: () => navigate('/providers/create/bedrock'),
     goToOpenRouter: () => navigate('/providers/create/openrouter'),
+    goToNewApi: () => navigate('/providers/create/newapi'),
+    goToOllama: () => navigate('/providers/create/ollama'),
     goToGrok: () => navigate('/providers/create/grok'),
     goToProviders: () => navigate('/providers'),
     goBack: () => navigate(-1),

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -17,6 +17,8 @@ describe('provider type helpers', () => {
       'bedrock',
       'openrouter',
       'grok',
+      'newapi',
+      'ollama',
       'custom',
     ]);
   });

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -1,7 +1,7 @@
 import type { ClientType, DisguiseType, Provider } from '@/lib/transport';
 import { getProviderColorVar } from '@/lib/theme';
 import type { LucideIcon } from 'lucide-react';
-import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud, Waypoints, Bot } from 'lucide-react';
+import { Wand2, Zap, Server, Mail, Globe, Code2, Sparkles, Cloud, Waypoints, Bot, Network, Boxes } from 'lucide-react';
 import duckcodingLogo from '@/assets/icons/duckcoding.gif';
 import freeDuckLogo from '@/assets/icons/free-duck.gif';
 import nvidiaLogo from '@/assets/icons/nvidia.svg';
@@ -14,7 +14,16 @@ import deepseekLogo from '@/assets/icons/deepseek.png';
 // 通用的 Provider 类型配置，添加新类型只需在这里配置
 
 export type ProviderTypeKey =
-  'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok';
+  | 'custom'
+  | 'antigravity'
+  | 'bedrock'
+  | 'kiro'
+  | 'codex'
+  | 'claude'
+  | 'openrouter'
+  | 'grok'
+  | 'newapi'
+  | 'ollama';
 
 export interface ProviderTypeConfig {
   key: ProviderTypeKey;
@@ -90,6 +99,22 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
     color: getProviderColorVar('grok'),
     isAccountBased: true,
     getDisplayInfo: (p) => p.config?.grok?.email || 'Grok Account',
+  },
+  newapi: {
+    key: 'newapi',
+    label: 'New API',
+    icon: Network,
+    color: getProviderColorVar('newapi'),
+    isAccountBased: false,
+    getDisplayInfo: (p) => p.config?.custom?.baseURL || 'Not configured',
+  },
+  ollama: {
+    key: 'ollama',
+    label: 'Ollama',
+    icon: Boxes,
+    color: getProviderColorVar('ollama'),
+    isAccountBased: false,
+    getDisplayInfo: (p) => p.config?.custom?.baseURL || 'Not configured',
   },
   custom: {
     key: 'custom',
@@ -298,7 +323,17 @@ export const defaultClients: ClientConfig[] = [
 
 // Form data types
 export type ProviderFormData = {
-  type: 'custom' | 'antigravity' | 'bedrock' | 'kiro' | 'codex' | 'claude' | 'openrouter' | 'grok';
+  type:
+    | 'custom'
+    | 'antigravity'
+    | 'bedrock'
+    | 'kiro'
+    | 'codex'
+    | 'claude'
+    | 'openrouter'
+    | 'grok'
+    | 'newapi'
+    | 'ollama';
   name: string;
   selectedTemplate: string | null;
   baseURL: string;


### PR DESCRIPTION
## 背景

同事报的 bug:`google/gemini-2.5-flash-image` 路由到 new-api 系上游(`type:custom`)时,客户端传的图片比例(`image_config`)被字节透传、上游不认 → 永远出 1024×1024。

根因:PR #710 的图片配置归一化只在 openrouter adapter 里。而"在 OpenAI 格式里表达图片比例"没有行业标准 —— OpenRouter 用顶层 `image_config`、new-api/Google 系用 `extra_body.google.image_config`、OpenAI 原生只有 `size`。custom adapter 透传,所以到 new-api 就丢了。

## 设计

顺着 OpenRouter 已是独立 type 的先例,把 **new-api 和 Ollama 也各自升为一等 provider type**(而不是给 custom 挂判别标志)。每个上游产品的方言待在自己的 adapter,`custom` 回归纯通用透传。`backend` 字段标 **Deprecated 但保留**。

## 后端(纯增量、零迁移)

- **`newapi` type**:薄壳复用 custom 核心 + 把 `image_config`/`size` → `extra_body.google.image_config`(补 `modalities`)翻译 —— openrouter 那半边的对称镜像,直接修复该 bug。
- **`ollama` type**:薄壳,驱动既有的 Claude↔Ollama 路径。
- `ProviderConfigCustom.Backend` 标 Deprecated,行为不变;存量 `custom+backend:ollama` 照跑。
- 接线:适配器注册、config/secret 保留(共用 `Config.Custom`)、默认 client types(newapi→OpenAI / ollama→Claude)、模型发现。
- 单测:翻译逻辑 + 适配器构造/注册。

## 前端

- new-api / Ollama 各自**独立的创建表单 + 编辑视图**(老 custom 表单零改动)。
- 类型系统 / 主题配色 / i18n 识别,存量 provider 正确显示。

## 影响面 & 迁移

**对线上零影响**:没有任何现存 provider 的 type 被改;无 DB 迁移;无 type 白名单拦截。要修复受影响的上游,只需把该 provider 的 type 从 `custom` 改成 `newapi`(一个字段,可回退)。

## 验证

`go build`/`go test`、`pnpm typecheck`/`build`/`eslint`/`vitest`(28 用例)、`gofmt`/`vet` —— 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 New API/One-API 提供商，可配置地址、密钥、客户端类型及模型映射。
  * 新增 Ollama 提供商，支持本地模型服务与 Claude 客户端。
  * 提供商创建、编辑、删除及配置页面新增专属流程和界面。
  * 改进图像请求兼容性，自动转换尺寸、比例及图像输出模式。
  * 支持 Gemini 与 OpenAI 图像请求及生成结果之间的双向转换。

* **修复**
  * 改进图像生成响应处理，确保生成图片可在流式和非流式结果中正确显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->