### PR TITLE
fix(requests): show mapped model chain in request list

### DIFF
--- a/tests/e2e/playwright/request-model-chain-display.spec.ts
+++ b/tests/e2e/playwright/request-model-chain-display.spec.ts
@@ -1,0 +1,319 @@
+import http from "node:http";
+
+import { expect, test, type Page } from "playwright/test";
+
+import {
+  BASE,
+  adminAPI,
+  closeServer,
+  loginToAdminAPI,
+  loginToAdminUI,
+} from "./helpers";
+
+const REQUEST_MODEL = "claude-client-display-model";
+const MAPPED_MODEL = "mock-upstream-mapped-model";
+const UPSTREAM_RESPONSE_MODEL = "mock-upstream-response-model";
+const REQUESTS_SCREENSHOT = "/tmp/maxx-request-model-chain-requests.png";
+const MOCK_SCREENSHOT = "/tmp/maxx-request-model-chain-mock.png";
+
+test.describe.configure({ mode: "serial" });
+
+type MockRequestLog = {
+  method: string;
+  url: string;
+  model: string;
+  body: unknown;
+};
+
+function startMockClaudeServer(): Promise<{
+  server: http.Server;
+  port: number;
+  logs: MockRequestLog[];
+}> {
+  const logs: MockRequestLog[] = [];
+
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      if (req.method === "GET" && req.url === "/__mock-log") {
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(`<!doctype html>
+          <html>
+            <head><title>Mock upstream interaction log</title></head>
+            <body style="font-family: sans-serif; padding: 24px;">
+              <h1>Mock upstream interaction log</h1>
+              <p>Received model: <strong>${logs[0]?.model ?? ""}</strong></p>
+              <p>Returned response model: <strong>${UPSTREAM_RESPONSE_MODEL}</strong></p>
+              <pre>${JSON.stringify(logs, null, 2)}</pre>
+            </body>
+          </html>`);
+        return;
+      }
+
+      if (req.method === "POST" && req.url?.includes("/v1/messages")) {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          let parsed: any = {};
+          try {
+            parsed = JSON.parse(body);
+          } catch {
+            // Keep the log useful even if a regression sends malformed JSON.
+          }
+
+          logs.push({
+            method: req.method || "POST",
+            url: req.url || "",
+            model: parsed.model || "",
+            body: parsed,
+          });
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              id: `msg_model_chain_${Date.now()}`,
+              type: "message",
+              role: "assistant",
+              model: UPSTREAM_RESPONSE_MODEL,
+              content: [
+                { type: "text", text: "mock response for model chain display" },
+              ],
+              stop_reason: "end_turn",
+              stop_sequence: null,
+              usage: {
+                input_tokens: 11,
+                output_tokens: 7,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+              },
+            }),
+          );
+        });
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to determine mock server port");
+      }
+      resolve({ server, port: address.port, logs });
+    });
+  });
+}
+
+async function sendClaudeRequest() {
+  const response = await fetch(`${BASE}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: REQUEST_MODEL,
+      max_tokens: 100,
+      messages: [
+        { role: "user", content: "verify request list model mapping display" },
+      ],
+    }),
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Proxy request failed (${response.status}): ${text}`);
+  }
+  return JSON.parse(text);
+}
+
+async function openRequestsPage(page: Page) {
+  const passwordInput = page.locator('input[type="password"]');
+  const requestsHeading = page.getByRole("heading", { name: "Requests" });
+
+  await page.goto(`${BASE}/requests`, { waitUntil: "domcontentloaded" });
+  await Promise.race([
+    requestsHeading
+      .waitFor({ state: "visible", timeout: 10_000 })
+      .catch(() => undefined),
+    passwordInput
+      .waitFor({ state: "visible", timeout: 10_000 })
+      .catch(() => undefined),
+  ]);
+
+  if (await passwordInput.isVisible().catch(() => false)) {
+    await loginToAdminUI(page);
+    await page.goto(`${BASE}/requests`, { waitUntil: "domcontentloaded" });
+  }
+
+  await expect(requestsHeading).toBeVisible({ timeout: 30_000 });
+}
+
+test("requests list displays request model to mapped model without response label", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(180_000);
+
+  const mock = await startMockClaudeServer();
+  let jwt: string | undefined;
+  let providerId: number | null = null;
+  let routeId: number | null = null;
+  let modelMappingId: number | null = null;
+  let previousApiTokenAuthEnabled: string | undefined;
+
+  try {
+    jwt = await loginToAdminAPI();
+    const settings = await adminAPI("GET", "/settings", undefined, jwt);
+    previousApiTokenAuthEnabled = settings.api_token_auth_enabled;
+    await adminAPI(
+      "PUT",
+      "/settings/api_token_auth_enabled",
+      { value: "false" },
+      jwt,
+    );
+
+    const suffix = Date.now();
+    const provider = await adminAPI(
+      "POST",
+      "/providers",
+      {
+        name: `Model Chain Mock ${suffix}`,
+        type: "custom",
+        config: {
+          custom: {
+            baseURL: `http://127.0.0.1:${mock.port}`,
+            apiKey: "mock-key",
+            responseModelMapping: {
+              [UPSTREAM_RESPONSE_MODEL]: REQUEST_MODEL,
+            },
+          },
+        },
+        supportedClientTypes: ["claude"],
+        supportModels: ["*"],
+      },
+      jwt,
+    );
+    providerId = provider.id;
+
+    const route = await adminAPI(
+      "POST",
+      "/routes",
+      {
+        isEnabled: true,
+        isNative: false,
+        clientType: "claude",
+        providerID: provider.id,
+        projectID: 0,
+        position: 1,
+      },
+      jwt,
+    );
+    routeId = route.id;
+
+    const modelMapping = await adminAPI(
+      "POST",
+      "/model-mappings",
+      {
+        scope: "provider",
+        clientType: "claude",
+        providerID: provider.id,
+        pattern: REQUEST_MODEL,
+        target: MAPPED_MODEL,
+        priority: 1,
+      },
+      jwt,
+    );
+    modelMappingId = modelMapping.id;
+
+    const proxyResponse = await sendClaudeRequest();
+    expect(proxyResponse.model).toBe(REQUEST_MODEL);
+    expect(mock.logs[0]?.model).toBe(MAPPED_MODEL);
+
+    await expect
+      .poll(
+        async () => {
+          const requests = await adminAPI(
+            "GET",
+            `/requests?limit=10&providerId=${providerId}`,
+            undefined,
+            jwt,
+          );
+          const item = requests.items?.find(
+            (candidate: any) => candidate.requestModel === REQUEST_MODEL,
+          );
+          if (!item) {
+            return null;
+          }
+          return {
+            requestModel: item.requestModel,
+            mappedModel: item.mappedModel,
+            responseModel: item.responseModel,
+          };
+        },
+        { timeout: 20_000 },
+      )
+      .toEqual({
+        requestModel: REQUEST_MODEL,
+        mappedModel: MAPPED_MODEL,
+        responseModel: UPSTREAM_RESPONSE_MODEL,
+      });
+
+    await openRequestsPage(page);
+    const firstRow = page.locator('tbody tr[data-request-row="true"]').first();
+    await expect(firstRow).toContainText(REQUEST_MODEL, { timeout: 30_000 });
+    await expect(firstRow).toContainText(MAPPED_MODEL);
+    await expect(firstRow).not.toContainText("response:");
+    await expect(firstRow).not.toContainText(UPSTREAM_RESPONSE_MODEL);
+    await page.screenshot({ path: REQUESTS_SCREENSHOT, fullPage: true });
+    await testInfo.attach("requests-list-model-chain.png", {
+      path: REQUESTS_SCREENSHOT,
+      contentType: "image/png",
+    });
+
+    const mockPage = await page.context().newPage();
+    await mockPage.goto(`http://127.0.0.1:${mock.port}/__mock-log`);
+    await expect(
+      mockPage.getByText(`Received model: ${MAPPED_MODEL}`),
+    ).toBeVisible();
+    await mockPage.screenshot({ path: MOCK_SCREENSHOT, fullPage: true });
+    await testInfo.attach("mock-upstream-interaction.png", {
+      path: MOCK_SCREENSHOT,
+      contentType: "image/png",
+    });
+  } finally {
+    if (previousApiTokenAuthEnabled !== undefined) {
+      try {
+        await adminAPI(
+          "PUT",
+          "/settings/api_token_auth_enabled",
+          { value: previousApiTokenAuthEnabled },
+          jwt,
+        );
+      } catch {}
+    }
+    if (modelMappingId) {
+      try {
+        await adminAPI(
+          "DELETE",
+          `/model-mappings/${modelMappingId}`,
+          undefined,
+          jwt,
+        );
+      } catch {}
+    }
+    if (routeId) {
+      try {
+        await adminAPI("DELETE", `/routes/${routeId}`, undefined, jwt);
+      } catch {}
+    }
+    if (providerId) {
+      try {
+        await adminAPI("DELETE", `/providers/${providerId}`, undefined, jwt);
+      } catch {}
+    }
+    await closeServer(mock.server);
+  }
+});

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -87,6 +87,7 @@ import { PageHeader } from '@/components/layout/page-header';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useAuth } from '@/lib/auth-context';
 import { calculateVirtualRange } from './virtual-range';
+import { getRequestModelChain } from './model-chain';
 import {
   PROVIDER_TYPE_CONFIGS,
   PROVIDER_TYPE_ORDER,
@@ -1089,19 +1090,6 @@ type LogRowProps = {
   onOpenRequest: (id: number) => void;
 };
 
-function getVisibleMappedModel(request: ProxyRequest) {
-  return request.mappedModel && request.mappedModel !== request.requestModel
-    ? request.mappedModel
-    : '';
-}
-
-function getVisibleResponseModel(request: ProxyRequest) {
-  const previousModel = getVisibleMappedModel(request) || request.requestModel;
-  return request.responseModel && request.responseModel !== previousModel
-    ? request.responseModel
-    : '';
-}
-
 function LogRow({
   request,
   providerName,
@@ -1135,8 +1123,7 @@ function LogRow({
   const startTimeMs = useMemo(() => new Date(request.startTime).getTime(), [request.startTime]);
   const liveDurationMs =
     isPending && Number.isFinite(startTimeMs) ? Math.max(0, nowMs - startTimeMs) : null;
-  const visibleMappedModel = getVisibleMappedModel(request);
-  const visibleResponseModel = getVisibleResponseModel(request);
+  const modelChain = getRequestModelChain(request);
 
   const formatDuration = (ns?: number | null) => {
     if (ns === undefined || ns === null) return '-';
@@ -1230,27 +1217,13 @@ function LogRow({
 
       {/* Model */}
       <TableCell className="w-[200px] min-w-[200px] px-2 py-1">
-        <div className="flex items-center gap-2 min-w-0 max-w-[280px]">
-          <span
-            className="text-sm text-foreground font-medium truncate"
-            title={request.requestModel}
-          >
-            {request.requestModel || '-'}
+        <div className="flex items-center gap-2 min-w-0 max-w-[280px]" title={modelChain.title}>
+          <span className="text-sm text-foreground font-medium truncate">
+            {modelChain.requestModel || '-'}
           </span>
-          {visibleMappedModel && (
-            <span
-              className="text-[10px] text-muted-foreground truncate"
-              title={`Mapped model: ${visibleMappedModel}`}
-            >
-              → {visibleMappedModel}
-            </span>
-          )}
-          {visibleResponseModel && (
-            <span
-              className="text-[10px] text-muted-foreground truncate"
-              title={`Response model: ${visibleResponseModel}`}
-            >
-              response: {visibleResponseModel}
+          {modelChain.mappedModel && (
+            <span className="text-[10px] text-muted-foreground truncate">
+              → {modelChain.mappedModel}
             </span>
           )}
         </div>
@@ -1433,8 +1406,7 @@ function MobileRequestCard({ request, providerName, onOpenRequest }: MobileReque
     request.endTime && new Date(request.endTime).getTime() > 0
       ? formatTime(request.endTime)
       : formatTime(request.startTime || request.createdAt);
-  const visibleMappedModel = getVisibleMappedModel(request);
-  const visibleResponseModel = getVisibleResponseModel(request);
+  const modelChain = getRequestModelChain(request);
 
   return (
     <div
@@ -1450,18 +1422,15 @@ function MobileRequestCard({ request, providerName, onOpenRequest }: MobileReque
       {/* Row 1: Client + Model + Status */}
       <div className="flex items-center gap-2 mb-1">
         <ClientIcon type={request.clientType} size={14} className="shrink-0" />
-        <span className="text-sm font-medium text-foreground truncate flex-1">
-          {request.requestModel || '-'}
-          {visibleMappedModel && (
+        <span
+          className="text-sm font-medium text-foreground truncate flex-1"
+          title={modelChain.title}
+        >
+          {modelChain.requestModel || '-'}
+          {modelChain.mappedModel && (
             <span className="text-xs text-muted-foreground font-normal">
               {' '}
-              → {visibleMappedModel}
-            </span>
-          )}
-          {visibleResponseModel && (
-            <span className="text-xs text-muted-foreground font-normal">
-              {' '}
-              ↳ {visibleResponseModel}
+              → {modelChain.mappedModel}
             </span>
           )}
         </span>

--- a/web/src/pages/requests/model-chain.test.ts
+++ b/web/src/pages/requests/model-chain.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getRequestModelChain } from './model-chain';
+
+describe('getRequestModelChain', () => {
+  it('shows the request to mapped model chain without leaking response model labels', () => {
+    const chain = getRequestModelChain({
+      requestModel: 'claude-sonnet-4-5',
+      mappedModel: 'openrouter/anthropic/claude-sonnet-4-5',
+    });
+
+    expect(chain).toEqual({
+      requestModel: 'claude-sonnet-4-5',
+      mappedModel: 'openrouter/anthropic/claude-sonnet-4-5',
+      title:
+        'Request model: claude-sonnet-4-5\nMapped model: openrouter/anthropic/claude-sonnet-4-5',
+    });
+    expect(chain.title).not.toContain('Response model');
+    expect(chain.title).not.toContain('response:');
+  });
+
+  it('does not render a mapped leg when the mapped model equals the requested model', () => {
+    expect(
+      getRequestModelChain({ requestModel: 'gpt-4.1-mini', mappedModel: 'gpt-4.1-mini' }),
+    ).toEqual({
+      requestModel: 'gpt-4.1-mini',
+      mappedModel: '',
+      title: 'gpt-4.1-mini',
+    });
+  });
+});

--- a/web/src/pages/requests/model-chain.ts
+++ b/web/src/pages/requests/model-chain.ts
@@ -1,0 +1,24 @@
+import type { ProxyRequest } from '@/lib/transport';
+
+export interface RequestModelChain {
+  requestModel: string;
+  mappedModel: string;
+  title: string;
+}
+
+export function getRequestModelChain(
+  request: Pick<ProxyRequest, 'requestModel' | 'mappedModel'>,
+): RequestModelChain {
+  const requestModel = request.requestModel || '';
+  const mappedModel =
+    request.mappedModel && request.mappedModel !== requestModel ? request.mappedModel : '';
+  const title = mappedModel
+    ? `Request model: ${requestModel || '-'}\nMapped model: ${mappedModel}`
+    : requestModel;
+
+  return {
+    requestModel,
+    mappedModel,
+    title,
+  };
+}


### PR DESCRIPTION
## Summary
- Update the requests list model column to show only the request-to-mapped model chain (`requestModel → mappedModel`).
- Remove the list-level `response:` / response-model leg from desktop and mobile request rows to avoid mixing response-model telemetry with mapping display.
- Add unit coverage for the model-chain helper and a Playwright e2e regression that exercises a real custom provider route, provider-scoped model mapping, response-model mapping, request submission, request-list UI, and mock upstream interaction screenshots.

## Validation
- `pnpm test -- model-chain` (25 files / 110 tests passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `go build -o /tmp/maxx-request-model-chain-build ./cmd/maxx`
- `go vet ./cmd/... ./internal/...`
- `go test -count=1 -timeout 600s ./cmd/... ./internal/...`
- `MAXX_E2E_BASE_URL=http://127.0.0.1:9880 MAXX_E2E_PASSWORD=test123 npx playwright test -c /tmp/maxx-request-model-chain-playwright.config.ts request-model-chain-display.spec.ts --project=e2e-chromium --reporter=list`

## Screenshot evidence
- Requests UI screenshot generated locally: `/tmp/maxx-request-model-chain-requests.png`
- Mock upstream interaction screenshot generated locally: `/tmp/maxx-request-model-chain-mock.png`

## Notes
- Did not check or trigger CodeRabbit; not requested in this task.
- Did not merge this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化请求列表中的模型信息展示，清晰呈现请求模型与映射后的模型。
  * 当模型未发生变化时，避免重复显示映射信息。
  * 优化模型提示文本，避免展示内部响应模型标签。

* **测试**
  * 新增端到端测试，验证模型映射、代理请求及请求列表展示结果。
  * 增加模型链展示场景的单元测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->