### PR TITLE
fix(codex): proxy Responses over native WebSocket

### DIFF
--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -40,6 +40,7 @@ func init() {
 				}
 			}
 			codexCacheMu.Unlock()
+			globalCodexWebSocketSessions.pruneIdle(now)
 		}
 	}()
 }
@@ -124,10 +125,6 @@ func (a *CodexAdapter) SupportedClientTypes() []domain.ClientType {
 }
 
 func (a *CodexAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
-	if handled, err := a.executeResponsesWebSocket(c, provider); handled {
-		return err
-	}
-
 	requestBody := flow.GetRequestBody(c)
 	clientWantsStream := flow.GetIsStream(c)
 	request := c.Request

--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -1,33 +1,39 @@
 package codex
 
 import (
-	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
+	pathpkg "path"
+	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
-	"github.com/awsl-project/maxx/internal/codexutil"
-	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
 	"github.com/gorilla/websocket"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 )
 
 const (
-	codexResponsesWebSocketBetaHeader = "responses_websockets=2026-02-06"
-	codexResponsesWebSocketHandshake  = 30 * time.Second
+	codexResponsesWebSocketBetaHeader         = "responses_websockets=2026-02-06"
+	codexResponsesWebSocketHandshake          = 30 * time.Second
+	codexResponsesWebSocketReadQueueSize      = 256
+	codexResponsesWebSocketMaxQueuedBytes     = 8 << 20
+	codexResponsesWebSocketMaxFrameBytes      = 32 << 20
+	codexResponsesWebSocketWriteTimeout       = 30 * time.Second
+	codexResponsesWebSocketFirstEventTimeout  = 20 * time.Second
+	codexResponsesWebSocketEventIdleTimeout   = 5 * time.Minute
+	codexResponsesWebSocketSessionIdleTimeout = 65 * time.Minute
+	codexResponsesWebSocketMaxSessions        = 512
 )
 
 type codexWebSocketRead struct {
@@ -45,18 +51,25 @@ type codexWebSocketSession struct {
 	handshakeHeader http.Header
 	reads           chan codexWebSocketRead
 	done            chan struct{}
+	queuedBytes     atomic.Int64
+	maxQueuedBytes  int64
+	fingerprint     string
+	lastUsedAt      atomic.Int64
+	activeTurns     atomic.Int32
 }
 
-func newCodexWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header) *codexWebSocketSession {
+func newCodexWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header, fingerprint string) *codexWebSocketSession {
 	session := &codexWebSocketSession{
 		conn:            conn,
 		handshakeHeader: handshakeHeader.Clone(),
-		reads:           make(chan codexWebSocketRead, 4096),
+		reads:           make(chan codexWebSocketRead, codexResponsesWebSocketReadQueueSize),
 		done:            make(chan struct{}),
+		maxQueuedBytes:  codexResponsesWebSocketMaxQueuedBytes,
+		fingerprint:     fingerprint,
 	}
+	session.touch()
+	conn.SetReadLimit(codexResponsesWebSocketMaxFrameBytes)
 	conn.SetPingHandler(func(data string) error {
-		session.writeMu.Lock()
-		defer session.writeMu.Unlock()
 		return conn.WriteControl(websocket.PongMessage, []byte(data), time.Now().Add(10*time.Second))
 	})
 	go session.readLoop()
@@ -68,32 +81,47 @@ func (s *codexWebSocketSession) readLoop() {
 	for {
 		messageType, payload, err := s.conn.ReadMessage()
 		if err != nil {
-			select {
-			case s.reads <- codexWebSocketRead{err: err}:
-			case <-s.done:
-			}
+			s.enqueueError(err)
+			s.close()
+			return
+		}
+		size := int64(len(payload))
+		if s.queuedBytes.Add(size) > s.maxQueuedBytes {
+			s.queuedBytes.Add(-size)
+			s.enqueueError(errors.New("codex websocket read queue byte limit exceeded"))
 			s.close()
 			return
 		}
 		select {
 		case s.reads <- codexWebSocketRead{messageType: messageType, payload: payload}:
 		case <-s.done:
+			s.queuedBytes.Add(-size)
+			return
+		default:
+			s.queuedBytes.Add(-size)
+			s.enqueueError(errors.New("codex websocket read queue is full"))
+			s.close()
 			return
 		}
 	}
 }
 
-func (s *codexWebSocketSession) write(payload []byte) error {
-	if s == nil || s.conn == nil {
-		return errors.New("codex websocket session is not connected")
-	}
+func (s *codexWebSocketSession) enqueueError(err error) {
 	select {
-	case <-s.done:
-		return errors.New("codex websocket session is closed")
+	case s.reads <- codexWebSocketRead{err: err}:
 	default:
+	}
+}
+
+func (s *codexWebSocketSession) write(payload []byte) error {
+	if s == nil || s.conn == nil || s.isClosed() {
+		return errors.New("codex websocket session is closed")
 	}
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
+	if err := s.conn.SetWriteDeadline(time.Now().Add(codexResponsesWebSocketWriteTimeout)); err != nil {
+		return err
+	}
 	return s.conn.WriteMessage(websocket.TextMessage, payload)
 }
 
@@ -121,37 +149,90 @@ func (s *codexWebSocketSession) isClosed() bool {
 	}
 }
 
+func (s *codexWebSocketSession) touch() {
+	s.lastUsedAt.Store(time.Now().UnixNano())
+}
+
+func (s *codexWebSocketSession) lastUsed() time.Time {
+	return time.Unix(0, s.lastUsedAt.Load())
+}
+
+type codexWebSocketSessionKey struct {
+	ConnectionID string
+	ProviderID   uint64
+}
+
 type codexWebSocketSessionStore struct {
-	mu       sync.Mutex
-	sessions map[string]*codexWebSocketSession
+	mu         sync.Mutex
+	sessions   map[codexWebSocketSessionKey]*codexWebSocketSession
+	maxEntries int
 }
 
 var globalCodexWebSocketSessions = &codexWebSocketSessionStore{
-	sessions: make(map[string]*codexWebSocketSession),
+	sessions:   make(map[codexWebSocketSessionKey]*codexWebSocketSession),
+	maxEntries: codexResponsesWebSocketMaxSessions,
 }
 
-func (s *codexWebSocketSessionStore) get(key string) *codexWebSocketSession {
+func (s *codexWebSocketSessionStore) get(key codexWebSocketSessionKey) *codexWebSocketSession {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	session := s.sessions[key]
-	if session != nil && session.isClosed() {
+	if session != nil && (session.isClosed() ||
+		(session.activeTurns.Load() == 0 && time.Since(session.lastUsed()) >= codexResponsesWebSocketSessionIdleTimeout)) {
 		delete(s.sessions, key)
+		s.mu.Unlock()
+		session.close()
 		return nil
 	}
+	if session != nil {
+		session.activeTurns.Add(1)
+		session.touch()
+	}
+	s.mu.Unlock()
 	return session
 }
 
-func (s *codexWebSocketSessionStore) put(key string, session *codexWebSocketSession) {
+func (s *codexWebSocketSessionStore) put(key codexWebSocketSessionKey, session *codexWebSocketSession) bool {
+	var stale []*codexWebSocketSession
+	canStore := true
 	s.mu.Lock()
-	previous := s.sessions[key]
-	s.sessions[key] = session
-	s.mu.Unlock()
-	if previous != nil && previous != session {
-		previous.close()
+	stale = append(stale, s.pruneIdleLocked(time.Now())...)
+	if previous := s.sessions[key]; previous != nil && previous != session {
+		if previous.activeTurns.Load() > 0 {
+			canStore = false
+		} else {
+			delete(s.sessions, key)
+			stale = append(stale, previous)
+		}
 	}
+	if canStore && s.maxEntries > 0 && len(s.sessions) >= s.maxEntries && s.sessions[key] == nil {
+		var oldestKey codexWebSocketSessionKey
+		var oldest *codexWebSocketSession
+		for candidateKey, candidate := range s.sessions {
+			if candidate.activeTurns.Load() > 0 {
+				continue
+			}
+			if oldest == nil || candidate.lastUsed().Before(oldest.lastUsed()) {
+				oldestKey, oldest = candidateKey, candidate
+			}
+		}
+		if oldest != nil {
+			delete(s.sessions, oldestKey)
+			stale = append(stale, oldest)
+		} else {
+			canStore = false
+		}
+	}
+	if canStore {
+		s.sessions[key] = session
+	}
+	s.mu.Unlock()
+	for _, candidate := range stale {
+		candidate.close()
+	}
+	return canStore
 }
 
-func (s *codexWebSocketSessionStore) remove(key string, session *codexWebSocketSession) {
+func (s *codexWebSocketSessionStore) remove(key codexWebSocketSessionKey, session *codexWebSocketSession) {
 	s.mu.Lock()
 	if s.sessions[key] == session {
 		delete(s.sessions, key)
@@ -162,266 +243,409 @@ func (s *codexWebSocketSessionStore) remove(key string, session *codexWebSocketS
 	}
 }
 
-func (a *CodexAdapter) executeResponsesWebSocket(c *flow.Ctx, provider *domain.Provider) (bool, error) {
-	if c == nil || provider == nil || c.Request == nil ||
-		flow.GetClientType(c) != domain.ClientTypeCodex ||
-		flow.GetOriginalClientType(c) != domain.ClientTypeCodex ||
-		flow.IsProtocolConversion(c) {
-		return false, nil
+func (s *codexWebSocketSessionStore) closeForConnection(connectionID string) {
+	var sessions []*codexWebSocketSession
+	s.mu.Lock()
+	for key, session := range s.sessions {
+		if key.ConnectionID == connectionID {
+			delete(s.sessions, key)
+			sessions = append(sessions, session)
+		}
 	}
-
-	metadata, ok := maxxctx.GetResponsesWebSocketRequest(c.Request.Context())
-	if !ok {
-		return false, nil
+	s.mu.Unlock()
+	for _, session := range sessions {
+		session.close()
 	}
+}
 
-	rawRequest, err := prepareCodexWebSocketRequest(metadata.Payload, c, provider)
-	if err != nil {
+func (s *codexWebSocketSessionStore) pruneIdle(now time.Time) {
+	s.mu.Lock()
+	stale := s.pruneIdleLocked(now)
+	s.mu.Unlock()
+	for _, session := range stale {
+		session.close()
+	}
+}
+
+func (s *codexWebSocketSessionStore) pruneIdleLocked(now time.Time) []*codexWebSocketSession {
+	var stale []*codexWebSocketSession
+	for key, session := range s.sessions {
+		if session.isClosed() ||
+			(session.activeTurns.Load() == 0 && now.Sub(session.lastUsed()) >= codexResponsesWebSocketSessionIdleTimeout) {
+			delete(s.sessions, key)
+			stale = append(stale, session)
+		}
+	}
+	return stale
+}
+
+func (a *CodexAdapter) CloseResponsesWebSocketConnection(connectionID string) {
+	globalCodexWebSocketSessions.closeForConnection(connectionID)
+}
+
+func (a *CodexAdapter) ExecuteResponsesWebSocket(
+	c *flow.Ctx,
+	provider *domain.Provider,
+	exchange *domain.ResponsesWebSocketExchange,
+) (*domain.ResponsesWebSocketResult, error) {
+	if c == nil || provider == nil || c.Request == nil || exchange == nil || exchange.Sink == nil {
+		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketProtocol, false, false)
+	}
+	if err := validateOutboundCodexWebSocketFrame(exchange.Frame); err != nil {
 		proxyErr := domain.NewProxyErrorWithMessage(err, false, "invalid Codex websocket request")
 		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "websocket_protocol_error"
 		proxyErr.HTTPStatusCode = http.StatusBadRequest
-		return true, proxyErr
-	}
-
-	key := strconv.FormatUint(provider.ID, 10) + ":" + metadata.SessionID
-	session := globalCodexWebSocketSessions.get(key)
-	previousResponseID := strings.TrimSpace(gjson.GetBytes(rawRequest, "previous_response_id").String())
-	if session == nil && previousResponseID != "" {
-		// A response ID is tied to the provider/session that produced it. If route
-		// selection moved elsewhere, use the handler's full-transcript HTTP fallback.
-		log.Printf("[Codex] Responses WebSocket session unavailable for provider=%d; falling back to HTTP/SSE", provider.ID)
-		return false, nil
+		return nil, newCodexWebSocketAttemptError(proxyErr, false, false)
 	}
 
 	ctx := c.Request.Context()
 	config := ensureCodexConfig(provider)
+	target, err := codexResponsesWebSocketURL(config)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, true, "failed to build Codex websocket URL")
+		proxyErr.Scope = domain.ScopeEndpoint
+		return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+	}
+	if isCodexWebSocketUnsupported(provider.ID, target) {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoResponsesWebSocketProviders, true, "Codex websocket endpoint is temporarily marked unsupported")
+		proxyErr.Scope = domain.ScopeEndpoint
+		proxyErr.Code = "upstream_websocket_upgrade_rejected"
+		attemptErr := newCodexWebSocketAttemptError(proxyErr, true, true)
+		return nil, attemptErr
+	}
+
 	accessToken, err := a.getAccessToken(ctx, false, "")
 	if err != nil {
 		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to get access token")
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
-		return true, proxyErr
+		return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+	}
+	headers := buildCodexWebSocketHeaders(c, accessToken, config.AccountID, exchange.Frame)
+	fingerprint := codexWebSocketFingerprint(provider.ID, target, headers)
+	key := codexWebSocketSessionKey{ConnectionID: exchange.ConnectionID, ProviderID: provider.ID}
+	session := globalCodexWebSocketSessions.get(key)
+	if session != nil && session.fingerprint != fingerprint {
+		session.activeTurns.Add(-1)
+		globalCodexWebSocketSessions.remove(key, session)
+		session = nil
+	}
+	if session == nil && exchange.PreviousResponseID != "" {
+		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketSessionUnavailable, false, false)
 	}
 
-	webSocketURL, err := codexResponsesWebSocketURL(c, config)
-	if err != nil {
-		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to build Codex websocket URL")
-		proxyErr.Scope = domain.ScopeEndpoint
-		return true, proxyErr
-	}
-	headers := buildCodexWebSocketHeaders(c, accessToken, config.AccountID, rawRequest)
-
+	reused := session != nil
 	if session == nil {
-		var response *http.Response
-		session, response, err = dialCodexWebSocket(ctx, webSocketURL, headers)
-		if err != nil && response != nil && response.StatusCode == http.StatusUnauthorized {
-			body := readCodexWebSocketHandshakeBody(response)
-			accessToken, err = a.getAccessToken(ctx, true, accessToken)
-			if err != nil {
-				return true, classifyCodexHTTPError(http.StatusUnauthorized, body, response.Header, flow.GetMappedModel(c))
-			}
-			headers.Set("Authorization", "Bearer "+accessToken)
-			session, response, err = dialCodexWebSocket(ctx, webSocketURL, headers)
-		}
+		session, err = a.dialResponsesWebSocketSession(ctx, provider, config, target, headers, fingerprint, accessToken)
 		if err != nil {
-			if response != nil {
-				body := readCodexWebSocketHandshakeBody(response)
-				if response.StatusCode == http.StatusUpgradeRequired {
-					log.Printf("[Codex] Responses WebSocket upgrade rejected with status=%d url=%s; falling back to HTTP/SSE", response.StatusCode, webSocketURL)
-					return false, nil
-				}
-				return true, classifyCodexHTTPError(response.StatusCode, body, response.Header, flow.GetMappedModel(c))
-			}
-			// A transport-level upgrade failure is safe to retry through the existing
-			// HTTP/SSE path because no upstream WebSocket event reached the client.
-			log.Printf("[Codex] Responses WebSocket upgrade failed url=%s error=%v; falling back to HTTP/SSE", webSocketURL, err)
-			return false, nil
+			return nil, err
 		}
-		globalCodexWebSocketSessions.put(key, session)
-		if done := ctx.Done(); done != nil {
-			go func() {
-				<-done
-				globalCodexWebSocketSessions.remove(key, session)
-			}()
+		session.activeTurns.Add(1)
+		if !globalCodexWebSocketSessions.put(key, session) {
+			session.activeTurns.Add(-1)
+			session.close()
+			proxyErr := domain.NewProxyErrorWithMessage(errors.New("Codex websocket session capacity reached"), true, "Codex websocket session capacity reached")
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.Code = "upstream_websocket_session_capacity"
+			proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+			return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
 		}
 	}
 
-	session.requestMu.Lock()
-	defer session.requestMu.Unlock()
+	result, execErr := session.executeTurn(ctx, exchange.Frame, exchange.Sink, flow.GetEventChan(c), provider.ID)
+	if result != nil {
+		result.ProviderID = provider.ID
+		result.Reused = reused
+	}
+	if execErr != nil {
+		var wsErr *domain.ResponsesWebSocketAttemptError
+		if errors.As(execErr, &wsErr) && (wsErr.RequestFrameMayHaveBeenSent || session.isClosed()) {
+			globalCodexWebSocketSessions.remove(key, session)
+		}
+		return result, execErr
+	}
+	return result, nil
+}
 
-	eventChan := flow.GetEventChan(c)
+func (a *CodexAdapter) dialResponsesWebSocketSession(
+	ctx context.Context,
+	provider *domain.Provider,
+	config *domain.ProviderConfigCodex,
+	target string,
+	headers http.Header,
+	fingerprint string,
+	accessToken string,
+) (*codexWebSocketSession, error) {
+	session, response, err := dialCodexWebSocket(ctx, target, headers, fingerprint)
+	if err != nil && response != nil && response.StatusCode == http.StatusUnauthorized && canRefreshCodexAccessToken(config) {
+		body := readCodexWebSocketHandshakeBody(response)
+		_ = body
+		refreshed, refreshErr := a.getAccessToken(ctx, true, accessToken)
+		if refreshErr != nil {
+			proxyErr := classifyCodexHTTPError(http.StatusUnauthorized, body, response.Header, "")
+			return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+		}
+		headers.Set("Authorization", "Bearer "+refreshed)
+		fingerprint = codexWebSocketFingerprint(provider.ID, target, headers)
+		session, response, err = dialCodexWebSocket(ctx, target, headers, fingerprint)
+	}
+	if err == nil {
+		return session, nil
+	}
+
+	if response != nil {
+		status := response.StatusCode
+		body := readCodexWebSocketHandshakeBody(response)
+		proxyErr := classifyCodexHTTPError(status, body, response.Header, "")
+		proxyErr.Code = "upstream_websocket_upgrade_rejected"
+		capabilityFailure := isCodexWebSocketCapabilityStatus(status)
+		if capabilityFailure {
+			markCodexWebSocketUnsupported(provider.ID, target, http.StatusText(status))
+		}
+		return nil, newCodexWebSocketAttemptError(proxyErr, true, capabilityFailure)
+	}
+
+	proxyErr := domain.NewProxyErrorWithMessage(err, true, "failed to upgrade Codex websocket connection")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonNetworkError
+	proxyErr.Code = "upstream_websocket_upgrade_rejected"
+	proxyErr.HTTPStatusCode = http.StatusBadGateway
+	return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+}
+
+func newCodexWebSocketAttemptError(err error, safeToTryNext, capabilityFailure bool) *domain.ResponsesWebSocketAttemptError {
+	return &domain.ResponsesWebSocketAttemptError{
+		Err:                   err,
+		SafeToTryNextProvider: safeToTryNext,
+		CapabilityFailure:     capabilityFailure,
+	}
+}
+
+func canRefreshCodexAccessToken(config *domain.ProviderConfigCodex) bool {
+	return config != nil && strings.TrimSpace(config.RefreshToken) != ""
+}
+
+func isCodexWebSocketCapabilityStatus(status int) bool {
+	switch status {
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusUpgradeRequired, http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateOutboundCodexWebSocketFrame(frame []byte) error {
+	if !gjson.ValidBytes(frame) || !gjson.ParseBytes(frame).IsObject() {
+		return domain.ErrResponsesWebSocketProtocol
+	}
+	if gjson.GetBytes(frame, "type").String() != "response.create" {
+		return domain.ErrResponsesWebSocketProtocol
+	}
+	if strings.TrimSpace(gjson.GetBytes(frame, "model").String()) == "" {
+		return domain.ErrResponsesWebSocketProtocol
+	}
+	return nil
+}
+
+func (s *codexWebSocketSession) executeTurn(
+	ctx context.Context,
+	frame []byte,
+	sink domain.ResponsesWebSocketFrameSink,
+	eventChan domain.AdapterEventChan,
+	providerID uint64,
+) (*domain.ResponsesWebSocketResult, error) {
+	defer func() { s.activeTurns.Add(-1) }()
+	s.requestMu.Lock()
+	defer s.requestMu.Unlock()
+	s.touch()
+
+	result := &domain.ResponsesWebSocketResult{ProviderID: providerID}
+	if s.isClosed() {
+		return result, newCodexWebSocketAttemptError(errors.New("codex websocket session is closed"), true, false)
+	}
 	if eventChan != nil {
 		eventChan.SendRequestInfo(&domain.RequestInfo{
 			Method:  "WEBSOCKET",
-			URL:     webSocketURL,
-			Headers: flattenHeaders(headers),
-			Body:    string(rawRequest),
+			Headers: flattenHeaders(s.handshakeHeader),
+			Body:    string(frame),
 		})
 	}
 
-	if err = session.write(rawRequest); err != nil {
-		globalCodexWebSocketSessions.remove(key, session)
-		log.Printf("[Codex] Responses WebSocket write failed provider=%d error=%v; falling back to HTTP/SSE", provider.ID, err)
-		return false, nil
-	}
-
-	c.Writer.Header().Set("Content-Type", "text/event-stream")
-	c.Writer.Header().Set("Cache-Control", "no-cache")
-	c.Writer.Header().Set("Connection", "keep-alive")
-	c.Writer.Header().Set("X-Accel-Buffering", "no")
-	flusher, ok := c.Writer.(http.Flusher)
-	if !ok {
-		globalCodexWebSocketSessions.remove(key, session)
-		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "streaming not supported")
-		proxyErr.Scope = domain.ScopeRequest
-		return true, proxyErr
+	result.RequestFrameMayHaveBeenSent = true
+	if err := s.write(frame); err != nil {
+		return result, &domain.ResponsesWebSocketAttemptError{
+			Err:                         err,
+			RequestFrameMayHaveBeenSent: true,
+		}
 	}
 
 	var collector usage.StreamCollector
-	responseModel := ""
-	firstChunkSent := false
+	firstEvent := true
+	timer := time.NewTimer(codexResponsesWebSocketFirstEventTimeout)
+	defer timer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			globalCodexWebSocketSessions.remove(key, session)
-			proxyErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
-			proxyErr.Scope = domain.ScopeRequest
-			return true, proxyErr
-		case read, open := <-session.reads:
+			return result, &domain.ResponsesWebSocketAttemptError{
+				Err:                         ctx.Err(),
+				RequestFrameMayHaveBeenSent: true,
+				FirstEventReceived:          result.FirstEventReceived,
+				ClientEventSent:             result.ClientEventSent,
+			}
+		case <-timer.C:
+			code := "upstream_websocket_first_event_timeout"
+			message := "Codex websocket first event timeout"
+			if result.FirstEventReceived {
+				code = "upstream_websocket_closed_before_terminal"
+				message = "Codex websocket event idle timeout"
+			}
+			proxyErr := domain.NewProxyErrorWithMessage(context.DeadlineExceeded, false, message)
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonNetworkError
+			proxyErr.Code = code
+			proxyErr.HTTPStatusCode = http.StatusGatewayTimeout
+			return result, &domain.ResponsesWebSocketAttemptError{
+				Err:                         proxyErr,
+				RequestFrameMayHaveBeenSent: true,
+				FirstEventReceived:          result.FirstEventReceived,
+				ClientEventSent:             result.ClientEventSent,
+			}
+		case read, open := <-s.reads:
+			if len(read.payload) > 0 {
+				s.queuedBytes.Add(-int64(len(read.payload)))
+			}
 			if !open || read.err != nil {
-				globalCodexWebSocketSessions.remove(key, session)
 				readErr := read.err
 				if readErr == nil {
 					readErr = io.ErrUnexpectedEOF
 				}
-				// The request frame was already written successfully, so retrying it
-				// through HTTP or another provider could duplicate side effects.
-				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, "Codex websocket closed before response.completed")
-				proxyErr.Scope = domain.ScopeRequest
+				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, "Codex websocket closed before terminal event")
+				proxyErr.Scope = domain.ScopeProvider
+				proxyErr.Reason = domain.CooldownReasonNetworkError
+				proxyErr.Code = "upstream_websocket_closed_before_terminal"
 				proxyErr.HTTPStatusCode = http.StatusBadGateway
-				return true, proxyErr
+				return result, &domain.ResponsesWebSocketAttemptError{
+					Err:                         proxyErr,
+					RequestFrameMayHaveBeenSent: true,
+					FirstEventReceived:          result.FirstEventReceived,
+					ClientEventSent:             result.ClientEventSent,
+				}
 			}
-			if read.messageType != websocket.TextMessage {
-				continue
-			}
-			payload := bytes.TrimSpace(read.payload)
-			if len(payload) == 0 {
-				continue
-			}
-
-			eventType := gjson.GetBytes(payload, "type").String()
-			if eventType == "error" || eventType == "response.failed" {
-				globalCodexWebSocketSessions.remove(key, session)
-				return true, classifyCodexWebSocketEvent(payload, flow.GetMappedModel(c))
-			}
-
-			collector.ProcessSSEPayload(payload)
-			if model := strings.TrimSpace(gjson.GetBytes(payload, "response.model").String()); model != "" {
-				responseModel = model
-			} else if model := strings.TrimSpace(gjson.GetBytes(payload, "model").String()); model != "" {
-				responseModel = model
+			if read.messageType != websocket.TextMessage || !gjson.ValidBytes(read.payload) || !gjson.ParseBytes(read.payload).IsObject() {
+				proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "invalid Codex websocket application frame")
+				proxyErr.Scope = domain.ScopeProvider
+				proxyErr.Code = "websocket_protocol_error"
+				proxyErr.HTTPStatusCode = http.StatusBadGateway
+				return result, &domain.ResponsesWebSocketAttemptError{
+					Err:                         proxyErr,
+					RequestFrameMayHaveBeenSent: true,
+					FirstEventReceived:          result.FirstEventReceived,
+					ClientEventSent:             result.ClientEventSent,
+				}
 			}
 
-			if _, err = c.Writer.Write([]byte("data: ")); err == nil {
-				_, err = c.Writer.Write(payload)
-			}
-			if err == nil {
-				_, err = c.Writer.Write([]byte("\n\n"))
-			}
-			if err != nil {
-				globalCodexWebSocketSessions.remove(key, session)
-				proxyErr := domain.NewProxyErrorWithMessage(err, false, "client disconnected")
-				proxyErr.Scope = domain.ScopeRequest
-				return true, proxyErr
-			}
-			flusher.Flush()
-			if !firstChunkSent {
-				firstChunkSent = true
+			result.FirstEventReceived = true
+			if firstEvent {
+				firstEvent = false
 				if eventChan != nil {
 					eventChan.SendFirstToken(time.Now().UnixMilli())
 				}
 			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(codexResponsesWebSocketEventIdleTimeout)
 
-			if eventType == "response.completed" || eventType == "response.done" {
-				sendCodexWebSocketFinalEvents(eventChan, session.handshakeHeader, &collector, responseModel)
-				return true, nil
+			if err := sink.WriteTextFrame(read.payload); err != nil {
+				return result, &domain.ResponsesWebSocketAttemptError{
+					Err:                         err,
+					RequestFrameMayHaveBeenSent: true,
+					FirstEventReceived:          true,
+					ClientEventSent:             result.ClientEventSent,
+				}
+			}
+			result.ClientEventSent = true
+			collector.ProcessSSEPayload(read.payload)
+			if model := strings.TrimSpace(gjson.GetBytes(read.payload, "response.model").String()); model != "" {
+				result.ResponseModel = model
+			} else if model := strings.TrimSpace(gjson.GetBytes(read.payload, "model").String()); model != "" {
+				result.ResponseModel = model
+			}
+
+			eventType := gjson.GetBytes(read.payload, "type").String()
+			if !isCodexWebSocketTerminalEvent(eventType) {
+				continue
+			}
+			result.TerminalEvent = eventType
+			sendCodexWebSocketFinalEvents(eventChan, s.handshakeHeader, &collector, result.ResponseModel)
+			if eventType == "response.completed" || eventType == "response.incomplete" {
+				return result, nil
+			}
+			proxyErr := classifyCodexWebSocketEvent(read.payload, result.ResponseModel)
+			result.TerminalErrorEventSent = true
+			return result, &domain.ResponsesWebSocketAttemptError{
+				Err:                         proxyErr,
+				RequestFrameMayHaveBeenSent: true,
+				FirstEventReceived:          true,
+				ClientEventSent:             true,
+				TerminalErrorEventSent:      true,
 			}
 		}
 	}
 }
 
-func prepareCodexWebSocketRequest(raw []byte, c *flow.Ctx, provider *domain.Provider) ([]byte, error) {
-	if !gjson.ValidBytes(raw) || !gjson.ParseBytes(raw).IsObject() {
-		return nil, errors.New("expected a JSON object")
+func isCodexWebSocketTerminalEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.incomplete", "error":
+		return true
+	default:
+		return false
 	}
-	body := bytes.Clone(raw)
-	body, _ = sjson.SetBytes(body, "type", "response.create")
-	if model := strings.TrimSpace(flow.GetMappedModel(c)); model != "" {
-		body, _ = sjson.SetBytes(body, "model", model)
-	}
-	body, _ = sjson.DeleteBytes(body, "stream")
-	body, _ = sjson.DeleteBytes(body, "background")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	if maxOutput := gjson.GetBytes(body, "max_output_tokens"); maxOutput.Exists() {
-		if !gjson.GetBytes(body, "max_tokens").Exists() {
-			body, _ = sjson.SetBytes(body, "max_tokens", maxOutput.Value())
-		}
-		body, _ = sjson.DeleteBytes(body, "max_output_tokens")
-	}
-	if !gjson.GetBytes(body, "previous_response_id").Exists() && !gjson.GetBytes(body, "instructions").Exists() {
-		body, _ = sjson.SetBytes(body, "instructions", "")
-	}
-	body = codexutil.NormalizeCodexInput(body)
-
-	config := ensureCodexConfig(provider)
-	if config.Reasoning != "" {
-		body, _ = sjson.SetBytes(body, "reasoning.effort", config.Reasoning)
-	}
-	if config.ServiceTier != "" {
-		body, _ = sjson.SetBytes(body, "service_tier", config.ServiceTier)
-	}
-	return body, nil
 }
 
-func codexResponsesWebSocketURL(c *flow.Ctx, config *domain.ProviderConfigCodex) (string, error) {
-	baseURL := CodexBaseURL
-	custom := config != nil && strings.TrimSpace(config.BaseURL) != ""
-	if custom {
-		baseURL = strings.TrimRight(config.BaseURL, "/")
+func codexResponsesWebSocketURL(config *domain.ProviderConfigCodex) (string, error) {
+	base := CodexBaseURL
+	if config != nil && strings.TrimSpace(config.BaseURL) != "" {
+		base = strings.TrimSpace(config.BaseURL)
 	}
+	return joinResponsesWebSocketURL(base)
+}
 
-	path := "/responses"
-	if custom && domain.ResponsesPassthroughEnabled(config.ResponsesPassthrough) {
-		path = flow.GetResponsesClientPath(c)
-		if path == "" {
-			path = "/v1/responses"
-		}
-	}
-	parsed, err := url.Parse(baseURL + path)
+func joinResponsesWebSocketURL(base string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(base))
 	if err != nil {
 		return "", err
+	}
+	if strings.TrimSpace(parsed.Host) == "" {
+		return "", errors.New("websocket URL host is empty")
+	}
+	if pathpkg.Base(strings.TrimRight(parsed.Path, "/")) != "responses" {
+		parsed.Path = pathpkg.Join(parsed.Path, "responses")
+		if !strings.HasPrefix(parsed.Path, "/") {
+			parsed.Path = "/" + parsed.Path
+		}
 	}
 	switch strings.ToLower(parsed.Scheme) {
 	case "http":
 		parsed.Scheme = "ws"
 	case "https":
 		parsed.Scheme = "wss"
+	case "ws", "wss":
 	default:
 		return "", fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
-	}
-	if strings.TrimSpace(parsed.Host) == "" {
-		return "", errors.New("websocket URL host is empty")
 	}
 	return parsed.String(), nil
 }
 
-func buildCodexWebSocketHeaders(c *flow.Ctx, accessToken, accountID string, body []byte) http.Header {
+func buildCodexWebSocketHeaders(c *flow.Ctx, accessToken, accountID string, frame []byte) http.Header {
 	headers := make(http.Header)
 	if c != nil && c.Request != nil {
 		for key, values := range c.Request.Header {
-			lowerKey := strings.ToLower(key)
-			if codexFilteredHeaders[lowerKey] || lowerKey == "authorization" || strings.HasPrefix(lowerKey, "sec-websocket-") {
+			if isForbiddenCodexWebSocketHeader(key) {
 				continue
 			}
 			for _, value := range values {
@@ -432,16 +656,15 @@ func buildCodexWebSocketHeaders(c *flow.Ctx, accessToken, accountID string, body
 	if strings.TrimSpace(accessToken) != "" {
 		headers.Set("Authorization", "Bearer "+accessToken)
 	}
-	betaHeader := strings.TrimSpace(headers.Get("OpenAI-Beta"))
-	if !strings.Contains(betaHeader, "responses_websockets=") {
-		headers.Set("OpenAI-Beta", codexResponsesWebSocketBetaHeader)
-	}
+	headers.Set("OpenAI-Beta", mergeCommaSeparatedHeader(headers.Get("OpenAI-Beta"), codexResponsesWebSocketBetaHeader))
 	if c != nil {
 		headers.Set("User-Agent", flow.ResolveUpstreamUserAgent(c, CodexUserAgent))
 	}
-	if sessionID := strings.TrimSpace(headers.Get("Session_id")); sessionID == "" {
-		if promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String()); promptCacheKey != "" {
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(frame, "prompt_cache_key").String()); promptCacheKey != "" {
+		if headers.Get("Session_id") == "" {
 			headers.Set("Session_id", promptCacheKey)
+		}
+		if headers.Get("Conversation_id") == "" {
 			headers.Set("Conversation_id", promptCacheKey)
 		}
 	}
@@ -456,7 +679,57 @@ func buildCodexWebSocketHeaders(c *flow.Ctx, accessToken, accountID string, body
 	return headers
 }
 
-func dialCodexWebSocket(ctx context.Context, target string, headers http.Header) (*codexWebSocketSession, *http.Response, error) {
+func mergeCommaSeparatedHeader(existing, required string) string {
+	parts := make([]string, 0, 4)
+	seen := make(map[string]struct{})
+	for _, value := range []string{existing, required} {
+		for _, part := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed == "" {
+				continue
+			}
+			key := strings.ToLower(trimmed)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func isForbiddenCodexWebSocketHeader(name string) bool {
+	lower := strings.ToLower(strings.TrimSpace(name))
+	if lower == "authorization" || lower == "host" || lower == "accept" || lower == "content-type" ||
+		lower == "content-length" || lower == "transfer-encoding" || lower == "connection" || lower == "upgrade" ||
+		lower == "cookie" || lower == "origin" || lower == "x-api-key" || lower == "x-goog-api-key" || lower == "api-key" ||
+		strings.HasPrefix(lower, "x-maxx-") ||
+		strings.HasPrefix(lower, "sec-websocket-") {
+		return true
+	}
+	return lower != "user-agent" && codexFilteredHeaders[lower]
+}
+
+func codexWebSocketFingerprint(providerID uint64, target string, headers http.Header) string {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, strings.ToLower(key))
+	}
+	sort.Strings(keys)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%d\n%s\n", providerID, target)
+	for _, key := range keys {
+		builder.WriteString(key)
+		builder.WriteByte(':')
+		builder.WriteString(strings.Join(headers.Values(key), "\x00"))
+		builder.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(builder.String()))
+	return fmt.Sprintf("%x", sum[:])
+}
+
+func dialCodexWebSocket(ctx context.Context, target string, headers http.Header, fingerprint string) (*codexWebSocketSession, *http.Response, error) {
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
 		HandshakeTimeout:  codexResponsesWebSocketHandshake,
@@ -477,7 +750,7 @@ func dialCodexWebSocket(ctx context.Context, target string, headers http.Header)
 			_ = response.Body.Close()
 		}
 	}
-	return newCodexWebSocketSession(conn, responseHeaders), response, nil
+	return newCodexWebSocketSession(conn, responseHeaders, fingerprint), response, nil
 }
 
 func readCodexWebSocketHandshakeBody(response *http.Response) []byte {
@@ -495,13 +768,24 @@ func classifyCodexWebSocketEvent(payload []byte, model string) *domain.ProxyErro
 		message = strings.TrimSpace(gjson.GetBytes(payload, "response.error.message").String())
 	}
 	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(payload, "message").String())
+	}
+	if message == "" {
 		message = "upstream websocket returned an error"
 	}
 	code := strings.TrimSpace(gjson.GetBytes(payload, "error.code").String())
 	if code == "" {
 		code = strings.TrimSpace(gjson.GetBytes(payload, "response.error.code").String())
 	}
-	errorType := strings.ToLower(gjson.GetBytes(payload, "error.type").String() + " " + code)
+	if code == "" {
+		code = strings.TrimSpace(gjson.GetBytes(payload, "code").String())
+	}
+	errorType := strings.ToLower(strings.Join([]string{
+		gjson.GetBytes(payload, "error.type").String(),
+		gjson.GetBytes(payload, "response.error.type").String(),
+		gjson.GetBytes(payload, "type").String(),
+		code,
+	}, " "))
 	proxyErr := domain.NewProxyErrorWithMessage(errors.New(string(payload)), true, message)
 	proxyErr.Code = code
 	proxyErr.ClientType = string(domain.ClientTypeCodex)

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -1,14 +1,17 @@
 package codex
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
-	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/google/uuid"
@@ -16,14 +19,31 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
+type recordingWebSocketSink struct {
+	mu     sync.Mutex
+	frames [][]byte
+}
+
+type failingWebSocketSink struct{ err error }
+
+func (s failingWebSocketSink) WriteTextFrame([]byte) error { return s.err }
+
+func (s *recordingWebSocketSink) WriteTextFrame(payload []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.frames = append(s.frames, bytes.Clone(payload))
+	return nil
+}
+
+func TestExecuteResponsesWebSocket_PreservesOfficialWirePayload(t *testing.T) {
+	clearCodexWebSocketUnsupportedForTests()
 	var connectionCount atomic.Int32
 	requests := make(chan []byte, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/responses" {
 			t.Errorf("path = %q, want /v1/responses", r.URL.Path)
 		}
-		if got := r.Header.Get("OpenAI-Beta"); got != codexResponsesWebSocketBetaHeader {
+		if got := r.Header.Get("OpenAI-Beta"); !strings.Contains(got, codexResponsesWebSocketBetaHeader) {
 			t.Errorf("OpenAI-Beta = %q", got)
 		}
 		if got := r.Header.Get("User-Agent"); got != "codex-test/1.0" {
@@ -58,7 +78,7 @@ func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
 		Type: "codex",
 		Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
 			AccessToken: "test-token",
-			BaseURL:     server.URL,
+			BaseURL:     server.URL + "/v1",
 		}},
 	}
 	adapter := &CodexAdapter{
@@ -66,90 +86,366 @@ func TestExecuteResponsesWebSocket_ReusesNativeUpstreamSession(t *testing.T) {
 		tokenCache: &TokenCache{AccessToken: "test-token"},
 		httpClient: newUpstreamHTTPClient(),
 	}
-	sessionID := uuid.NewString()
-	storeKey := "42:" + sessionID
-	t.Cleanup(func() {
-		if session := globalCodexWebSocketSessions.get(storeKey); session != nil {
-			globalCodexWebSocketSessions.remove(storeKey, session)
-		}
-	})
+	connectionID := uuid.NewString()
+	t.Cleanup(func() { adapter.CloseResponsesWebSocketConnection(connectionID) })
+	sink := &recordingWebSocketSink{}
 
-	firstRaw := []byte(`{"type":"response.create","model":"client-model","generate":false,"stream":true,"background":true,"input":[]}`)
-	firstCtx := newCodexWebSocketTestContext(t, firstRaw, sessionID)
-	handled, err := adapter.executeResponsesWebSocket(firstCtx, provider)
-	if !handled || err != nil {
-		t.Fatalf("first execute handled=%v err=%v", handled, err)
+	firstRaw := []byte(`{"type":"response.create","model":"gpt-test","generate":false,"stream":true,"store":true,"background":true,"stream_options":{"include_usage":true},"client_metadata":{"source":"test"},"unknown_field":"preserve","input":[]}`)
+	firstCtx := newCodexWebSocketTestContext(t)
+	firstExchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID: connectionID,
+		Frame:        firstRaw,
+		Sink:         sink,
+	}
+	result, err := adapter.ExecuteResponsesWebSocket(firstCtx, provider, firstExchange)
+	if err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	if result.Reused {
+		t.Fatal("first turn unexpectedly reused a connection")
 	}
 	firstUpstream := <-requests
-	if got := gjson.GetBytes(firstUpstream, "type").String(); got != "response.create" {
-		t.Fatalf("type = %q", got)
+	if !bytes.Equal(firstUpstream, firstRaw) {
+		t.Fatalf("upstream frame mutated:\n got %s\nwant %s", firstUpstream, firstRaw)
 	}
-	if got := gjson.GetBytes(firstUpstream, "model").String(); got != "gpt-test" {
-		t.Fatalf("model = %q, want mapped model", got)
-	}
-	if gjson.GetBytes(firstUpstream, "stream").Exists() || gjson.GetBytes(firstUpstream, "background").Exists() {
-		t.Fatalf("websocket-only implicit fields not removed: %s", firstUpstream)
-	}
-	generate := gjson.GetBytes(firstUpstream, "generate")
-	if !generate.Exists() || generate.Bool() {
-		t.Fatalf("native v2 prewarm generate = %s, want false", generate.Raw)
+	for _, field := range []string{"stream", "store", "generate", "stream_options", "client_metadata", "unknown_field"} {
+		if !gjson.GetBytes(firstUpstream, field).Exists() {
+			t.Fatalf("field %q was removed: %s", field, firstUpstream)
+		}
 	}
 
-	secondRaw := []byte(`{"type":"response.append","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
-	secondCtx := newCodexWebSocketTestContext(t, secondRaw, sessionID)
-	handled, err = adapter.executeResponsesWebSocket(secondCtx, provider)
-	if !handled || err != nil {
-		t.Fatalf("second execute handled=%v err=%v", handled, err)
+	secondRaw := []byte(`{"type":"response.create","model":"gpt-test","previous_response_id":"resp_1","generate":true,"input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
+	secondExchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID:       connectionID,
+		Frame:              secondRaw,
+		PreviousResponseID: "resp_1",
+		PinnedProviderID:   provider.ID,
+		Sink:               sink,
+	}
+	result, err = adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, secondExchange)
+	if err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	if !result.Reused {
+		t.Fatal("continuation did not reuse the upstream connection")
 	}
 	secondUpstream := <-requests
-	if got := gjson.GetBytes(secondUpstream, "type").String(); got != "response.create" {
-		t.Fatalf("second type = %q", got)
-	}
-	if got := gjson.GetBytes(secondUpstream, "previous_response_id").String(); got != "resp_1" {
-		t.Fatalf("previous_response_id = %q", got)
+	if !bytes.Equal(secondUpstream, secondRaw) {
+		t.Fatalf("continuation frame mutated:\n got %s\nwant %s", secondUpstream, secondRaw)
 	}
 	if connectionCount.Load() != 1 {
 		t.Fatalf("connections = %d, want 1", connectionCount.Load())
 	}
-}
-
-func TestExecuteResponsesWebSocket_SkipsProtocolConversion(t *testing.T) {
-	provider := &domain.Provider{ID: 1, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{}}}
-	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{}}
-	raw := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
-	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", strings.NewReader(`{"model":"gpt-test","stream":true,"input":[]}`))
-	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), "session", raw))
-	c := flow.NewCtx(httptest.NewRecorder(), request)
-	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
-	c.Set(flow.KeyOriginalClientType, domain.ClientTypeClaude)
-
-	handled, err := adapter.executeResponsesWebSocket(c, provider)
-	if handled || err != nil {
-		t.Fatalf("conversion handled=%v err=%v", handled, err)
+	if len(sink.frames) != 2 {
+		t.Fatalf("forwarded frames = %d, want 2", len(sink.frames))
 	}
 }
 
-func TestBuildCodexWebSocketHeadersPassesResponsesLite(t *testing.T) {
-	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
-	request.Header.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
-	c := flow.NewCtx(httptest.NewRecorder(), request)
-
-	headers := buildCodexWebSocketHeaders(c, "test-token", "", nil)
-	if got := headers.Get("X-OpenAI-Internal-Codex-Responses-Lite"); got != "true" {
-		t.Fatalf("Codex Responses Lite header = %q, want passthrough", got)
+func TestExecuteResponsesWebSocket_MissingContinuationSessionFails(t *testing.T) {
+	provider := &domain.Provider{
+		ID: 7,
+		Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+			AccessToken: "static-token",
+			BaseURL:     "https://example.test/v1",
+		}},
+	}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{AccessToken: "static-token"}}
+	exchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID:       uuid.NewString(),
+		Frame:              []byte(`{"type":"response.create","model":"gpt-test","previous_response_id":"resp_missing","input":[]}`),
+		PreviousResponseID: "resp_missing",
+		PinnedProviderID:   provider.ID,
+		Sink:               &recordingWebSocketSink{},
+	}
+	_, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, exchange)
+	if !errors.Is(err, domain.ErrResponsesWebSocketSessionUnavailable) {
+		t.Fatalf("error = %v, want session unavailable", err)
 	}
 }
 
-func newCodexWebSocketTestContext(t *testing.T, raw []byte, sessionID string) *flow.Ctx {
-	t.Helper()
+func TestExecuteResponsesWebSocket_StaticToken401DoesNotGeneratePlaceholder(t *testing.T) {
+	clearCodexWebSocketUnsupportedForTests()
+	var handshakes atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshakes.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Bearer static-token" {
+			t.Errorf("Authorization = %q", got)
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{ID: 81, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+		AccessToken: "static-token",
+		BaseURL:     server.URL + "/v1",
+	}}}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{AccessToken: "static-token"}}
+	exchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID: uuid.NewString(),
+		Frame:        []byte(`{"type":"response.create","model":"gpt-test","input":[]}`),
+		Sink:         &recordingWebSocketSink{},
+	}
+	_, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, exchange)
+	if err == nil {
+		t.Fatal("expected unauthorized handshake error")
+	}
+	if handshakes.Load() != 1 {
+		t.Fatalf("handshakes = %d, want 1 without refresh retry", handshakes.Load())
+	}
+	if got := adapter.tokenCache.AccessToken; got != "static-token" || isFallbackCodexAccessToken(got) {
+		t.Fatalf("token cache changed to %q", got)
+	}
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	if !errors.As(err, &wsErr) || wsErr.RequestFrameMayHaveBeenSent {
+		t.Fatalf("attempt error = %#v, want pre-write failure", wsErr)
+	}
+	var proxyErr *domain.ProxyError
+	if !errors.As(err, &proxyErr) || proxyErr.HTTPStatusCode != http.StatusUnauthorized || proxyErr.Scope != domain.ScopeKey {
+		t.Fatalf("proxy error = %#v, want 401 key scope", proxyErr)
+	}
+}
+
+func TestExecuteResponsesWebSocket_Upgrade404IsCachedSafeBeforeWrite(t *testing.T) {
+	clearCodexWebSocketUnsupportedForTests()
+	var handshakes atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshakes.Add(1)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{ID: 82, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+		AccessToken: "static-token",
+		BaseURL:     server.URL + "/v1",
+	}}}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{AccessToken: "static-token"}}
+	for turn := 0; turn < 2; turn++ {
+		exchange := &domain.ResponsesWebSocketExchange{
+			ConnectionID: uuid.NewString(),
+			Frame:        []byte(`{"type":"response.create","model":"gpt-test","input":[]}`),
+			Sink:         &recordingWebSocketSink{},
+		}
+		_, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, exchange)
+		var wsErr *domain.ResponsesWebSocketAttemptError
+		if !errors.As(err, &wsErr) || !wsErr.CapabilityFailure || !wsErr.CanTryNextProvider() {
+			t.Fatalf("turn %d error = %#v, want cached safe capability failure", turn, wsErr)
+		}
+	}
+	if handshakes.Load() != 1 {
+		t.Fatalf("handshakes = %d, want 1 after unsupported cache hit", handshakes.Load())
+	}
+}
+
+func TestExecuteResponsesWebSocket_ResponseIncompleteTerminates(t *testing.T) {
+	clearCodexWebSocketUnsupportedForTests()
+	incomplete := []byte(`{"type":"response.incomplete","response":{"id":"resp_incomplete","model":"gpt-test","output":[]}}`)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err = conn.ReadMessage(); err != nil {
+			t.Errorf("read request: %v", err)
+			return
+		}
+		if err = conn.WriteMessage(websocket.TextMessage, incomplete); err != nil {
+			t.Errorf("write incomplete: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{ID: 83, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+		AccessToken: "static-token",
+		BaseURL:     server.URL + "/v1",
+	}}}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{AccessToken: "static-token"}}
+	connectionID := uuid.NewString()
+	t.Cleanup(func() { adapter.CloseResponsesWebSocketConnection(connectionID) })
+	sink := &recordingWebSocketSink{}
+	result, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, &domain.ResponsesWebSocketExchange{
+		ConnectionID: connectionID,
+		Frame:        []byte(`{"type":"response.create","model":"gpt-test","input":[]}`),
+		Sink:         sink,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if result.TerminalEvent != "response.incomplete" {
+		t.Fatalf("terminal event = %q", result.TerminalEvent)
+	}
+	if len(sink.frames) != 1 || !bytes.Equal(sink.frames[0], incomplete) {
+		t.Fatalf("forwarded frames = %q, want raw incomplete frame", sink.frames)
+	}
+}
+
+func TestExecuteResponsesWebSocket_SinkWriteErrorIsNotReplayable(t *testing.T) {
+	clearCodexWebSocketUnsupportedForTests()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err = conn.ReadMessage(); err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed","response":{"model":"gpt-test","output":[]}}`))
+	}))
+	defer server.Close()
+
+	provider := &domain.Provider{ID: 84, Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+		AccessToken: "static-token",
+		BaseURL:     server.URL + "/v1",
+	}}}
+	adapter := &CodexAdapter{provider: provider, tokenCache: &TokenCache{AccessToken: "static-token"}}
+	sinkErr := errors.New("downstream write failed")
+	_, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, &domain.ResponsesWebSocketExchange{
+		ConnectionID: uuid.NewString(),
+		Frame:        []byte(`{"type":"response.create","model":"gpt-test","input":[]}`),
+		Sink:         failingWebSocketSink{err: sinkErr},
+	})
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	if !errors.As(err, &wsErr) || !errors.Is(err, sinkErr) {
+		t.Fatalf("error = %#v, want downstream write error", err)
+	}
+	if wsErr.CanTryNextProvider() || !wsErr.RequestFrameMayHaveBeenSent || !wsErr.FirstEventReceived {
+		t.Fatalf("attempt flags = %#v, want committed non-replayable failure", wsErr)
+	}
+}
+
+func TestCodexResponsesWebSocketURL(t *testing.T) {
+	tests := map[string]string{
+		"https://host.example/v1":               "wss://host.example/v1/responses",
+		"https://host.example/v1/responses":     "wss://host.example/v1/responses",
+		"https://chatgpt.com/backend-api/codex": "wss://chatgpt.com/backend-api/codex/responses",
+		"ws://host.example/api?source=test":     "ws://host.example/api/responses?source=test",
+	}
+	for base, want := range tests {
+		t.Run(base, func(t *testing.T) {
+			got, err := joinResponsesWebSocketURL(base)
+			if err != nil {
+				t.Fatalf("join URL: %v", err)
+			}
+			if got != want {
+				t.Fatalf("URL = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildCodexWebSocketHeaders_StripsHopByHopAndMergesBeta(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil)
+	request.Header.Set("Authorization", "Bearer client-token")
+	request.Header.Set("Connection", "upgrade")
+	request.Header.Set("Sec-WebSocket-Key", "client-key")
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("OpenAI-Beta", "feature=1")
 	request.Header.Set("User-Agent", "codex-test/1.0")
-	request = request.WithContext(maxxctx.WithResponsesWebSocketRequest(context.Background(), sessionID, raw))
+	request.Header.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
+	request.Header.Set("Cookie", "session=client-secret")
+	request.Header.Set("Origin", "https://client.example")
+	request.Header.Set("X-Api-Key", "client-api-key")
+	request.Header.Set("X-Goog-Api-Key", "client-google-key")
+	request.Header.Set("Api-Key", "client-azure-key")
+	request.Header.Set("X-Maxx-Route", "internal-route")
+	c := flow.NewCtx(httptest.NewRecorder(), request)
+
+	headers := buildCodexWebSocketHeaders(c, "provider-token", "account-1", []byte(`{"prompt_cache_key":"session-1"}`))
+	if got := headers.Get("Authorization"); got != "Bearer provider-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	for _, key := range []string{
+		"Connection", "Sec-WebSocket-Key", "Content-Type", "Cookie", "Origin",
+		"X-Api-Key", "X-Goog-Api-Key", "Api-Key", "X-Maxx-Route",
+	} {
+		if got := headers.Get(key); got != "" {
+			t.Fatalf("forbidden %s = %q", key, got)
+		}
+	}
+	if got := headers.Get("OpenAI-Beta"); !strings.Contains(got, "feature=1") || !strings.Contains(got, codexResponsesWebSocketBetaHeader) {
+		t.Fatalf("OpenAI-Beta = %q", got)
+	}
+	if got := headers.Get("Session_id"); got != "session-1" {
+		t.Fatalf("Session_id = %q", got)
+	}
+	if got := headers.Get("X-OpenAI-Internal-Codex-Responses-Lite"); got != "true" {
+		t.Fatalf("Responses Lite header = %q", got)
+	}
+}
+
+func TestCodexWebSocketSessionStore_DoesNotEvictActiveSession(t *testing.T) {
+	store := &codexWebSocketSessionStore{
+		sessions:   make(map[codexWebSocketSessionKey]*codexWebSocketSession),
+		maxEntries: 1,
+	}
+	active := newStoredCodexWebSocketSession(time.Now().Add(-time.Hour), 1)
+	activeKey := codexWebSocketSessionKey{ConnectionID: "active", ProviderID: 1}
+	store.sessions[activeKey] = active
+	newSession := newStoredCodexWebSocketSession(time.Now(), 1)
+	if store.put(codexWebSocketSessionKey{ConnectionID: "new", ProviderID: 2}, newSession) {
+		t.Fatal("put succeeded while every stored session was active")
+	}
+	if store.sessions[activeKey] != active || active.isClosed() {
+		t.Fatal("active session was evicted or closed")
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("stored sessions = %d, want 1", len(store.sessions))
+	}
+}
+
+func TestCodexWebSocketSessionStore_PrunesOnlyIdleSessions(t *testing.T) {
+	store := &codexWebSocketSessionStore{
+		sessions:   make(map[codexWebSocketSessionKey]*codexWebSocketSession),
+		maxEntries: 2,
+	}
+	now := time.Now()
+	idle := newStoredCodexWebSocketSession(now.Add(-codexResponsesWebSocketSessionIdleTimeout-time.Minute), 0)
+	active := newStoredCodexWebSocketSession(now.Add(-codexResponsesWebSocketSessionIdleTimeout-time.Minute), 1)
+	store.sessions[codexWebSocketSessionKey{ConnectionID: "idle", ProviderID: 1}] = idle
+	store.sessions[codexWebSocketSessionKey{ConnectionID: "active", ProviderID: 2}] = active
+
+	store.pruneIdle(now)
+
+	if !idle.isClosed() {
+		t.Fatal("idle session was not closed")
+	}
+	if active.isClosed() {
+		t.Fatal("active session was closed by idle pruning")
+	}
+	if len(store.sessions) != 1 {
+		t.Fatalf("stored sessions = %d, want active session only", len(store.sessions))
+	}
+}
+
+func TestClassifyCodexWebSocketEvent_RootQuotaError(t *testing.T) {
+	proxyErr := classifyCodexWebSocketEvent(
+		[]byte(`{"type":"error","code":"insufficient_quota","message":"quota exhausted"}`),
+		"gpt-test",
+	)
+	if proxyErr.HTTPStatusCode != http.StatusTooManyRequests || proxyErr.Scope != domain.ScopeKey ||
+		proxyErr.Reason != domain.CooldownReasonRateLimitExceeded || proxyErr.Message != "quota exhausted" {
+		t.Fatalf("classified error = %#v", proxyErr)
+	}
+}
+
+func newStoredCodexWebSocketSession(lastUsed time.Time, activeTurns int32) *codexWebSocketSession {
+	session := &codexWebSocketSession{done: make(chan struct{})}
+	session.lastUsedAt.Store(lastUsed.UnixNano())
+	session.activeTurns.Store(activeTurns)
+	return session
+}
+
+func newCodexWebSocketTestContext(t *testing.T) *flow.Ctx {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/v1/responses", nil).WithContext(context.Background())
+	request.Header.Set("User-Agent", "codex-test/1.0")
 	c := flow.NewCtx(httptest.NewRecorder(), request)
 	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
 	c.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
 	c.Set(flow.KeyMappedModel, "gpt-test")
 	c.Set(flow.KeyIsStream, true)
-	c.Set(flow.KeyResponsesClientPath, "/v1/responses")
 	return c
 }

--- a/internal/adapter/provider/codex/websocket_unsupported_cache.go
+++ b/internal/adapter/provider/codex/websocket_unsupported_cache.go
@@ -1,0 +1,57 @@
+package codex
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const codexWebSocketUnsupportedTTL = 5 * time.Minute
+
+type codexWebSocketUnsupportedEntry struct {
+	reason    string
+	expiresAt time.Time
+}
+
+type codexWebSocketUnsupportedCache struct {
+	mu      sync.Mutex
+	entries map[string]codexWebSocketUnsupportedEntry
+}
+
+var globalCodexWebSocketUnsupported = &codexWebSocketUnsupportedCache{
+	entries: make(map[string]codexWebSocketUnsupportedEntry),
+}
+
+func codexWebSocketUnsupportedKey(providerID uint64, target string) string {
+	return fmt.Sprintf("%d:%s", providerID, target)
+}
+
+func markCodexWebSocketUnsupported(providerID uint64, target, reason string) {
+	globalCodexWebSocketUnsupported.mu.Lock()
+	globalCodexWebSocketUnsupported.entries[codexWebSocketUnsupportedKey(providerID, target)] = codexWebSocketUnsupportedEntry{
+		reason:    reason,
+		expiresAt: time.Now().Add(codexWebSocketUnsupportedTTL),
+	}
+	globalCodexWebSocketUnsupported.mu.Unlock()
+}
+
+func isCodexWebSocketUnsupported(providerID uint64, target string) bool {
+	key := codexWebSocketUnsupportedKey(providerID, target)
+	globalCodexWebSocketUnsupported.mu.Lock()
+	defer globalCodexWebSocketUnsupported.mu.Unlock()
+	entry, ok := globalCodexWebSocketUnsupported.entries[key]
+	if !ok {
+		return false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(globalCodexWebSocketUnsupported.entries, key)
+		return false
+	}
+	return true
+}
+
+func clearCodexWebSocketUnsupportedForTests() {
+	globalCodexWebSocketUnsupported.mu.Lock()
+	globalCodexWebSocketUnsupported.entries = make(map[string]codexWebSocketUnsupportedEntry)
+	globalCodexWebSocketUnsupported.mu.Unlock()
+}

--- a/internal/adapter/provider/responses_websocket.go
+++ b/internal/adapter/provider/responses_websocket.go
@@ -1,0 +1,22 @@
+package provider
+
+import (
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// ResponsesWebSocketAdapter is an optional native Responses WebSocket
+// transport capability. HTTP-only adapters must not implement it.
+type ResponsesWebSocketAdapter interface {
+	ExecuteResponsesWebSocket(
+		c *flow.Ctx,
+		provider *domain.Provider,
+		exchange *domain.ResponsesWebSocketExchange,
+	) (*domain.ResponsesWebSocketResult, error)
+}
+
+// ResponsesWebSocketSessionCleaner releases upstream sessions owned by one
+// downstream WebSocket connection.
+type ResponsesWebSocketSessionCleaner interface {
+	CloseResponsesWebSocketConnection(connectionID string)
+}

--- a/internal/context/responses_websocket.go
+++ b/internal/context/responses_websocket.go
@@ -6,8 +6,8 @@ import (
 
 type responsesWebSocketRequestKey struct{}
 
-// ResponsesWebSocketRequest carries the original downstream WebSocket event
-// alongside the HTTP/SSE fallback request built by the handler.
+// ResponsesWebSocketRequest carries the immutable response.create frame and
+// downstream WebSocket connection ID used by the control-plane request.
 type ResponsesWebSocketRequest struct {
 	SessionID string
 	Payload   []byte

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -18,18 +18,21 @@ var (
 	// every candidate was rejected because the requested model is not in the
 	// provider's SupportModels allowlist — a client-side request error (the model
 	// is disallowed), distinct from the transient ErrNoAvailableProviders.
-	ErrModelNotSupported   = errors.New("model not supported by any provider")
-	ErrAllRoutesFailed     = errors.New("all routes failed")
-	ErrFirstByteTimeout    = errors.New("first byte timeout")
-	ErrStreamIdleTimeout   = errors.New("stream idle timeout")
-	ErrUpstreamError       = errors.New("upstream error")
-	ErrFormatConversion    = errors.New("format conversion error")
-	ErrUnsupportedFormat   = errors.New("unsupported format")
-	ErrInviteCodeRequired  = errors.New("invite code required")
-	ErrInviteCodeInvalid   = errors.New("invite code invalid")
-	ErrInviteCodeExpired   = errors.New("invite code expired")
-	ErrInviteCodeExhausted = errors.New("invite code exhausted")
-	ErrInviteCodeDisabled  = errors.New("invite code disabled")
+	ErrModelNotSupported                    = errors.New("model not supported by any provider")
+	ErrAllRoutesFailed                      = errors.New("all routes failed")
+	ErrFirstByteTimeout                     = errors.New("first byte timeout")
+	ErrStreamIdleTimeout                    = errors.New("stream idle timeout")
+	ErrUpstreamError                        = errors.New("upstream error")
+	ErrFormatConversion                     = errors.New("format conversion error")
+	ErrUnsupportedFormat                    = errors.New("unsupported format")
+	ErrNoResponsesWebSocketProviders        = errors.New("no native responses websocket providers available")
+	ErrResponsesWebSocketSessionUnavailable = errors.New("responses websocket session unavailable")
+	ErrResponsesWebSocketProtocol           = errors.New("responses websocket protocol error")
+	ErrInviteCodeRequired                   = errors.New("invite code required")
+	ErrInviteCodeInvalid                    = errors.New("invite code invalid")
+	ErrInviteCodeExpired                    = errors.New("invite code expired")
+	ErrInviteCodeExhausted                  = errors.New("invite code exhausted")
+	ErrInviteCodeDisabled                   = errors.New("invite code disabled")
 )
 
 // ErrorScope defines what resource is broken, determining cooldown granularity

--- a/internal/domain/responses_websocket.go
+++ b/internal/domain/responses_websocket.go
@@ -1,0 +1,60 @@
+package domain
+
+// ResponsesWebSocketFrameSink writes upstream application frames to the
+// downstream WebSocket. Implementations must serialize writes.
+type ResponsesWebSocketFrameSink interface {
+	WriteTextFrame(payload []byte) error
+}
+
+// ResponsesWebSocketExchange describes one response.create turn on a
+// downstream WebSocket connection.
+type ResponsesWebSocketExchange struct {
+	ConnectionID       string
+	Frame              []byte
+	PreviousResponseID string
+	PinnedProviderID   uint64
+	Sink               ResponsesWebSocketFrameSink
+}
+
+type ResponsesWebSocketResult struct {
+	ProviderID uint64
+	Reused     bool
+
+	RequestFrameMayHaveBeenSent bool
+	FirstEventReceived          bool
+	ClientEventSent             bool
+	TerminalErrorEventSent      bool
+
+	TerminalEvent string
+	ResponseModel string
+}
+
+type ResponsesWebSocketAttemptError struct {
+	Err error
+
+	SafeToTryNextProvider       bool
+	RequestFrameMayHaveBeenSent bool
+	FirstEventReceived          bool
+	ClientEventSent             bool
+	TerminalErrorEventSent      bool
+	CapabilityFailure           bool
+}
+
+func (e *ResponsesWebSocketAttemptError) Error() string {
+	if e == nil || e.Err == nil {
+		return "responses websocket attempt failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *ResponsesWebSocketAttemptError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *ResponsesWebSocketAttemptError) CanTryNextProvider() bool {
+	return e != nil && e.SafeToTryNextProvider &&
+		!e.RequestFrameMayHaveBeenSent && !e.FirstEventReceived && !e.ClientEventSent
+}

--- a/internal/domain/responses_websocket_test.go
+++ b/internal/domain/responses_websocket_test.go
@@ -1,0 +1,23 @@
+package domain
+
+import "testing"
+
+func TestResponsesWebSocketAttemptError_SafeRetryInvariant(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *ResponsesWebSocketAttemptError
+		want bool
+	}{
+		{name: "pre-send", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true}, want: true},
+		{name: "may have sent", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, RequestFrameMayHaveBeenSent: true}},
+		{name: "event received", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, FirstEventReceived: true}},
+		{name: "client event sent", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, ClientEventSent: true}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.err.CanTryNextProvider(); got != test.want {
+				t.Fatalf("CanTryNextProvider = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -71,6 +71,12 @@ func (e *Executor) Use(handlers ...flow.HandlerFunc) {
 	e.middlewares = append(e.middlewares, handlers...)
 }
 
+func (e *Executor) CloseResponsesWebSocketConnection(connectionID string) {
+	if e != nil && e.router != nil {
+		e.router.CloseResponsesWebSocketConnection(connectionID)
+	}
+}
+
 // Execute runs the executor middleware chain with a new flow context.
 func (e *Executor) Execute(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	c := flow.NewCtx(w, req)

--- a/internal/executor/flow_state.go
+++ b/internal/executor/flow_state.go
@@ -29,6 +29,7 @@ type execState struct {
 	originalRequestBody []byte
 	requestHeaders      http.Header
 	requestURI          string
+	wsExchange          *domain.ResponsesWebSocketExchange
 }
 
 func getExecState(c *flow.Ctx) (*execState, bool) {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -30,6 +30,10 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 	proxyReq := state.proxyReq
 	ctx := state.ctx
 	clearDetail := e.shouldClearRequestDetailFor(state)
+	if state.wsExchange != nil {
+		e.dispatchResponsesWebSocket(c)
+		return
+	}
 
 	// Pre-warm tokens for all matched routes in parallel.
 	// This avoids serial token refresh delays when failing over between providers.

--- a/internal/executor/middleware_dispatch_websocket.go
+++ b/internal/executor/middleware_dispatch_websocket.go
@@ -1,0 +1,223 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/pricing"
+	"github.com/awsl-project/maxx/internal/sticky"
+	"github.com/tidwall/sjson"
+)
+
+func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
+	state, ok := getExecState(c)
+	if !ok || state.wsExchange == nil || state.proxyReq == nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrInvalidState, false, "responses websocket dispatch state missing")
+		proxyErr.Scope = domain.ScopeRequest
+		if state != nil {
+			state.lastErr = proxyErr
+		}
+		c.Err = proxyErr
+		return
+	}
+
+	exchange := state.wsExchange
+	proxyReq := state.proxyReq
+	ctx := state.ctx
+	clearDetail := e.shouldClearRequestDetailFor(state)
+	var lastAttemptErr error
+
+	for _, matched := range state.routes {
+		if ctx.Err() != nil {
+			state.lastErr = ctx.Err()
+			c.Err = state.lastErr
+			return
+		}
+		if matched == nil || matched.Route == nil || matched.Provider == nil || matched.ProviderAdapter == nil || !matched.Route.IsNative {
+			continue
+		}
+		wsAdapter, ok := matched.ProviderAdapter.(provideradapter.ResponsesWebSocketAdapter)
+		if !ok {
+			continue
+		}
+
+		mappedModel := e.mapModel(
+			state.tenantID,
+			state.requestModel,
+			matched.Route,
+			matched.Provider,
+			domain.ClientTypeCodex,
+			state.projectID,
+			state.apiTokenID,
+		)
+		outboundFrame, err := sjson.SetBytes(bytes.Clone(exchange.Frame), "model", mappedModel)
+		if err != nil {
+			proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "failed to map websocket request model")
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.Code = "websocket_protocol_error"
+			proxyErr.HTTPStatusCode = http.StatusBadRequest
+			state.lastErr = proxyErr
+			c.Err = proxyErr
+			return
+		}
+		outboundFrame = e.applyOutboundParamPolicy(outboundFrame, domain.ClientTypeCodex, mappedModel, matched.Provider)
+		turnExchange := *exchange
+		turnExchange.Frame = outboundFrame
+
+		proxyReq.RouteID = matched.Route.ID
+		proxyReq.ProviderID = matched.Provider.ID
+		proxyReq.MappedModel = mappedModel
+		_ = e.proxyRequestRepo.Update(proxyReq)
+
+		attempt := &domain.ProxyUpstreamAttempt{
+			TenantID:       proxyReq.TenantID,
+			ProxyRequestID: proxyReq.ID,
+			RouteID:        matched.Route.ID,
+			ProviderID:     matched.Provider.ID,
+			IsStream:       true,
+			Status:         "IN_PROGRESS",
+			StartTime:      time.Now(),
+			RequestModel:   state.requestModel,
+			MappedModel:    mappedModel,
+			RequestInfo:    proxyReq.RequestInfo,
+		}
+		if attempt.TenantID == 0 {
+			attempt.TenantID = state.tenantID
+		}
+		if err := e.attemptRepo.Create(attempt); err != nil {
+			proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to create websocket upstream attempt")
+			proxyErr.Scope = domain.ScopeRequest
+			state.lastErr = proxyErr
+			c.Err = proxyErr
+			return
+		}
+		if e.broadcaster != nil {
+			e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+		}
+		state.currentAttempt = attempt
+		proxyReq.ProxyUpstreamAttemptCount++
+
+		eventChan := domain.NewAdapterEventChan()
+		c.Set(flow.KeyClientType, domain.ClientTypeCodex)
+		c.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
+		c.Set(flow.KeyMappedModel, mappedModel)
+		c.Set(flow.KeyEventChan, eventChan)
+		c.Set(flow.KeyProxyRequest, proxyReq)
+		c.Set(flow.KeyUpstreamAttempt, attempt)
+		c.Set(flow.KeyBroadcaster, e.broadcaster)
+		eventDone := make(chan struct{})
+		go e.processAdapterEventsRealtime(eventChan, attempt, eventDone, clearDetail)
+
+		result, execErr := wsAdapter.ExecuteResponsesWebSocket(c, matched.Provider, &turnExchange)
+		eventChan.Close()
+		<-eventDone
+
+		attempt.EndTime = time.Now()
+		attempt.Duration = attempt.EndTime.Sub(attempt.StartTime)
+		multiplier := getProviderMultiplier(matched.Provider, domain.ClientTypeCodex)
+
+		if execErr == nil {
+			attempt.Status = "COMPLETED"
+			attempt.Error = ""
+			if result != nil && result.ResponseModel != "" {
+				attempt.ResponseModel = result.ResponseModel
+			}
+			pricing.FinalizeAttemptCost(attempt, multiplier)
+			if clearDetail {
+				attempt.RequestInfo = nil
+				attempt.ResponseInfo = nil
+			}
+			_ = e.attemptRepo.Update(attempt)
+			if e.broadcaster != nil {
+				e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+			}
+			state.currentAttempt = nil
+			cooldown.Default().RecordSuccess(matched.Provider.ID, string(domain.ClientTypeCodex), mappedModel)
+
+			if state.stickyWrite != nil {
+				stickyCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+				_ = sticky.Default().Set(stickyCtx, state.stickyWrite.Key, matched.Provider.ID, state.stickyWrite.TTL)
+				cancel()
+			}
+
+			exchange.PinnedProviderID = matched.Provider.ID
+			proxyReq.Status = "COMPLETED"
+			proxyReq.StatusCode = http.StatusSwitchingProtocols
+			proxyReq.EndTime = time.Now()
+			proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
+			proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
+			proxyReq.ResponseModel = attempt.ResponseModel
+			if proxyReq.ResponseModel == "" {
+				proxyReq.ResponseModel = mappedModel
+			}
+			if !clearDetail {
+				proxyReq.ResponseInfo = attempt.ResponseInfo
+			}
+			pricing.MirrorCostToRequest(proxyReq, attempt)
+			proxyReq.TTFT = attempt.TTFT
+			clearProxyRequestDetail(proxyReq, clearDetail)
+			_ = e.proxyRequestRepo.Update(proxyReq)
+			if e.broadcaster != nil {
+				e.broadcaster.BroadcastProxyRequest(proxyReq)
+			}
+			state.lastErr = nil
+			state.ctx = ctx
+			return
+		}
+
+		attempt.Status = attemptFailureStatus(ctx, execErr)
+		attempt.Error = execErr.Error()
+		pricing.FinalizeAttemptCost(attempt, multiplier)
+		if clearDetail {
+			attempt.RequestInfo = nil
+			attempt.ResponseInfo = nil
+		}
+		_ = e.attemptRepo.Update(attempt)
+		if e.broadcaster != nil {
+			e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+		}
+		state.currentAttempt = nil
+		proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
+		pricing.MirrorCostToRequest(proxyReq, attempt)
+		proxyReq.TTFT = attempt.TTFT
+		_ = e.proxyRequestRepo.Update(proxyReq)
+
+		var wsErr *domain.ResponsesWebSocketAttemptError
+		errors.As(execErr, &wsErr)
+		if proxyErr, ok := asProxyError(execErr); ok && (wsErr == nil || !wsErr.CapabilityFailure) &&
+			ctx.Err() == nil && !shouldSkipErrorCooldown(matched.Provider) {
+			e.handleCooldown(proxyErr, matched.Provider, domain.ClientTypeCodex, mappedModel)
+		}
+		if wsErr != nil && exchange.PinnedProviderID == 0 &&
+			exchange.PreviousResponseID == "" && wsErr.CanTryNextProvider() {
+			lastAttemptErr = execErr
+			continue
+		}
+		state.lastErr = execErr
+		c.Err = execErr
+		return
+	}
+	if lastAttemptErr != nil {
+		state.lastErr = lastAttemptErr
+		c.Err = lastAttemptErr
+		return
+	}
+
+	proxyErr := domain.NewProxyErrorWithMessage(
+		domain.ErrNoResponsesWebSocketProviders,
+		true,
+		"all native Codex Responses WebSocket providers were exhausted before request submission",
+	)
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.Code = "websocket_transport_unavailable"
+	proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+	state.lastErr = proxyErr
+	c.Err = proxyErr
+}

--- a/internal/executor/middleware_dispatch_websocket_test.go
+++ b/internal/executor/middleware_dispatch_websocket_test.go
@@ -1,0 +1,375 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+	"github.com/tidwall/gjson"
+)
+
+// recordingWSAdapter records whether HTTP Execute or native WS dispatch ran.
+// errSequence is drained one error per ExecuteResponsesWebSocket call; once
+// exhausted the adapter succeeds.
+type recordingWSAdapter struct {
+	httpExecuteCalls int
+	wsCalls          int
+	errSequence      []error
+	lastFrame        []byte
+	resultModel      string
+}
+
+func (a *recordingWSAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeCodex}
+}
+
+func (a *recordingWSAdapter) Execute(*flow.Ctx, *domain.Provider) error {
+	a.httpExecuteCalls++
+	return errors.New("HTTP Execute must not run on native Responses WebSocket path")
+}
+
+func (a *recordingWSAdapter) ExecuteResponsesWebSocket(
+	_ *flow.Ctx,
+	provider *domain.Provider,
+	exchange *domain.ResponsesWebSocketExchange,
+) (*domain.ResponsesWebSocketResult, error) {
+	a.wsCalls++
+	if exchange != nil {
+		a.lastFrame = append([]byte(nil), exchange.Frame...)
+	}
+	if len(a.errSequence) > 0 {
+		err := a.errSequence[0]
+		a.errSequence = a.errSequence[1:]
+		return nil, err
+	}
+	model := a.resultModel
+	if model == "" {
+		model = gjson.GetBytes(exchange.Frame, "model").String()
+	}
+	return &domain.ResponsesWebSocketResult{
+		ProviderID:    provider.ID,
+		ResponseModel: model,
+	}, nil
+}
+
+func newWSDispatchExecutor(proxyRepo *recordingProxyRequestRepo, attemptRepo *recordingAttemptRepo) *Executor {
+	return &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &stubModelMappingRepo{},
+		settingsRepo:     &stubExecutorSettingsRepo{},
+	}
+}
+
+func newWSDispatchCtx(
+	t *testing.T,
+	frame []byte,
+	exchange *domain.ResponsesWebSocketExchange,
+	routes []*router.MatchedRoute,
+) (*flow.Ctx, *recordingProxyRequestRepo, *recordingAttemptRepo) {
+	t.Helper()
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses", nil).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	if exchange == nil {
+		exchange = &domain.ResponsesWebSocketExchange{
+			ConnectionID: "ws-conn-test",
+			Frame:        frame,
+		}
+	} else if exchange.Frame == nil {
+		exchange.Frame = frame
+	}
+	proxyReq := &domain.ProxyRequest{
+		ID:           501,
+		TenantID:     domain.DefaultTenantID,
+		ClientType:   domain.ClientTypeCodex,
+		RequestModel: "gpt-test",
+		Status:       "IN_PROGRESS",
+		StartTime:    time.Now(),
+	}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeCodex,
+		requestModel: "gpt-test",
+		isStream:     true,
+		requestBody:  frame,
+		requestURI:   "/v1/responses",
+		routes:       routes,
+		wsExchange:   exchange,
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c, proxyRepo, attemptRepo
+}
+
+func wsMatchedRoute(id, providerID uint64, adapter *recordingWSAdapter, native bool) *router.MatchedRoute {
+	return &router.MatchedRoute{
+		Route: &domain.Route{
+			ID:         id,
+			TenantID:   domain.DefaultTenantID,
+			ProviderID: providerID,
+			ClientType: domain.ClientTypeCodex,
+			IsNative:   native,
+		},
+		Provider: &domain.Provider{
+			ID:                   providerID,
+			TenantID:             domain.DefaultTenantID,
+			Type:                 "codex",
+			Name:                 "ws-provider",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+		ProviderAdapter: adapter,
+		RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	}
+}
+
+func preWriteWSErr() *domain.ResponsesWebSocketAttemptError {
+	return &domain.ResponsesWebSocketAttemptError{
+		Err:                   errors.New("handshake failed before request frame write"),
+		SafeToTryNextProvider: true,
+	}
+}
+
+func postWriteWSErr(flags domain.ResponsesWebSocketAttemptError) *domain.ResponsesWebSocketAttemptError {
+	flags.Err = errors.New("attempt failed after downstream commitment")
+	if !flags.SafeToTryNextProvider {
+		// Keep the flag true so tests assert the secondary safety gates
+		// (frame sent / first event / client write), not SafeToTryNext alone.
+		flags.SafeToTryNextProvider = true
+	}
+	return &flags
+}
+
+// dispatch must take the native WS path and never call ProviderAdapter.Execute.
+func TestDispatch_ResponsesWebSocketBypassesHTTPExecute(t *testing.T) {
+	adapter := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, 11, adapter, true),
+	})
+	e := newWSDispatchExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	if adapter.httpExecuteCalls != 0 {
+		t.Fatalf("HTTP Execute calls = %d, want 0", adapter.httpExecuteCalls)
+	}
+	if adapter.wsCalls != 1 {
+		t.Fatalf("ExecuteResponsesWebSocket calls = %d, want 1", adapter.wsCalls)
+	}
+	if len(attemptRepo.created) != 1 {
+		t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
+	}
+	if len(proxyRepo.updated) == 0 {
+		t.Fatal("expected proxy request updates")
+	}
+	last := proxyRepo.updated[len(proxyRepo.updated)-1]
+	if last.Status != "COMPLETED" {
+		t.Fatalf("proxy status = %q, want COMPLETED", last.Status)
+	}
+	if last.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("proxy status code = %d, want 101", last.StatusCode)
+	}
+	state, ok := getExecState(c)
+	if !ok || state.wsExchange == nil {
+		t.Fatal("missing exec state / ws exchange")
+	}
+	if state.wsExchange.PinnedProviderID != 11 {
+		t.Fatalf("PinnedProviderID = %d, want 11 after success", state.wsExchange.PinnedProviderID)
+	}
+}
+
+// Failover is allowed only while the attempt is still pre-write / pre-event.
+func TestDispatch_ResponsesWebSocketFailsOverBeforeClientWrite(t *testing.T) {
+	first := &recordingWSAdapter{errSequence: []error{preWriteWSErr()}}
+	second := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, 21, first, true),
+		wsMatchedRoute(2, 22, second, true),
+	})
+	e := newWSDispatchExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	if first.httpExecuteCalls != 0 || second.httpExecuteCalls != 0 {
+		t.Fatalf("HTTP Execute calls first=%d second=%d, want 0/0", first.httpExecuteCalls, second.httpExecuteCalls)
+	}
+	if first.wsCalls != 1 || second.wsCalls != 1 {
+		t.Fatalf("WS calls first=%d second=%d, want 1/1 (pre-write failover)", first.wsCalls, second.wsCalls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	}
+	if attemptRepo.created[0].ProviderID != 21 || attemptRepo.created[1].ProviderID != 22 {
+		t.Fatalf("attempt providers = [%d %d], want [21 22]",
+			attemptRepo.created[0].ProviderID, attemptRepo.created[1].ProviderID)
+	}
+	state, _ := getExecState(c)
+	if state.wsExchange.PinnedProviderID != 22 {
+		t.Fatalf("PinnedProviderID = %d, want second provider 22", state.wsExchange.PinnedProviderID)
+	}
+	last := proxyRepo.updated[len(proxyRepo.updated)-1]
+	if last.Status != "COMPLETED" || last.ProviderID != 22 {
+		t.Fatalf("final proxy = status=%s provider=%d, want COMPLETED/22", last.Status, last.ProviderID)
+	}
+}
+
+func TestDispatch_ResponsesWebSocketRecordsCooldownBeforeFailover(t *testing.T) {
+	const firstProviderID = uint64(920021)
+	cooldown.Default().ClearCooldown(firstProviderID, string(domain.ClientTypeCodex), "")
+	t.Cleanup(func() {
+		cooldown.Default().ClearCooldown(firstProviderID, string(domain.ClientTypeCodex), "")
+	})
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New("dial failed"), true, "dial failed")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonNetworkError
+	proxyErr.HTTPStatusCode = http.StatusBadGateway
+	first := &recordingWSAdapter{errSequence: []error{&domain.ResponsesWebSocketAttemptError{
+		Err:                   proxyErr,
+		SafeToTryNextProvider: true,
+	}}}
+	second := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, firstProviderID, first, true),
+		wsMatchedRoute(2, firstProviderID+1, second, true),
+	})
+	e := newWSDispatchExecutor(proxyRepo, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	if !cooldown.Default().IsInCooldown(firstProviderID, string(domain.ClientTypeCodex), "") {
+		t.Fatal("pre-write provider failure did not enter cooldown before failover")
+	}
+}
+
+// After a downstream frame/client write (or first event), failover is forbidden.
+func TestDispatch_ResponsesWebSocketNoFailoverAfterClientWrite(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *domain.ResponsesWebSocketAttemptError
+	}{
+		{
+			name: "client_event_sent",
+			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{ClientEventSent: true}),
+		},
+		{
+			name: "first_event_received",
+			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{FirstEventReceived: true}),
+		},
+		{
+			name: "request_frame_may_have_been_sent",
+			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{RequestFrameMayHaveBeenSent: true}),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			first := &recordingWSAdapter{errSequence: []error{tc.err}}
+			second := &recordingWSAdapter{resultModel: "gpt-test"}
+			frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+			c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+				wsMatchedRoute(1, 31, first, true),
+				wsMatchedRoute(2, 32, second, true),
+			})
+			e := newWSDispatchExecutor(proxyRepo, attemptRepo)
+
+			e.dispatch(c)
+
+			if c.Err == nil {
+				t.Fatal("expected dispatch error without failover")
+			}
+			if !errors.Is(c.Err, tc.err) {
+				t.Fatalf("c.Err = %v, want %v", c.Err, tc.err)
+			}
+			if first.wsCalls != 1 {
+				t.Fatalf("first WS calls = %d, want 1", first.wsCalls)
+			}
+			if second.wsCalls != 0 {
+				t.Fatalf("second WS calls = %d, want 0 (no failover after client/write commitment)", second.wsCalls)
+			}
+			if first.httpExecuteCalls != 0 || second.httpExecuteCalls != 0 {
+				t.Fatalf("HTTP Execute must stay unused; first=%d second=%d", first.httpExecuteCalls, second.httpExecuteCalls)
+			}
+			if len(attemptRepo.created) != 1 {
+				t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
+			}
+			_ = proxyRepo
+		})
+	}
+}
+
+// A pinned session must not fail over even when the error is still "safe".
+func TestDispatch_ResponsesWebSocketNoFailoverWhenPinned(t *testing.T) {
+	first := &recordingWSAdapter{errSequence: []error{preWriteWSErr()}}
+	second := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	exchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID:     "ws-conn-pinned",
+		Frame:            frame,
+		PinnedProviderID: 41,
+	}
+	c, _, attemptRepo := newWSDispatchCtx(t, frame, exchange, []*router.MatchedRoute{
+		wsMatchedRoute(1, 41, first, true),
+		wsMatchedRoute(2, 42, second, true),
+	})
+	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected error when pinned provider fails")
+	}
+	if first.wsCalls != 1 || second.wsCalls != 0 {
+		t.Fatalf("WS calls first=%d second=%d, want 1/0 with pin", first.wsCalls, second.wsCalls)
+	}
+	if len(attemptRepo.created) != 1 || attemptRepo.created[0].ProviderID != 41 {
+		t.Fatalf("attempts = %#v, want single attempt on pinned provider 41", attemptRepo.created)
+	}
+}
+
+// Non-native routes are skipped even if the adapter implements the WS interface.
+func TestDispatch_ResponsesWebSocketSkipsNonNativeRoutes(t *testing.T) {
+	nonNative := &recordingWSAdapter{resultModel: "should-not-run"}
+	native := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, _, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, 51, nonNative, false),
+		wsMatchedRoute(2, 52, native, true),
+	})
+	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, attemptRepo)
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	if nonNative.wsCalls != 0 {
+		t.Fatalf("non-native WS calls = %d, want 0", nonNative.wsCalls)
+	}
+	if native.wsCalls != 1 {
+		t.Fatalf("native WS calls = %d, want 1", native.wsCalls)
+	}
+	if len(attemptRepo.created) != 1 || attemptRepo.created[0].ProviderID != 52 {
+		t.Fatalf("attempts = %#v, want provider 52 only", attemptRepo.created)
+	}
+}

--- a/internal/executor/middleware_ingress.go
+++ b/internal/executor/middleware_ingress.go
@@ -86,6 +86,24 @@ func (e *Executor) ingress(c *flow.Ctx) {
 			state.requestURI = uri
 		}
 	}
+	state.wsExchange = flow.GetResponsesWebSocketExchange(c)
+	if state.wsExchange != nil {
+		if state.clientType != domain.ClientTypeCodex {
+			proxyErr := domain.NewProxyErrorWithMessage(
+				domain.ErrResponsesWebSocketProtocol,
+				false,
+				"responses websocket request was not detected as Codex",
+			)
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.Code = "websocket_protocol_error"
+			proxyErr.HTTPStatusCode = http.StatusBadRequest
+			state.lastErr = proxyErr
+			c.Err = proxyErr
+			c.Abort()
+			return
+		}
+		state.isStream = true
+	}
 
 	state.ctx = ctx
 

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -21,14 +21,21 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		return
 	}
 
+	requireWS := state.wsExchange != nil
+	requiredProviderID := uint64(0)
+	if requireWS {
+		requiredProviderID = state.wsExchange.PinnedProviderID
+	}
 	result, err := e.router.Match(&router.MatchContext{
-		Ctx:          state.ctx,
-		TenantID:     state.tenantID,
-		ClientType:   state.clientType,
-		ProjectID:    state.projectID,
-		RequestModel: state.requestModel,
-		APITokenID:   state.apiTokenID,
-		SessionID:    state.sessionID,
+		Ctx:                       state.ctx,
+		TenantID:                  state.tenantID,
+		ClientType:                state.clientType,
+		ProjectID:                 state.projectID,
+		RequestModel:              state.requestModel,
+		APITokenID:                state.apiTokenID,
+		SessionID:                 state.sessionID,
+		RequireResponsesWebSocket: requireWS,
+		RequiredProviderID:        requiredProviderID,
 	})
 	if err != nil {
 		// Default: the match failed for a transient/server reason (no routes, all
@@ -39,7 +46,17 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		status := http.StatusServiceUnavailable
 
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
-		if errors.Is(err, domain.ErrModelNotSupported) {
+		if errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
+			message = "no native Codex Responses WebSocket provider is available"
+			status = http.StatusServiceUnavailable
+			proxyErr = domain.NewProxyErrorWithMessage(err, true, message)
+			proxyErr.Code = "websocket_transport_unavailable"
+		} else if errors.Is(err, domain.ErrResponsesWebSocketSessionUnavailable) {
+			message = "the pinned Codex WebSocket provider/session is unavailable"
+			status = http.StatusBadGateway
+			proxyErr = domain.NewProxyErrorWithMessage(err, false, message)
+			proxyErr.Code = "websocket_session_unavailable"
+		} else if errors.Is(err, domain.ErrModelNotSupported) {
 			message = fmt.Sprintf("model %q is not supported by any configured provider", state.requestModel)
 			status = http.StatusBadRequest
 			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrModelNotSupported, false, message)

--- a/internal/flow/helpers.go
+++ b/internal/flow/helpers.go
@@ -186,3 +186,15 @@ func GetBroadcaster(c *Ctx) event.Broadcaster {
 	}
 	return nil
 }
+
+func GetResponsesWebSocketExchange(c *Ctx) *domain.ResponsesWebSocketExchange {
+	if c == nil {
+		return nil
+	}
+	v, ok := c.Get(KeyResponsesWebSocketExchange)
+	if !ok {
+		return nil
+	}
+	exchange, _ := v.(*domain.ResponsesWebSocketExchange)
+	return exchange
+}

--- a/internal/flow/keys.go
+++ b/internal/flow/keys.go
@@ -20,12 +20,13 @@ const (
 	// — path + query (e.g. "/v1/responses" or "/responses?source=codex-cli") —
 	// captured before any /v1 normalization, so a custom Codex downstream can be
 	// forwarded the path the client actually used instead of a hardcoded one.
-	KeyResponsesClientPath = "responses_client_path"
-	KeyIsStream            = "is_stream"
-	KeyAPITokenID          = "api_token_id"
-	KeyAPITokenDevMode     = "api_token_dev_mode"
-	KeyProxyRequest        = "proxy_request"
-	KeyUpstreamAttempt     = "upstream_attempt"
-	KeyEventChan           = "event_chan"
-	KeyBroadcaster         = "broadcaster"
+	KeyResponsesClientPath        = "responses_client_path"
+	KeyIsStream                   = "is_stream"
+	KeyAPITokenID                 = "api_token_id"
+	KeyAPITokenDevMode            = "api_token_dev_mode"
+	KeyProxyRequest               = "proxy_request"
+	KeyUpstreamAttempt            = "upstream_attempt"
+	KeyEventChan                  = "event_chan"
+	KeyBroadcaster                = "broadcaster"
+	KeyResponsesWebSocketExchange = "responses_websocket_exchange"
 )

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -104,15 +104,19 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if h.uploadLimiter != nil {
 			readLimit = h.uploadLimiter.maxBytes
 		}
-		serveResponsesWebSocket(w, r, h, readLimit)
+		h.serveResponsesWebSocket(w, r, readLimit)
 		return
 	}
 
 	ctx := flow.NewCtx(w, r)
+	h.engine.HandleWith(ctx, h.proxyHandlers()...)
+}
+
+func (h *ProxyHandler) proxyHandlers() []flow.HandlerFunc {
 	handlers := make([]flow.HandlerFunc, len(h.extra)+1)
 	copy(handlers, h.extra)
 	handlers[len(h.extra)] = h.dispatch
-	h.engine.HandleWith(ctx, handlers...)
+	return handlers
 }
 
 func (h *ProxyHandler) ingress(c *flow.Ctx) {
@@ -355,6 +359,11 @@ func (h *ProxyHandler) dispatch(c *flow.Ctx) {
 
 	err := h.executor.ExecuteWith(c)
 	if err == nil {
+		return
+	}
+	if flow.GetResponsesWebSocketExchange(c) != nil {
+		c.Err = err
+		c.Abort()
 		return
 	}
 	proxyErr, ok := asHandlerProxyError(err)

--- a/internal/handler/responses_websocket.go
+++ b/internal/handler/responses_websocket.go
@@ -2,47 +2,88 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	stdjson "encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
+	"net/url"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/jsonutil"
-	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const (
 	responsesWebSocketRequestCreate = "response.create"
-	responsesWebSocketRequestAppend = "response.append"
+	responsesWSMaxPendingFrames     = 64
+	responsesWSMaxPendingBytes      = 64 << 20
+	responsesWSWriteTimeout         = 30 * time.Second
 )
 
 var responsesWebSocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
-	CheckOrigin: func(*http.Request) bool {
-		return true
-	},
+	CheckOrigin:     checkResponsesWebSocketOrigin,
 }
 
-type responsesWebSocketSessionState struct {
-	initialized        bool
-	lastInput          []sonic.NoCopyRawMessage
-	model              sonic.NoCopyRawMessage
-	instructions       sonic.NoCopyRawMessage
-	lastResponseOutput []stdjson.RawMessage
+type responsesWebSocketClient struct {
+	conn      *websocket.Conn
+	writeMu   sync.Mutex
+	closeOnce sync.Once
+	done      chan struct{}
 }
 
-type responsesWebSocketNormalizedRequest struct {
-	body         []byte
-	input        []sonic.NoCopyRawMessage
-	model        sonic.NoCopyRawMessage
-	instructions sonic.NoCopyRawMessage
+func newResponsesWebSocketClient(conn *websocket.Conn) *responsesWebSocketClient {
+	return &responsesWebSocketClient{conn: conn, done: make(chan struct{})}
+}
+
+func (c *responsesWebSocketClient) WriteTextFrame(payload []byte) error {
+	if c == nil || c.conn == nil {
+		return errors.New("downstream websocket is unavailable")
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if err := c.conn.SetWriteDeadline(time.Now().Add(responsesWSWriteTimeout)); err != nil {
+		return err
+	}
+	return c.conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+func (c *responsesWebSocketClient) writeControl(messageType int, payload []byte) error {
+	if c == nil || c.conn == nil {
+		return errors.New("downstream websocket is unavailable")
+	}
+	return c.conn.WriteControl(messageType, payload, time.Now().Add(10*time.Second))
+}
+
+func (c *responsesWebSocketClient) close(code int, reason string) {
+	if c == nil {
+		return
+	}
+	c.closeOnce.Do(func() {
+		close(c.done)
+		if c.conn != nil {
+			_ = c.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, reason), time.Now().Add(10*time.Second))
+			_ = c.conn.Close()
+		}
+	})
+}
+
+type responsesWebSocketInboundFrame struct {
+	payload []byte
+	size    int64
 }
 
 func isResponsesWebSocketUpgrade(r *http.Request) bool {
@@ -52,469 +93,296 @@ func isResponsesWebSocketUpgrade(r *http.Request) bool {
 	return r.URL.Path == "/v1/responses" || r.URL.Path == "/responses"
 }
 
-func serveResponsesWebSocket(w http.ResponseWriter, r *http.Request, next http.Handler, readLimit int64) {
-	if next == nil {
+func checkResponsesWebSocketOrigin(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return true
+	}
+	parsed, err := url.Parse(origin)
+	if err == nil && strings.EqualFold(parsed.Host, r.Host) {
+		return true
+	}
+	return ParseCORSOrigins(os.Getenv("MAXX_CORS_ALLOW_ORIGINS")).allows(strings.TrimRight(origin, "/"))
+}
+
+func (c *responsesWebSocketClient) readPump(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	frames chan<- responsesWebSocketInboundFrame,
+	queuedBytes *atomic.Int64,
+	readLimit int64,
+) {
+	defer close(frames)
+	defer cancel()
+	c.conn.SetReadLimit(responsesWebSocketReadLimit(readLimit))
+	c.conn.SetPingHandler(func(data string) error {
+		return c.writeControl(websocket.PongMessage, []byte(data))
+	})
+	for {
+		messageType, payload, err := c.conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		if messageType != websocket.TextMessage {
+			_ = writeResponsesWebSocketClientError(c, http.StatusBadRequest, "binary websocket frames are not supported", nil)
+			c.close(websocket.CloseUnsupportedData, "text frames required")
+			return
+		}
+		size := int64(len(payload))
+		if queuedBytes.Add(size) > responsesWSMaxPendingBytes {
+			queuedBytes.Add(-size)
+			_ = writeResponsesWebSocketClientError(c, http.StatusTooManyRequests, "websocket request queue byte limit exceeded", nil)
+			c.close(websocket.ClosePolicyViolation, "request queue limit exceeded")
+			return
+		}
+		select {
+		case frames <- responsesWebSocketInboundFrame{payload: payload, size: size}:
+		case <-ctx.Done():
+			queuedBytes.Add(-size)
+			return
+		default:
+			queuedBytes.Add(-size)
+			_ = writeResponsesWebSocketClientError(c, http.StatusTooManyRequests, "websocket request queue is full", nil)
+			c.close(websocket.ClosePolicyViolation, "request queue is full")
+			return
+		}
+	}
+}
+
+func responsesWebSocketReadLimit(configured int64) int64 {
+	if configured <= 0 || configured > responsesWSMaxPendingBytes {
+		return responsesWSMaxPendingBytes
+	}
+	return configured
+}
+
+func (h *ProxyHandler) serveResponsesWebSocket(w http.ResponseWriter, r *http.Request, readLimit int64) {
+	if h == nil || h.engine == nil || h.executor == nil {
 		writeError(w, http.StatusInternalServerError, "responses websocket proxy is not configured")
 		return
 	}
-
 	conn, err := responsesWebSocketUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
 	}
-	defer conn.Close()
-	if readLimit > 0 {
-		conn.SetReadLimit(readLimit)
+	client := newResponsesWebSocketClient(conn)
+	connectionID := uuid.NewString()
+	connectionCtx, cancel := context.WithCancel(r.Context())
+	frames := make(chan responsesWebSocketInboundFrame, responsesWSMaxPendingFrames)
+	var queuedBytes atomic.Int64
+	go client.readPump(connectionCtx, cancel, frames, &queuedBytes, readLimit)
+	defer func() {
+		cancel()
+		h.executor.CloseResponsesWebSocketConnection(connectionID)
+		client.close(websocket.CloseNormalClosure, "")
+	}()
+
+	exchange := &domain.ResponsesWebSocketExchange{
+		ConnectionID: connectionID,
+		Sink:         client,
 	}
-
-	state := &responsesWebSocketSessionState{}
-	sessionID := uuid.NewString()
 	for {
-		messageType, payload, errRead := conn.ReadMessage()
-		if errRead != nil {
+		select {
+		case <-connectionCtx.Done():
 			return
-		}
-		if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
-			continue
-		}
-
-		normalized, errNormalize := state.normalizeRequest(payload)
-		if errNormalize != nil {
-			if errWrite := writeResponsesWebSocketError(conn, http.StatusBadRequest, errNormalize.Error(), nil); errWrite != nil {
+		case frame, ok := <-frames:
+			if !ok {
 				return
 			}
-			continue
-		}
-
-		request := newResponsesWebSocketHTTPRequest(r, normalized.body, sessionID, payload)
-		writer := newResponsesWebSocketResponseWriter(conn)
-		next.ServeHTTP(writer, request)
-		if errFinish := writer.finish(); errFinish != nil {
-			return
-		}
-		if writer.completed {
-			state.initialized = true
-			state.lastInput = normalized.input
-			state.model = normalized.model
-			state.instructions = normalized.instructions
-			state.lastResponseOutput = writer.completedOutput
+			queuedBytes.Add(-frame.size)
+			previousResponseID, errValidate := validateResponsesWebSocketFrame(frame.payload)
+			if errValidate != nil {
+				if writeErr := writeResponsesWebSocketClientError(client, http.StatusBadRequest, errValidate.Error(), nil); writeErr != nil {
+					return
+				}
+				continue
+			}
+			logicalBody, errBody := responsesWebSocketLogicalBody(frame.payload)
+			if errBody != nil {
+				if writeErr := writeResponsesWebSocketClientError(client, http.StatusBadRequest, errBody.Error(), nil); writeErr != nil {
+					return
+				}
+				continue
+			}
+			exchange.Frame = frame.payload
+			exchange.PreviousResponseID = previousResponseID
+			flowCtx, writer := h.runResponsesWebSocketTurn(r, connectionCtx, logicalBody, exchange)
+			if flowCtx.Err == nil {
+				continue
+			}
+			if responsesWebSocketErrorAlreadySent(flowCtx.Err) {
+				continue
+			}
+			status, message, errorBody := responsesWebSocketTurnError(flowCtx.Err, writer)
+			if writeErr := writeResponsesWebSocketClientError(client, status, message, errorBody); writeErr != nil {
+				return
+			}
+			if responsesWebSocketTurnCommitted(flowCtx.Err) {
+				client.close(websocket.CloseInternalServerErr, "upstream websocket turn failed")
+				return
+			}
 		}
 	}
 }
 
-func newResponsesWebSocketHTTPRequest(original *http.Request, body []byte, sessionID string, payload []byte) *http.Request {
-	ctx := maxxctx.WithResponsesWebSocketRequest(original.Context(), sessionID, payload)
-	ctx = maxxctx.WithRequestBody(ctx, body)
+func validateResponsesWebSocketFrame(payload []byte) (string, error) {
+	if !gjson.ValidBytes(payload) || !gjson.ParseBytes(payload).IsObject() {
+		return "", fmt.Errorf("invalid websocket request JSON: %w", domain.ErrResponsesWebSocketProtocol)
+	}
+	if gjson.GetBytes(payload, "type").String() != responsesWebSocketRequestCreate {
+		return "", fmt.Errorf("unsupported websocket request type: only response.create is accepted")
+	}
+	model := gjson.GetBytes(payload, "model")
+	if model.Type != gjson.String || strings.TrimSpace(model.String()) == "" {
+		return "", fmt.Errorf("missing model in response.create request")
+	}
+	if input := gjson.GetBytes(payload, "input"); input.Exists() && !input.IsArray() {
+		return "", fmt.Errorf("websocket request requires array field: input")
+	}
+	previous := gjson.GetBytes(payload, "previous_response_id")
+	if previous.Exists() && previous.Type != gjson.String {
+		return "", fmt.Errorf("previous_response_id must be a string")
+	}
+	return strings.TrimSpace(previous.String()), nil
+}
+
+func responsesWebSocketLogicalBody(payload []byte) ([]byte, error) {
+	if !gjson.ValidBytes(payload) || !gjson.ParseBytes(payload).IsObject() {
+		return nil, domain.ErrResponsesWebSocketProtocol
+	}
+	return sjson.DeleteBytes(bytes.Clone(payload), "type")
+}
+
+func newResponsesWebSocketTurnRequest(
+	original *http.Request,
+	connectionCtx context.Context,
+	logicalBody []byte,
+	connectionID string,
+	rawFrame []byte,
+) *http.Request {
+	ctx := maxxctx.WithResponsesWebSocketRequest(connectionCtx, connectionID, rawFrame)
+	ctx = maxxctx.WithRequestBody(ctx, logicalBody)
 	request := original.Clone(ctx)
 	request.Method = http.MethodPost
-	request.Body = http.NoBody
-	if len(body) > 0 {
-		request.Body = io.NopCloser(bytes.NewReader(body))
-	}
-	request.ContentLength = int64(len(body))
+	request.Body = io.NopCloser(bytes.NewReader(logicalBody))
+	request.ContentLength = int64(len(logicalBody))
 	request.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(body)), nil
+		return io.NopCloser(bytes.NewReader(logicalBody)), nil
 	}
 	request.Header = original.Header.Clone()
-	for _, key := range []string{
-		"Connection",
-		"Upgrade",
-		"Sec-Websocket-Key",
-		"Sec-Websocket-Version",
-		"Sec-Websocket-Extensions",
-		"Sec-Websocket-Protocol",
-		"Content-Length",
-	} {
-		request.Header.Del(key)
+	for key := range request.Header {
+		lower := strings.ToLower(key)
+		if lower == "connection" || lower == "upgrade" || lower == "host" ||
+			lower == "content-length" || lower == "transfer-encoding" || strings.HasPrefix(lower, "sec-websocket-") {
+			request.Header.Del(key)
+		}
 	}
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Accept", "text/event-stream")
+	request.Header.Set("Accept", "application/json")
 	return request
 }
 
-func (s *responsesWebSocketSessionState) normalizeRequest(payload []byte) (responsesWebSocketNormalizedRequest, error) {
-	request, err := decodeJSONObjectNoCopy(payload)
-	if err != nil {
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("invalid websocket request JSON: %w", err)
-	}
+type responsesWebSocketTurnWriter struct {
+	header http.Header
+	status int
+	body   bytes.Buffer
+}
 
-	requestType := jsonString(request["type"])
-	switch requestType {
-	case responsesWebSocketRequestCreate:
-		if !s.initialized {
-			return normalizeInitialResponsesWebSocketRequest(request)
-		}
-		return s.normalizeSubsequentResponsesWebSocketRequest(request)
-	case responsesWebSocketRequestAppend:
-		if !s.initialized {
-			return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request received before response.create")
-		}
-		return s.normalizeSubsequentResponsesWebSocketRequest(request)
-	default:
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("unsupported websocket request type: %s", requestType)
+func newResponsesWebSocketTurnWriter() *responsesWebSocketTurnWriter {
+	return &responsesWebSocketTurnWriter{header: make(http.Header), status: http.StatusOK}
+}
+
+func (w *responsesWebSocketTurnWriter) Header() http.Header { return w.header }
+
+func (w *responsesWebSocketTurnWriter) WriteHeader(status int) {
+	if w.status == http.StatusOK {
+		w.status = status
 	}
 }
 
-func normalizeInitialResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage) (responsesWebSocketNormalizedRequest, error) {
-	delete(request, "type")
-	delete(request, "generate")
-	request["stream"] = sonic.NoCopyRawMessage("true")
-	if _, ok := request["input"]; !ok {
-		request["input"] = sonic.NoCopyRawMessage("[]")
-	}
-	if strings.TrimSpace(jsonString(request["model"])) == "" {
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("missing model in response.create request")
-	}
-	input, err := decodeJSONArrayNoCopy(request["input"])
-	if err != nil {
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request requires array field: input")
-	}
-	normalized, err := marshalResponsesWebSocketRequest(request, input)
-	if err != nil {
-		return responsesWebSocketNormalizedRequest{}, err
-	}
-	return responsesWebSocketNormalizedRequest{
-		body:         normalized,
-		input:        input,
-		model:        request["model"],
-		instructions: request["instructions"],
-	}, nil
+func (w *responsesWebSocketTurnWriter) Write(payload []byte) (int, error) {
+	return w.body.Write(payload)
 }
 
-func (s *responsesWebSocketSessionState) normalizeSubsequentResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage) (responsesWebSocketNormalizedRequest, error) {
-	nextInput, err := decodeJSONArrayNoCopy(request["input"])
-	if err != nil {
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("websocket request requires array field: input")
-	}
+func (w *responsesWebSocketTurnWriter) Flush() {}
 
-	previousResponseID := strings.TrimSpace(jsonString(request["previous_response_id"]))
-	var mergedInput []sonic.NoCopyRawMessage
-	if previousResponseID == "" && responsesWebSocketInputReplacesTranscript(nextInput) {
-		mergedInput = nextInput
-	} else {
-		mergedInput = make([]sonic.NoCopyRawMessage, 0, len(s.lastInput)+len(s.lastResponseOutput)+len(nextInput))
-		mergedInput = append(mergedInput, s.lastInput...)
-		for _, output := range s.lastResponseOutput {
-			mergedInput = append(mergedInput, sonic.NoCopyRawMessage(output))
+func (h *ProxyHandler) runResponsesWebSocketTurn(
+	original *http.Request,
+	connectionCtx context.Context,
+	logicalBody []byte,
+	exchange *domain.ResponsesWebSocketExchange,
+) (*flow.Ctx, *responsesWebSocketTurnWriter) {
+	writer := newResponsesWebSocketTurnWriter()
+	request := newResponsesWebSocketTurnRequest(
+		original,
+		connectionCtx,
+		logicalBody,
+		exchange.ConnectionID,
+		exchange.Frame,
+	)
+	c := flow.NewCtx(writer, request)
+	c.Set(flow.KeyResponsesWebSocketExchange, exchange)
+	h.engine.HandleWith(c, h.proxyHandlers()...)
+	return c, writer
+}
+
+func responsesWebSocketErrorAlreadySent(err error) bool {
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	return errors.As(err, &wsErr) && wsErr.TerminalErrorEventSent
+}
+
+func responsesWebSocketTurnCommitted(err error) bool {
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	return errors.As(err, &wsErr) &&
+		(wsErr.RequestFrameMayHaveBeenSent || wsErr.FirstEventReceived || wsErr.ClientEventSent)
+}
+
+func responsesWebSocketTurnError(err error, writer *responsesWebSocketTurnWriter) (int, string, stdjson.RawMessage) {
+	status := http.StatusInternalServerError
+	message := err.Error()
+	var errorBody stdjson.RawMessage
+	if proxyErr, ok := asHandlerProxyError(err); ok {
+		if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode <= 599 {
+			status = proxyErr.HTTPStatusCode
 		}
-		mergedInput = append(mergedInput, nextInput...)
-		mergedInput = dedupeResponsesWebSocketItems(mergedInput)
-	}
-
-	delete(request, "type")
-	delete(request, "generate")
-	delete(request, "previous_response_id")
-	request["stream"] = sonic.NoCopyRawMessage("true")
-	if _, ok := request["model"]; !ok {
-		request["model"] = s.model
-	}
-	if _, ok := request["instructions"]; !ok {
-		if len(s.instructions) > 0 {
-			request["instructions"] = s.instructions
+		if strings.TrimSpace(proxyErr.Message) != "" {
+			message = proxyErr.Message
+		}
+		detail := map[string]any{
+			"type":      "proxy_error",
+			"message":   message,
+			"retryable": proxyErr.Retryable,
+		}
+		if proxyErr.Code != "" {
+			detail["code"] = proxyErr.Code
+		}
+		if encoded, marshalErr := jsonutil.Marshal(detail); marshalErr == nil {
+			errorBody = encoded
 		}
 	}
-
-	normalized, err := marshalResponsesWebSocketRequest(request, mergedInput)
-	if err != nil {
-		return responsesWebSocketNormalizedRequest{}, fmt.Errorf("failed to merge websocket input: %w", err)
-	}
-	return responsesWebSocketNormalizedRequest{
-		body:         normalized,
-		input:        mergedInput,
-		model:        request["model"],
-		instructions: request["instructions"],
-	}, nil
-}
-
-func marshalResponsesWebSocketRequest(request map[string]sonic.NoCopyRawMessage, input []sonic.NoCopyRawMessage) ([]byte, error) {
-	wireRequest := make(map[string]interface{}, len(request))
-	for key, value := range request {
-		if key != "input" {
-			wireRequest[key] = value
+	if writer != nil {
+		if writer.status >= 400 && writer.status <= 599 {
+			status = writer.status
 		}
-	}
-	wireRequest["input"] = input
-	return jsonutil.Marshal(wireRequest)
-}
-
-func responsesWebSocketInputReplacesTranscript(input []sonic.NoCopyRawMessage) bool {
-	for _, item := range input {
-		switch gjson.GetBytes(item, "type").String() {
-		case "compaction", "compaction_summary", "function_call", "custom_tool_call":
-			return true
-		case "message":
-			if gjson.GetBytes(item, "role").String() == "assistant" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func dedupeResponsesWebSocketItems(items []sonic.NoCopyRawMessage) []sonic.NoCopyRawMessage {
-	seenItemIDs := make(map[string]struct{}, len(items))
-	seenCallIDs := make(map[string]struct{}, len(items))
-	result := make([]sonic.NoCopyRawMessage, 0, len(items))
-	for _, item := range items {
-		if id := strings.TrimSpace(gjson.GetBytes(item, "id").String()); id != "" {
-			if _, exists := seenItemIDs[id]; exists {
-				continue
-			}
-			seenItemIDs[id] = struct{}{}
-		}
-		switch gjson.GetBytes(item, "type").String() {
-		case "function_call", "custom_tool_call":
-			if callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String()); callID != "" {
-				if _, exists := seenCallIDs[callID]; exists {
-					continue
-				}
-				seenCallIDs[callID] = struct{}{}
-			}
-		}
-		result = append(result, item)
-	}
-	return result
-}
-
-func newResponsesWebSocketResponseWriter(conn *websocket.Conn) *responsesWebSocketResponseWriter {
-	return &responsesWebSocketResponseWriter{
-		conn:               conn,
-		header:             make(http.Header),
-		statusCode:         http.StatusOK,
-		outputItemsByIndex: make(map[int]stdjson.RawMessage),
-	}
-}
-
-type responsesWebSocketResponseWriter struct {
-	conn        *websocket.Conn
-	header      http.Header
-	statusCode  int
-	wroteHeader bool
-
-	modeSSE    bool
-	modeChosen bool
-	lineBuffer []byte
-	eventData  bytes.Buffer
-	rawBody    bytes.Buffer
-
-	outputItemsByIndex  map[int]stdjson.RawMessage
-	outputItemsFallback []stdjson.RawMessage
-	completed           bool
-	completedOutput     []stdjson.RawMessage
-	sentError           bool
-	writeErr            error
-}
-
-func (w *responsesWebSocketResponseWriter) Header() http.Header {
-	return w.header
-}
-
-func (w *responsesWebSocketResponseWriter) WriteHeader(statusCode int) {
-	if w.wroteHeader {
-		return
-	}
-	w.statusCode = statusCode
-	w.wroteHeader = true
-}
-
-func (w *responsesWebSocketResponseWriter) Write(p []byte) (int, error) {
-	if w.writeErr != nil {
-		return 0, w.writeErr
-	}
-	if !w.wroteHeader {
-		w.WriteHeader(http.StatusOK)
-	}
-	if !w.modeChosen {
-		contentType := strings.ToLower(w.header.Get("Content-Type"))
-		trimmed := bytes.TrimSpace(p)
-		w.modeSSE = strings.Contains(contentType, "text/event-stream") || bytes.HasPrefix(trimmed, []byte("data:"))
-		w.modeChosen = true
-	}
-	if !w.modeSSE {
-		_, _ = w.rawBody.Write(p)
-		return len(p), nil
-	}
-
-	w.lineBuffer = append(w.lineBuffer, p...)
-	w.processSSELines(false)
-	if w.writeErr != nil {
-		return 0, w.writeErr
-	}
-	return len(p), nil
-}
-
-func (w *responsesWebSocketResponseWriter) Flush() {
-	if w.modeSSE {
-		w.processSSELines(false)
-	}
-}
-
-func (w *responsesWebSocketResponseWriter) finish() error {
-	if w.writeErr != nil {
-		return w.writeErr
-	}
-	if w.modeSSE {
-		w.processSSELines(true)
-	} else if w.rawBody.Len() > 0 {
-		w.forwardRawResponse()
-	}
-	if w.writeErr != nil {
-		return w.writeErr
-	}
-	if !w.completed && !w.sentError {
-		w.writeErr = writeResponsesWebSocketError(w.conn, http.StatusBadGateway, "stream closed before response.completed", nil)
-	}
-	return w.writeErr
-}
-
-func (w *responsesWebSocketResponseWriter) processSSELines(final bool) {
-	for {
-		index := bytes.IndexByte(w.lineBuffer, '\n')
-		if index < 0 {
-			break
-		}
-		line := bytes.TrimSuffix(w.lineBuffer[:index], []byte("\r"))
-		w.lineBuffer = w.lineBuffer[index+1:]
-		w.processSSELine(line)
-		if w.writeErr != nil {
-			return
-		}
-	}
-	if final {
-		if len(w.lineBuffer) > 0 {
-			w.processSSELine(bytes.TrimSuffix(w.lineBuffer, []byte("\r")))
-			w.lineBuffer = nil
-		}
-		w.flushSSEEvent()
-	}
-}
-
-func (w *responsesWebSocketResponseWriter) processSSELine(line []byte) {
-	if len(line) == 0 {
-		w.flushSSEEvent()
-		return
-	}
-	if !bytes.HasPrefix(line, []byte("data:")) {
-		return
-	}
-	data := bytes.TrimSpace(line[len("data:"):])
-	if w.eventData.Len() > 0 {
-		w.eventData.WriteByte('\n')
-	}
-	w.eventData.Write(data)
-}
-
-func (w *responsesWebSocketResponseWriter) flushSSEEvent() {
-	if w.eventData.Len() == 0 || w.writeErr != nil {
-		w.eventData.Reset()
-		return
-	}
-	payload := w.eventData.Bytes()
-	if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
-		w.eventData.Reset()
-		return
-	}
-	w.forwardPayload(payload)
-	w.eventData.Reset()
-}
-
-func (w *responsesWebSocketResponseWriter) forwardPayload(payload []byte) {
-	object, err := decodeJSONObject(payload)
-	if err != nil {
-		w.writeErr = writeResponsesWebSocketError(w.conn, http.StatusBadGateway, "invalid JSON event from upstream", nil)
-		w.sentError = true
-		return
-	}
-
-	eventType := jsonString(object["type"])
-	if eventType == "response.output_item.done" {
-		if item, ok := object["item"]; ok && len(item) > 0 {
-			if outputIndex, okIndex := jsonInt(object["output_index"]); okIndex {
-				w.outputItemsByIndex[outputIndex] = item
-			} else {
-				w.outputItemsFallback = append(w.outputItemsFallback, item)
-			}
-		}
-	}
-
-	if eventType == "response.completed" || eventType == "response.done" {
-		response, errResponse := decodeJSONObject(object["response"])
-		if errResponse == nil {
-			output, errOutput := decodeJSONArray(response["output"])
-			if errOutput != nil || len(output) == 0 {
-				output = w.collectedOutput()
-				if encodedOutput, errMarshal := jsonutil.Marshal(output); errMarshal == nil {
-					response["output"] = encodedOutput
-					if encodedResponse, errMarshalResponse := jsonutil.Marshal(response); errMarshalResponse == nil {
-						object["response"] = encodedResponse
+		if body := bytes.TrimSpace(writer.body.Bytes()); len(body) > 0 && stdjson.Valid(body) {
+			var object map[string]stdjson.RawMessage
+			if jsonutil.Unmarshal(body, &object) == nil {
+				if rawError := object["error"]; len(rawError) > 0 {
+					if got := gjson.GetBytes(rawError, "message").String(); got != "" {
+						message = got
 					}
+					return status, message, rawError
 				}
 			}
-			w.completedOutput = output
 		}
-		w.completed = true
 	}
-	if eventType == "error" {
-		w.sentError = true
-	}
-
-	encoded, errMarshal := jsonutil.Marshal(object)
-	if errMarshal != nil {
-		w.writeErr = errMarshal
-		return
-	}
-	w.writeErr = w.conn.WriteMessage(websocket.TextMessage, encoded)
+	return status, message, errorBody
 }
 
-func (w *responsesWebSocketResponseWriter) collectedOutput() []stdjson.RawMessage {
-	indexes := make([]int, 0, len(w.outputItemsByIndex))
-	for index := range w.outputItemsByIndex {
-		indexes = append(indexes, index)
-	}
-	sort.Ints(indexes)
-	result := make([]stdjson.RawMessage, 0, len(indexes)+len(w.outputItemsFallback))
-	for _, index := range indexes {
-		result = append(result, w.outputItemsByIndex[index])
-	}
-	result = append(result, w.outputItemsFallback...)
-	return result
-}
-
-func (w *responsesWebSocketResponseWriter) forwardRawResponse() {
-	payload := bytes.TrimSpace(w.rawBody.Bytes())
-	if len(payload) == 0 {
-		return
-	}
-	object, err := decodeJSONObject(payload)
-	if err != nil {
-		w.writeErr = writeResponsesWebSocketError(w.conn, w.statusCode, string(payload), nil)
-		w.sentError = true
-		return
-	}
-	if _, ok := object["type"]; ok {
-		w.forwardPayload(payload)
-		return
-	}
-	if errorBody, ok := object["error"]; ok || w.statusCode >= http.StatusBadRequest {
-		w.writeErr = writeResponsesWebSocketError(w.conn, w.statusCode, http.StatusText(w.statusCode), errorBody)
-		w.sentError = true
-		return
-	}
-
-	completion := map[string]any{
-		"type":            "response.completed",
-		"sequence_number": 0,
-		"response":        stdjson.RawMessage(payload),
-	}
-	encoded, errMarshal := jsonutil.Marshal(completion)
-	if errMarshal != nil {
-		w.writeErr = errMarshal
-		return
-	}
-	w.forwardPayload(encoded)
-}
-
-func writeResponsesWebSocketError(conn *websocket.Conn, status int, message string, errorBody stdjson.RawMessage) error {
+func writeResponsesWebSocketClientError(client *responsesWebSocketClient, status int, message string, errorBody stdjson.RawMessage) error {
 	if status < http.StatusBadRequest || status > 599 {
 		status = http.StatusInternalServerError
 	}
@@ -536,80 +404,5 @@ func writeResponsesWebSocketError(conn *websocket.Conn, status int, message stri
 	if err != nil {
 		return err
 	}
-	return conn.WriteMessage(websocket.TextMessage, payload)
-}
-
-func decodeJSONObject(raw []byte) (map[string]stdjson.RawMessage, error) {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, fmt.Errorf("empty JSON object")
-	}
-	var object map[string]stdjson.RawMessage
-	if err := jsonutil.Unmarshal(raw, &object); err != nil {
-		return nil, err
-	}
-	if object == nil {
-		return nil, fmt.Errorf("expected JSON object")
-	}
-	return object, nil
-}
-
-func decodeJSONObjectNoCopy(raw []byte) (map[string]sonic.NoCopyRawMessage, error) {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, fmt.Errorf("empty JSON object")
-	}
-	if !gjson.ValidBytes(raw) {
-		return nil, fmt.Errorf("invalid JSON object")
-	}
-	var object map[string]sonic.NoCopyRawMessage
-	if err := jsonutil.Unmarshal(raw, &object); err != nil {
-		return nil, err
-	}
-	if object == nil {
-		return nil, fmt.Errorf("expected JSON object")
-	}
-	return object, nil
-}
-
-func decodeJSONArray(raw []byte) ([]stdjson.RawMessage, error) {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, fmt.Errorf("missing JSON array")
-	}
-	var array []stdjson.RawMessage
-	if err := jsonutil.Unmarshal(raw, &array); err != nil {
-		return nil, err
-	}
-	if array == nil {
-		array = []stdjson.RawMessage{}
-	}
-	return array, nil
-}
-
-func decodeJSONArrayNoCopy(raw []byte) ([]sonic.NoCopyRawMessage, error) {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, fmt.Errorf("missing JSON array")
-	}
-	var array []sonic.NoCopyRawMessage
-	if err := jsonutil.Unmarshal(raw, &array); err != nil {
-		return nil, err
-	}
-	if array == nil {
-		array = []sonic.NoCopyRawMessage{}
-	}
-	return array, nil
-}
-
-func jsonString(raw []byte) string {
-	var value string
-	if jsonutil.Unmarshal(raw, &value) != nil {
-		return ""
-	}
-	return value
-}
-
-func jsonInt(raw []byte) (int, bool) {
-	var value int
-	if jsonutil.Unmarshal(raw, &value) != nil {
-		return 0, false
-	}
-	return value, true
+	return client.WriteTextFrame(payload)
 }

--- a/internal/handler/responses_websocket_test.go
+++ b/internal/handler/responses_websocket_test.go
@@ -2,295 +2,176 @@ package handler
 
 import (
 	"bytes"
-	"encoding/json"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
-	"time"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
-	"github.com/bytedance/sonic"
+	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/gorilla/websocket"
+	"github.com/tidwall/gjson"
 )
 
-func TestResponsesWebSocket_ReplaysTranscriptThroughHTTPProxy(t *testing.T) {
-	requestBodies := make(chan []byte, 2)
-	callCount := 0
-	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("method = %s, want POST", r.Method)
-		}
-		if got := r.Header.Get("Upgrade"); got != "" {
-			t.Errorf("Upgrade header leaked to HTTP proxy: %q", got)
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read request body: %v", err)
-			return
-		}
-		requestBodies <- body
-		callCount++
-
-		w.Header().Set("Content-Type", "text/event-stream")
-		if callCount == 1 {
-			writeTestSSEEvent(t, w, `{"type":"response.created","response":{"id":"resp_1"}}`)
-			writeTestSSEEvent(t, w, `{"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{}"}}`)
-			writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_1","output":[]}}`)
-			return
-		}
-		writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_2","output":[{"type":"message","id":"msg_2","role":"assistant","content":[]}]}}`)
-	})
-
-	conn := dialResponsesWebSocket(t, backend)
-	defer conn.Close()
-
-	firstRequest := `{"type":"response.create","model":"gpt-test","instructions":"be concise","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"call the tool"}]}]}`
-	if err := conn.WriteMessage(websocket.TextMessage, []byte(firstRequest)); err != nil {
-		t.Fatalf("write first request: %v", err)
+func TestResponsesWebSocket_PreservesResponseCreateFrame(t *testing.T) {
+	payload := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"store":true,"generate":false,"previous_response_id":"resp_1","stream_options":{"include_usage":true},"client_metadata":{"source":"test"},"unknown":42,"input":[]}`)
+	previous, err := validateResponsesWebSocketFrame(payload)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
 	}
-	firstCompleted := readWebSocketEventType(t, conn, "response.completed")
-	firstResponse := decodeTestObject(t, firstCompleted["response"])
-	firstOutput := decodeTestArray(t, firstResponse["output"])
-	if len(firstOutput) != 1 {
-		t.Fatalf("first completion output length = %d, want 1", len(firstOutput))
+	if previous != "resp_1" {
+		t.Fatalf("previous response = %q", previous)
 	}
-	firstBody := receiveTestBody(t, requestBodies)
-	assertNormalizedWebSocketHTTPBody(t, firstBody, "gpt-test", 1)
-
-	secondRequest := `{"type":"response.create","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"tool result"}]}`
-	if err := conn.WriteMessage(websocket.TextMessage, []byte(secondRequest)); err != nil {
-		t.Fatalf("write second request: %v", err)
+	body, err := responsesWebSocketLogicalBody(payload)
+	if err != nil {
+		t.Fatalf("logical body: %v", err)
 	}
-	readWebSocketEventType(t, conn, "response.completed")
-	secondBody := receiveTestBody(t, requestBodies)
-	assertNormalizedWebSocketHTTPBody(t, secondBody, "gpt-test", 3)
-
-	secondObject := decodeTestObject(t, secondBody)
-	if _, exists := secondObject["previous_response_id"]; exists {
-		t.Fatal("previous_response_id must be removed for transcript replay")
+	if gjson.GetBytes(body, "type").Exists() {
+		t.Fatalf("logical body retained event type: %s", body)
 	}
-	if got := jsonString(secondObject["instructions"]); got != "be concise" {
-		t.Fatalf("instructions = %q, want inherited value", got)
+	for _, field := range []string{"model", "stream", "store", "generate", "previous_response_id", "stream_options", "client_metadata", "unknown", "input"} {
+		if !gjson.GetBytes(body, field).Exists() {
+			t.Fatalf("field %q removed from logical body: %s", field, body)
+		}
 	}
 }
 
-func TestResponsesWebSocket_PreservesNativePayloadAndSession(t *testing.T) {
-	type capturedRequest struct {
-		body     []byte
-		metadata maxxctx.ResponsesWebSocketRequest
-	}
-	requests := make(chan capturedRequest, 2)
-	backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		metadata, ok := maxxctx.GetResponsesWebSocketRequest(r.Context())
-		if !ok {
-			t.Error("missing responses websocket request metadata")
-		}
-		requests <- capturedRequest{body: body, metadata: metadata}
-		w.Header().Set("Content-Type", "text/event-stream")
-		writeTestSSEEvent(t, w, `{"type":"response.completed","response":{"id":"resp_test","output":[]}}`)
-	})
-
-	conn := dialResponsesWebSocket(t, backend)
-	defer conn.Close()
-
-	firstPayload := []byte(`{"type":"response.create","model":"gpt-test","generate":false,"input":[]}`)
-	if err := conn.WriteMessage(websocket.TextMessage, firstPayload); err != nil {
-		t.Fatalf("write first request: %v", err)
-	}
-	readWebSocketEventType(t, conn, "response.completed")
-	first := <-requests
-	if string(first.metadata.Payload) != string(firstPayload) {
-		t.Fatalf("native payload = %s, want %s", first.metadata.Payload, firstPayload)
-	}
-	if first.metadata.SessionID == "" {
-		t.Fatal("websocket session ID is empty")
-	}
-	firstBody := decodeTestObject(t, first.body)
-	if _, ok := firstBody["generate"]; ok {
-		t.Fatalf("fallback request leaked websocket-only generate field: %s", first.body)
-	}
-
-	secondPayload := []byte(`{"type":"response.create","previous_response_id":"resp_test","generate":false,"input":[]}`)
-	if err := conn.WriteMessage(websocket.TextMessage, secondPayload); err != nil {
-		t.Fatalf("write second request: %v", err)
-	}
-	readWebSocketEventType(t, conn, "response.completed")
-	second := <-requests
-	if second.metadata.SessionID != first.metadata.SessionID {
-		t.Fatalf("session ID changed: %q -> %q", first.metadata.SessionID, second.metadata.SessionID)
-	}
-	if string(second.metadata.Payload) != string(secondPayload) {
-		t.Fatalf("second native payload = %s, want %s", second.metadata.Payload, secondPayload)
-	}
-	secondBody := decodeTestObject(t, second.body)
-	if _, ok := secondBody["generate"]; ok {
-		t.Fatalf("subsequent fallback request leaked websocket-only generate field: %s", second.body)
+func TestResponsesWebSocket_RejectsResponseAppend(t *testing.T) {
+	_, err := validateResponsesWebSocketFrame([]byte(`{"type":"response.append","model":"gpt-test","input":[]}`))
+	if err == nil {
+		t.Fatal("response.append was accepted")
 	}
 }
 
-func TestNewResponsesWebSocketHTTPRequestReusesImmutableBodies(t *testing.T) {
+func TestResponsesWebSocket_ValidatesInputAndPreviousResponseID(t *testing.T) {
+	tests := [][]byte{
+		[]byte(`{"type":"response.create","model":"gpt-test","input":{}}`),
+		[]byte(`{"type":"response.create","model":"gpt-test","previous_response_id":1,"input":[]}`),
+		[]byte(`{"type":"response.create","model":"","input":[]}`),
+	}
+	for _, payload := range tests {
+		if _, err := validateResponsesWebSocketFrame(payload); err == nil {
+			t.Fatalf("invalid payload accepted: %s", payload)
+		}
+	}
+}
+
+func TestNewResponsesWebSocketTurnRequestReusesImmutableBodies(t *testing.T) {
 	original := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	original.Header.Set("Connection", "upgrade")
+	original.Header.Set("Sec-WebSocket-Key", "secret")
 	body := []byte(`{"model":"gpt-test","stream":true,"input":[]}`)
-	payload := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	payload := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"input":[]}`)
 
-	request := newResponsesWebSocketHTTPRequest(original, body, "session-test", payload)
+	request := newResponsesWebSocketTurnRequest(original, context.Background(), body, "connection-test", payload)
 	preloaded := maxxctx.GetRequestBody(request.Context())
 	if len(preloaded) == 0 || &preloaded[0] != &body[0] {
-		t.Fatal("internal HTTP request should reuse the normalized body")
+		t.Fatal("internal request should reuse the logical body")
 	}
 	metadata, ok := maxxctx.GetResponsesWebSocketRequest(request.Context())
-	if !ok {
-		t.Fatal("missing websocket request metadata")
+	if !ok || metadata.SessionID != "connection-test" {
+		t.Fatalf("metadata = %#v, %v", metadata, ok)
 	}
 	if len(metadata.Payload) == 0 || &metadata.Payload[0] != &payload[0] {
-		t.Fatal("websocket metadata should reuse the immutable client payload")
+		t.Fatal("metadata should reuse the immutable client frame")
 	}
 	readBody, err := io.ReadAll(request.Body)
 	if err != nil {
-		t.Fatalf("read request body: %v", err)
+		t.Fatalf("read body: %v", err)
 	}
 	if !bytes.Equal(readBody, body) {
-		t.Fatalf("request body = %s, want %s", readBody, body)
+		t.Fatalf("body = %s, want %s", readBody, body)
 	}
-}
-
-func BenchmarkResponsesWebSocketNormalizeSubsequent(b *testing.B) {
-	state := responsesWebSocketSessionState{
-		initialized: true,
-		lastInput: []sonic.NoCopyRawMessage{
-			sonic.NoCopyRawMessage(`{"type":"message","role":"user","content":[{"type":"input_text","text":"` + strings.Repeat("x", 1<<20) + `"}]}`),
-		},
-		model: sonic.NoCopyRawMessage(`"gpt-test"`),
-	}
-	payload := []byte(`{"type":"response.create","previous_response_id":"resp_1","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		normalized, err := state.normalizeRequest(payload)
-		if err != nil || len(normalized.body) < 1<<20 {
-			b.Fatalf("normalizeRequest = %d bytes, %v", len(normalized.body), err)
+	for _, key := range []string{"Connection", "Sec-WebSocket-Key"} {
+		if got := request.Header.Get(key); got != "" {
+			t.Fatalf("%s leaked: %q", key, got)
 		}
 	}
-}
-
-func TestResponsesWebSocket_MapsHTTPErrorToWebSocketError(t *testing.T) {
-	backend := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":{"type":"authentication_error","message":"bad token"}}`))
-	})
-
-	conn := dialResponsesWebSocket(t, backend)
-	defer conn.Close()
-
-	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-	event := readWebSocketEventType(t, conn, "error")
-	var status int
-	if err := json.Unmarshal(event["status"], &status); err != nil {
-		t.Fatalf("decode status: %v", err)
-	}
-	if status != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want %d", status, http.StatusUnauthorized)
-	}
-	errorBody := decodeTestObject(t, event["error"])
-	if got := jsonString(errorBody["message"]); got != "bad token" {
-		t.Fatalf("error message = %q, want bad token", got)
+	if got := request.Header.Get("Accept"); got != "application/json" {
+		t.Fatalf("Accept = %q", got)
 	}
 }
 
-func dialResponsesWebSocket(t *testing.T, backend http.Handler) *websocket.Conn {
-	t.Helper()
+func TestResponsesWebSocket_OriginPolicy(t *testing.T) {
+	t.Setenv("MAXX_CORS_ALLOW_ORIGINS", "https://allowed.example")
+	req := httptest.NewRequest(http.MethodGet, "http://maxx.example/v1/responses", nil)
+	req.Host = "maxx.example"
+	if !checkResponsesWebSocketOrigin(req) {
+		t.Fatal("CLI request without Origin was rejected")
+	}
+	req.Header.Set("Origin", "http://maxx.example")
+	if !checkResponsesWebSocketOrigin(req) {
+		t.Fatal("same-origin browser request was rejected")
+	}
+	req.Header.Set("Origin", "https://allowed.example")
+	if !checkResponsesWebSocketOrigin(req) {
+		t.Fatal("allowlisted browser request was rejected")
+	}
+	req.Header.Set("Origin", "https://evil.example")
+	if checkResponsesWebSocketOrigin(req) {
+		t.Fatal("cross-site browser request was accepted")
+	}
+}
+
+func TestResponsesWebSocketClient_WriteTextFrame(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		serveResponsesWebSocket(w, r, backend, 0)
-	}))
-	t.Cleanup(server.Close)
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
-	conn, response, err := websocket.DefaultDialer.Dial(wsURL, nil)
-	if err != nil {
-		if response != nil {
-			t.Fatalf("dial responses websocket: %v (status %s)", err, response.Status)
-		}
-		t.Fatalf("dial responses websocket: %v", err)
-	}
-	return conn
-}
-
-func writeTestSSEEvent(t *testing.T, w http.ResponseWriter, payload string) {
-	t.Helper()
-	if _, err := io.WriteString(w, "data: "+payload+"\n\n"); err != nil {
-		t.Errorf("write SSE event: %v", err)
-		return
-	}
-	if flusher, ok := w.(http.Flusher); ok {
-		flusher.Flush()
-	}
-}
-
-func readWebSocketEventType(t *testing.T, conn *websocket.Conn, wantedType string) map[string]json.RawMessage {
-	t.Helper()
-	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
-		t.Fatalf("set websocket read deadline: %v", err)
-	}
-	for {
-		_, payload, err := conn.ReadMessage()
+		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
-			t.Fatalf("read websocket event %s: %v", wantedType, err)
+			t.Errorf("upgrade: %v", err)
+			return
 		}
-		event := decodeTestObject(t, payload)
-		if jsonString(event["type"]) == wantedType {
-			return event
+		client := newResponsesWebSocketClient(conn)
+		defer client.close(websocket.CloseNormalClosure, "")
+		_ = client.WriteTextFrame([]byte(`{"type":"response.completed"}`))
+	}))
+	defer server.Close()
+	wsURL := "ws" + server.URL[len("http"):] + "/v1/responses"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	_, payload, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(payload) != `{"type":"response.completed"}` {
+		t.Fatalf("payload = %s", payload)
+	}
+}
+
+func TestResponsesWebSocketReadLimit(t *testing.T) {
+	for configured, want := range map[int64]int64{
+		0:                              responsesWSMaxPendingBytes,
+		responsesWSMaxPendingBytes + 1: responsesWSMaxPendingBytes,
+		responsesWSMaxPendingBytes / 2: responsesWSMaxPendingBytes / 2,
+	} {
+		if got := responsesWebSocketReadLimit(configured); got != want {
+			t.Fatalf("read limit for %d = %d, want %d", configured, got, want)
 		}
 	}
 }
 
-func receiveTestBody(t *testing.T, bodies <-chan []byte) []byte {
-	t.Helper()
-	select {
-	case body := <-bodies:
-		return body
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for proxied request body")
-		return nil
+func TestResponsesWebSocketErrorAlreadySentRequiresTerminalError(t *testing.T) {
+	partial := &domain.ResponsesWebSocketAttemptError{
+		Err:             errors.New("upstream closed"),
+		ClientEventSent: true,
 	}
-}
-
-func assertNormalizedWebSocketHTTPBody(t *testing.T, body []byte, model string, inputLength int) {
-	t.Helper()
-	object := decodeTestObject(t, body)
-	if _, exists := object["type"]; exists {
-		t.Fatal("websocket event type leaked into HTTP Responses body")
+	if responsesWebSocketErrorAlreadySent(partial) {
+		t.Fatal("ordinary upstream event suppressed the terminal client error")
 	}
-	var stream bool
-	if err := json.Unmarshal(object["stream"], &stream); err != nil || !stream {
-		t.Fatalf("stream = %s, want true", object["stream"])
+	if !responsesWebSocketTurnCommitted(partial) {
+		t.Fatal("ordinary upstream event did not commit the turn")
 	}
-	if got := jsonString(object["model"]); got != model {
-		t.Fatalf("model = %q, want %q", got, model)
+	terminal := &domain.ResponsesWebSocketAttemptError{
+		Err:                    errors.New("upstream error event"),
+		ClientEventSent:        true,
+		TerminalErrorEventSent: true,
 	}
-	input := decodeTestArray(t, object["input"])
-	if len(input) != inputLength {
-		t.Fatalf("input length = %d, want %d; body=%s", len(input), inputLength, body)
+	if !responsesWebSocketErrorAlreadySent(terminal) {
+		t.Fatal("forwarded terminal error event was not recognized")
 	}
-}
-
-func decodeTestObject(t *testing.T, raw []byte) map[string]json.RawMessage {
-	t.Helper()
-	object, err := decodeJSONObject(raw)
-	if err != nil {
-		t.Fatalf("decode JSON object %s: %v", raw, err)
-	}
-	return object
-}
-
-func decodeTestArray(t *testing.T, raw []byte) []json.RawMessage {
-	t.Helper()
-	array, err := decodeJSONArray(raw)
-	if err != nil {
-		t.Fatalf("decode JSON array %s: %v", raw, err)
-	}
-	return array
 }

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -1,0 +1,302 @@
+package router
+
+import (
+	"errors"
+	"testing"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+)
+
+const (
+	wsRouterNativeType   = "responses-ws-router-native-test"
+	wsRouterHTTPOnlyType = "responses-ws-router-http-only-test"
+)
+
+func init() {
+	provideradapter.RegisterAdapterFactory(wsRouterNativeType, func(p *domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return &wsRouterNativeAdapter{providerID: p.ID}, nil
+	})
+	provideradapter.RegisterAdapterFactory(wsRouterHTTPOnlyType, func(*domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return wsRouterHTTPOnlyAdapter{}, nil
+	})
+}
+
+// wsRouterNativeAdapter is Codex-native and implements ResponsesWebSocketAdapter.
+type wsRouterNativeAdapter struct {
+	providerID uint64
+}
+
+func (wsRouterNativeAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeCodex}
+}
+
+func (wsRouterNativeAdapter) Execute(*flow.Ctx, *domain.Provider) error { return nil }
+
+func (a *wsRouterNativeAdapter) ExecuteResponsesWebSocket(
+	*flow.Ctx,
+	*domain.Provider,
+	*domain.ResponsesWebSocketExchange,
+) (*domain.ResponsesWebSocketResult, error) {
+	return &domain.ResponsesWebSocketResult{ProviderID: a.providerID}, nil
+}
+
+// wsRouterHTTPOnlyAdapter speaks Codex over HTTP only — no WS capability.
+type wsRouterHTTPOnlyAdapter struct{}
+
+func (wsRouterHTTPOnlyAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeCodex}
+}
+
+func (wsRouterHTTPOnlyAdapter) Execute(*flow.Ctx, *domain.Provider) error { return nil }
+
+type wsRouterRouteRepo struct{ routes []*domain.Route }
+
+func (r *wsRouterRouteRepo) Create(route *domain.Route) error {
+	r.routes = append(r.routes, route)
+	return nil
+}
+func (r *wsRouterRouteRepo) Update(*domain.Route) error { return nil }
+func (r *wsRouterRouteRepo) Delete(uint64, uint64) error {
+	return nil
+}
+func (r *wsRouterRouteRepo) BulkDelete(uint64, domain.RouteBulkDeleteRequest) (*domain.RouteBulkDeleteResult, error) {
+	return &domain.RouteBulkDeleteResult{}, nil
+}
+func (r *wsRouterRouteRepo) GetByID(tenantID, id uint64) (*domain.Route, error) {
+	for _, route := range r.routes {
+		if route.TenantID == tenantID && route.ID == id {
+			return route, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *wsRouterRouteRepo) FindByKey(tenantID, projectID, providerID uint64, clientType domain.ClientType) (*domain.Route, error) {
+	for _, route := range r.routes {
+		if route.TenantID == tenantID && route.ProjectID == projectID && route.ProviderID == providerID && route.ClientType == clientType {
+			return route, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *wsRouterRouteRepo) List(tenantID uint64) ([]*domain.Route, error) {
+	var out []*domain.Route
+	for _, route := range r.routes {
+		if tenantID == domain.TenantIDAll || route.TenantID == tenantID {
+			out = append(out, route)
+		}
+	}
+	return out, nil
+}
+func (r *wsRouterRouteRepo) BatchUpdatePositions(uint64, []domain.RoutePositionUpdate) error {
+	return nil
+}
+
+type wsRouterProviderRepo struct{ providers []*domain.Provider }
+
+func (r *wsRouterProviderRepo) Create(p *domain.Provider) error {
+	r.providers = append(r.providers, p)
+	return nil
+}
+func (r *wsRouterProviderRepo) Update(*domain.Provider) error { return nil }
+func (r *wsRouterProviderRepo) Delete(uint64, uint64) error   { return nil }
+func (r *wsRouterProviderRepo) GetByID(tenantID, id uint64) (*domain.Provider, error) {
+	for _, p := range r.providers {
+		if p.TenantID == tenantID && p.ID == id {
+			return p, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+func (r *wsRouterProviderRepo) List(tenantID uint64) ([]*domain.Provider, error) {
+	var out []*domain.Provider
+	for _, p := range r.providers {
+		if tenantID == domain.TenantIDAll || p.TenantID == tenantID {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+type wsRouterRetryRepo struct{}
+
+func (wsRouterRetryRepo) Create(*domain.RetryConfig) error { return nil }
+func (wsRouterRetryRepo) Update(*domain.RetryConfig) error { return nil }
+func (wsRouterRetryRepo) Delete(uint64, uint64) error      { return nil }
+func (wsRouterRetryRepo) GetByID(uint64, uint64) (*domain.RetryConfig, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterRetryRepo) GetDefault(uint64) (*domain.RetryConfig, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterRetryRepo) List(uint64) ([]*domain.RetryConfig, error) { return nil, nil }
+
+type wsRouterStrategyRepo struct{}
+
+func (wsRouterStrategyRepo) Create(*domain.RoutingStrategy) error { return nil }
+func (wsRouterStrategyRepo) Update(*domain.RoutingStrategy) error { return nil }
+func (wsRouterStrategyRepo) Delete(uint64, uint64) error          { return nil }
+func (wsRouterStrategyRepo) GetByID(uint64, uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterStrategyRepo) GetByProjectID(uint64, uint64) (*domain.RoutingStrategy, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterStrategyRepo) List(uint64) ([]*domain.RoutingStrategy, error) { return nil, nil }
+
+type wsRouterProjectRepo struct{}
+
+func (wsRouterProjectRepo) Create(*domain.Project) error { return nil }
+func (wsRouterProjectRepo) Update(*domain.Project) error { return nil }
+func (wsRouterProjectRepo) Delete(uint64, uint64) error  { return nil }
+func (wsRouterProjectRepo) GetByID(uint64, uint64) (*domain.Project, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterProjectRepo) GetBySlug(uint64, string) (*domain.Project, error) {
+	return nil, domain.ErrNotFound
+}
+func (wsRouterProjectRepo) List(uint64) ([]*domain.Project, error) { return nil, nil }
+
+func newResponsesWebSocketTestRouter(t *testing.T, routes []*domain.Route, providers []*domain.Provider) *Router {
+	t.Helper()
+	routeRepo := cached.NewRouteRepository(&wsRouterRouteRepo{routes: routes})
+	providerRepo := cached.NewProviderRepository(&wsRouterProviderRepo{providers: providers})
+	retryRepo := cached.NewRetryConfigRepository(wsRouterRetryRepo{})
+	strategyRepo := cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(wsRouterProjectRepo{})
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+	return r
+}
+
+func matchedProviderIDs(result *MatchResult) []uint64 {
+	if result == nil {
+		return nil
+	}
+	ids := make([]uint64, 0, len(result.Routes))
+	for _, mr := range result.Routes {
+		ids = append(ids, mr.Provider.ID)
+	}
+	return ids
+}
+
+// Only native routes whose adapter implements ResponsesWebSocketAdapter (and
+// Codex) are eligible when RequireResponsesWebSocket is set.
+func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T) {
+	const (
+		nativeWSProviderID  = uint64(101)
+		httpOnlyProviderID  = uint64(102)
+		nonNativeWSProvider = uint64(103)
+	)
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: nativeWSProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
+			{ID: 2, TenantID: 1, ProviderID: httpOnlyProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 2},
+			{ID: 3, TenantID: 1, ProviderID: nonNativeWSProvider, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: false, Position: 3},
+		},
+		[]*domain.Provider{
+			{ID: nativeWSProviderID, TenantID: 1, Type: wsRouterNativeType, Name: "native-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: httpOnlyProviderID, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "http-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: nonNativeWSProvider, TenantID: 1, Type: wsRouterNativeType, Name: "non-native-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+
+	result, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+	})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	ids := matchedProviderIDs(result)
+	if len(ids) != 1 || ids[0] != nativeWSProviderID {
+		t.Fatalf("matched provider IDs = %v, want only native capable %d", ids, nativeWSProviderID)
+	}
+}
+
+// RequiredProviderID pins eligibility to one provider; a missing pin is a
+// dedicated session-unavailable error (not the generic no-providers error).
+func TestMatch_ResponsesWebSocketRequiredProviderIDPinsProvider(t *testing.T) {
+	const (
+		providerA = uint64(201)
+		providerB = uint64(202)
+	)
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 11, TenantID: 1, ProviderID: providerA, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
+			{ID: 12, TenantID: 1, ProviderID: providerB, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: providerA, TenantID: 1, Type: wsRouterNativeType, Name: "ws-a", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: providerB, TenantID: 1, Type: wsRouterNativeType, Name: "ws-b", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+
+	result, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+		RequiredProviderID:        providerB,
+	})
+	if err != nil {
+		t.Fatalf("Match with pin: %v", err)
+	}
+	ids := matchedProviderIDs(result)
+	if len(ids) != 1 || ids[0] != providerB {
+		t.Fatalf("matched provider IDs = %v, want pinned %d", ids, providerB)
+	}
+
+	_, err = r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+		RequiredProviderID:        99999,
+	})
+	if !errors.Is(err, domain.ErrResponsesWebSocketSessionUnavailable) {
+		t.Fatalf("missing pin error = %v, want %v", err, domain.ErrResponsesWebSocketSessionUnavailable)
+	}
+}
+
+func TestMatch_ResponsesWebSocketNoEligibleProviders(t *testing.T) {
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 21, TenantID: 1, ProviderID: 301, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
+			{ID: 22, TenantID: 1, ProviderID: 302, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: false, Position: 2},
+		},
+		[]*domain.Provider{
+			// Native route but HTTP-only adapter → not WS-capable.
+			{ID: 301, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "http-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			// WS adapter on a non-native route → still ineligible under RequireResponsesWebSocket.
+			{ID: 302, TenantID: 1, Type: wsRouterNativeType, Name: "ws-non-native", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+
+	_, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+	})
+	if !errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
+		t.Fatalf("Match error = %v, want %v", err, domain.ErrNoResponsesWebSocketProviders)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -51,13 +51,15 @@ type StickyWrite struct {
 // nil we fall back to context.Background; nil is allowed so existing
 // non-proxy call sites don't have to plumb a context in.
 type MatchContext struct {
-	Ctx          context.Context
-	TenantID     uint64
-	ClientType   domain.ClientType
-	ProjectID    uint64
-	RequestModel string
-	APITokenID   uint64
-	SessionID    string
+	Ctx                       context.Context
+	TenantID                  uint64
+	ClientType                domain.ClientType
+	ProjectID                 uint64
+	RequestModel              string
+	APITokenID                uint64
+	SessionID                 string
+	RequireResponsesWebSocket bool
+	RequiredProviderID        uint64
 }
 
 // Router handles route matching and selection
@@ -220,6 +222,9 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	}
 
 	if len(filtered) == 0 {
+		if ctx.RequireResponsesWebSocket {
+			return nil, domain.ErrNoResponsesWebSocketProviders
+		}
 		return nil, domain.ErrNoRoutes
 	}
 
@@ -272,6 +277,14 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if !ok {
 			continue
 		}
+		if ctx.RequiredProviderID != 0 && prov.ID != ctx.RequiredProviderID {
+			continue
+		}
+		if ctx.RequireResponsesWebSocket {
+			if !route.IsNative || !adapterSupportsResponsesWebSocket(adp) {
+				continue
+			}
+		}
 
 		// Check if provider supports the request model only when the adapter
 		// natively speaks the request protocol. Converted routes (for example an
@@ -303,6 +316,12 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	r.mu.RUnlock()
 
 	if len(matched) == 0 {
+		if ctx.RequireResponsesWebSocket {
+			if ctx.RequiredProviderID != 0 {
+				return nil, domain.ErrResponsesWebSocketSessionUnavailable
+			}
+			return nil, domain.ErrNoResponsesWebSocketProviders
+		}
 		// Only blame the model when the emptiness is entirely due to SupportModels
 		// rejections; a transient skip (cooldown) may hide a provider that does
 		// support it, so fall back to the generic error to avoid mislabeling.
@@ -362,6 +381,31 @@ func adapterSupportsClientType(adapter provider.ProviderAdapter, clientType doma
 		}
 	}
 	return false
+}
+
+func adapterSupportsResponsesWebSocket(adapter provider.ProviderAdapter) bool {
+	if adapter == nil || !adapterSupportsClientType(adapter, domain.ClientTypeCodex) {
+		return false
+	}
+	_, ok := adapter.(provider.ResponsesWebSocketAdapter)
+	return ok
+}
+
+func (r *Router) CloseResponsesWebSocketConnection(connectionID string) {
+	if r == nil || connectionID == "" {
+		return
+	}
+	r.mu.RLock()
+	cleaners := make([]provider.ResponsesWebSocketSessionCleaner, 0, len(r.adapters))
+	for _, adapter := range r.adapters {
+		if cleaner, ok := adapter.(provider.ResponsesWebSocketSessionCleaner); ok {
+			cleaners = append(cleaners, cleaner)
+		}
+	}
+	r.mu.RUnlock()
+	for _, cleaner := range cleaners {
+		cleaner.CloseResponsesWebSocketConnection(connectionID)
+	}
 }
 
 // isModelSupported checks if a model matches any pattern in the support list

--- a/tests/e2e/codex_websocket_proxy_test.go
+++ b/tests/e2e/codex_websocket_proxy_test.go
@@ -1,0 +1,196 @@
+package e2e_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestCodexWebSocketE2E_UsesNativeUpstreamAndReusesConnection(t *testing.T) {
+	var websocketConnections atomic.Int32
+	var codexHTTPPosts atomic.Int32
+	upstreamFrames := make(chan []byte, 2)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !websocket.IsWebSocketUpgrade(r) {
+			codexHTTPPosts.Add(1)
+			http.Error(w, "HTTP fallback is forbidden", http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path != "/v1/responses" {
+			t.Errorf("upstream path = %q, want /v1/responses", r.URL.Path)
+		}
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade upstream: %v", err)
+			return
+		}
+		defer conn.Close()
+		websocketConnections.Add(1)
+		for turn := 1; turn <= 2; turn++ {
+			messageType, frame, readErr := conn.ReadMessage()
+			if readErr != nil {
+				t.Errorf("read upstream turn %d: %v", turn, readErr)
+				return
+			}
+			if messageType != websocket.TextMessage {
+				t.Errorf("upstream message type = %d, want text", messageType)
+				return
+			}
+			upstreamFrames <- bytes.Clone(frame)
+			responseID := "resp_1"
+			if turn == 2 {
+				responseID = "resp_2"
+			}
+			response := `{"type":"response.completed","response":{"id":"` + responseID + `","model":"gpt-test","output":[]}}`
+			if writeErr := conn.WriteMessage(websocket.TextMessage, []byte(response)); writeErr != nil {
+				t.Errorf("write upstream turn %d: %v", turn, writeErr)
+				return
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	var customHTTPCalls atomic.Int32
+	customHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		customHTTPCalls.Add(1)
+		http.Error(w, "HTTP-only provider must not be selected", http.StatusInternalServerError)
+	}))
+	defer customHTTP.Close()
+
+	env := NewProxyTestEnv(t)
+	codexProviderID := createCodexProvider(t, env, map[string]any{
+		"accessToken": "static-token",
+		"baseURL":     upstream.URL + "/v1",
+	})
+	customProviderID := createProvider(t, env, "HTTP-only Codex candidate", customHTTP.URL, []string{"codex"})
+	createNativeRoute(t, env, "codex", customProviderID, 1)
+	createNativeRoute(t, env, "codex", codexProviderID, 2)
+
+	downstreamURL := "ws" + strings.TrimPrefix(env.Server.URL, "http") + "/v1/responses"
+	downstream, response, err := websocket.DefaultDialer.Dial(downstreamURL, nil)
+	if err != nil {
+		if response != nil && response.Body != nil {
+			body, _ := io.ReadAll(response.Body)
+			response.Body.Close()
+			t.Fatalf("dial downstream: %v: %s", err, body)
+		}
+		t.Fatalf("dial downstream: %v", err)
+	}
+	defer downstream.Close()
+
+	first := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"store":true,"generate":false,"unknown_field":"preserve","input":[]}`)
+	second := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
+	for turn, frame := range [][]byte{first, second} {
+		if err := downstream.WriteMessage(websocket.TextMessage, frame); err != nil {
+			t.Fatalf("write downstream turn %d: %v", turn+1, err)
+		}
+		messageType, event, err := downstream.ReadMessage()
+		if err != nil {
+			t.Fatalf("read downstream turn %d: %v", turn+1, err)
+		}
+		if messageType != websocket.TextMessage || !bytes.Contains(event, []byte(`"type":"response.completed"`)) {
+			t.Fatalf("downstream turn %d event = %s", turn+1, event)
+		}
+	}
+
+	if got := <-upstreamFrames; !bytes.Equal(got, first) {
+		t.Fatalf("first upstream frame mutated:\n got %s\nwant %s", got, first)
+	}
+	if got := <-upstreamFrames; !bytes.Equal(got, second) {
+		t.Fatalf("second upstream frame mutated:\n got %s\nwant %s", got, second)
+	}
+	if got := websocketConnections.Load(); got != 1 {
+		t.Fatalf("upstream websocket connections = %d, want 1", got)
+	}
+	if got := codexHTTPPosts.Load(); got != 0 {
+		t.Fatalf("Codex HTTP POST calls = %d, want 0", got)
+	}
+	if got := customHTTPCalls.Load(); got != 0 {
+		t.Fatalf("HTTP-only provider calls = %d, want 0", got)
+	}
+}
+
+func TestCodexWebSocketE2E_DeltaThenCloseSendsTerminalError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade upstream: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err = conn.ReadMessage(); err != nil {
+			t.Errorf("read upstream request: %v", err)
+			return
+		}
+		if err = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.output_text.delta","delta":"partial"}`)); err != nil {
+			t.Errorf("write upstream delta: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createCodexProvider(t, env, map[string]any{
+		"accessToken": "static-token",
+		"baseURL":     upstream.URL + "/v1",
+	})
+	createNativeRoute(t, env, "codex", providerID, 1)
+
+	downstreamURL := "ws" + strings.TrimPrefix(env.Server.URL, "http") + "/v1/responses"
+	downstream, _, err := websocket.DefaultDialer.Dial(downstreamURL, nil)
+	if err != nil {
+		t.Fatalf("dial downstream: %v", err)
+	}
+	defer downstream.Close()
+	_ = downstream.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if err = downstream.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)); err != nil {
+		t.Fatalf("write downstream request: %v", err)
+	}
+
+	_, delta, err := downstream.ReadMessage()
+	if err != nil {
+		t.Fatalf("read downstream delta: %v", err)
+	}
+	if !bytes.Contains(delta, []byte(`"type":"response.output_text.delta"`)) {
+		t.Fatalf("first downstream event = %s, want delta", delta)
+	}
+	_, terminal, err := downstream.ReadMessage()
+	if err != nil {
+		t.Fatalf("read downstream terminal error: %v", err)
+	}
+	if !bytes.Contains(terminal, []byte(`"type":"error"`)) ||
+		!bytes.Contains(terminal, []byte(`"code":"upstream_websocket_closed_before_terminal"`)) {
+		t.Fatalf("terminal downstream event = %s", terminal)
+	}
+	if _, _, err = downstream.ReadMessage(); err == nil {
+		t.Fatal("downstream connection remained open after committed upstream turn failure")
+	}
+}
+
+func createNativeRoute(t *testing.T, env *ProxyTestEnv, clientType string, providerID uint64, position int) uint64 {
+	t.Helper()
+	resp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   true,
+		"clientType": clientType,
+		"providerID": providerID,
+		"position":   position,
+	})
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("create native route: status=%d body=%s", resp.StatusCode, body)
+	}
+	var route struct {
+		ID uint64 `json:"id"`
+	}
+	DecodeJSON(t, resp, &route)
+	return route.ID
+}


### PR DESCRIPTION
## Summary
- route Codex Responses WebSocket requests only to native WebSocket-capable adapters
- preserve official `response.create` and upstream event frames without HTTP/SSE fallback or transcript replay
- pin and reuse bounded upstream sessions with fingerprinting, idle cleanup, safe pre-write failover, write deadlines, and sensitive-header filtering
- report terminal upstream failures exactly once and close committed broken turns

## Tests
- `go test ./internal/domain ./internal/handler ./internal/adapter/provider/codex ./internal/executor ./internal/router ./tests/e2e -run 'ResponsesWebSocket|CodexWebSocket' -count=1`
- `go vet ./cmd/... ./internal/...`
- Linux amd64 and arm64 cross-builds of `./cmd/maxx`
- `go test ./...` (all feature packages pass; Windows-only pre-existing failures remain in `cmd/maxx-cli/internal/cfg` for POSIX 0600 permissions and legacy XDG migration)

## Safety invariants
- no provider failover after an upstream request frame may have been written or any client event was emitted
- continuation requests require the pinned provider and live upstream session
- HTTP-only/custom/conversion adapters cannot enter the native WebSocket route set
- upstream WebSocket error frames are forwarded raw and are not duplicated by the downstream handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持 Codex Responses WebSocket 原生转发，并复用上游连接，提升连续请求效率。
  * 保留并准确转发客户端请求帧及上游事件。
  * 支持原生提供商筛选、会话固定、故障转移与连接主动清理。
  * 增强 WebSocket 输入校验、来源限制、队列保护及错误事件反馈。

* **错误修复**
  * 改善连接升级失败、会话不可用、上游中断及写入失败时的错误提示与重试判断。
  * 防止不支持 WebSocket 的提供商被错误选中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->