### PR TITLE
fix(retry): classify upstream connection failures as retryable

### DIFF
--- a/internal/adapter/provider/antigravity/adapter.go
+++ b/internal/adapter/provider/antigravity/adapter.go
@@ -242,9 +242,7 @@ func (a *AntigravityAdapter) Execute(c *flow.Ctx, provider *domain.Provider) err
 					if hasNextEndpoint(idx, len(baseURLs)) {
 						continue
 					}
-					proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-					proxyErr.Message = "failed to connect to upstream"
-					return proxyErr
+					return domain.NewUpstreamConnectionError("failed to connect to upstream")
 				}
 
 				// Check for 401 (token expired) and retry once
@@ -282,9 +280,7 @@ func (a *AntigravityAdapter) Execute(c *flow.Ctx, provider *domain.Provider) err
 						if hasNextEndpoint(idx, len(baseURLs)) {
 							continue
 						}
-						proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-						proxyErr.Message = "failed to connect to upstream after token refresh"
-						return proxyErr
+						return domain.NewUpstreamConnectionError("failed to connect to upstream after token refresh")
 					}
 				}
 

--- a/internal/adapter/provider/claude/adapter.go
+++ b/internal/adapter/provider/claude/adapter.go
@@ -139,9 +139,7 @@ func (a *ClaudeAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// Execute request
 	resp, err := a.httpClient.Do(upstreamReq)
 	if err != nil {
-		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-		proxyErr.Message = "failed to connect to upstream"
-		return proxyErr
+		return domain.NewUpstreamConnectionError("failed to connect to upstream")
 	}
 	defer resp.Body.Close()
 
@@ -176,9 +174,7 @@ func (a *ClaudeAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 		resp, err = a.httpClient.Do(upstreamReq)
 		if err != nil {
-			proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-			proxyErr.Message = "failed to connect to upstream after token refresh"
-			return proxyErr
+			return domain.NewUpstreamConnectionError("failed to connect to upstream after token refresh")
 		}
 		defer resp.Body.Close()
 	}

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -222,9 +222,7 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// Execute request
 	resp, err := a.httpClient.Do(upstreamReq)
 	if err != nil {
-		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-		proxyErr.Message = "failed to connect to upstream"
-		return proxyErr
+		return domain.NewUpstreamConnectionError("failed to connect to upstream")
 	}
 	defer resp.Body.Close()
 
@@ -257,9 +255,7 @@ func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 		resp, err = a.httpClient.Do(upstreamReq)
 		if err != nil {
-			proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-			proxyErr.Message = "failed to connect to upstream after token refresh"
-			return proxyErr
+			return domain.NewUpstreamConnectionError("failed to connect to upstream after token refresh")
 		}
 		defer resp.Body.Close()
 	}

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -269,9 +269,7 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	}
 	resp, err := client.Do(upstreamReq)
 	if err != nil {
-		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-		proxyErr.Message = "failed to connect to upstream"
-		return proxyErr
+		return domain.NewUpstreamConnectionError("failed to connect to upstream")
 	}
 	defer resp.Body.Close()
 
@@ -1305,8 +1303,15 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 			proxyErr.Reason = domain.CooldownReasonServerError
 		}
 
-	// 400, 408, 413, 422 — request-level errors
-	case statusCode == 400 || statusCode == 408 || statusCode == 413 || statusCode == 422:
+	// 408 is an upstream timeout before a useful response; retry/fail over instead
+	// of treating it like a client request validation error.
+	case statusCode == http.StatusRequestTimeout:
+		proxyErr.Scope = domain.ScopeEndpoint
+		proxyErr.Reason = domain.CooldownReasonNetworkError
+		proxyErr.Retryable = true
+
+	// 400, 413, 422 — request-level errors
+	case statusCode == 400 || statusCode == 413 || statusCode == 422:
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.Retryable = false
 

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -102,3 +102,17 @@ func TestExtractStructuredResetTimeFindsNestedQuotaResetTime(t *testing.T) {
 		t.Fatalf("reset time = %v, want %v", got, want)
 	}
 }
+
+func TestClassifyHTTPErrorRequestTimeoutIsRetryableNetworkError(t *testing.T) {
+	proxyErr := classifyHTTPError(http.StatusRequestTimeout, []byte(`failed to connect to upstream: upstream error`), http.Header{}, domain.ClientTypeOpenAI, "gpt-4")
+
+	if proxyErr.Scope != domain.ScopeEndpoint {
+		t.Fatalf("scope = %q, want endpoint", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Fatalf("reason = %q, want network_error", proxyErr.Reason)
+	}
+	if !proxyErr.Retryable {
+		t.Fatal("408 upstream timeout should be retryable")
+	}
+}

--- a/internal/adapter/provider/kiro/adapter.go
+++ b/internal/adapter/provider/kiro/adapter.go
@@ -142,9 +142,7 @@ func (a *KiroAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// Execute request
 	resp, err := a.httpClient.Do(upstreamReq)
 	if err != nil {
-		proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-		proxyErr.Message = "failed to connect to upstream"
-		return proxyErr
+		return domain.NewUpstreamConnectionError("failed to connect to upstream")
 	}
 	defer resp.Body.Close()
 
@@ -179,9 +177,7 @@ func (a *KiroAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 
 		resp, err = a.httpClient.Do(upstreamReq)
 		if err != nil {
-			proxyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeProvider, domain.CooldownReasonNetworkError)
-			proxyErr.Message = "failed to connect to upstream after token refresh"
-			return proxyErr
+			return domain.NewUpstreamConnectionError("failed to connect to upstream after token refresh")
 		}
 		defer resp.Body.Close()
 	}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -104,3 +104,12 @@ func NewScopedProxyError(err error, scope ErrorScope, reason CooldownReason) *Pr
 		Retryable: scope != ScopeRequest,
 	}
 }
+
+func NewUpstreamConnectionError(message string) *ProxyError {
+	if message == "" {
+		message = "failed to connect to upstream"
+	}
+	proxyErr := NewScopedProxyError(ErrUpstreamError, ScopeProvider, CooldownReasonNetworkError)
+	proxyErr.Message = message
+	return proxyErr
+}

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,23 @@
+package domain
+
+import "testing"
+
+func TestNewUpstreamConnectionErrorIsRetryableProviderNetworkError(t *testing.T) {
+	proxyErr := NewUpstreamConnectionError("failed to connect to upstream")
+
+	if proxyErr.Err != ErrUpstreamError {
+		t.Fatalf("err = %v, want ErrUpstreamError", proxyErr.Err)
+	}
+	if proxyErr.Message != "failed to connect to upstream" {
+		t.Fatalf("message = %q", proxyErr.Message)
+	}
+	if proxyErr.Scope != ScopeProvider {
+		t.Fatalf("scope = %q, want provider", proxyErr.Scope)
+	}
+	if proxyErr.Reason != CooldownReasonNetworkError {
+		t.Fatalf("reason = %q, want network_error", proxyErr.Reason)
+	}
+	if !proxyErr.Retryable {
+		t.Fatal("upstream connection errors must be retryable")
+	}
+}


### PR DESCRIPTION
## Summary
- centralize upstream connection failures as provider/network retryable errors
- use the shared connection-error constructor across custom, codex, claude, kiro, and antigravity adapters
- classify custom-adapter upstream HTTP 408 as endpoint/network retryable instead of request-scoped non-retryable
- add regressions for the shared connection error and 408 classification

## Validation
- `go test ./internal/domain ./internal/adapter/provider/custom ./internal/executor`
- `git diff --check`
- `pnpm --dir web build`
- `go test ./...`

Note: first `go test ./...` on a fresh clone failed because `web/dist` did not exist for the root embed; after `pnpm --dir web build`, full Go tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化上游连接失败的错误提示，区分首次连接失败与刷新凭证后的重试失败，便于识别问题。
  * 网络连接错误现会被正确标记为可重试，提升临时网络故障下的恢复能力。
  * 请求超时（408）现归类为可重试的网络错误，系统将更合理地处理此类情况。

* **测试**
  * 增加连接失败与请求超时场景的验证，确保错误分类和重试行为符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->