### PR TITLE
fix(api-tokens): reset expired token validity

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1840,12 +1840,13 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 			return
 		}
 		var body struct {
-			Name        *string `json:"name"`
-			Description *string `json:"description"`
-			ProjectID   *uint64 `json:"projectID"`
-			IsEnabled   *bool   `json:"isEnabled"`
-			DevMode     *bool   `json:"devMode"`
-			ExpiresAt   *string `json:"expiresAt"`
+			Name          *string `json:"name"`
+			Description   *string `json:"description"`
+			ProjectID     *uint64 `json:"projectID"`
+			IsEnabled     *bool   `json:"isEnabled"`
+			DevMode       *bool   `json:"devMode"`
+			ExpiresAt     *string `json:"expiresAt"`
+			ResetValidity *bool   `json:"resetValidity"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -1881,6 +1882,13 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 				}
 				existing.ExpiresAt = &t
 			}
+		}
+		if body.ResetValidity != nil && *body.ResetValidity {
+			existing.IsEnabled = true
+			existing.ExpiresAt = nil
+			existing.LastUsedAt = nil
+			existing.LastIP = ""
+			existing.LastIPAt = nil
 		}
 		if err := h.svc.UpdateAPIToken(tenantID, existing); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/handler/admin_api_tokens_test.go
+++ b/internal/handler/admin_api_tokens_test.go
@@ -2,8 +2,11 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,6 +55,84 @@ func newAdminAPITokenRequest(method string, path string) *http.Request {
 	ctx := maxxctx.WithUserRole(req.Context(), string(domain.UserRoleAdmin))
 	ctx = maxxctx.WithTenantID(ctx, 1)
 	return req.WithContext(ctx)
+}
+
+func TestAdminHandlerResetAPITokenValidityClearsExpiryAndActivityState(t *testing.T) {
+	h, repo := newAdminHandlerForAPITokenTests(t)
+	now := time.Now().UTC()
+	expiredAt := now.Add(-time.Hour)
+	lastUsedAt := now.Add(-domain.APITokenInactiveExpiry - time.Minute)
+	lastIPAt := now.Add(-2 * time.Hour)
+	token := &domain.APIToken{
+		TenantID:    1,
+		Token:       "maxx_expired_reset_validity",
+		TokenPrefix: "maxx_exp",
+		Name:        "expired-token",
+		ProjectID:   7,
+		IsEnabled:   false,
+		ExpiresAt:   &expiredAt,
+		LastUsedAt:  &lastUsedAt,
+		LastIP:      "203.0.113.9",
+		LastIPAt:    &lastIPAt,
+		UseCount:    12,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := newAdminAPITokenRequest(http.MethodPut, fmt.Sprintf("/admin/api-tokens/%d", token.ID))
+	req.Body = io.NopCloser(strings.NewReader(`{"resetValidity":true}`))
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	updated, err := repo.GetByID(1, token.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if !updated.IsEnabled {
+		t.Fatalf("token IsEnabled = false, want true")
+	}
+	if updated.ExpiresAt != nil || updated.LastUsedAt != nil || updated.LastIPAt != nil || updated.LastIP != "" {
+		t.Fatalf("activity/expiry state = expiresAt:%v lastUsedAt:%v lastIP:%q lastIPAt:%v, want cleared", updated.ExpiresAt, updated.LastUsedAt, updated.LastIP, updated.LastIPAt)
+	}
+	if updated.UseCount != 12 || updated.ProjectID != 7 || updated.Token != "maxx_expired_reset_validity" {
+		t.Fatalf("stable fields changed unexpectedly: %+v", updated)
+	}
+}
+
+func TestAdminHandlerResetAPITokenValidityClearsInactiveOnlyExpiry(t *testing.T) {
+	h, repo := newAdminHandlerForAPITokenTests(t)
+	lastUsedAt := time.Now().UTC().Add(-domain.APITokenInactiveExpiry - time.Minute)
+	token := &domain.APIToken{
+		TenantID:    1,
+		Token:       "maxx_inactive_reset_validity",
+		TokenPrefix: "maxx_ina",
+		Name:        "inactive-token",
+		IsEnabled:   true,
+		LastUsedAt:  &lastUsedAt,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := newAdminAPITokenRequest(http.MethodPut, fmt.Sprintf("/admin/api-tokens/%d", token.ID))
+	req.Body = io.NopCloser(strings.NewReader(`{"resetValidity":true}`))
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d, body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	updated, err := repo.GetByID(1, token.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if updated.LastUsedAt != nil || !updated.IsEnabled {
+		t.Fatalf("updated token = %+v, want active token with cleared lastUsedAt", updated)
+	}
 }
 
 func TestAdminHandlerCleanupExpiredAPITokens(t *testing.T) {

--- a/internal/repository/sqlite/api_token.go
+++ b/internal/repository/sqlite/api_token.go
@@ -33,13 +33,16 @@ func (r *APITokenRepository) Create(t *domain.APIToken) error {
 func (r *APITokenRepository) Update(t *domain.APIToken) error {
 	t.UpdatedAt = time.Now()
 	updates := map[string]any{
-		"updated_at":  toTimestamp(t.UpdatedAt),
-		"name":        t.Name,
-		"description": LongText(t.Description),
-		"project_id":  t.ProjectID,
-		"is_enabled":  boolToInt(t.IsEnabled),
-		"dev_mode":    boolToInt(t.DevMode),
-		"expires_at":  toTimestampPtr(t.ExpiresAt),
+		"updated_at":   toTimestamp(t.UpdatedAt),
+		"name":         t.Name,
+		"description":  LongText(t.Description),
+		"project_id":   t.ProjectID,
+		"is_enabled":   boolToInt(t.IsEnabled),
+		"dev_mode":     boolToInt(t.DevMode),
+		"expires_at":   toTimestampPtr(t.ExpiresAt),
+		"last_used_at": toTimestampPtr(t.LastUsedAt),
+		"last_ip":      t.LastIP,
+		"last_ip_at":   toTimestampPtr(t.LastIPAt),
 	}
 	if t.Token != "" {
 		updates["token"] = t.Token

--- a/tests/e2e/playwright/api-token-reactivate.spec.ts
+++ b/tests/e2e/playwright/api-token-reactivate.spec.ts
@@ -1,0 +1,263 @@
+import http from "node:http";
+
+import { expect, test } from "playwright/test";
+
+import {
+  BASE,
+  adminAPI,
+  closeServer,
+  loginToAdminAPI,
+  loginToAdminUI,
+} from "./helpers";
+
+async function startMockOpenAIServer(): Promise<{
+  server: http.Server;
+  port: number;
+  requests: string[];
+}> {
+  const requests: string[] = [];
+
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === "POST" && req.url?.includes("/v1/chat/completions")) {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          requests.push(body);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              id: `chatcmpl_token_reactivate_${Date.now()}`,
+              object: "chat.completion",
+              created: Math.floor(Date.now() / 1000),
+              model: "gpt-4o-mini",
+              choices: [
+                {
+                  index: 0,
+                  message: {
+                    role: "assistant",
+                    content: "mock token reactivate ok",
+                  },
+                  finish_reason: "stop",
+                },
+              ],
+              usage: {
+                prompt_tokens: 7,
+                completion_tokens: 5,
+                total_tokens: 12,
+              },
+            }),
+          );
+        });
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to determine mock server port");
+      }
+      resolve({ server, port: address.port, requests });
+    });
+  });
+}
+
+async function sendOpenAIProxyRequest(
+  apiToken: string,
+  marker: string,
+): Promise<Response> {
+  return fetch(`${BASE}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiToken}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: marker }],
+      max_tokens: 32,
+    }),
+  });
+}
+
+test("expired API token can be reactivated from the token tab and used for proxy requests", async ({
+  page,
+}, testInfo) => {
+  const adminToken = await loginToAdminAPI();
+  const mock = await startMockOpenAIServer();
+  const tokenName = `expired-reactivate-${Date.now()}`;
+  let providerId: number | null = null;
+  let routeId: number | null = null;
+  let tokenId: number | null = null;
+
+  try {
+    await adminAPI(
+      "PUT",
+      "/settings/api_token_auth_enabled",
+      { value: "true" },
+      adminToken,
+    );
+
+    const provider = await adminAPI(
+      "POST",
+      "/providers",
+      {
+        name: `Token Reactivate Mock OpenAI ${Date.now()}`,
+        type: "custom",
+        config: {
+          custom: {
+            baseURL: `http://127.0.0.1:${mock.port}`,
+            apiKey: "mock-provider-key",
+          },
+        },
+        supportedClientTypes: ["openai"],
+        supportModels: ["*"],
+      },
+      adminToken,
+    );
+    providerId = provider.id;
+
+    const route = await adminAPI(
+      "POST",
+      "/routes",
+      {
+        isEnabled: true,
+        isNative: false,
+        clientType: "openai",
+        providerID: provider.id,
+        projectID: 0,
+        position: 1,
+      },
+      adminToken,
+    );
+    routeId = route.id;
+
+    const expiredToken = await adminAPI(
+      "POST",
+      "/api-tokens",
+      {
+        name: tokenName,
+        description: "E2E expired token reactivation",
+        projectID: 0,
+        expiresAt: "2020-01-01T00:00:00.000Z",
+      },
+      adminToken,
+    );
+    tokenId = expiredToken.apiToken.id;
+    const rawToken = expiredToken.token as string;
+
+    const rejected = await sendOpenAIProxyRequest(
+      rawToken,
+      "before-reactivate",
+    );
+    expect(rejected.status).toBe(401);
+    expect(mock.requests).toHaveLength(0);
+
+    await loginToAdminUI(page);
+    await page.goto(`${BASE}/api-tokens`);
+    await expect(page.getByText(tokenName)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/Expired|已过期/)).toBeVisible();
+
+    const expiredScreenshot =
+      "/tmp/maxx-api-token-expired-before-reactivate.png";
+    await page.screenshot({ path: expiredScreenshot, fullPage: true });
+    await testInfo.attach("api-token-expired-before-reactivate", {
+      path: expiredScreenshot,
+      contentType: "image/png",
+    });
+
+    await page
+      .getByRole("button", { name: /Reset validity|Reactivate|恢复有效/ })
+      .first()
+      .click();
+
+    await expect
+      .poll(
+        async () => {
+          const token = await adminAPI(
+            "GET",
+            `/api-tokens/${tokenId}`,
+            undefined,
+            adminToken,
+          );
+          return {
+            isEnabled: token.isEnabled,
+            expiresAt: token.expiresAt ?? null,
+            lastUsedAt: token.lastUsedAt ?? null,
+          };
+        },
+        { timeout: 15000 },
+      )
+      .toEqual({ isEnabled: true, expiresAt: null, lastUsedAt: null });
+
+    await expect(page.getByText(tokenName)).toBeVisible();
+    await expect(page.getByText(/Active|启用|正常/)).toBeVisible();
+
+    const activeScreenshot = "/tmp/maxx-api-token-active-after-reactivate.png";
+    await page.screenshot({ path: activeScreenshot, fullPage: true });
+    await testInfo.attach("api-token-active-after-reactivate", {
+      path: activeScreenshot,
+      contentType: "image/png",
+    });
+
+    const marker = `token reactivate marker ${Date.now()}`;
+    const accepted = await sendOpenAIProxyRequest(rawToken, marker);
+    expect(accepted.status).toBe(200);
+    const acceptedBody = await accepted.json();
+    expect(acceptedBody.choices?.[0]?.message?.content).toBe(
+      "mock token reactivate ok",
+    );
+    expect(mock.requests).toHaveLength(1);
+    expect(mock.requests[0]).toContain(marker);
+
+    const proxyScreenshot = "/tmp/maxx-api-token-reactivated-proxy-ok.png";
+    await page.evaluate(
+      ({ markerText, mockCount }) => {
+        const panel = document.createElement("section");
+        panel.setAttribute("data-testid", "token-reactivate-proxy-evidence");
+        panel.style.cssText =
+          "position:fixed;left:24px;right:24px;bottom:24px;z-index:9999;padding:16px;border:2px solid #16a34a;border-radius:12px;background:white;color:#111;font:13px ui-monospace,monospace;box-shadow:0 12px 30px rgba(0,0,0,.18)";
+        panel.textContent = `Reactivated token proxy request succeeded; mockCount=${mockCount}; marker=${markerText}`;
+        document.body.appendChild(panel);
+      },
+      { markerText: marker, mockCount: mock.requests.length },
+    );
+    await page.screenshot({ path: proxyScreenshot, fullPage: true });
+    await testInfo.attach("api-token-reactivated-proxy-ok", {
+      path: proxyScreenshot,
+      contentType: "image/png",
+    });
+  } finally {
+    if (routeId) {
+      await adminAPI(
+        "DELETE",
+        `/routes/${routeId}`,
+        undefined,
+        adminToken,
+      ).catch(() => undefined);
+    }
+    if (providerId) {
+      await adminAPI(
+        "DELETE",
+        `/providers/${providerId}`,
+        undefined,
+        adminToken,
+      ).catch(() => undefined);
+    }
+    if (tokenId) {
+      await adminAPI(
+        "DELETE",
+        `/api-tokens/${tokenId}`,
+        undefined,
+        adminToken,
+      ).catch(() => undefined);
+    }
+    await closeServer(mock.server).catch(() => undefined);
+  }
+});

--- a/web/src/hooks/queries/use-api-tokens.ts
+++ b/web/src/hooks/queries/use-api-tokens.ts
@@ -3,7 +3,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTransport, type APIToken, type CreateAPITokenData } from '@/lib/transport';
+import { getTransport, type APITokenUpdateData, type CreateAPITokenData } from '@/lib/transport';
 
 // Query Keys
 export const apiTokenKeys = {
@@ -55,7 +55,7 @@ export function useUpdateAPIToken() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<APIToken> }) =>
+    mutationFn: ({ id, data }: { id: number; data: APITokenUpdateData }) =>
       getTransport().updateAPIToken(id, data),
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: apiTokenKeys.detail(id) });

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -71,6 +71,7 @@ import type {
   APIToken,
   APITokenCleanupResult,
   APITokenCreateResult,
+  APITokenUpdateData,
   CreateAPITokenData,
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
@@ -1084,7 +1085,9 @@ export class HttpTransport implements Transport {
   }
 
   async revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult> {
-    const { data } = await this.client.post<UserPanelAPITokenRevealResult>('/user-panel-token/reveal');
+    const { data } = await this.client.post<UserPanelAPITokenRevealResult>(
+      '/user-panel-token/reveal',
+    );
     return data;
   }
 
@@ -1093,7 +1096,7 @@ export class HttpTransport implements Transport {
     return data;
   }
 
-  async updateAPIToken(id: number, payload: Partial<APIToken>): Promise<APIToken> {
+  async updateAPIToken(id: number, payload: APITokenUpdateData): Promise<APIToken> {
     const { data } = await this.adminClient.put<APIToken>(`/api-tokens/${id}`, payload);
     return data;
   }

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -118,6 +118,7 @@ export type {
   APITokenCleanupItem,
   APITokenCleanupResult,
   APITokenCreateResult,
+  APITokenUpdateData,
   CreateAPITokenData,
   UserPanelAPITokenResponse,
   // Usage Stats

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -70,6 +70,7 @@ import type {
   APIToken,
   APITokenCleanupResult,
   APITokenCreateResult,
+  APITokenUpdateData,
   CreateAPITokenData,
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
@@ -298,7 +299,7 @@ export interface Transport {
   regenerateUserPanelAPIToken(): Promise<APITokenCreateResult>;
   revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
-  updateAPIToken(id: number, data: Partial<APIToken>): Promise<APIToken>;
+  updateAPIToken(id: number, data: APITokenUpdateData): Promise<APIToken>;
   deleteAPIToken(id: number): Promise<void>;
   cleanupExpiredAPITokens(): Promise<APITokenCleanupResult>;
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1126,6 +1126,10 @@ export interface APITokenCleanupResult {
   tokens: APITokenCleanupItem[];
 }
 
+export interface APITokenUpdateData extends Partial<APIToken> {
+  resetValidity?: boolean;
+}
+
 export interface CreateAPITokenData {
   name: string;
   description?: string;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1572,7 +1572,9 @@
         "tokenEnabled": "This token is disabled. Enable it before using the copied config.",
         "tokenExpiry": "This token has expired. Replace it with a valid token."
       }
-    }
+    },
+    "reactivateToken": "Reset validity",
+    "reactivateHint": "Saving will clear expiration and inactivity state."
   },
   "app": {
     "title": "Maxx Next"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1569,7 +1569,9 @@
         "tokenEnabled": "该令牌当前已禁用，复制后请先启用再使用。",
         "tokenExpiry": "该令牌已过期，复制后请更换有效令牌。"
       }
-    }
+    },
+    "reactivateToken": "恢复有效",
+    "reactivateHint": "保存后会清除过期时间和非活跃状态。"
   },
   "app": {
     "title": "Maxx Next"

--- a/web/src/pages/api-tokens/form-utils.test.ts
+++ b/web/src/pages/api-tokens/form-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAPITokenUpdatePayload } from './form-utils';
+import { buildAPITokenReactivatePayload, buildAPITokenUpdatePayload } from './form-utils';
 
 describe('buildAPITokenUpdatePayload', () => {
   it('does not clear expiration when the date field was not touched', () => {
@@ -45,5 +45,13 @@ describe('buildAPITokenUpdatePayload', () => {
     });
 
     expect(payload.expiresAt).toBe(new Date('2026-07-20').toISOString());
+  });
+});
+
+it('builds a validity reset payload', () => {
+  expect(buildAPITokenReactivatePayload()).toEqual({
+    isEnabled: true,
+    expiresAt: '',
+    resetValidity: true,
   });
 });

--- a/web/src/pages/api-tokens/form-utils.ts
+++ b/web/src/pages/api-tokens/form-utils.ts
@@ -1,4 +1,4 @@
-import type { APIToken } from '@/lib/transport';
+import type { APITokenUpdateData } from '@/lib/transport';
 
 type BuildAPITokenUpdatePayloadInput = {
   name: string;
@@ -16,8 +16,8 @@ export function buildAPITokenUpdatePayload({
   devMode,
   expiresAt,
   expiresAtTouched,
-}: BuildAPITokenUpdatePayloadInput): Partial<APIToken> {
-  const payload: Partial<APIToken> = {
+}: BuildAPITokenUpdatePayloadInput): APITokenUpdateData {
+  const payload: APITokenUpdateData = {
     name,
     description,
     projectID: parseInt(projectID) || 0,
@@ -29,4 +29,12 @@ export function buildAPITokenUpdatePayload({
   }
 
   return payload;
+}
+
+export function buildAPITokenReactivatePayload(): APITokenUpdateData {
+  return {
+    isEnabled: true,
+    expiresAt: '',
+    resetValidity: true,
+  };
 }

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -53,7 +53,7 @@ import { PageHeader } from '@/components/layout';
 import { isAPITokenExpired } from '@/lib/api-token-expiry';
 import type { APIToken } from '@/lib/transport';
 import { buildCodexConfigBundle, buildProxyBaseUrl } from '@/lib/codex-config';
-import { buildAPITokenUpdatePayload } from './form-utils';
+import { buildAPITokenReactivatePayload, buildAPITokenUpdatePayload } from './form-utils';
 
 type CodexConfigDialogState = {
   tokenName: string;
@@ -163,14 +163,27 @@ export function APITokensPage() {
     updateToken.mutate(
       {
         id: editingToken.id,
-        data: buildAPITokenUpdatePayload({
-          name,
-          description,
-          projectID,
-          expiresAt,
-          expiresAtTouched,
-          devMode,
-        }),
+        data:
+          editingToken && isExpired(editingToken) && expiresAtTouched && !expiresAt
+            ? {
+                ...buildAPITokenUpdatePayload({
+                  name,
+                  description,
+                  projectID,
+                  expiresAt,
+                  expiresAtTouched,
+                  devMode,
+                }),
+                ...buildAPITokenReactivatePayload(),
+              }
+            : buildAPITokenUpdatePayload({
+                name,
+                description,
+                projectID,
+                expiresAt,
+                expiresAtTouched,
+                devMode,
+              }),
       },
       {
         onSuccess: () => closeEditDialog(),
@@ -182,6 +195,13 @@ export function APITokensPage() {
     updateToken.mutate({
       id: token.id,
       data: { isEnabled: !token.isEnabled },
+    });
+  };
+
+  const handleReactivateToken = (token: APIToken) => {
+    updateToken.mutate({
+      id: token.id,
+      data: buildAPITokenReactivatePayload(),
     });
   };
 
@@ -537,6 +557,18 @@ export function APITokensPage() {
                         </TableCell>
                         <TableCell className="text-right">
                           <div className="flex justify-end gap-1">
+                            {isExpired(token) && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                aria-label={t('apiTokens.reactivateToken')}
+                                title={t('apiTokens.reactivateToken')}
+                                disabled={updateToken.isPending}
+                                onClick={() => handleReactivateToken(token)}
+                              >
+                                <RotateCcw className="h-4 w-4" />
+                              </Button>
+                            )}
                             <Button
                               variant="ghost"
                               size="sm"
@@ -757,15 +789,22 @@ export function APITokensPage() {
                     setExpiresAt('');
                     setExpiresAtTouched(true);
                   }}
-                  disabled={updateToken.isPending || !expiresAt}
+                  disabled={
+                    updateToken.isPending ||
+                    (!expiresAt && !(editingToken && isExpired(editingToken)))
+                  }
                 >
                   <RotateCcw className="h-4 w-4 mr-2" />
-                  {t('apiTokens.editDialog.resetExpiresAt')}
+                  {editingToken && isExpired(editingToken)
+                    ? t('apiTokens.reactivateToken')
+                    : t('apiTokens.editDialog.resetExpiresAt')}
                 </Button>
               </div>
               <p className="text-xs text-text-muted">
                 {expiresAtTouched && !expiresAt
-                  ? t('apiTokens.editDialog.resetExpiresAtHint')
+                  ? editingToken && isExpired(editingToken)
+                    ? t('apiTokens.reactivateHint')
+                    : t('apiTokens.editDialog.resetExpiresAtHint')
                   : t('apiTokens.createDialog.expiresAtHint')}
               </p>
             </div>


### PR DESCRIPTION
## Summary
- add an admin API `resetValidity` update path for API tokens so expired tokens can be restored in place
- add a token-tab `恢复有效` / `Reset validity` action for expired tokens
- preserve token ID, token secret, request history, and `useCount` while clearing explicit expiration and inactivity state
- add backend, frontend payload, and Playwright E2E coverage for the reset-validity flow

## Referenced awsl investigation
> 重新调研结论（令牌 tab，不是 user-panel）：
>
> 根因分两层：
> • 令牌 tab 的“已过期”由 `isAPITokenExpired()` 判断：`expiresAt` 过期，或 `lastUsedAt + 10 天` 非活跃过期。
> • 编辑弹窗里的“重置过期时间”只清 `expiresAt`，不会清 `lastUsedAt`。
> • 如果令牌是“非活跃过期”，通常 `expiresAt` 为空，按钮还会因为 `!expiresAt` 被 disabled，所以用户根本没法把它重置成有效。
> • 如果同时有显式过期 + 非活跃过期，清了 `expiresAt` 后仍会因为 `lastUsedAt` 过老继续显示已过期。
>
> 所以问题不是后端不能保存 `expiresAt`，而是令牌 tab 的重置语义太窄：只重置显式过期，不重置“有效性过期状态”。
>
> 推荐方案：在令牌 tab 做“恢复有效”语义，不只是“清过期时间”。
> • 对已过期 token 显示一个明确按钮：`恢复有效` / `Reset validity`。
> • 点击后同 ID 更新：`isEnabled=true`、`expiresAt=null`、`lastUsedAt=null`、`lastIP=''`、`lastIPAt=null`。
> • 不清 `useCount`，不换 token secret，不删除重建，保留历史统计和请求归属。
> • 如果用户只是编辑普通过期日期，仍保留现有日期字段逻辑。
>
> 验证应覆盖：
> • 显式 `expiresAt` 过期 → 恢复后 active。
> • 非活跃 `lastUsedAt` 过期、`expiresAt` 为空 → 恢复后 active。
> • 两者同时过期 → 恢复后 active。
> • 代理鉴权用该 token 真实请求 mock provider 通过。
> • 令牌 tab 状态从“已过期”变“启用/有效”，截图留证。

## Validation
- `go test -count=1 ./internal/handler -run 'TestAdminHandlerResetAPITokenValidity|TestAdminHandlerCleanupExpiredAPITokens'`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- api-token-expiry form-utils`
- `pnpm build`
- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s ./cmd/... ./internal/...`
- `go build -o /tmp/maxx-token-reactivate-final-build ./cmd/maxx`
- `MAXX_E2E_BASE_URL=http://localhost:9880 MAXX_E2E_USERNAME=admin MAXX_E2E_PASSWORD='test123' pnpm exec playwright test -c playwright.config.ts api-token-reactivate.spec.ts --project=e2e-chromium`

## E2E screenshot evidence
Generated locally, not committed because they are runtime evidence:
- `/tmp/maxx-api-token-expired-before-reactivate.png`
- `/tmp/maxx-api-token-active-after-reactivate.png`
- `/tmp/maxx-api-token-reactivated-proxy-ok.png`

## Notes
- CodeRabbit was not checked or triggered in this work, per current instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 API Token“恢复有效”功能，可一键重新启用已过期或非活跃的 Token。
  - 恢复后将清除过期时间及最近使用状态，Token 可继续用于代理请求。
  - 编辑 Token 时提供相关提示，并支持中英文界面文案。

- **改进**
  - API Token 更新操作支持更明确的数据校验，保留其他字段的按需修改行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->