### PR TITLE
feat(settings): split diagnostics into dedicated tab

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { RetryConfigsPage } from '@/pages/retry-configs';
 import { RoutingStrategiesPage } from '@/pages/routing-strategies';
 import { ConsolePage } from '@/pages/console';
 import { SettingsPage } from '@/pages/settings';
+import { DiagnosticsPage } from '@/pages/diagnostics';
 import { DocumentationPage } from '@/pages/documentation';
 import { LoginPage } from '@/pages/login';
 import { APITokensPage } from '@/pages/api-tokens';
@@ -149,6 +150,14 @@ function AppRoutes() {
           />
           <Route path="stats" element={<StatsPage />} />
           <Route path="settings" element={<SettingsPage />} />
+          <Route
+            path="diagnostics"
+            element={
+              <AdminRoute>
+                <DiagnosticsPage />
+              </AdminRoute>
+            }
+          />
           <Route
             path="users"
             element={

--- a/web/src/components/layout/app-sidebar/sidebar-config.test.ts
+++ b/web/src/components/layout/app-sidebar/sidebar-config.test.ts
@@ -31,4 +31,17 @@ describe('sidebarConfig', () => {
     });
     expect(item).not.toHaveProperty('authOnly', true);
   });
+
+  it('keeps diagnostics visible when admin auth is disabled', () => {
+    const item = findItem('diagnostics');
+
+    expect(item).toMatchObject({
+      type: 'standard',
+      to: '/diagnostics',
+      labelKey: 'nav.diagnostics',
+      adminOnly: true,
+    });
+    expect(item).not.toHaveProperty('authOnly', true);
+  });
+
 });

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -15,6 +15,7 @@ import {
   Ticket,
   Workflow,
   Gauge,
+  Activity,
 } from 'lucide-react';
 import type { SidebarConfig } from '@/types/sidebar';
 import { RequestsNavItem } from './requests-nav-item';
@@ -169,6 +170,14 @@ export const sidebarConfig: SidebarConfig = {
           to: '/api-token-limits',
           icon: Gauge,
           labelKey: 'nav.apiTokenLimits',
+          adminOnly: true,
+        },
+        {
+          type: 'standard',
+          key: 'diagnostics',
+          to: '/diagnostics',
+          icon: Activity,
+          labelKey: 'nav.diagnostics',
           adminOnly: true,
         },
         {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -81,7 +81,8 @@
     "modelPrices": "Model Prices",
     "retryConfigs": "Retry Configs",
     "routingStrategies": "Routing Strategies",
-    "settings": "Settings",
+    "settings": "General Settings",
+    "diagnostics": "Diagnostics",
     "stats": "Statistics",
     "routes": "ROUTES",
     "management": "MANAGEMENT",
@@ -1260,9 +1261,13 @@
     "tokenManagement": "Token Management",
     "tokenManagementDesc": "Go to the 'API Tokens' page to create and manage API tokens. Token format: 64-character string starting with maxx_."
   },
+  "diagnostics": {
+    "title": "Diagnostics",
+    "description": "Manage request diagnostics and pprof profiling tools in one place."
+  },
   "settings": {
-    "title": "Settings",
-    "description": "Configure your maxx instance",
+    "title": "General Settings",
+    "description": "Manage theme, language, timezone, and basic preferences.",
     "general": "General",
     "appearance": "Appearance",
     "themePreference": "Theme Preference",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -81,7 +81,8 @@
     "modelPrices": "模型价格",
     "retryConfigs": "重试配置",
     "routingStrategies": "路由策略",
-    "settings": "设置",
+    "settings": "常规设置",
+    "diagnostics": "诊断调试",
     "stats": "统计",
     "routes": "路由",
     "management": "管理",
@@ -1257,9 +1258,13 @@
     "tokenManagement": "Token 管理",
     "tokenManagementDesc": "前往「API 令牌」页面创建和管理 API Token。Token 格式为 maxx_ 开头的 64 位字符串。"
   },
+  "diagnostics": {
+    "title": "诊断调试",
+    "description": "集中管理请求诊断和 pprof 性能分析工具。"
+  },
   "settings": {
-    "title": "设置",
-    "description": "配置您的 Maxx 实例",
+    "title": "常规设置",
+    "description": "管理主题、语言、时区和基础偏好。",
     "general": "通用",
     "appearance": "外观",
     "themePreference": "主题偏好",

--- a/web/src/pages/diagnostics/index.tsx
+++ b/web/src/pages/diagnostics/index.tsx
@@ -1,0 +1,28 @@
+import { Activity } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PageHeader } from '@/components/layout/page-header';
+import { PprofSection, RequestDiagnosticsSection } from '@/pages/settings';
+
+export function DiagnosticsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <PageHeader
+        icon={Activity}
+        iconClassName="text-zinc-500"
+        title={t('diagnostics.title')}
+        description={t('diagnostics.description')}
+      />
+
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="space-y-6">
+          <RequestDiagnosticsSection />
+          <PprofSection />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DiagnosticsPage;

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -145,12 +145,10 @@ export function SettingsPage() {
               <MultiTenantUISection />
               <TimezoneSection />
               <DataRetentionSection />
-              <RequestDiagnosticsSection />
               <ForceProjectSection />
               <CodexReasoningGuardSection />
               <ProxyRouteExposureSection />
               <AntigravitySection />
-              <PprofSection />
               <BackupSection />
             </>
           )}
@@ -994,7 +992,7 @@ function CodexReasoningGuardSection() {
   );
 }
 
-function RequestDiagnosticsSection() {
+export function RequestDiagnosticsSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
@@ -1215,7 +1213,7 @@ function AntigravitySection() {
   );
 }
 
-function PprofSection() {
+export function PprofSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const deleteSetting = useDeleteSetting();


### PR DESCRIPTION
## Summary
- add a dedicated Diagnostics tab/page for request diagnostics and pprof profiling
- rename the existing Settings navigation/page label to General Settings / 常规设置
- move request diagnostics and pprof sections out of the general settings page
- add sidebar regression coverage for the new diagnostics item

## Validation
- `pnpm --dir web test -- src/components/layout/app-sidebar/sidebar-config.test.ts` (24 files / 107 tests passed)
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `git diff --check`

## Notes
- This PR does not change diagnostics or pprof backend behavior; it only changes navigation/page grouping.
- CodeRabbit was not checked or requested for this task.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“诊断调试”页面，集中提供请求诊断和性能分析工具。
  * 管理员可通过侧边栏访问诊断调试功能。

* **界面与本地化**
  * 将“设置”更名为“常规设置”，并更新相关说明。
  * 新增中文和英文的诊断调试页面标题及描述。

* **调整**
  * 将请求诊断和性能分析功能从常规设置页面移至独立的诊断调试页面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->