### PR TITLE
feat(user-panel): reveal managed API key

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -231,6 +231,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleUserPanelAPIToken(w, r, false)
 		case len(parts) == 3 && parts[2] == "regenerate":
 			h.handleUserPanelAPIToken(w, r, true)
+		case len(parts) == 3 && parts[2] == "reveal":
+			h.handleUserPanelAPITokenReveal(w, r)
 		default:
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		}
@@ -1179,6 +1181,46 @@ func getUserPanelUsageStatsForUser(svc *service.AdminService, tenantID uint64, u
 		stats = append(stats, tokenStats...)
 	}
 	return stats, nil
+}
+
+func (h *SelfServiceHandler) handleUserPanelAPITokenReveal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	if !h.userPanelLayoutEnabled() {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user panel token is not enabled"})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	userID := maxxctx.GetUserID(r.Context())
+	if tenantID == 0 || userID == 0 {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user required"})
+		return
+	}
+
+	existing, err := findUserPanelAPITokensForUser(h.svc, tenantID, userID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetUserPanelAPITokens failed", err)
+		return
+	}
+	canonicalToken, err := normalizeUserPanelAPITokensForUser(h.svc, tenantID, userID, existing)
+	if err != nil {
+		writeSelfServiceInternalError(w, "NormalizeUserPanelAPITokens failed", err)
+		return
+	}
+	if canonicalToken == nil || !canonicalToken.IsEnabled {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user panel token not found"})
+		return
+	}
+	if canonicalToken.Token == "" {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user panel token secret is not available"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"token": canonicalToken.Token})
 }
 
 func (h *SelfServiceHandler) handleUserPanelAPIToken(w http.ResponseWriter, r *http.Request, regenerate bool) {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -2332,6 +2332,72 @@ func TestSelfServiceHandler_UserPanelExistingTokenProjectBindingIsCleared(t *tes
 	}
 }
 
+func TestSelfServiceHandler_UserPanelTokenRevealReturnsCurrentUsersSecret(t *testing.T) {
+	marker := userPanelAPITokenDescription(9)
+	tokenRepo := &selfServiceAPITokenRepo{
+		tokens: []*domain.APIToken{
+			{ID: 10, TenantID: 1, Name: "user 9", Description: marker, Token: "maxx_full_user_key", TokenPrefix: "maxx_full...", IsEnabled: true, ProjectID: 42},
+			{ID: 11, TenantID: 1, Name: "other", Description: userPanelAPITokenDescription(10), Token: "maxx_other_user_key", TokenPrefix: "maxx_other...", IsEnabled: true},
+		},
+	}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: tokenRepo,
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodPost, "/user-panel-token/reveal"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var result map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if result["token"] != "maxx_full_user_key" {
+		t.Fatalf("token = %q, want current user's full token", result["token"])
+	}
+	if tokenRepo.tokens[0].ProjectID != 0 {
+		t.Fatalf("reveal should normalize user panel token projectID = %d, want 0", tokenRepo.tokens[0].ProjectID)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelTokenRevealRequiresPost(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: &selfServiceAPITokenRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodGet, "/user-panel-token/reveal"))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusMethodNotAllowed, rec.Body.String())
+	}
+}
+
+func TestSelfServiceHandler_UserPanelTokenRevealMissingToken(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled": "true",
+			"ui_multitenant_layout":  "user_panel",
+		}},
+		apiTokenRepo: &selfServiceAPITokenRepo{},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newSelfServiceRequest(http.MethodPost, "/user-panel-token/reveal"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
 func TestSelfServiceHandler_UserPanelRegenerateRotatesExistingTokenInPlace(t *testing.T) {
 	marker := userPanelAPITokenDescription(9)
 	tokenRepo := &selfServiceAPITokenRepo{

--- a/tests/e2e/playwright/user-panel-key-reveal.spec.ts
+++ b/tests/e2e/playwright/user-panel-key-reveal.spec.ts
@@ -1,8 +1,86 @@
+import http from 'node:http';
+
 import { expect, test } from 'playwright/test';
 
-import { BASE, PASS, USER, adminAPI, loginToAdminAPI } from './helpers';
+import { BASE, adminAPI, closeServer, loginToAdminAPI } from './helpers';
 
 test.describe.configure({ mode: 'serial' });
+
+function startMockOpenAIServer(): Promise<{ server: http.Server; port: number; requests: string[] }> {
+  const requests: string[] = [];
+
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === 'POST' && req.url?.includes('/v1/chat/completions')) {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          requests.push(body);
+
+          let parsed: any = {};
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            // keep mock permissive; malformed bodies still get captured above
+          }
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              id: `chatcmpl_key_reveal_${Date.now()}`,
+              object: 'chat.completion',
+              created: Math.floor(Date.now() / 1000),
+              model: parsed.model || 'gpt-4o-mini',
+              choices: [
+                {
+                  index: 0,
+                  message: { role: 'assistant', content: 'mock key reveal proxy ok' },
+                  finish_reason: 'stop',
+                },
+              ],
+              usage: { prompt_tokens: 9, completion_tokens: 6, total_tokens: 15 },
+            }),
+          );
+        });
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to determine mock server port');
+      }
+      resolve({ server, port: address.port, requests });
+    });
+  });
+}
+
+async function sendOpenAIProxyRequest(apiToken: string, marker: string) {
+  const response = await fetch(`${BASE}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiToken}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: marker }],
+      max_tokens: 32,
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Proxy request failed (${response.status}): ${text}`);
+  }
+  return JSON.parse(text);
+}
 
 async function loginViaUI(page: import('playwright/test').Page, username: string, password: string) {
   await page.goto(BASE);
@@ -38,12 +116,49 @@ test('user panel key reveal uses a controlled endpoint and eye-toggle UI', async
   const adminToken = await loginToAdminAPI();
   const username = `member-key-reveal-${Date.now()}`;
   const password = 'Member123!';
+  const mock = await startMockOpenAIServer();
   let createdUserId: number | null = null;
+  let providerId: number | null = null;
+  let routeId: number | null = null;
   const previousSettings = await adminAPI('GET', '/settings', undefined, adminToken);
 
   try {
     await adminAPI('PUT', '/settings/ui_multitenant_enabled', { value: 'true' }, adminToken);
     await adminAPI('PUT', '/settings/ui_multitenant_layout', { value: 'user_panel' }, adminToken);
+
+    const provider = await adminAPI(
+      'POST',
+      '/providers',
+      {
+        name: `Key Reveal Mock OpenAI ${Date.now()}`,
+        type: 'custom',
+        config: {
+          custom: {
+            baseURL: `http://127.0.0.1:${mock.port}`,
+            apiKey: 'mock-provider-key',
+          },
+        },
+        supportedClientTypes: ['openai'],
+        supportModels: ['*'],
+      },
+      adminToken,
+    );
+    providerId = provider.id;
+
+    const route = await adminAPI(
+      'POST',
+      '/routes',
+      {
+        isEnabled: true,
+        isNative: false,
+        clientType: 'openai',
+        providerID: provider.id,
+        projectID: 0,
+        position: 1,
+      },
+      adminToken,
+    );
+    routeId = route.id;
 
     const user = await adminAPI(
       'POST',
@@ -112,6 +227,41 @@ test('user panel key reveal uses a controlled endpoint and eye-toggle UI', async
     await page.getByRole('button', { name: /Hide key|隐藏密钥/ }).click();
     await expect(reloadedKeyInput).toHaveAttribute('type', 'password');
     await expect(reloadedKeyInput).not.toHaveValue(createdFullKey);
+
+    const marker = `key reveal proxy marker ${Date.now()}`;
+    const proxyResponse = await sendOpenAIProxyRequest(revealed.token, marker);
+    expect(proxyResponse.choices?.[0]?.message?.content).toBe('mock key reveal proxy ok');
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]).toContain(marker);
+
+    const mockFlowScreenshot = '/tmp/maxx-user-panel-key-mock-proxy-response.png';
+    await page.evaluate(
+      ({ markerText, responseText, mockCount }) => {
+        const panel = document.createElement('section');
+        panel.setAttribute('data-testid', 'mock-proxy-evidence');
+        panel.style.cssText =
+          'position:fixed;left:24px;right:24px;bottom:24px;z-index:9999;padding:16px;border:2px solid #16a34a;border-radius:12px;background:white;color:#111;font:13px ui-monospace,monospace;box-shadow:0 12px 30px rgba(0,0,0,.18)';
+        panel.textContent = `Mock OpenAI received ${mockCount} request(s); marker=${markerText}; response=${responseText}`;
+        document.body.appendChild(panel);
+      },
+      { markerText: marker, responseText: proxyResponse.choices[0].message.content, mockCount: mock.requests.length },
+    );
+    await page.screenshot({ path: mockFlowScreenshot, fullPage: true });
+    await testInfo.attach('user-panel-key-mock-proxy-response', {
+      path: mockFlowScreenshot,
+      contentType: 'image/png',
+    });
+
+    await page.getByRole('tab', { name: /Requests|请求记录/ }).click();
+    await expect(page.locator('body')).toContainText('gpt-4o-mini', { timeout: 15000 });
+    await expect(page.locator('body')).toContainText(/mock key reveal proxy ok|200/);
+
+    const requestListScreenshot = '/tmp/maxx-user-panel-key-request-list.png';
+    await page.screenshot({ path: requestListScreenshot, fullPage: true });
+    await testInfo.attach('user-panel-key-request-list', {
+      path: requestListScreenshot,
+      contentType: 'image/png',
+    });
   } finally {
     await adminAPI(
       'PUT',
@@ -125,8 +275,15 @@ test('user panel key reveal uses a controlled endpoint and eye-toggle UI', async
       { value: previousSettings.ui_multitenant_layout ?? 'admin_panel' },
       adminToken,
     ).catch(() => undefined);
+    if (routeId) {
+      await adminAPI('DELETE', `/routes/${routeId}`, undefined, adminToken).catch(() => undefined);
+    }
+    if (providerId) {
+      await adminAPI('DELETE', `/providers/${providerId}`, undefined, adminToken).catch(() => undefined);
+    }
     if (createdUserId) {
       await adminAPI('DELETE', `/users/${createdUserId}`, undefined, adminToken).catch(() => undefined);
     }
+    await closeServer(mock.server).catch(() => undefined);
   }
 });

--- a/tests/e2e/playwright/user-panel-key-reveal.spec.ts
+++ b/tests/e2e/playwright/user-panel-key-reveal.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test } from 'playwright/test';
+
+import { BASE, PASS, USER, adminAPI, loginToAdminAPI } from './helpers';
+
+test.describe.configure({ mode: 'serial' });
+
+async function loginViaUI(page: import('playwright/test').Page, username: string, password: string) {
+  await page.goto(BASE);
+  await page.locator('input[type="text"]').fill(username);
+  await page.locator('input[type="password"]').fill(password);
+  await page.locator('button[type="submit"]').click();
+  await expect(page.locator('body')).toContainText(/User Console|用户控制台/, { timeout: 15000 });
+}
+
+async function memberAPI(method: string, path: string, token: string, body?: unknown): Promise<any> {
+  const response = await fetch(`${BASE}/api${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  let json: any = text;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // keep text for error reporting
+  }
+  if (!response.ok) {
+    throw new Error(`Member API ${method} ${path} failed (${response.status}): ${text}`);
+  }
+  return json;
+}
+
+test('user panel key reveal uses a controlled endpoint and eye-toggle UI', async ({ page }, testInfo) => {
+  const adminToken = await loginToAdminAPI();
+  const username = `member-key-reveal-${Date.now()}`;
+  const password = 'Member123!';
+  let createdUserId: number | null = null;
+  const previousSettings = await adminAPI('GET', '/settings', undefined, adminToken);
+
+  try {
+    await adminAPI('PUT', '/settings/ui_multitenant_enabled', { value: 'true' }, adminToken);
+    await adminAPI('PUT', '/settings/ui_multitenant_layout', { value: 'user_panel' }, adminToken);
+
+    const user = await adminAPI(
+      'POST',
+      '/users',
+      {
+        username,
+        password,
+        role: 'member',
+      },
+      adminToken,
+    );
+    createdUserId = user.id;
+
+    await loginViaUI(page, username, password);
+    await expect(page.getByText(/Generate|生成/)).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: /Generate|生成/ }).click();
+    await expect(page.getByText(/Shown once|仅显示一次/)).toBeVisible({ timeout: 10000 });
+    const createdBodyText = (await page.textContent('body')) ?? '';
+    const createdFullKey = createdBodyText.match(/maxx_[0-9a-f]{64}/)?.[0] ?? '';
+    expect(createdFullKey).toMatch(/^maxx_[0-9a-f]{64}$/);
+
+    const createdScreenshot = '/tmp/maxx-user-panel-key-created-visible.png';
+    await page.screenshot({ path: createdScreenshot, fullPage: true });
+    await testInfo.attach('user-panel-key-created-visible', {
+      path: createdScreenshot,
+      contentType: 'image/png',
+    });
+
+    const memberLogin = await adminAPI('POST', '/auth/login', { username, password });
+    const memberToken = memberLogin.token as string;
+    expect(memberToken).toBeTruthy();
+
+    const tokenMetadata = await memberAPI('GET', '/user-panel-token', memberToken);
+    expect(tokenMetadata.apiToken.token).toBe('');
+    expect(tokenMetadata.apiToken.tokenPrefix).toMatch(/^maxx_/);
+
+    await page.reload();
+    await expect(page.locator('body')).toContainText(/User Console|用户控制台/, { timeout: 15000 });
+    const reloadedKeyInput = page.getByLabel(/Key|密钥/).first();
+    await expect(reloadedKeyInput).toHaveAttribute('type', 'password');
+    await expect(reloadedKeyInput).not.toHaveValue(createdFullKey);
+
+    const hiddenScreenshot = '/tmp/maxx-user-panel-key-hidden-after-reload.png';
+    await page.screenshot({ path: hiddenScreenshot, fullPage: true });
+    await testInfo.attach('user-panel-key-hidden-after-reload', {
+      path: hiddenScreenshot,
+      contentType: 'image/png',
+    });
+
+    const revealed = await memberAPI('POST', '/user-panel-token/reveal', memberToken);
+    expect(revealed.token).toBe(createdFullKey);
+
+    await page.getByRole('button', { name: /Show key|显示密钥/ }).click();
+    await expect(reloadedKeyInput).toHaveAttribute('type', 'text');
+    await expect(reloadedKeyInput).toHaveValue(createdFullKey);
+    await expect(page.getByText(/Full key is visible|完整密钥已显示/)).toBeVisible();
+
+    const revealedScreenshot = '/tmp/maxx-user-panel-key-revealed-by-eye.png';
+    await page.screenshot({ path: revealedScreenshot, fullPage: true });
+    await testInfo.attach('user-panel-key-revealed-by-eye', {
+      path: revealedScreenshot,
+      contentType: 'image/png',
+    });
+
+    await page.getByRole('button', { name: /Hide key|隐藏密钥/ }).click();
+    await expect(reloadedKeyInput).toHaveAttribute('type', 'password');
+    await expect(reloadedKeyInput).not.toHaveValue(createdFullKey);
+  } finally {
+    await adminAPI(
+      'PUT',
+      '/settings/ui_multitenant_enabled',
+      { value: previousSettings.ui_multitenant_enabled ?? 'false' },
+      adminToken,
+    ).catch(() => undefined);
+    await adminAPI(
+      'PUT',
+      '/settings/ui_multitenant_layout',
+      { value: previousSettings.ui_multitenant_layout ?? 'admin_panel' },
+      adminToken,
+    ).catch(() => undefined);
+    if (createdUserId) {
+      await adminAPI('DELETE', `/users/${createdUserId}`, undefined, adminToken).catch(() => undefined);
+    }
+  }
+});

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -125,6 +125,7 @@ export {
   useUserPanelAPIToken,
   useCreateUserPanelAPIToken,
   useRegenerateUserPanelAPIToken,
+  useRevealUserPanelAPIToken,
 } from './use-user-panel-token';
 
 // Invite Code hooks

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -42,3 +42,9 @@ export function useRegenerateUserPanelAPIToken() {
     onSuccess: () => refreshUserPanelTokenDependents(queryClient),
   });
 }
+
+export function useRevealUserPanelAPIToken() {
+  return useMutation({
+    mutationFn: () => getTransport().revealUserPanelAPIToken(),
+  });
+}

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -73,6 +73,7 @@ import type {
   APITokenCreateResult,
   CreateAPITokenData,
   UserPanelAPITokenResponse,
+  UserPanelAPITokenRevealResult,
   RouteBulkDeleteRequest,
   RouteBulkDeleteResult,
   RouteSyncRequest,
@@ -1079,6 +1080,11 @@ export class HttpTransport implements Transport {
 
   async regenerateUserPanelAPIToken(): Promise<APITokenCreateResult> {
     const { data } = await this.client.post<APITokenCreateResult>('/user-panel-token/regenerate');
+    return data;
+  }
+
+  async revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult> {
+    const { data } = await this.client.post<UserPanelAPITokenRevealResult>('/user-panel-token/reveal');
     return data;
   }
 

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -72,6 +72,7 @@ import type {
   APITokenCreateResult,
   CreateAPITokenData,
   UserPanelAPITokenResponse,
+  UserPanelAPITokenRevealResult,
   RouteBulkDeleteRequest,
   RouteBulkDeleteResult,
   RouteSyncRequest,
@@ -295,6 +296,7 @@ export interface Transport {
   getUserPanelAPIToken(): Promise<UserPanelAPITokenResponse>;
   createUserPanelAPIToken(): Promise<APITokenCreateResult>;
   regenerateUserPanelAPIToken(): Promise<APITokenCreateResult>;
+  revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
   updateAPIToken(id: number, data: Partial<APIToken>): Promise<APIToken>;
   deleteAPIToken(id: number): Promise<void>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1111,6 +1111,10 @@ export interface UserPanelAPITokenResponse {
   apiToken: APIToken | null;
 }
 
+export interface UserPanelAPITokenRevealResult {
+  token: string;
+}
+
 export interface APITokenCleanupItem {
   id: number;
   name: string;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -181,7 +181,11 @@
     "noRequestsDescription": "Only requests made with your dedicated key will appear here.",
     "requestDuration": "Duration",
     "requestInputTokens": "Input tokens",
-    "requestOutputTokens": "Output tokens"
+    "requestOutputTokens": "Output tokens",
+    "showKey": "Show key",
+    "hideKey": "Hide key",
+    "fullKeyVisible": "Full key is visible. Hide it when you are done.",
+    "revealKeyError": "Failed to reveal key. Please try again."
   },
   "dashboard": {
     "title": "Dashboard",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -181,7 +181,11 @@
     "noRequestsDescription": "这里只显示你自己的专用 Key 发起的请求。",
     "requestDuration": "耗时",
     "requestInputTokens": "输入 Token",
-    "requestOutputTokens": "输出 Token"
+    "requestOutputTokens": "输出 Token",
+    "showKey": "显示密钥",
+    "hideKey": "隐藏密钥",
+    "fullKeyVisible": "完整密钥已显示，使用后请及时隐藏。",
+    "revealKeyError": "密钥显示失败，请重试。"
   },
   "dashboard": {
     "title": "仪表板",

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Clock3, Copy, KeyRound, ListChecks, LogOut, Server, UserRound } from 'lucide-react';
+import { Clock3, Copy, Eye, EyeOff, KeyRound, ListChecks, LogOut, Server, UserRound } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   Badge,
@@ -22,6 +22,7 @@ import {
   useCreateUserPanelAPIToken,
   useProxyRequests,
   useRegenerateUserPanelAPIToken,
+  useRevealUserPanelAPIToken,
   useUserPanelAPIToken,
   useProxyRequestUpdates,
   usePublicSettings,
@@ -174,10 +175,13 @@ export function UserPanelPage() {
   useProxyRequestUpdates();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
+  const revealUserPanelToken = useRevealUserPanelAPIToken();
   const [copiedEndpointId, setCopiedEndpointId] = useState('');
   const [exampleCopied, setExampleCopied] = useState(false);
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
+  const [revealedUserPanelToken, setRevealedUserPanelToken] = useState('');
+  const [revealKeyError, setRevealKeyError] = useState('');
   const tabStorageKey = getUserPanelTabStorageKey(user?.id);
   const [activeTab, setActiveTab] = useState<UserPanelTab>(() => {
     if (typeof window === 'undefined') return 'main';
@@ -197,6 +201,8 @@ export function UserPanelPage() {
     userPanelRequests?.items.filter((request) => isActiveUserPanelRequest(request)).length ?? 0;
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const maskedUserPanelToken = userPanelToken?.tokenPrefix || 'maxx_••••';
+  const userPanelTokenValue = revealedUserPanelToken || maskedUserPanelToken;
+  const userPanelTokenRevealed = Boolean(revealedUserPanelToken);
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
   const endpointHints = buildUserPanelEndpointHints(origin, publicSettings).map((endpoint) => ({
     ...endpoint,
@@ -211,6 +217,11 @@ export function UserPanelPage() {
   const curlExample = showChatCompletionsExample
     ? buildUserPanelChatCompletionsExample({ origin })
     : '';
+
+  useEffect(() => {
+    setRevealedUserPanelToken('');
+    setRevealKeyError('');
+  }, [userPanelToken?.id]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -248,6 +259,22 @@ export function UserPanelPage() {
     window.setTimeout(() => setKeyCopied(false), 1600);
   };
 
+  const handleToggleUserPanelTokenReveal = async () => {
+    if (revealedUserPanelToken) {
+      setRevealedUserPanelToken('');
+      setRevealKeyError('');
+      return;
+    }
+
+    setRevealKeyError('');
+    try {
+      const result = await revealUserPanelToken.mutateAsync();
+      setRevealedUserPanelToken(result.token);
+    } catch {
+      setRevealKeyError(t('userPanel.revealKeyError'));
+    }
+  };
+
   const handleCopyExample = async () => {
     if (!curlExample || typeof navigator === 'undefined' || !navigator.clipboard) return;
     await navigator.clipboard.writeText(curlExample);
@@ -258,16 +285,21 @@ export function UserPanelPage() {
   const handleCreateUserPanelToken = async () => {
     const result = await createUserPanelToken.mutateAsync();
     setOneTimeToken(result.token);
+    setRevealedUserPanelToken(result.token);
+    setRevealKeyError('');
   };
 
   const handleRegenerateUserPanelToken = async () => {
     if (typeof window !== 'undefined' && !window.confirm(t('userPanel.regenerateConfirm'))) return;
     const result = await regenerateUserPanelToken.mutateAsync();
     setOneTimeToken(result.token);
+    setRevealedUserPanelToken(result.token);
+    setRevealKeyError('');
     setKeyCopied(false);
   };
 
   const tokenActionPending = createUserPanelToken.isPending || regenerateUserPanelToken.isPending;
+  const revealActionPending = revealUserPanelToken.isPending;
 
   return (
     <main className="min-h-svh bg-muted/30 px-4 py-6 text-foreground sm:px-6 lg:px-8">
@@ -364,13 +396,38 @@ export function UserPanelPage() {
                     </div>
 
                     <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_360px]">
-                      <Input
-                        readOnly
-                        type="password"
-                        value={maskedUserPanelToken}
-                        className="h-9 font-mono text-xs"
-                        aria-label={t('userPanel.myKey')}
-                      />
+                      <div className="space-y-1">
+                        <div className="relative">
+                          <Input
+                            readOnly
+                            type={userPanelTokenRevealed ? 'text' : 'password'}
+                            value={userPanelTokenValue}
+                            className="h-9 pr-10 font-mono text-xs"
+                            aria-label={t('userPanel.myKey')}
+                          />
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="absolute right-1 top-1/2 size-7 -translate-y-1/2"
+                            disabled={tokenActionPending || revealActionPending}
+                            aria-label={t(userPanelTokenRevealed ? 'userPanel.hideKey' : 'userPanel.showKey')}
+                            title={t(userPanelTokenRevealed ? 'userPanel.hideKey' : 'userPanel.showKey')}
+                            onClick={handleToggleUserPanelTokenReveal}
+                          >
+                            {userPanelTokenRevealed ? (
+                              <EyeOff className="size-3.5" />
+                            ) : (
+                              <Eye className="size-3.5" />
+                            )}
+                          </Button>
+                        </div>
+                        {revealKeyError ? (
+                          <p className="text-xs text-destructive">{revealKeyError}</p>
+                        ) : userPanelTokenRevealed ? (
+                          <p className="text-xs text-muted-foreground">{t('userPanel.fullKeyVisible')}</p>
+                        ) : null}
+                      </div>
                       <div className="grid grid-cols-3 gap-2">
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
                           <p className="text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- Add `POST /api/user-panel-token/reveal` for the current user's managed user-panel API key.
- Add an eye toggle in the user console to reveal/hide the full key on demand.
- Keep default `GET /user-panel-token` sanitized.
- Add backend coverage and strict Playwright E2E for reveal → proxy request → request list.

## Validation
- `go test -count=1 ./internal/handler -run 'TestSelfServiceHandler_UserPanel(TokenReveal|ExistingTokenProjectBinding|RegenerateRotates|CreateReuses|Dedup)'`
- `cd web && pnpm typecheck && pnpm lint && pnpm test && pnpm build`
- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s ./cmd/... ./internal/...`
- `go build -o /tmp/maxx-key-reveal-final-build ./cmd/maxx`
- `npx playwright test -c tests/e2e/playwright/playwright.config.ts user-panel-key-reveal.spec.ts --project=e2e-chromium`

## Screenshots
Local Playwright evidence generated under `/tmp/maxx-user-panel-key-*.png` and shared in chat.