### PR TITLE
fix(retry): retry upstream connection proxy errors

### DIFF
--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"sync"
@@ -358,8 +359,9 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 				}
 			}
 
-			proxyErr, ok := err.(*domain.ProxyError)
+			proxyErr, ok := asProxyError(err)
 			if ok {
+				normalizeUpstreamConnectionError(proxyErr)
 				applyDisabledErrorCooldownRetryPolicy(matchedRoute.Provider, proxyErr)
 				applyCommittedStreamReadRetryPolicy(proxyErr)
 			}
@@ -491,7 +493,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 	proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
 	if state.lastErr != nil {
 		proxyReq.Error = state.lastErr.Error()
-		if proxyErr, ok := state.lastErr.(*domain.ProxyError); ok && proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+		if proxyErr, ok := asProxyError(state.lastErr); ok && proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
 			proxyReq.StatusCode = proxyErr.HTTPStatusCode
 		}
 	}
@@ -530,4 +532,27 @@ func clearProxyRequestDetail(req *domain.ProxyRequest, clearDetail bool) {
 	}
 	req.RequestInfo = nil
 	req.ResponseInfo = nil
+}
+
+func asProxyError(err error) (*domain.ProxyError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var proxyErr *domain.ProxyError
+	if errors.As(err, &proxyErr) {
+		return proxyErr, true
+	}
+	return nil, false
+}
+
+func normalizeUpstreamConnectionError(proxyErr *domain.ProxyError) {
+	if proxyErr == nil || !errors.Is(proxyErr.Err, domain.ErrUpstreamError) {
+		return
+	}
+	if proxyErr.Message != "failed to connect to upstream" && proxyErr.Message != "failed to connect to upstream after token refresh" {
+		return
+	}
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonNetworkError
+	proxyErr.Retryable = true
 }

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -510,6 +511,106 @@ func TestExecuteProviderProxyFreezesNetworkErrorAfterRetryExhaustion(t *testing.
 	remaining := time.Until(until)
 	if remaining < 10*time.Second || remaining > 20*time.Second {
 		t.Fatalf("remaining cooldown = %v, want configurable 429 fallback around 15s", remaining)
+	}
+}
+
+func TestExecuteProviderProxyRetriesWrappedUpstreamConnectionError(t *testing.T) {
+	providerID := uint64(99008)
+	cooldown.Default().ClearCooldown(providerID, "", "")
+	defer cooldown.Default().ClearCooldown(providerID, "", "")
+
+	adapterErr := domain.NewUpstreamConnectionError("failed to connect to upstream")
+	adapter := &sequenceAdapter{errs: []error{fmt.Errorf("adapter wrapper: %w", adapterErr)}}
+	e := &Executor{
+		proxyRequestRepo: &codexGuardProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      1,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+	c.Set(flow.KeyRequestHeaders, http.Header{})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:     1,
+		ID:           42,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "minimaxai/minimax-m3",
+		IsStream:     false,
+		Status:       "IN_PROGRESS",
+		RouteID:      11,
+		ProviderID:   providerID,
+	}
+	route := &domain.Route{ID: 11, ProviderID: providerID, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: providerID, Type: "custom"}
+
+	if err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter); err != nil {
+		t.Fatalf("ExecuteProviderProxy returned error: %v", err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 2 {
+		t.Fatalf("attempt count = %d, want 2", proxyReq.ProxyUpstreamAttemptCount)
+	}
+}
+
+func TestExecuteProviderProxyNormalizesLegacyUpstreamConnectionError(t *testing.T) {
+	providerID := uint64(99009)
+	cooldown.Default().ClearCooldown(providerID, "", "")
+	defer cooldown.Default().ClearCooldown(providerID, "", "")
+
+	legacyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to connect to upstream")
+	adapter := &sequenceAdapter{errs: []error{legacyErr}}
+	e := &Executor{
+		proxyRequestRepo: &codexGuardProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      1,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+	c.Set(flow.KeyRequestHeaders, http.Header{})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:     1,
+		ID:           42,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "minimaxai/minimax-m3",
+		IsStream:     false,
+		Status:       "IN_PROGRESS",
+		RouteID:      11,
+		ProviderID:   providerID,
+	}
+	route := &domain.Route{ID: 11, ProviderID: providerID, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: providerID, Type: "custom"}
+
+	if err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter); err != nil {
+		t.Fatalf("ExecuteProviderProxy returned error: %v", err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 2 {
+		t.Fatalf("attempt count = %d, want 2", proxyReq.ProxyUpstreamAttemptCount)
 	}
 }
 

--- a/internal/handler/provider_proxy.go
+++ b/internal/handler/provider_proxy.go
@@ -143,7 +143,7 @@ func (h *ProviderProxyHandler) directDispatch(provider *domain.Provider) flow.Ha
 			return
 		}
 
-		if proxyErr, ok := err.(*domain.ProxyError); ok {
+		if proxyErr, ok := asHandlerProxyError(err); ok {
 			if isStream {
 				writeStreamError(c.Writer, proxyErr)
 			} else {

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"math"
@@ -356,7 +357,7 @@ func (h *ProxyHandler) dispatch(c *flow.Ctx) {
 	if err == nil {
 		return
 	}
-	proxyErr, ok := err.(*domain.ProxyError)
+	proxyErr, ok := asHandlerProxyError(err)
 	if ok {
 		if stream {
 			writeStreamError(c.Writer, proxyErr)
@@ -530,4 +531,15 @@ func writeStreamError(w http.ResponseWriter, err *domain.ProxyError) {
 
 func isOpenAIChatCompletionsPath(path string) bool {
 	return strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/chat/completions")
+}
+
+func asHandlerProxyError(err error) (*domain.ProxyError, bool) {
+	if err == nil {
+		return nil, false
+	}
+	var proxyErr *domain.ProxyError
+	if errors.As(err, &proxyErr) {
+		return proxyErr, true
+	}
+	return nil, false
 }


### PR DESCRIPTION
## Summary
- make executor retry classification unwrap `ProxyError` with `errors.As` instead of direct type assertions
- normalize `failed to connect to upstream` / `failed to connect to upstream after token refresh` upstream errors as provider-scoped network errors with `Retryable=true`
- make proxy response handlers also unwrap wrapped `ProxyError` values before writing client-facing proxy errors
- add regression coverage proving wrapped and legacy upstream connection errors retry within the same request attempt budget

## Why
The reported failure mode was `failed to connect to upstream: upstream error` not continuing retries inside the current request. The dispatch loop only retried errors it recognized as retryable `*domain.ProxyError`. Wrapped proxy errors, or legacy upstream connection errors without scope/reason/retryable fields, could fall through as non-retryable and stop after one attempt.

## Validation
- `go test -count=1 ./internal/executor -run 'TestExecuteProviderProxyRetriesSameProvider|TestExecuteProviderProxyRetriesWrappedUpstreamConnectionError|TestExecuteProviderProxyNormalizesLegacyUpstreamConnectionError|TestExecuteProviderProxyHonorsZeroMaxRetries|TestDispatchForceRetryUpstreamErrors'`
- `go test -count=1 ./internal/handler -run 'TestWriteProxyError|TestWriteStreamError|TestProviderProxy|TestProxy'`
- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s ./cmd/... ./internal/...`
- `go build -o /tmp/maxx-upstream-retry-build ./cmd/maxx`

## Notes
- No frontend changes.
- This does not change `MaxRetries=0` semantics: retry budget is still honored. It only makes connection failures that should be retryable actually enter the same-request retry path when retry budget exists.
- CodeRabbit was not checked or triggered in this work, per current instruction.
