### PR TITLE
fix(routes): make IsNative canonical and route Codex WS once

### DIFF
--- a/cmd/maxx-cli/cmd/route.go
+++ b/cmd/maxx-cli/cmd/route.go
@@ -121,7 +121,6 @@ func newRouteUpdateCmd() *cobra.Command {
 	var (
 		fromFile      string
 		isEnabled     string
-		isNative      string
 		projectID     int64
 		clientType    string
 		providerID    int64
@@ -134,7 +133,9 @@ func newRouteUpdateCmd() *cobra.Command {
 		Short: "Patch a route — only flags you pass are sent",
 		Long: `Update a route via partial PUT. Only the flags you actually pass on the
 command line are included in the request. Pass -f to send a full JSON patch
-instead, which overrides any individual flags.`,
+instead, which overrides any individual flags.
+
+isNative is server-derived from provider capability and cannot be set here.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := strconv.ParseUint(args[0], 10, 64)
@@ -158,13 +159,6 @@ instead, which overrides any individual flags.`,
 						return fmt.Errorf("--enabled: %w", err)
 					}
 					patch["isEnabled"] = b
-				}
-				if cmd.Flags().Changed("native") {
-					b, err := strconv.ParseBool(isNative)
-					if err != nil {
-						return fmt.Errorf("--native: %w", err)
-					}
-					patch["isNative"] = b
 				}
 				if cmd.Flags().Changed("project-id") {
 					if projectID < 0 {
@@ -197,7 +191,7 @@ instead, which overrides any individual flags.`,
 					patch["retryConfigID"] = uint64(retryConfigID)
 				}
 				if len(patch) == 0 {
-					return fmt.Errorf("no fields to update; pass one of --enabled/--native/--project-id/--client-type/--provider-id/--position/--weight/--retry-config-id, or use -f")
+					return fmt.Errorf("no fields to update; pass one of --enabled/--project-id/--client-type/--provider-id/--position/--weight/--retry-config-id, or use -f")
 				}
 			}
 			if flagDryRun {
@@ -216,7 +210,6 @@ instead, which overrides any individual flags.`,
 	}
 	cmd.Flags().StringVarP(&fromFile, "file", "f", "", "JSON patch file (overrides individual flags when set)")
 	cmd.Flags().StringVar(&isEnabled, "enabled", "", "true|false")
-	cmd.Flags().StringVar(&isNative, "native", "", "true|false")
 	cmd.Flags().Int64Var(&projectID, "project-id", 0, "")
 	cmd.Flags().StringVar(&clientType, "client-type", "", "")
 	cmd.Flags().Int64Var(&providerID, "provider-id", 0, "")

--- a/cmd/maxx-cli/internal/api/client.go
+++ b/cmd/maxx-cli/internal/api/client.go
@@ -324,7 +324,8 @@ func (c *Client) CreateRoute(r *domain.Route) (*domain.Route, error) {
 }
 
 // UpdateRoute sends a partial JSON patch. The server picks up isEnabled,
-// isNative, projectID, clientType, providerID, position, weight, retryConfigID.
+// projectID, clientType, providerID, position, weight, retryConfigID.
+// isNative is server-derived and ignored if present.
 func (c *Client) UpdateRoute(id uint64, patch map[string]any) (*domain.Route, error) {
 	var out domain.Route
 	return &out, c.do(http.MethodPut, fmt.Sprintf("/api/admin/routes/%d", id), patch, &out)

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -117,6 +117,9 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 		}
 	}
 
+	// Provider rebuild/update may change BaseURL; clear unsupported WS cache.
+	clearCodexWebSocketUnsupported(p.ID)
+
 	return adapter, nil
 }
 

--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -1,4 +1,4 @@
-package codex
+﻿package codex
 
 import (
 	"context"
@@ -289,14 +289,14 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 	exchange *domain.ResponsesWebSocketExchange,
 ) (*domain.ResponsesWebSocketResult, error) {
 	if c == nil || provider == nil || c.Request == nil || exchange == nil || exchange.Sink == nil {
-		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketProtocol, false, false)
+		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketProtocol, false)
 	}
 	if err := validateOutboundCodexWebSocketFrame(exchange.Frame); err != nil {
 		proxyErr := domain.NewProxyErrorWithMessage(err, false, "invalid Codex websocket request")
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.Code = "websocket_protocol_error"
 		proxyErr.HTTPStatusCode = http.StatusBadRequest
-		return nil, newCodexWebSocketAttemptError(proxyErr, false, false)
+		return nil, newCodexWebSocketAttemptError(proxyErr, false)
 	}
 
 	ctx := c.Request.Context()
@@ -305,13 +305,13 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 	if err != nil {
 		proxyErr := domain.NewProxyErrorWithMessage(err, true, "failed to build Codex websocket URL")
 		proxyErr.Scope = domain.ScopeEndpoint
-		return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+		return nil, newCodexWebSocketAttemptError(proxyErr, false)
 	}
 	if isCodexWebSocketUnsupported(provider.ID, target) {
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoResponsesWebSocketProviders, true, "Codex websocket endpoint is temporarily marked unsupported")
 		proxyErr.Scope = domain.ScopeEndpoint
 		proxyErr.Code = "upstream_websocket_upgrade_rejected"
-		attemptErr := newCodexWebSocketAttemptError(proxyErr, true, true)
+		attemptErr := newCodexWebSocketAttemptError(proxyErr, true)
 		return nil, attemptErr
 	}
 
@@ -320,7 +320,7 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to get access token")
 		proxyErr.Scope = domain.ScopeKey
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
-		return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+		return nil, newCodexWebSocketAttemptError(proxyErr, false)
 	}
 	headers := buildCodexWebSocketHeaders(c, accessToken, config.AccountID, exchange.Frame)
 	fingerprint := codexWebSocketFingerprint(provider.ID, target, headers)
@@ -332,7 +332,7 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 		session = nil
 	}
 	if session == nil && exchange.PreviousResponseID != "" {
-		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketSessionUnavailable, false, false)
+		return nil, newCodexWebSocketAttemptError(domain.ErrResponsesWebSocketSessionUnavailable, false)
 	}
 
 	reused := session != nil
@@ -349,7 +349,7 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 			proxyErr.Scope = domain.ScopeRequest
 			proxyErr.Code = "upstream_websocket_session_capacity"
 			proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
-			return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+			return nil, newCodexWebSocketAttemptError(proxyErr, false)
 		}
 	}
 
@@ -384,7 +384,7 @@ func (a *CodexAdapter) dialResponsesWebSocketSession(
 		refreshed, refreshErr := a.getAccessToken(ctx, true, accessToken)
 		if refreshErr != nil {
 			proxyErr := classifyCodexHTTPError(http.StatusUnauthorized, body, response.Header, "")
-			return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+			return nil, newCodexWebSocketAttemptError(proxyErr, false)
 		}
 		headers.Set("Authorization", "Bearer "+refreshed)
 		fingerprint = codexWebSocketFingerprint(provider.ID, target, headers)
@@ -403,7 +403,7 @@ func (a *CodexAdapter) dialResponsesWebSocketSession(
 		if capabilityFailure {
 			markCodexWebSocketUnsupported(provider.ID, target, http.StatusText(status))
 		}
-		return nil, newCodexWebSocketAttemptError(proxyErr, true, capabilityFailure)
+		return nil, newCodexWebSocketAttemptError(proxyErr, capabilityFailure)
 	}
 
 	proxyErr := domain.NewProxyErrorWithMessage(err, true, "failed to upgrade Codex websocket connection")
@@ -411,14 +411,13 @@ func (a *CodexAdapter) dialResponsesWebSocketSession(
 	proxyErr.Reason = domain.CooldownReasonNetworkError
 	proxyErr.Code = "upstream_websocket_upgrade_rejected"
 	proxyErr.HTTPStatusCode = http.StatusBadGateway
-	return nil, newCodexWebSocketAttemptError(proxyErr, true, false)
+	return nil, newCodexWebSocketAttemptError(proxyErr, false)
 }
 
-func newCodexWebSocketAttemptError(err error, safeToTryNext, capabilityFailure bool) *domain.ResponsesWebSocketAttemptError {
+func newCodexWebSocketAttemptError(err error, capabilityFailure bool) *domain.ResponsesWebSocketAttemptError {
 	return &domain.ResponsesWebSocketAttemptError{
-		Err:                   err,
-		SafeToTryNextProvider: safeToTryNext,
-		CapabilityFailure:     capabilityFailure,
+		Err:               err,
+		CapabilityFailure: capabilityFailure,
 	}
 }
 
@@ -462,7 +461,7 @@ func (s *codexWebSocketSession) executeTurn(
 
 	result := &domain.ResponsesWebSocketResult{ProviderID: providerID}
 	if s.isClosed() {
-		return result, newCodexWebSocketAttemptError(errors.New("codex websocket session is closed"), true, false)
+		return result, newCodexWebSocketAttemptError(errors.New("codex websocket session is closed"), false)
 	}
 	if eventChan != nil {
 		eventChan.SendRequestInfo(&domain.RequestInfo{

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -227,8 +227,8 @@ func TestExecuteResponsesWebSocket_Upgrade404IsCachedSafeBeforeWrite(t *testing.
 		}
 		_, err := adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, exchange)
 		var wsErr *domain.ResponsesWebSocketAttemptError
-		if !errors.As(err, &wsErr) || !wsErr.CapabilityFailure || !wsErr.CanTryNextProvider() {
-			t.Fatalf("turn %d error = %#v, want cached safe capability failure", turn, wsErr)
+		if !errors.As(err, &wsErr) || !wsErr.CapabilityFailure {
+			t.Fatalf("turn %d error = %#v, want cached capability failure", turn, wsErr)
 		}
 	}
 	if handshakes.Load() != 1 {
@@ -311,8 +311,8 @@ func TestExecuteResponsesWebSocket_SinkWriteErrorIsNotReplayable(t *testing.T) {
 	if !errors.As(err, &wsErr) || !errors.Is(err, sinkErr) {
 		t.Fatalf("error = %#v, want downstream write error", err)
 	}
-	if wsErr.CanTryNextProvider() || !wsErr.RequestFrameMayHaveBeenSent || !wsErr.FirstEventReceived {
-		t.Fatalf("attempt flags = %#v, want committed non-replayable failure", wsErr)
+	if !wsErr.RequestFrameMayHaveBeenSent || !wsErr.FirstEventReceived {
+		t.Fatalf("attempt flags = %#v, want committed failure", wsErr)
 	}
 }
 

--- a/internal/adapter/provider/codex/websocket_unsupported_cache.go
+++ b/internal/adapter/provider/codex/websocket_unsupported_cache.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -53,5 +54,18 @@ func isCodexWebSocketUnsupported(providerID uint64, target string) bool {
 func clearCodexWebSocketUnsupportedForTests() {
 	globalCodexWebSocketUnsupported.mu.Lock()
 	globalCodexWebSocketUnsupported.entries = make(map[string]codexWebSocketUnsupportedEntry)
+	globalCodexWebSocketUnsupported.mu.Unlock()
+}
+
+// clearCodexWebSocketUnsupported drops unsupported-cache entries for a
+// provider so configuration/URL updates can re-probe the endpoint.
+func clearCodexWebSocketUnsupported(providerID uint64) {
+	prefix := fmt.Sprintf("%d:", providerID)
+	globalCodexWebSocketUnsupported.mu.Lock()
+	for key := range globalCodexWebSocketUnsupported.entries {
+		if strings.HasPrefix(key, prefix) {
+			delete(globalCodexWebSocketUnsupported.entries, key)
+		}
+	}
 	globalCodexWebSocketUnsupported.mu.Unlock()
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -505,8 +505,9 @@ type Route struct {
 
 	IsEnabled bool `json:"isEnabled"`
 
-	// 是否为原生支持的路由（自动创建，跟随 Provider 设置）
-	// false 表示通过 API 转换支持（手动创建，独立管理）
+	// IsNative 是后端根据目标 Provider 的原生 ClientType 能力计算出的
+	// 只读派生字段。客户端提交值会被忽略。
+	// 数据库 routes.is_native 仅保存物化快照，运行时不得直接信任历史值。
 	IsNative bool `json:"isNative"`
 
 	// 0 表示没有项目即全局

--- a/internal/domain/provider_capability.go
+++ b/internal/domain/provider_capability.go
@@ -1,0 +1,83 @@
+package domain
+
+// CanonicalSupportedClientTypes returns the authoritative native ClientType
+// capabilities for a provider type. configured is only consulted for
+// providers that allow user-defined protocol support (custom/newapi/openrouter).
+func CanonicalSupportedClientTypes(providerType string, configured []ClientType) []ClientType {
+	switch providerType {
+	case "antigravity":
+		return []ClientType{ClientTypeGemini, ClientTypeClaude}
+
+	case "kiro":
+		return []ClientType{ClientTypeClaude}
+
+	case "codex":
+		return []ClientType{ClientTypeCodex}
+
+	case "claude":
+		return []ClientType{ClientTypeClaude}
+
+	case "ollama":
+		return []ClientType{ClientTypeClaude}
+
+	case "grok":
+		return []ClientType{ClientTypeOpenAI}
+
+	case "custom", "newapi":
+		if len(configured) == 0 {
+			return []ClientType{ClientTypeOpenAI}
+		}
+
+	case "openrouter":
+		if len(configured) == 0 {
+			return []ClientType{
+				ClientTypeClaude,
+				ClientTypeOpenAI,
+			}
+		}
+	}
+
+	return append([]ClientType(nil), configured...)
+}
+
+// NormalizeProviderSupportedClientTypes rewrites provider.SupportedClientTypes
+// to the canonical native capability set for its type.
+func NormalizeProviderSupportedClientTypes(provider *Provider) {
+	if provider == nil {
+		return
+	}
+
+	provider.SupportedClientTypes = CanonicalSupportedClientTypes(
+		provider.Type,
+		provider.SupportedClientTypes,
+	)
+}
+
+// ProviderNativelySupports reports whether the provider natively understands
+// clientType. Stale SupportedClientTypes snapshots are ignored via the
+// canonical helper so historical codex providers still count as native Codex.
+func ProviderNativelySupports(provider *Provider, clientType ClientType) bool {
+	if provider == nil {
+		return false
+	}
+
+	supportedTypes := CanonicalSupportedClientTypes(
+		provider.Type,
+		provider.SupportedClientTypes,
+	)
+
+	for _, supported := range supportedTypes {
+		if supported == clientType {
+			return true
+		}
+	}
+
+	return false
+}
+
+// RouteIsNative is the single source of truth for Route.IsNative:
+// true when the target provider natively supports the route client type.
+func RouteIsNative(provider *Provider, route *Route) bool {
+	return route != nil &&
+		ProviderNativelySupports(provider, route.ClientType)
+}

--- a/internal/domain/provider_capability_test.go
+++ b/internal/domain/provider_capability_test.go
@@ -1,0 +1,156 @@
+package domain
+
+import "testing"
+
+func TestCanonicalSupportedClientTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerType string
+		configured []ClientType
+		want       []ClientType
+	}{
+		{
+			name:         "codex ignores configured",
+			providerType: "codex",
+			configured:   []ClientType{ClientTypeOpenAI},
+			want:         []ClientType{ClientTypeCodex},
+		},
+		{
+			name:         "claude fixed",
+			providerType: "claude",
+			configured:   nil,
+			want:         []ClientType{ClientTypeClaude},
+		},
+		{
+			name:         "custom empty defaults openai",
+			providerType: "custom",
+			configured:   nil,
+			want:         []ClientType{ClientTypeOpenAI},
+		},
+		{
+			name:         "custom keeps configured codex",
+			providerType: "custom",
+			configured:   []ClientType{ClientTypeCodex},
+			want:         []ClientType{ClientTypeCodex},
+		},
+		{
+			name:         "openrouter empty defaults both",
+			providerType: "openrouter",
+			configured:   nil,
+			want:         []ClientType{ClientTypeClaude, ClientTypeOpenAI},
+		},
+		{
+			name:         "openrouter keeps configured",
+			providerType: "openrouter",
+			configured:   []ClientType{ClientTypeOpenAI},
+			want:         []ClientType{ClientTypeOpenAI},
+		},
+		{
+			name:         "antigravity fixed",
+			providerType: "antigravity",
+			configured:   []ClientType{ClientTypeOpenAI},
+			want:         []ClientType{ClientTypeGemini, ClientTypeClaude},
+		},
+		{
+			name:         "unknown type keeps configured",
+			providerType: "responses-ws-router-native-test",
+			configured:   []ClientType{ClientTypeCodex},
+			want:         []ClientType{ClientTypeCodex},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CanonicalSupportedClientTypes(tt.providerType, tt.configured)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestProviderNativelySupports(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   *Provider
+		clientType ClientType
+		want       bool
+	}{
+		{
+			name:       "codex provider + codex route",
+			provider:   &Provider{Type: "codex"},
+			clientType: ClientTypeCodex,
+			want:       true,
+		},
+		{
+			name:       "codex provider + openai route",
+			provider:   &Provider{Type: "codex"},
+			clientType: ClientTypeOpenAI,
+			want:       false,
+		},
+		{
+			name:       "openai provider + codex route",
+			provider:   &Provider{Type: "custom", SupportedClientTypes: []ClientType{ClientTypeOpenAI}},
+			clientType: ClientTypeCodex,
+			want:       false,
+		},
+		{
+			name: "custom configured codex + codex route",
+			provider: &Provider{
+				Type:                 "custom",
+				SupportedClientTypes: []ClientType{ClientTypeCodex},
+			},
+			clientType: ClientTypeCodex,
+			want:       true,
+		},
+		{
+			name:       "nil provider",
+			provider:   nil,
+			clientType: ClientTypeCodex,
+			want:       false,
+		},
+		{
+			name: "historical codex empty supported types still native",
+			provider: &Provider{
+				Type:                 "codex",
+				SupportedClientTypes: nil,
+			},
+			clientType: ClientTypeCodex,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProviderNativelySupports(tt.provider, tt.clientType); got != tt.want {
+				t.Fatalf("ProviderNativelySupports = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteIsNative(t *testing.T) {
+	codexProvider := &Provider{Type: "codex"}
+	openaiProvider := &Provider{
+		Type:                 "custom",
+		SupportedClientTypes: []ClientType{ClientTypeOpenAI},
+	}
+
+	if !RouteIsNative(codexProvider, &Route{ClientType: ClientTypeCodex}) {
+		t.Fatal("codex→codex should be native")
+	}
+	if RouteIsNative(codexProvider, &Route{ClientType: ClientTypeOpenAI}) {
+		t.Fatal("codex→openai should not be native")
+	}
+	if RouteIsNative(openaiProvider, &Route{ClientType: ClientTypeCodex}) {
+		t.Fatal("openai→codex should not be native")
+	}
+	if RouteIsNative(codexProvider, nil) {
+		t.Fatal("nil route should not be native")
+	}
+}

--- a/internal/domain/responses_websocket.go
+++ b/internal/domain/responses_websocket.go
@@ -29,15 +29,21 @@ type ResponsesWebSocketResult struct {
 	ResponseModel string
 }
 
+// ResponsesWebSocketAttemptError describes a failed WS turn.
+// CapabilityFailure distinguishes unsupported-WS endpoints from ordinary
+// network/model errors for cooldown/unsupported-cache only — it must never
+// switch providers.
 type ResponsesWebSocketAttemptError struct {
 	Err error
 
-	SafeToTryNextProvider       bool
 	RequestFrameMayHaveBeenSent bool
 	FirstEventReceived          bool
 	ClientEventSent             bool
 	TerminalErrorEventSent      bool
-	CapabilityFailure           bool
+
+	// CapabilityFailure is used only for cooldown/unsupported cache.
+	// It must never trigger cross-provider fallback.
+	CapabilityFailure bool
 }
 
 func (e *ResponsesWebSocketAttemptError) Error() string {
@@ -52,9 +58,4 @@ func (e *ResponsesWebSocketAttemptError) Unwrap() error {
 		return nil
 	}
 	return e.Err
-}
-
-func (e *ResponsesWebSocketAttemptError) CanTryNextProvider() bool {
-	return e != nil && e.SafeToTryNextProvider &&
-		!e.RequestFrameMayHaveBeenSent && !e.FirstEventReceived && !e.ClientEventSent
 }

--- a/internal/domain/responses_websocket_test.go
+++ b/internal/domain/responses_websocket_test.go
@@ -1,23 +1,23 @@
 package domain
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
-func TestResponsesWebSocketAttemptError_SafeRetryInvariant(t *testing.T) {
-	tests := []struct {
-		name string
-		err  *ResponsesWebSocketAttemptError
-		want bool
-	}{
-		{name: "pre-send", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true}, want: true},
-		{name: "may have sent", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, RequestFrameMayHaveBeenSent: true}},
-		{name: "event received", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, FirstEventReceived: true}},
-		{name: "client event sent", err: &ResponsesWebSocketAttemptError{SafeToTryNextProvider: true, ClientEventSent: true}},
+func TestResponsesWebSocketAttemptError_UnwrapAndMessage(t *testing.T) {
+	inner := errors.New("dial failed")
+	err := &ResponsesWebSocketAttemptError{
+		Err:               inner,
+		CapabilityFailure: true,
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := test.err.CanTryNextProvider(); got != test.want {
-				t.Fatalf("CanTryNextProvider = %v, want %v", got, test.want)
-			}
-		})
+	if err.Error() != "dial failed" {
+		t.Fatalf("Error() = %q", err.Error())
+	}
+	if !errors.Is(err, inner) {
+		t.Fatalf("Unwrap/Is failed for %#v", err)
+	}
+	if (&ResponsesWebSocketAttemptError{}).Error() != "responses websocket attempt failed" {
+		t.Fatal("empty attempt error message mismatch")
 	}
 }

--- a/internal/executor/middleware_dispatch_websocket.go
+++ b/internal/executor/middleware_dispatch_websocket.go
@@ -32,148 +32,140 @@ func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
 	proxyReq := state.proxyReq
 	ctx := state.ctx
 	clearDetail := e.shouldClearRequestDetailFor(state)
-	var lastAttemptErr error
 
-	for _, matched := range state.routes {
-		if ctx.Err() != nil {
-			state.lastErr = ctx.Err()
-			c.Err = state.lastErr
-			return
-		}
-		if matched == nil || matched.Route == nil || matched.Provider == nil || matched.ProviderAdapter == nil || !matched.Route.IsNative {
-			continue
-		}
-		wsAdapter, ok := matched.ProviderAdapter.(provideradapter.ResponsesWebSocketAdapter)
-		if !ok {
-			continue
-		}
-
-		mappedModel := e.mapModel(
-			state.tenantID,
-			state.requestModel,
-			matched.Route,
-			matched.Provider,
-			domain.ClientTypeCodex,
-			state.projectID,
-			state.apiTokenID,
+	if len(state.routes) == 0 {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			domain.ErrNoResponsesWebSocketProviders,
+			true,
+			"no eligible native Codex Responses WebSocket adapter is available",
 		)
-		outboundFrame, err := sjson.SetBytes(bytes.Clone(exchange.Frame), "model", mappedModel)
-		if err != nil {
-			proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "failed to map websocket request model")
-			proxyErr.Scope = domain.ScopeRequest
-			proxyErr.Code = "websocket_protocol_error"
-			proxyErr.HTTPStatusCode = http.StatusBadRequest
-			state.lastErr = proxyErr
-			c.Err = proxyErr
-			return
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "websocket_transport_unavailable"
+		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+		state.lastErr = proxyErr
+		c.Err = proxyErr
+		return
+	}
+
+	// Router returns at most one candidate for WebSocket; execute that route only.
+	// No cross-provider fallback and no second pass on Route.IsNative snapshot.
+	matched := state.routes[0]
+	if matched == nil || matched.Route == nil || matched.Provider == nil || matched.ProviderAdapter == nil {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			domain.ErrNoResponsesWebSocketProviders,
+			true,
+			"no eligible native Codex Responses WebSocket adapter is available",
+		)
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "websocket_transport_unavailable"
+		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+		state.lastErr = proxyErr
+		c.Err = proxyErr
+		return
+	}
+
+	wsAdapter, ok := matched.ProviderAdapter.(provideradapter.ResponsesWebSocketAdapter)
+	if !ok {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			domain.ErrNoResponsesWebSocketProviders,
+			true,
+			"no eligible native Codex Responses WebSocket adapter is available",
+		)
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "websocket_transport_unavailable"
+		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+		state.lastErr = proxyErr
+		c.Err = proxyErr
+		return
+	}
+
+	if ctx.Err() != nil {
+		state.lastErr = ctx.Err()
+		c.Err = state.lastErr
+		return
+	}
+
+	mappedModel := e.mapModel(
+		state.tenantID,
+		state.requestModel,
+		matched.Route,
+		matched.Provider,
+		domain.ClientTypeCodex,
+		state.projectID,
+		state.apiTokenID,
+	)
+	outboundFrame, err := sjson.SetBytes(bytes.Clone(exchange.Frame), "model", mappedModel)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "failed to map websocket request model")
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Code = "websocket_protocol_error"
+		proxyErr.HTTPStatusCode = http.StatusBadRequest
+		state.lastErr = proxyErr
+		c.Err = proxyErr
+		return
+	}
+	outboundFrame = e.applyOutboundParamPolicy(outboundFrame, domain.ClientTypeCodex, mappedModel, matched.Provider)
+	turnExchange := *exchange
+	turnExchange.Frame = outboundFrame
+
+	proxyReq.RouteID = matched.Route.ID
+	proxyReq.ProviderID = matched.Provider.ID
+	proxyReq.MappedModel = mappedModel
+	_ = e.proxyRequestRepo.Update(proxyReq)
+
+	attempt := &domain.ProxyUpstreamAttempt{
+		TenantID:       proxyReq.TenantID,
+		ProxyRequestID: proxyReq.ID,
+		RouteID:        matched.Route.ID,
+		ProviderID:     matched.Provider.ID,
+		IsStream:       true,
+		Status:         "IN_PROGRESS",
+		StartTime:      time.Now(),
+		RequestModel:   state.requestModel,
+		MappedModel:    mappedModel,
+		RequestInfo:    proxyReq.RequestInfo,
+	}
+	if attempt.TenantID == 0 {
+		attempt.TenantID = state.tenantID
+	}
+	if err := e.attemptRepo.Create(attempt); err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to create websocket upstream attempt")
+		proxyErr.Scope = domain.ScopeRequest
+		state.lastErr = proxyErr
+		c.Err = proxyErr
+		return
+	}
+	if e.broadcaster != nil {
+		e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+	}
+	state.currentAttempt = attempt
+	proxyReq.ProxyUpstreamAttemptCount++
+
+	eventChan := domain.NewAdapterEventChan()
+	c.Set(flow.KeyClientType, domain.ClientTypeCodex)
+	c.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
+	c.Set(flow.KeyMappedModel, mappedModel)
+	c.Set(flow.KeyEventChan, eventChan)
+	c.Set(flow.KeyProxyRequest, proxyReq)
+	c.Set(flow.KeyUpstreamAttempt, attempt)
+	c.Set(flow.KeyBroadcaster, e.broadcaster)
+	eventDone := make(chan struct{})
+	go e.processAdapterEventsRealtime(eventChan, attempt, eventDone, clearDetail)
+
+	result, execErr := wsAdapter.ExecuteResponsesWebSocket(c, matched.Provider, &turnExchange)
+	eventChan.Close()
+	<-eventDone
+
+	attempt.EndTime = time.Now()
+	attempt.Duration = attempt.EndTime.Sub(attempt.StartTime)
+	multiplier := getProviderMultiplier(matched.Provider, domain.ClientTypeCodex)
+
+	if execErr == nil {
+		attempt.Status = "COMPLETED"
+		attempt.Error = ""
+		if result != nil && result.ResponseModel != "" {
+			attempt.ResponseModel = result.ResponseModel
 		}
-		outboundFrame = e.applyOutboundParamPolicy(outboundFrame, domain.ClientTypeCodex, mappedModel, matched.Provider)
-		turnExchange := *exchange
-		turnExchange.Frame = outboundFrame
-
-		proxyReq.RouteID = matched.Route.ID
-		proxyReq.ProviderID = matched.Provider.ID
-		proxyReq.MappedModel = mappedModel
-		_ = e.proxyRequestRepo.Update(proxyReq)
-
-		attempt := &domain.ProxyUpstreamAttempt{
-			TenantID:       proxyReq.TenantID,
-			ProxyRequestID: proxyReq.ID,
-			RouteID:        matched.Route.ID,
-			ProviderID:     matched.Provider.ID,
-			IsStream:       true,
-			Status:         "IN_PROGRESS",
-			StartTime:      time.Now(),
-			RequestModel:   state.requestModel,
-			MappedModel:    mappedModel,
-			RequestInfo:    proxyReq.RequestInfo,
-		}
-		if attempt.TenantID == 0 {
-			attempt.TenantID = state.tenantID
-		}
-		if err := e.attemptRepo.Create(attempt); err != nil {
-			proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to create websocket upstream attempt")
-			proxyErr.Scope = domain.ScopeRequest
-			state.lastErr = proxyErr
-			c.Err = proxyErr
-			return
-		}
-		if e.broadcaster != nil {
-			e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
-		}
-		state.currentAttempt = attempt
-		proxyReq.ProxyUpstreamAttemptCount++
-
-		eventChan := domain.NewAdapterEventChan()
-		c.Set(flow.KeyClientType, domain.ClientTypeCodex)
-		c.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
-		c.Set(flow.KeyMappedModel, mappedModel)
-		c.Set(flow.KeyEventChan, eventChan)
-		c.Set(flow.KeyProxyRequest, proxyReq)
-		c.Set(flow.KeyUpstreamAttempt, attempt)
-		c.Set(flow.KeyBroadcaster, e.broadcaster)
-		eventDone := make(chan struct{})
-		go e.processAdapterEventsRealtime(eventChan, attempt, eventDone, clearDetail)
-
-		result, execErr := wsAdapter.ExecuteResponsesWebSocket(c, matched.Provider, &turnExchange)
-		eventChan.Close()
-		<-eventDone
-
-		attempt.EndTime = time.Now()
-		attempt.Duration = attempt.EndTime.Sub(attempt.StartTime)
-		multiplier := getProviderMultiplier(matched.Provider, domain.ClientTypeCodex)
-
-		if execErr == nil {
-			attempt.Status = "COMPLETED"
-			attempt.Error = ""
-			if result != nil && result.ResponseModel != "" {
-				attempt.ResponseModel = result.ResponseModel
-			}
-			pricing.FinalizeAttemptCost(attempt, multiplier)
-			if clearDetail {
-				attempt.RequestInfo = nil
-				attempt.ResponseInfo = nil
-			}
-			_ = e.attemptRepo.Update(attempt)
-			if e.broadcaster != nil {
-				e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
-			}
-			state.currentAttempt = nil
-			cooldown.Default().RecordSuccess(matched.Provider.ID, string(domain.ClientTypeCodex), mappedModel)
-
-			if state.stickyWrite != nil {
-				stickyCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
-				_ = sticky.Default().Set(stickyCtx, state.stickyWrite.Key, matched.Provider.ID, state.stickyWrite.TTL)
-				cancel()
-			}
-
-			exchange.PinnedProviderID = matched.Provider.ID
-			proxyReq.Status = "COMPLETED"
-			proxyReq.StatusCode = http.StatusSwitchingProtocols
-			proxyReq.EndTime = time.Now()
-			proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
-			proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
-			proxyReq.ResponseModel = attempt.ResponseModel
-			if proxyReq.ResponseModel == "" {
-				proxyReq.ResponseModel = mappedModel
-			}
-			if !clearDetail {
-				proxyReq.ResponseInfo = attempt.ResponseInfo
-			}
-			pricing.MirrorCostToRequest(proxyReq, attempt)
-			proxyReq.TTFT = attempt.TTFT
-			clearProxyRequestDetail(proxyReq, clearDetail)
-			_ = e.proxyRequestRepo.Update(proxyReq)
-			if e.broadcaster != nil {
-				e.broadcaster.BroadcastProxyRequest(proxyReq)
-			}
-			state.lastErr = nil
-			state.ctx = ctx
-			return
-		}
-
-		attempt.Status = attemptFailureStatus(ctx, execErr)
-		attempt.Error = execErr.Error()
 		pricing.FinalizeAttemptCost(attempt, multiplier)
 		if clearDetail {
 			attempt.RequestInfo = nil
@@ -184,40 +176,62 @@ func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
 			e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
 		}
 		state.currentAttempt = nil
+		cooldown.Default().RecordSuccess(matched.Provider.ID, string(domain.ClientTypeCodex), mappedModel)
+
+		if state.stickyWrite != nil {
+			stickyCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			_ = sticky.Default().Set(stickyCtx, state.stickyWrite.Key, matched.Provider.ID, state.stickyWrite.TTL)
+			cancel()
+		}
+
+		exchange.PinnedProviderID = matched.Provider.ID
+		proxyReq.Status = "COMPLETED"
+		proxyReq.StatusCode = http.StatusSwitchingProtocols
+		proxyReq.EndTime = time.Now()
+		proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
 		proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
+		proxyReq.ResponseModel = attempt.ResponseModel
+		if proxyReq.ResponseModel == "" {
+			proxyReq.ResponseModel = mappedModel
+		}
+		if !clearDetail {
+			proxyReq.ResponseInfo = attempt.ResponseInfo
+		}
 		pricing.MirrorCostToRequest(proxyReq, attempt)
 		proxyReq.TTFT = attempt.TTFT
+		clearProxyRequestDetail(proxyReq, clearDetail)
 		_ = e.proxyRequestRepo.Update(proxyReq)
-
-		var wsErr *domain.ResponsesWebSocketAttemptError
-		errors.As(execErr, &wsErr)
-		if proxyErr, ok := asProxyError(execErr); ok && (wsErr == nil || !wsErr.CapabilityFailure) &&
-			ctx.Err() == nil && !shouldSkipErrorCooldown(matched.Provider) {
-			e.handleCooldown(proxyErr, matched.Provider, domain.ClientTypeCodex, mappedModel)
+		if e.broadcaster != nil {
+			e.broadcaster.BroadcastProxyRequest(proxyReq)
 		}
-		if wsErr != nil && exchange.PinnedProviderID == 0 &&
-			exchange.PreviousResponseID == "" && wsErr.CanTryNextProvider() {
-			lastAttemptErr = execErr
-			continue
-		}
-		state.lastErr = execErr
-		c.Err = execErr
-		return
-	}
-	if lastAttemptErr != nil {
-		state.lastErr = lastAttemptErr
-		c.Err = lastAttemptErr
+		state.lastErr = nil
+		state.ctx = ctx
 		return
 	}
 
-	proxyErr := domain.NewProxyErrorWithMessage(
-		domain.ErrNoResponsesWebSocketProviders,
-		true,
-		"all native Codex Responses WebSocket providers were exhausted before request submission",
-	)
-	proxyErr.Scope = domain.ScopeRequest
-	proxyErr.Code = "websocket_transport_unavailable"
-	proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
-	state.lastErr = proxyErr
-	c.Err = proxyErr
+	attempt.Status = attemptFailureStatus(ctx, execErr)
+	attempt.Error = execErr.Error()
+	pricing.FinalizeAttemptCost(attempt, multiplier)
+	if clearDetail {
+		attempt.RequestInfo = nil
+		attempt.ResponseInfo = nil
+	}
+	_ = e.attemptRepo.Update(attempt)
+	if e.broadcaster != nil {
+		e.broadcaster.BroadcastProxyUpstreamAttempt(attempt)
+	}
+	state.currentAttempt = nil
+	proxyReq.FinalProxyUpstreamAttemptID = attempt.ID
+	pricing.MirrorCostToRequest(proxyReq, attempt)
+	proxyReq.TTFT = attempt.TTFT
+	_ = e.proxyRequestRepo.Update(proxyReq)
+
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	errors.As(execErr, &wsErr)
+	if proxyErr, ok := asProxyError(execErr); ok && (wsErr == nil || !wsErr.CapabilityFailure) &&
+		ctx.Err() == nil && !shouldSkipErrorCooldown(matched.Provider) {
+		e.handleCooldown(proxyErr, matched.Provider, domain.ClientTypeCodex, mappedModel)
+	}
+	state.lastErr = execErr
+	c.Err = execErr
 }

--- a/internal/executor/middleware_dispatch_websocket_test.go
+++ b/internal/executor/middleware_dispatch_websocket_test.go
@@ -135,19 +135,8 @@ func wsMatchedRoute(id, providerID uint64, adapter *recordingWSAdapter, native b
 
 func preWriteWSErr() *domain.ResponsesWebSocketAttemptError {
 	return &domain.ResponsesWebSocketAttemptError{
-		Err:                   errors.New("handshake failed before request frame write"),
-		SafeToTryNextProvider: true,
+		Err: errors.New("handshake failed before request frame write"),
 	}
-}
-
-func postWriteWSErr(flags domain.ResponsesWebSocketAttemptError) *domain.ResponsesWebSocketAttemptError {
-	flags.Err = errors.New("attempt failed after downstream commitment")
-	if !flags.SafeToTryNextProvider {
-		// Keep the flag true so tests assert the secondary safety gates
-		// (frame sent / first event / client write), not SafeToTryNext alone.
-		flags.SafeToTryNextProvider = true
-	}
-	return &flags
 }
 
 // dispatch must take the native WS path and never call ProviderAdapter.Execute.
@@ -192,8 +181,8 @@ func TestDispatch_ResponsesWebSocketBypassesHTTPExecute(t *testing.T) {
 	}
 }
 
-// Failover is allowed only while the attempt is still pre-write / pre-event.
-func TestDispatch_ResponsesWebSocketFailsOverBeforeClientWrite(t *testing.T) {
+// One WebSocket turn executes only the first matched provider; second is never tried.
+func TestDispatch_ResponsesWebSocketExecutesFirstProviderOnly(t *testing.T) {
 	first := &recordingWSAdapter{errSequence: []error{preWriteWSErr()}}
 	second := &recordingWSAdapter{resultModel: "gpt-test"}
 	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
@@ -205,33 +194,25 @@ func TestDispatch_ResponsesWebSocketFailsOverBeforeClientWrite(t *testing.T) {
 
 	e.dispatch(c)
 
-	if c.Err != nil {
-		t.Fatalf("dispatch error: %v", c.Err)
+	if c.Err == nil {
+		t.Fatal("expected dispatch error from first provider")
 	}
 	if first.httpExecuteCalls != 0 || second.httpExecuteCalls != 0 {
 		t.Fatalf("HTTP Execute calls first=%d second=%d, want 0/0", first.httpExecuteCalls, second.httpExecuteCalls)
 	}
-	if first.wsCalls != 1 || second.wsCalls != 1 {
-		t.Fatalf("WS calls first=%d second=%d, want 1/1 (pre-write failover)", first.wsCalls, second.wsCalls)
+	if first.wsCalls != 1 || second.wsCalls != 0 {
+		t.Fatalf("WS calls first=%d second=%d, want 1/0 (no cross-provider fallback)", first.wsCalls, second.wsCalls)
 	}
-	if len(attemptRepo.created) != 2 {
-		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	if len(attemptRepo.created) != 1 {
+		t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
 	}
-	if attemptRepo.created[0].ProviderID != 21 || attemptRepo.created[1].ProviderID != 22 {
-		t.Fatalf("attempt providers = [%d %d], want [21 22]",
-			attemptRepo.created[0].ProviderID, attemptRepo.created[1].ProviderID)
+	if attemptRepo.created[0].ProviderID != 21 {
+		t.Fatalf("attempt provider = %d, want 21", attemptRepo.created[0].ProviderID)
 	}
-	state, _ := getExecState(c)
-	if state.wsExchange.PinnedProviderID != 22 {
-		t.Fatalf("PinnedProviderID = %d, want second provider 22", state.wsExchange.PinnedProviderID)
-	}
-	last := proxyRepo.updated[len(proxyRepo.updated)-1]
-	if last.Status != "COMPLETED" || last.ProviderID != 22 {
-		t.Fatalf("final proxy = status=%s provider=%d, want COMPLETED/22", last.Status, last.ProviderID)
-	}
+	_ = proxyRepo
 }
 
-func TestDispatch_ResponsesWebSocketRecordsCooldownBeforeFailover(t *testing.T) {
+func TestDispatch_ResponsesWebSocketRecordsCooldownWithoutSecondProvider(t *testing.T) {
 	const firstProviderID = uint64(920021)
 	cooldown.Default().ClearCooldown(firstProviderID, string(domain.ClientTypeCodex), "")
 	t.Cleanup(func() {
@@ -242,8 +223,7 @@ func TestDispatch_ResponsesWebSocketRecordsCooldownBeforeFailover(t *testing.T) 
 	proxyErr.Reason = domain.CooldownReasonNetworkError
 	proxyErr.HTTPStatusCode = http.StatusBadGateway
 	first := &recordingWSAdapter{errSequence: []error{&domain.ResponsesWebSocketAttemptError{
-		Err:                   proxyErr,
-		SafeToTryNextProvider: true,
+		Err: proxyErr,
 	}}}
 	second := &recordingWSAdapter{resultModel: "gpt-test"}
 	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
@@ -255,121 +235,80 @@ func TestDispatch_ResponsesWebSocketRecordsCooldownBeforeFailover(t *testing.T) 
 
 	e.dispatch(c)
 
+	if c.Err == nil {
+		t.Fatal("expected error without second provider")
+	}
+	if second.wsCalls != 0 {
+		t.Fatalf("second WS calls = %d, want 0", second.wsCalls)
+	}
+	if !cooldown.Default().IsInCooldown(firstProviderID, string(domain.ClientTypeCodex), "") {
+		t.Fatal("provider failure did not enter cooldown")
+	}
+	_ = proxyRepo
+	_ = attemptRepo
+}
+
+// Dispatcher no longer re-checks Route.IsNative — a stale false snapshot still executes.
+func TestDispatch_ResponsesWebSocketDoesNotRecheckStoredNativeFlag(t *testing.T) {
+	adapter := &recordingWSAdapter{resultModel: "gpt-test"}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, _, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, 51, adapter, false),
+	})
+	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, attemptRepo)
+
+	e.dispatch(c)
+
 	if c.Err != nil {
 		t.Fatalf("dispatch error: %v", c.Err)
 	}
-	if !cooldown.Default().IsInCooldown(firstProviderID, string(domain.ClientTypeCodex), "") {
-		t.Fatal("pre-write provider failure did not enter cooldown before failover")
+	if adapter.wsCalls != 1 {
+		t.Fatalf("WS calls = %d, want 1 despite IsNative=false snapshot", adapter.wsCalls)
+	}
+	if len(attemptRepo.created) != 1 || attemptRepo.created[0].ProviderID != 51 {
+		t.Fatalf("attempts = %#v, want provider 51", attemptRepo.created)
 	}
 }
 
-// After a downstream frame/client write (or first event), failover is forbidden.
-func TestDispatch_ResponsesWebSocketNoFailoverAfterClientWrite(t *testing.T) {
-	cases := []struct {
-		name string
-		err  *domain.ResponsesWebSocketAttemptError
-	}{
-		{
-			name: "client_event_sent",
-			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{ClientEventSent: true}),
-		},
-		{
-			name: "first_event_received",
-			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{FirstEventReceived: true}),
-		},
-		{
-			name: "request_frame_may_have_been_sent",
-			err:  postWriteWSErr(domain.ResponsesWebSocketAttemptError{RequestFrameMayHaveBeenSent: true}),
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			first := &recordingWSAdapter{errSequence: []error{tc.err}}
-			second := &recordingWSAdapter{resultModel: "gpt-test"}
-			frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
-			c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
-				wsMatchedRoute(1, 31, first, true),
-				wsMatchedRoute(2, 32, second, true),
-			})
-			e := newWSDispatchExecutor(proxyRepo, attemptRepo)
-
-			e.dispatch(c)
-
-			if c.Err == nil {
-				t.Fatal("expected dispatch error without failover")
-			}
-			if !errors.Is(c.Err, tc.err) {
-				t.Fatalf("c.Err = %v, want %v", c.Err, tc.err)
-			}
-			if first.wsCalls != 1 {
-				t.Fatalf("first WS calls = %d, want 1", first.wsCalls)
-			}
-			if second.wsCalls != 0 {
-				t.Fatalf("second WS calls = %d, want 0 (no failover after client/write commitment)", second.wsCalls)
-			}
-			if first.httpExecuteCalls != 0 || second.httpExecuteCalls != 0 {
-				t.Fatalf("HTTP Execute must stay unused; first=%d second=%d", first.httpExecuteCalls, second.httpExecuteCalls)
-			}
-			if len(attemptRepo.created) != 1 {
-				t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
-			}
-			_ = proxyRepo
-		})
-	}
-}
-
-// A pinned session must not fail over even when the error is still "safe".
-func TestDispatch_ResponsesWebSocketNoFailoverWhenPinned(t *testing.T) {
-	first := &recordingWSAdapter{errSequence: []error{preWriteWSErr()}}
-	second := &recordingWSAdapter{resultModel: "gpt-test"}
-	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
-	exchange := &domain.ResponsesWebSocketExchange{
-		ConnectionID:     "ws-conn-pinned",
-		Frame:            frame,
-		PinnedProviderID: 41,
-	}
-	c, _, attemptRepo := newWSDispatchCtx(t, frame, exchange, []*router.MatchedRoute{
-		wsMatchedRoute(1, 41, first, true),
-		wsMatchedRoute(2, 42, second, true),
+func TestDispatch_ResponsesWebSocketPreservesProtocolFields(t *testing.T) {
+	adapter := &recordingWSAdapter{}
+	frame := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"store":true,"generate":false,"previous_response_id":"resp_1","stream_options":{"include_obfuscation":true},"client_metadata":{"x":1},"prompt_cache_key":"pc","input":[],"tools":[{"type":"function"}],"tool_choice":"auto","parallel_tool_calls":true,"unknown_field":"keep"}`)
+	c, _, _ := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
+		wsMatchedRoute(1, 61, adapter, true),
 	})
-	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, attemptRepo)
+	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	for _, path := range []string{
+		"type", "stream", "store", "generate", "previous_response_id",
+		"stream_options", "client_metadata", "prompt_cache_key",
+		"input", "tools", "tool_choice", "parallel_tool_calls", "unknown_field",
+	} {
+		if !gjson.GetBytes(adapter.lastFrame, path).Exists() {
+			t.Fatalf("outbound frame lost field %q: %s", path, adapter.lastFrame)
+		}
+	}
+	if gjson.GetBytes(adapter.lastFrame, "type").String() != "response.create" {
+		t.Fatalf("type mutated: %s", adapter.lastFrame)
+	}
+}
+
+func TestDispatch_ResponsesWebSocketUnavailableWhenNoAdapter(t *testing.T) {
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, _, _ := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{})
+	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, &recordingAttemptRepo{})
 
 	e.dispatch(c)
 
 	if c.Err == nil {
-		t.Fatal("expected error when pinned provider fails")
+		t.Fatal("expected unavailable error")
 	}
-	if first.wsCalls != 1 || second.wsCalls != 0 {
-		t.Fatalf("WS calls first=%d second=%d, want 1/0 with pin", first.wsCalls, second.wsCalls)
-	}
-	if len(attemptRepo.created) != 1 || attemptRepo.created[0].ProviderID != 41 {
-		t.Fatalf("attempts = %#v, want single attempt on pinned provider 41", attemptRepo.created)
-	}
-}
-
-// Non-native routes are skipped even if the adapter implements the WS interface.
-func TestDispatch_ResponsesWebSocketSkipsNonNativeRoutes(t *testing.T) {
-	nonNative := &recordingWSAdapter{resultModel: "should-not-run"}
-	native := &recordingWSAdapter{resultModel: "gpt-test"}
-	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
-	c, _, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{
-		wsMatchedRoute(1, 51, nonNative, false),
-		wsMatchedRoute(2, 52, native, true),
-	})
-	e := newWSDispatchExecutor(&recordingProxyRequestRepo{}, attemptRepo)
-
-	e.dispatch(c)
-
-	if c.Err != nil {
-		t.Fatalf("dispatch error: %v", c.Err)
-	}
-	if nonNative.wsCalls != 0 {
-		t.Fatalf("non-native WS calls = %d, want 0", nonNative.wsCalls)
-	}
-	if native.wsCalls != 1 {
-		t.Fatalf("native WS calls = %d, want 1", native.wsCalls)
-	}
-	if len(attemptRepo.created) != 1 || attemptRepo.created[0].ProviderID != 52 {
-		t.Fatalf("attempts = %#v, want provider 52 only", attemptRepo.created)
+	proxyErr, ok := asProxyError(c.Err)
+	if !ok || proxyErr.Code != "websocket_transport_unavailable" {
+		t.Fatalf("error = %#v, want websocket_transport_unavailable", c.Err)
 	}
 }

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -47,7 +47,7 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoRoutes, false, message)
 		if errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
-			message = "no native Codex Responses WebSocket provider is available"
+			message = "no eligible native Codex Responses WebSocket adapter is available"
 			status = http.StatusServiceUnavailable
 			proxyErr = domain.NewProxyErrorWithMessage(err, true, message)
 			proxyErr.Code = "websocket_transport_unavailable"

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -638,11 +638,7 @@ func (h *AdminHandler) handleRoutes(w http.ResponseWriter, r *http.Request, id u
 				existing.IsEnabled = b
 			}
 		}
-		if v, ok := updates["isNative"]; ok {
-			if b, ok := v.(bool); ok {
-				existing.IsNative = b
-			}
-		}
+		// isNative is a server-derived field; ignore client-supplied values.
 		if v, ok := updates["projectID"]; ok {
 			if f, ok := v.(float64); ok {
 				existing.ProjectID = uint64(f)

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -622,11 +622,7 @@ func (h *SelfServiceHandler) handleRoutes(w http.ResponseWriter, r *http.Request
 				existing.IsEnabled = b
 			}
 		}
-		if v, ok := updates["isNative"]; ok {
-			if b, ok := v.(bool); ok {
-				existing.IsNative = b
-			}
-		}
+		// isNative is a server-derived field; ignore client-supplied values.
 		if v, ok := updates["projectID"]; ok {
 			if f, ok := v.(float64); ok {
 				existing.ProjectID = uint64(f)

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -687,9 +687,15 @@ func (r *selfServiceProviderRepoWithListError) List(tenantID uint64) ([]*domain.
 }
 
 func newSelfServiceHandlerForTests(deps selfServiceTestDeps) *SelfServiceHandler {
+	// Avoid typed-nil RouteRepository: (*selfServiceRouteRepo)(nil) is non-nil as
+	// an interface and panics on method call during provider update reconcile.
+	routeRepo := deps.routeRepo
+	if routeRepo == nil {
+		routeRepo = &selfServiceRouteRepo{}
+	}
 	adminSvc := service.NewAdminService(
 		deps.providerRepo,
-		deps.routeRepo,
+		routeRepo,
 		deps.projectRepo,
 		nil,
 		deps.retryConfigRepo,
@@ -1941,9 +1947,15 @@ func TestSelfServiceHandler_SyncRoutesFromProject_OverwriteDefaultToProject(t *t
 		projects: []*domain.Project{{ID: 42, TenantID: 1, Name: "demo", Slug: "demo"}},
 	}
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
-		providerRepo: &selfServiceProviderRepo{},
-		routeRepo:    routeRepo,
-		projectRepo:  projectRepo,
+		providerRepo: &selfServiceProviderRepo{
+			providers: []*domain.Provider{
+				{ID: 10, TenantID: 1, Type: "claude", Name: "p10", SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude}},
+				{ID: 11, TenantID: 1, Type: "claude", Name: "p11", SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude}},
+				{ID: 99, TenantID: 1, Type: "custom", Name: "p99", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}},
+			},
+		},
+		routeRepo:   routeRepo,
+		projectRepo: projectRepo,
 	})
 
 	rec := httptest.NewRecorder()
@@ -1998,9 +2010,15 @@ func TestSelfServiceHandler_SyncRoutesFromProject_AddMissingUsesEffectiveSource(
 		},
 	}
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
-		providerRepo: &selfServiceProviderRepo{},
-		routeRepo:    routeRepo,
-		projectRepo:  projectRepo,
+		providerRepo: &selfServiceProviderRepo{
+			providers: []*domain.Provider{
+				{ID: 10, TenantID: 1, Type: "codex", Name: "p10", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+				{ID: 20, TenantID: 1, Type: "codex", Name: "p20", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+				{ID: 77, TenantID: 1, Type: "codex", Name: "p77", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			},
+		},
+		routeRepo:   routeRepo,
+		projectRepo: projectRepo,
 	})
 
 	rec := httptest.NewRecorder()
@@ -2694,9 +2712,13 @@ func TestSelfServiceHandler_BulkDeleteProvidersErrorStatusCodes(t *testing.T) {
 }
 
 func newAdminHandlerForSelfServiceTestDeps(deps selfServiceTestDeps) *AdminHandler {
+	routeRepo := deps.routeRepo
+	if routeRepo == nil {
+		routeRepo = &selfServiceRouteRepo{}
+	}
 	adminSvc := service.NewAdminService(
 		deps.providerRepo,
-		deps.routeRepo,
+		routeRepo,
 		deps.projectRepo,
 		nil,
 		deps.retryConfigRepo,

--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	mysqlDriver "github.com/go-sql-driver/mysql"
+	"github.com/awsl-project/maxx/internal/domain"
 	"gorm.io/gorm"
 )
 
@@ -575,6 +577,89 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     21,
+		Description: "Canonicalize provider client types and route native flags",
+		Up: func(db *gorm.DB) error {
+			return backfillRouteNativeFlags(db)
+		},
+		Down: func(db *gorm.DB) error {
+			// Data-only correction; no schema change to reverse.
+			return nil
+		},
+	},
+}
+
+func backfillRouteNativeFlags(db *gorm.DB) error {
+	var providers []Provider
+	if err := db.
+		Where("deleted_at = 0").
+		Find(&providers).Error; err != nil {
+		return err
+	}
+
+	nativeTypesByProvider := make(map[uint64]map[string]struct{}, len(providers))
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		for _, row := range providers {
+			var configured []domain.ClientType
+
+			raw := strings.TrimSpace(string(row.SupportedClientTypes))
+			if raw != "" {
+				if err := json.Unmarshal([]byte(raw), &configured); err != nil {
+					return fmt.Errorf("decode provider %d supported_client_types: %w", row.ID, err)
+				}
+			}
+
+			canonical := domain.CanonicalSupportedClientTypes(row.Type, configured)
+			encoded, err := json.Marshal(canonical)
+			if err != nil {
+				return err
+			}
+
+			if err := tx.
+				Model(&Provider{}).
+				Where("id = ?", row.ID).
+				Update("supported_client_types", string(encoded)).Error; err != nil {
+				return err
+			}
+
+			set := make(map[string]struct{}, len(canonical))
+			for _, clientType := range canonical {
+				set[string(clientType)] = struct{}{}
+			}
+			nativeTypesByProvider[row.ID] = set
+		}
+
+		var routes []Route
+		if err := tx.
+			Where("deleted_at = 0").
+			Find(&routes).Error; err != nil {
+			return err
+		}
+
+		for _, route := range routes {
+			native := 0
+			if _, ok := nativeTypesByProvider[route.ProviderID][route.ClientType]; ok {
+				native = 1
+			}
+			if route.IsNative == native {
+				continue
+			}
+			if err := tx.
+				Model(&Route{}).
+				Where("id = ?", route.ID).
+				Update("is_native", native).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func runForceRetryUpstreamErrorsRetryConfigMigration(db *gorm.DB) error {

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -117,6 +117,7 @@ func TestLatestMigrationsAreOrderedAndUnique(t *testing.T) {
 	v18Count := 0
 	v19Count := 0
 	v20Count := 0
+	v21Count := 0
 	for _, migration := range migrations {
 		if migration.Version <= lastVersion {
 			t.Fatalf("migrations are not strictly ordered: v%d follows v%d", migration.Version, lastVersion)
@@ -131,9 +132,12 @@ func TestLatestMigrationsAreOrderedAndUnique(t *testing.T) {
 		if migration.Version == 20 {
 			v20Count++
 		}
+		if migration.Version == 21 {
+			v21Count++
+		}
 	}
-	if lastVersion != 20 {
-		t.Fatalf("latest migration = v%d, want v20", lastVersion)
+	if lastVersion != 21 {
+		t.Fatalf("latest migration = v%d, want v21", lastVersion)
 	}
 	if v18Count != 1 {
 		t.Fatalf("migration v18 registered %d times, want once", v18Count)
@@ -143,6 +147,217 @@ func TestLatestMigrationsAreOrderedAndUnique(t *testing.T) {
 	}
 	if v20Count != 1 {
 		t.Fatalf("migration v20 registered %d times, want once", v20Count)
+	}
+	if v21Count != 1 {
+		t.Fatalf("migration v21 registered %d times, want once", v21Count)
+	}
+}
+
+func TestMigrationV21CanonicalizesProviderClientTypes(t *testing.T) {
+	db := openRawSQLiteDB(t)
+	if err := db.AutoMigrate(&Provider{}, &Route{}); err != nil {
+		t.Fatalf("AutoMigrate Provider/Route: %v", err)
+	}
+
+	fixtures := []struct {
+		name string
+		row  Provider
+		want string
+	}{
+		{
+			name: "codex ignores stale openai config",
+			row: Provider{
+				TenantID:             1,
+				Type:                 "codex",
+				Name:                 "codex-stale",
+				SupportedClientTypes: LongText(`["openai"]`),
+			},
+			want: `["codex"]`,
+		},
+		{
+			name: "custom empty defaults openai",
+			row: Provider{
+				TenantID:             1,
+				Type:                 "custom",
+				Name:                 "custom-empty",
+				SupportedClientTypes: LongText(""),
+			},
+			want: `["openai"]`,
+		},
+		{
+			name: "custom keeps configured openai",
+			row: Provider{
+				TenantID:             1,
+				Type:                 "custom",
+				Name:                 "custom-openai",
+				SupportedClientTypes: LongText(`["openai"]`),
+			},
+			want: `["openai"]`,
+		},
+		{
+			name: "custom keeps configured codex",
+			row: Provider{
+				TenantID:             1,
+				Type:                 "custom",
+				Name:                 "custom-codex",
+				SupportedClientTypes: LongText(`["codex"]`),
+			},
+			want: `["codex"]`,
+		},
+	}
+
+	for i := range fixtures {
+		if err := db.Create(&fixtures[i].row).Error; err != nil {
+			t.Fatalf("insert provider %s: %v", fixtures[i].name, err)
+		}
+	}
+
+	migration := findMigrationByVersion(t, 21)
+	if err := migration.Up(db); err != nil {
+		t.Fatalf("run migration v21: %v", err)
+	}
+
+	for _, fixture := range fixtures {
+		var got string
+		if err := db.Model(&Provider{}).
+			Select("supported_client_types").
+			Where("id = ?", fixture.row.ID).
+			Scan(&got).Error; err != nil {
+			t.Fatalf("read provider %s supported_client_types: %v", fixture.name, err)
+		}
+		if got != fixture.want {
+			t.Fatalf("provider %s supported_client_types = %q, want %q", fixture.name, got, fixture.want)
+		}
+	}
+}
+
+func TestMigrationV21BackfillsRouteNativeFlags(t *testing.T) {
+	db := openRawSQLiteDB(t)
+	if err := db.AutoMigrate(&Provider{}, &Route{}); err != nil {
+		t.Fatalf("AutoMigrate Provider/Route: %v", err)
+	}
+
+	providers := map[string]*Provider{
+		"codex": {
+			TenantID:             1,
+			Type:                 "codex",
+			Name:                 "codex-provider",
+			SupportedClientTypes: LongText(`["openai"]`),
+		},
+		"custom-openai": {
+			TenantID:             1,
+			Type:                 "custom",
+			Name:                 "custom-openai-provider",
+			SupportedClientTypes: LongText(`["openai"]`),
+		},
+		"custom-empty": {
+			TenantID:             1,
+			Type:                 "custom",
+			Name:                 "custom-empty-provider",
+			SupportedClientTypes: LongText(""),
+		},
+		"custom-codex": {
+			TenantID:             1,
+			Type:                 "custom",
+			Name:                 "custom-codex-provider",
+			SupportedClientTypes: LongText(`["codex"]`),
+		},
+	}
+	for name, provider := range providers {
+		if err := db.Create(provider).Error; err != nil {
+			t.Fatalf("insert provider %s: %v", name, err)
+		}
+	}
+
+	type routeFixture struct {
+		name       string
+		route      Route
+		wantNative int
+	}
+	routes := []routeFixture{
+		{
+			name: "codex provider + codex route forces native",
+			route: Route{
+				TenantID:   1,
+				ProviderID: providers["codex"].ID,
+				ClientType: "codex",
+				IsNative:   0,
+				IsEnabled:  1,
+				Weight:     1,
+			},
+			wantNative: 1,
+		},
+		{
+			name: "custom openai + codex route clears native",
+			route: Route{
+				TenantID:   1,
+				ProviderID: providers["custom-openai"].ID,
+				ClientType: "codex",
+				IsNative:   1,
+				IsEnabled:  1,
+				Weight:     1,
+			},
+			wantNative: 0,
+		},
+		{
+			name: "custom empty defaults openai + codex route clears native",
+			route: Route{
+				TenantID:   1,
+				ProviderID: providers["custom-empty"].ID,
+				ClientType: "codex",
+				IsNative:   1,
+				IsEnabled:  1,
+				Weight:     1,
+			},
+			wantNative: 0,
+		},
+		{
+			name: "custom codex + codex route forces native",
+			route: Route{
+				TenantID:   1,
+				ProviderID: providers["custom-codex"].ID,
+				ClientType: "codex",
+				IsNative:   0,
+				IsEnabled:  1,
+				Weight:     1,
+			},
+			wantNative: 1,
+		},
+		{
+			name: "codex provider + openai route clears native",
+			route: Route{
+				TenantID:   1,
+				ProviderID: providers["codex"].ID,
+				ClientType: "openai",
+				IsNative:   1,
+				IsEnabled:  1,
+				Weight:     1,
+			},
+			wantNative: 0,
+		},
+	}
+	for i := range routes {
+		if err := db.Create(&routes[i].route).Error; err != nil {
+			t.Fatalf("insert route %s: %v", routes[i].name, err)
+		}
+	}
+
+	migration := findMigrationByVersion(t, 21)
+	if err := migration.Up(db); err != nil {
+		t.Fatalf("run migration v21: %v", err)
+	}
+
+	for _, fixture := range routes {
+		var got int
+		if err := db.Model(&Route{}).
+			Select("is_native").
+			Where("id = ?", fixture.route.ID).
+			Scan(&got).Error; err != nil {
+			t.Fatalf("read route %s is_native: %v", fixture.name, err)
+		}
+		if got != fixture.wantNative {
+			t.Fatalf("route %s is_native = %d, want %d", fixture.name, got, fixture.wantNative)
+		}
 	}
 }
 

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -129,7 +129,9 @@ type Route struct {
 	SoftDeleteModel
 	TenantID      uint64 `gorm:"index"`
 	IsEnabled     int    `gorm:"default:1"`
-	IsNative      int    `gorm:"default:1"`
+	// IsNative has no gorm default tag: a zero value must persist as 0.
+	// With default:1, GORM Create omits the field and the column falls back to 1.
+	IsNative      int
 	ProjectID     uint64
 	ClientType    string `gorm:"size:64"`
 	ProviderID    uint64

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -195,8 +195,8 @@ func matchedProviderIDs(result *MatchResult) []uint64 {
 	return ids
 }
 
-// Only native routes whose adapter implements ResponsesWebSocketAdapter (and
-// Codex) are eligible when RequireResponsesWebSocket is set.
+// Only providers that natively support Codex and whose adapter implements
+// ResponsesWebSocketAdapter are eligible. Stale is_native=false is ignored.
 func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T) {
 	const (
 		nativeWSProviderID  = uint64(101)
@@ -205,14 +205,16 @@ func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T)
 	)
 	r := newResponsesWebSocketTestRouter(t,
 		[]*domain.Route{
-			{ID: 1, TenantID: 1, ProviderID: nativeWSProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
+			{ID: 1, TenantID: 1, ProviderID: nativeWSProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: false, Position: 1},
 			{ID: 2, TenantID: 1, ProviderID: httpOnlyProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 2},
-			{ID: 3, TenantID: 1, ProviderID: nonNativeWSProvider, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: false, Position: 3},
+			{ID: 3, TenantID: 1, ProviderID: nonNativeWSProvider, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 3},
 		},
 		[]*domain.Provider{
+			// Stale IsNative=false still eligible via canonical native check.
 			{ID: nativeWSProviderID, TenantID: 1, Type: wsRouterNativeType, Name: "native-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
 			{ID: httpOnlyProviderID, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "http-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
-			{ID: nonNativeWSProvider, TenantID: 1, Type: wsRouterNativeType, Name: "non-native-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			// Stale IsNative=true but provider does not natively support Codex.
+			{ID: nonNativeWSProvider, TenantID: 1, Type: wsRouterNativeType, Name: "non-native-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}},
 		},
 	)
 
@@ -228,6 +230,37 @@ func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T)
 	ids := matchedProviderIDs(result)
 	if len(ids) != 1 || ids[0] != nativeWSProviderID {
 		t.Fatalf("matched provider IDs = %v, want only native capable %d", ids, nativeWSProviderID)
+	}
+}
+
+func TestMatch_ResponsesWebSocketReturnsOneProvider(t *testing.T) {
+	const (
+		providerA = uint64(401)
+		providerB = uint64(402)
+	)
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 41, TenantID: 1, ProviderID: providerA, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
+			{ID: 42, TenantID: 1, ProviderID: providerB, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: providerA, TenantID: 1, Type: wsRouterNativeType, Name: "ws-a", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: providerB, TenantID: 1, Type: wsRouterNativeType, Name: "ws-b", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+
+	result, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+	})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	ids := matchedProviderIDs(result)
+	if len(ids) != 1 || ids[0] != providerA {
+		t.Fatalf("matched provider IDs = %v, want single first provider %d", ids, providerA)
 	}
 }
 
@@ -280,13 +313,13 @@ func TestMatch_ResponsesWebSocketNoEligibleProviders(t *testing.T) {
 	r := newResponsesWebSocketTestRouter(t,
 		[]*domain.Route{
 			{ID: 21, TenantID: 1, ProviderID: 301, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 1},
-			{ID: 22, TenantID: 1, ProviderID: 302, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: false, Position: 2},
+			{ID: 22, TenantID: 1, ProviderID: 302, ClientType: domain.ClientTypeCodex, IsEnabled: true, IsNative: true, Position: 2},
 		},
 		[]*domain.Provider{
 			// Native route but HTTP-only adapter → not WS-capable.
 			{ID: 301, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "http-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
-			// WS adapter on a non-native route → still ineligible under RequireResponsesWebSocket.
-			{ID: 302, TenantID: 1, Type: wsRouterNativeType, Name: "ws-non-native", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			// WS adapter but provider does not natively support Codex.
+			{ID: 302, TenantID: 1, Type: wsRouterNativeType, Name: "ws-non-native", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}},
 		},
 	)
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -280,8 +280,11 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if ctx.RequiredProviderID != 0 && prov.ID != ctx.RequiredProviderID {
 			continue
 		}
+		// Derive native capability from provider + client type; never trust
+		// the historical routes.is_native snapshot for WebSocket eligibility.
+		native := domain.RouteIsNative(prov, route)
 		if ctx.RequireResponsesWebSocket {
-			if !route.IsNative || !adapterSupportsResponsesWebSocket(adp) {
+			if !native || !adapterSupportsResponsesWebSocket(adp) {
 				continue
 			}
 		}
@@ -369,6 +372,12 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 			matched = promoteByProvider(matched, pinned)
 		}
 		stickyCancel()
+	}
+
+	// Codex Responses WebSocket turns execute exactly one provider: no
+	// cross-provider fallback is allowed after match.
+	if ctx.RequireResponsesWebSocket && len(matched) > 1 {
+		matched = matched[:1]
 	}
 
 	return &MatchResult{Routes: matched, Sticky: stickyWrite}, nil

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -184,6 +184,12 @@ func (s *AdminService) UpdateProvider(tenantID uint64, provider *domain.Provider
 	if s.adapterRefresher != nil {
 		s.adapterRefresher.RefreshAdapter(provider)
 	}
+	// Best-effort: keep route is_native snapshots in sync with provider capability.
+	// Runtime match/API reads use canonical helpers, so a failed reconcile does
+	// not break request correctness.
+	if err := s.reconcileProviderRouteNative(tenantID, provider); err != nil {
+		log.Printf("[Admin] reconcile provider %d route native flags: %v", provider.ID, err)
+	}
 	return nil
 }
 
@@ -616,21 +622,131 @@ type ImportResult struct {
 
 // ===== Route API =====
 
+func cloneRoute(route *domain.Route) *domain.Route {
+	if route == nil {
+		return nil
+	}
+	cloned := *route
+	return &cloned
+}
+
+func (s *AdminService) canonicalRouteCopy(tenantID uint64, route *domain.Route) (*domain.Route, error) {
+	cloned := cloneRoute(route)
+	if cloned == nil || cloned.ProviderID == 0 {
+		return nil, domain.ErrInvalidInput
+	}
+
+	provider, err := s.providerRepo.GetByID(tenantID, cloned.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve route provider %d: %w", cloned.ProviderID, err)
+	}
+
+	cloned.TenantID = tenantID
+	cloned.IsNative = domain.RouteIsNative(provider, cloned)
+	return cloned, nil
+}
+
+func (s *AdminService) canonicalRouteCopies(tenantID uint64, routes []*domain.Route) ([]*domain.Route, error) {
+	providers, err := s.providerRepo.List(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	providerByID := make(map[uint64]*domain.Provider, len(providers))
+	for _, provider := range providers {
+		providerByID[provider.ID] = provider
+	}
+
+	result := make([]*domain.Route, 0, len(routes))
+	for _, route := range routes {
+		cloned := cloneRoute(route)
+		if cloned == nil {
+			continue
+		}
+		cloned.IsNative = domain.RouteIsNative(providerByID[cloned.ProviderID], cloned)
+		result = append(result, cloned)
+	}
+	return result, nil
+}
+
+func (s *AdminService) reconcileProviderRouteNative(tenantID uint64, provider *domain.Provider) error {
+	if provider == nil {
+		return domain.ErrInvalidInput
+	}
+	if s.routeRepo == nil {
+		return nil
+	}
+
+	routes, err := s.routeRepo.List(tenantID)
+	if err != nil {
+		return err
+	}
+
+	for _, cachedRoute := range routes {
+		if cachedRoute == nil || cachedRoute.ProviderID != provider.ID {
+			continue
+		}
+
+		native := domain.RouteIsNative(provider, cachedRoute)
+		if cachedRoute.IsNative == native {
+			continue
+		}
+
+		updated := cloneRoute(cachedRoute)
+		updated.IsNative = native
+		if err := s.routeRepo.Update(updated); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *AdminService) GetRoutes(tenantID uint64) ([]*domain.Route, error) {
-	return s.routeRepo.List(tenantID)
+	routes, err := s.routeRepo.List(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return s.canonicalRouteCopies(tenantID, routes)
 }
 
 func (s *AdminService) GetRoute(tenantID uint64, id uint64) (*domain.Route, error) {
-	return s.routeRepo.GetByID(tenantID, id)
+	route, err := s.routeRepo.GetByID(tenantID, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.canonicalRouteCopy(tenantID, route)
 }
 
 func (s *AdminService) CreateRoute(tenantID uint64, route *domain.Route) error {
-	route.TenantID = tenantID
-	return s.routeRepo.Create(route)
+	canonical, err := s.canonicalRouteCopy(tenantID, route)
+	if err != nil {
+		return err
+	}
+
+	canonical.ID = 0
+	canonical.CreatedAt = time.Time{}
+	canonical.UpdatedAt = time.Time{}
+
+	if err := s.routeRepo.Create(canonical); err != nil {
+		return err
+	}
+
+	*route = *canonical
+	return nil
 }
 
 func (s *AdminService) UpdateRoute(tenantID uint64, route *domain.Route) error {
-	return s.routeRepo.Update(route)
+	canonical, err := s.canonicalRouteCopy(tenantID, route)
+	if err != nil {
+		return err
+	}
+
+	if err := s.routeRepo.Update(canonical); err != nil {
+		return err
+	}
+
+	*route = *canonical
+	return nil
 }
 
 func (s *AdminService) BatchUpdateRoutePositions(tenantID uint64, updates []domain.RoutePositionUpdate) error {
@@ -723,11 +839,15 @@ func (s *AdminService) SyncRoutesFromProject(tenantID uint64, req domain.RouteSy
 			}
 			maxPosition++
 			created := cloneRouteForTarget(source, tenantID, req.TargetProjectID, maxPosition)
-			if err := s.routeRepo.Create(created); err != nil {
+			canonical, err := s.canonicalRouteCopy(tenantID, created)
+			if err != nil {
+				return nil, err
+			}
+			if err := s.routeRepo.Create(canonical); err != nil {
 				return nil, err
 			}
 			result.CreatedCount++
-			result.Routes = append(result.Routes, created)
+			result.Routes = append(result.Routes, canonical)
 		}
 	} else {
 		sourceProviderIDs := make(map[uint64]struct{}, len(sourceRoutes))
@@ -735,22 +855,35 @@ func (s *AdminService) SyncRoutesFromProject(tenantID uint64, req domain.RouteSy
 			sourceProviderIDs[source.ProviderID] = struct{}{}
 			position := index + 1
 			if target, exists := targetByProvider[source.ProviderID]; exists {
-				if copyRouteFields(target, source, position) {
-					if err := s.routeRepo.Update(target); err != nil {
+				updated := cloneRoute(target)
+				changed := copyRouteFields(updated, source, position)
+				canonical, err := s.canonicalRouteCopy(tenantID, updated)
+				if err != nil {
+					return nil, err
+				}
+				if canonical.IsNative != target.IsNative {
+					changed = true
+				}
+				if changed {
+					if err := s.routeRepo.Update(canonical); err != nil {
 						return nil, err
 					}
 					result.UpdatedCount++
 				}
-				result.Routes = append(result.Routes, target)
+				result.Routes = append(result.Routes, canonical)
 				continue
 			}
 
 			created := cloneRouteForTarget(source, tenantID, req.TargetProjectID, position)
-			if err := s.routeRepo.Create(created); err != nil {
+			canonical, err := s.canonicalRouteCopy(tenantID, created)
+			if err != nil {
+				return nil, err
+			}
+			if err := s.routeRepo.Create(canonical); err != nil {
 				return nil, err
 			}
 			result.CreatedCount++
-			result.Routes = append(result.Routes, created)
+			result.Routes = append(result.Routes, canonical)
 		}
 
 		for _, target := range targetRoutes {
@@ -795,7 +928,8 @@ func cloneRouteForTarget(source *domain.Route, tenantID, targetProjectID uint64,
 	return &domain.Route{
 		TenantID:      tenantID,
 		IsEnabled:     source.IsEnabled,
-		IsNative:      source.IsNative,
+		// IsNative is always recomputed from provider capability before save.
+		IsNative:      false,
 		ProjectID:     targetProjectID,
 		ClientType:    source.ClientType,
 		ProviderID:    source.ProviderID,
@@ -811,10 +945,7 @@ func copyRouteFields(target, source *domain.Route, position int) bool {
 		target.IsEnabled = source.IsEnabled
 		changed = true
 	}
-	if target.IsNative != source.IsNative {
-		target.IsNative = source.IsNative
-		changed = true
-	}
+	// IsNative is not a syncable config field; it is recomputed by canonicalRouteCopy.
 	if target.Position != position {
 		target.Position = position
 		changed = true
@@ -1376,56 +1507,11 @@ func (s *AdminService) GetLogs(limit int) (*LogsResult, error) {
 
 // ===== Private helpers =====
 
-// autoSetSupportedClientTypes sets SupportedClientTypes based on provider type
+// autoSetSupportedClientTypes sets SupportedClientTypes based on provider type.
+// Delegates to domain.NormalizeProviderSupportedClientTypes so Admin, Backup,
+// Migration, and Router share one capability rule.
 func (s *AdminService) autoSetSupportedClientTypes(provider *domain.Provider) {
-	switch provider.Type {
-	case "antigravity":
-		// Antigravity natively supports Claude and Gemini.
-		// Conversion preference is Gemini-first.
-		provider.SupportedClientTypes = []domain.ClientType{
-			domain.ClientTypeGemini,
-			domain.ClientTypeClaude,
-		}
-	case "kiro":
-		// Kiro natively supports Claude protocol only
-		provider.SupportedClientTypes = []domain.ClientType{
-			domain.ClientTypeClaude,
-		}
-	case "codex":
-		// Codex natively supports Codex protocol only
-		provider.SupportedClientTypes = []domain.ClientType{
-			domain.ClientTypeCodex,
-		}
-	case "claude":
-		// Claude natively supports Claude protocol only
-		provider.SupportedClientTypes = []domain.ClientType{
-			domain.ClientTypeClaude,
-		}
-	case "custom", "newapi":
-		// Custom and new-api providers use their configured SupportedClientTypes.
-		// If not set, default to OpenAI (both are OpenAI-compatible relays).
-		if len(provider.SupportedClientTypes) == 0 {
-			provider.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
-		}
-	case "ollama":
-		// Ollama's custom-core path only supports Claude-compatible requests.
-		provider.SupportedClientTypes = []domain.ClientType{
-			domain.ClientTypeClaude,
-		}
-	case "openrouter":
-		// OpenRouter natively serves both the OpenAI and Anthropic protocols, so
-		// honor whatever the client configured. If left empty, default to both
-		// rather than leaving the provider with no serviceable client types.
-		if len(provider.SupportedClientTypes) == 0 {
-			provider.SupportedClientTypes = []domain.ClientType{
-				domain.ClientTypeClaude,
-				domain.ClientTypeOpenAI,
-			}
-		}
-	case "grok":
-		// Grok CPA xAI executor speaks OpenAI-compatible chat only.
-		provider.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
-	}
+	domain.NormalizeProviderSupportedClientTypes(provider)
 }
 
 // ===== API Token API =====

--- a/internal/service/admin_route_native_test.go
+++ b/internal/service/admin_route_native_test.go
@@ -1,0 +1,589 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
+)
+
+func setupRouteNativeTestEnv(t *testing.T) (
+	*AdminService,
+	*sqlite.ProviderRepository,
+	*sqlite.RouteRepository,
+	*sqlite.ProjectRepository,
+) {
+	t.Helper()
+
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	providerRepo := sqlite.NewProviderRepository(db)
+	routeRepo := sqlite.NewRouteRepository(db)
+	projectRepo := sqlite.NewProjectRepository(db)
+	svc := NewAdminService(
+		providerRepo, routeRepo, projectRepo,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		"", nil, nil, nil,
+	)
+	return svc, providerRepo, routeRepo, projectRepo
+}
+
+func newTestCodexProvider(name string) *domain.Provider {
+	return &domain.Provider{
+		TenantID: domain.DefaultTenantID,
+		Name:     name,
+		Type:     "codex",
+		Config: &domain.ProviderConfig{Codex: &domain.ProviderConfigCodex{
+			Email:        name + "@example.com",
+			RefreshToken: "rt-test",
+			AccessToken:  "at-test",
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		SupportModels:        []string{"*"},
+	}
+}
+
+func newTestOpenAIOnlyCustomProvider(name string) *domain.Provider {
+	return &domain.Provider{
+		TenantID: domain.DefaultTenantID,
+		Name:     name,
+		Type:     "custom",
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://api.example.com/" + name,
+			APIKey:  "sk-test",
+		}},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+		SupportModels:        []string{"*"},
+	}
+}
+
+func mustCreateProvider(t *testing.T, repo *sqlite.ProviderRepository, provider *domain.Provider) *domain.Provider {
+	t.Helper()
+	if err := repo.Create(provider); err != nil {
+		t.Fatalf("Create(provider %s) error = %v", provider.Name, err)
+	}
+	return provider
+}
+
+func TestCreateRouteDerivesNativeFromProvider(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-native"))
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-only"))
+
+	codexRoute := &domain.Route{
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, codexRoute); err != nil {
+		t.Fatalf("CreateRoute(codex) error = %v", err)
+	}
+	if !codexRoute.IsNative {
+		t.Fatalf("CreateRoute(codex→codex) IsNative = false, want true")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, codexRoute.ID)
+	if err != nil {
+		t.Fatalf("GetByID(codex route) error = %v", err)
+	}
+	if !stored.IsNative {
+		t.Fatalf("stored codex route IsNative = false, want true")
+	}
+
+	conversionRoute := &domain.Route{
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   2,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, conversionRoute); err != nil {
+		t.Fatalf("CreateRoute(conversion) error = %v", err)
+	}
+	if conversionRoute.IsNative {
+		t.Fatalf("CreateRoute(openai→codex) IsNative = true, want false")
+	}
+
+	storedConversion, err := routeRepo.GetByID(domain.DefaultTenantID, conversionRoute.ID)
+	if err != nil {
+		t.Fatalf("GetByID(conversion route) error = %v", err)
+	}
+	if storedConversion.IsNative {
+		t.Fatalf("stored conversion route IsNative = true, want false")
+	}
+}
+
+func TestCreateRouteOverridesClientFalseForCodex(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-override-false"))
+
+	route := &domain.Route{
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   false, // client-submitted value must be ignored
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+	if !route.IsNative {
+		t.Fatalf("CreateRoute() IsNative = false, want true (override client false)")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if !stored.IsNative {
+		t.Fatalf("stored IsNative = false, want true")
+	}
+}
+
+func TestCreateRouteOverridesClientTrueForConversion(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-override-true"))
+
+	route := &domain.Route{
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   true, // client-submitted value must be ignored
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+	if route.IsNative {
+		t.Fatalf("CreateRoute() IsNative = true, want false (override client true)")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if stored.IsNative {
+		t.Fatalf("stored IsNative = true, want false")
+	}
+}
+
+func TestUpdateRouteRecomputesNativeWhenProviderChanges(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-for-update"))
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-for-update"))
+
+	route := &domain.Route{
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+	if !route.IsNative {
+		t.Fatalf("initial IsNative = false, want true")
+	}
+
+	route.ProviderID = openaiProvider.ID
+	route.IsNative = true // client false claim must still be recomputed
+	if err := svc.UpdateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("UpdateRoute() error = %v", err)
+	}
+	if route.IsNative {
+		t.Fatalf("after provider change IsNative = true, want false")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if stored.ProviderID != openaiProvider.ID {
+		t.Fatalf("stored ProviderID = %d, want %d", stored.ProviderID, openaiProvider.ID)
+	}
+	if stored.IsNative {
+		t.Fatalf("stored IsNative = true, want false")
+	}
+
+	route.ProviderID = codexProvider.ID
+	route.IsNative = false
+	if err := svc.UpdateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("UpdateRoute(back to codex) error = %v", err)
+	}
+	if !route.IsNative {
+		t.Fatalf("after switch back to codex IsNative = false, want true")
+	}
+}
+
+func TestUpdateRouteRecomputesNativeWhenClientTypeChanges(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-client-type"))
+
+	route := &domain.Route{
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+	if !route.IsNative {
+		t.Fatalf("initial IsNative = false, want true")
+	}
+
+	route.ClientType = domain.ClientTypeOpenAI
+	route.IsNative = true
+	if err := svc.UpdateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("UpdateRoute() error = %v", err)
+	}
+	if route.IsNative {
+		t.Fatalf("after ClientType→openai IsNative = true, want false")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if stored.ClientType != domain.ClientTypeOpenAI {
+		t.Fatalf("stored ClientType = %s, want %s", stored.ClientType, domain.ClientTypeOpenAI)
+	}
+	if stored.IsNative {
+		t.Fatalf("stored IsNative = true, want false")
+	}
+
+	route.ClientType = domain.ClientTypeCodex
+	route.IsNative = false
+	if err := svc.UpdateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("UpdateRoute(back to codex) error = %v", err)
+	}
+	if !route.IsNative {
+		t.Fatalf("after ClientType→codex IsNative = false, want true")
+	}
+}
+
+func TestGetRoutesReturnsCanonicalCopies(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-get-routes"))
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-get-routes"))
+
+	// Seed stale is_native snapshots directly in the repository.
+	staleNativeFalse := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   false,
+	}
+	staleNativeTrue := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   2,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   true,
+	}
+	if err := routeRepo.Create(staleNativeFalse); err != nil {
+		t.Fatalf("Create(stale false) error = %v", err)
+	}
+	if err := routeRepo.Create(staleNativeTrue); err != nil {
+		t.Fatalf("Create(stale true) error = %v", err)
+	}
+
+	routes, err := svc.GetRoutes(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("GetRoutes() error = %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("GetRoutes() len = %d, want 2", len(routes))
+	}
+
+	byProvider := make(map[uint64]*domain.Route, len(routes))
+	for _, route := range routes {
+		byProvider[route.ProviderID] = route
+	}
+
+	if got := byProvider[codexProvider.ID]; got == nil || !got.IsNative {
+		t.Fatalf("codex route IsNative = %v, want true (canonical)", got)
+	}
+	if got := byProvider[openaiProvider.ID]; got == nil || got.IsNative {
+		t.Fatalf("openai→codex route IsNative = %v, want false (canonical)", got)
+	}
+
+	// Mutating the returned slice must not change the next GetRoutes result.
+	byProvider[codexProvider.ID].IsNative = false
+	byProvider[openaiProvider.ID].IsNative = true
+	byProvider[codexProvider.ID].Weight = 99
+
+	routes2, err := svc.GetRoutes(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("GetRoutes() second call error = %v", err)
+	}
+	byProvider2 := make(map[uint64]*domain.Route, len(routes2))
+	for _, route := range routes2 {
+		byProvider2[route.ProviderID] = route
+	}
+	if !byProvider2[codexProvider.ID].IsNative {
+		t.Fatal("second GetRoutes codex IsNative mutated via previous return value")
+	}
+	if byProvider2[openaiProvider.ID].IsNative {
+		t.Fatal("second GetRoutes conversion IsNative mutated via previous return value")
+	}
+	if byProvider2[codexProvider.ID].Weight != 1 {
+		t.Fatalf("second GetRoutes Weight = %d, want 1", byProvider2[codexProvider.ID].Weight)
+	}
+}
+
+func TestGetRouteDoesNotExposeCachedPointer(t *testing.T) {
+	svc, providerRepo, _, _ := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-get-route-ptr"))
+
+	route := &domain.Route{
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute() error = %v", err)
+	}
+
+	first, err := svc.GetRoute(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetRoute() first error = %v", err)
+	}
+	if !first.IsNative {
+		t.Fatalf("first IsNative = false, want true")
+	}
+
+	first.IsNative = false
+	first.Weight = 42
+	first.IsEnabled = false
+	first.ProviderID = 999999
+
+	second, err := svc.GetRoute(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetRoute() second error = %v", err)
+	}
+	if second == first {
+		t.Fatal("GetRoute returned same pointer twice")
+	}
+	if !second.IsNative {
+		t.Fatal("mutating first GetRoute result changed next GetRoute IsNative")
+	}
+	if second.Weight != 1 {
+		t.Fatalf("second Weight = %d, want 1", second.Weight)
+	}
+	if !second.IsEnabled {
+		t.Fatal("second IsEnabled = false, want true")
+	}
+	if second.ProviderID != codexProvider.ID {
+		t.Fatalf("second ProviderID = %d, want %d", second.ProviderID, codexProvider.ID)
+	}
+}
+
+func TestProviderUpdateReconcilesRouteNativeSnapshot(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	provider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("reconcile-provider"))
+
+	// Stale snapshot: custom openai-only provider with a codex route marked native.
+	route := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: provider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   true,
+	}
+	if err := routeRepo.Create(route); err != nil {
+		t.Fatalf("Create(route) error = %v", err)
+	}
+
+	// Re-load provider for UpdateProvider so write-only fields are preserved.
+	existing, err := providerRepo.GetByID(domain.DefaultTenantID, provider.ID)
+	if err != nil {
+		t.Fatalf("GetByID(provider) error = %v", err)
+	}
+	existing.SupportedClientTypes = []domain.ClientType{domain.ClientTypeOpenAI}
+	if err := svc.UpdateProvider(domain.DefaultTenantID, existing); err != nil {
+		t.Fatalf("UpdateProvider() error = %v", err)
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID(route) error = %v", err)
+	}
+	if stored.IsNative {
+		t.Fatal("after reconcile with openai-only provider, IsNative still true, want false")
+	}
+
+	// Expand capability to natively support codex; snapshot must flip to true.
+	existing, err = providerRepo.GetByID(domain.DefaultTenantID, provider.ID)
+	if err != nil {
+		t.Fatalf("GetByID(provider) reload error = %v", err)
+	}
+	existing.SupportedClientTypes = []domain.ClientType{domain.ClientTypeCodex}
+	if err := svc.UpdateProvider(domain.DefaultTenantID, existing); err != nil {
+		t.Fatalf("UpdateProvider(codex capable) error = %v", err)
+	}
+
+	stored, err = routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID(route) after codex expand error = %v", err)
+	}
+	if !stored.IsNative {
+		t.Fatal("after reconcile with codex-capable provider, IsNative still false, want true")
+	}
+
+	// API read path should also report the canonical value.
+	got, err := svc.GetRoute(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetRoute() error = %v", err)
+	}
+	if !got.IsNative {
+		t.Fatal("GetRoute IsNative = false after reconcile, want true")
+	}
+}
+
+func TestSyncRoutesRecomputesNative(t *testing.T) {
+	svc, providerRepo, routeRepo, projectRepo := setupRouteNativeTestEnv(t)
+
+	codexProvider := mustCreateProvider(t, providerRepo, newTestCodexProvider("codex-sync"))
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-sync"))
+
+	// Global source routes with intentionally wrong is_native snapshots.
+	sourceNative := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: codexProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     2,
+		IsEnabled:  true,
+		IsNative:   false,
+	}
+	sourceConversion := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		Position:   2,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   true,
+	}
+	if err := routeRepo.Create(sourceNative); err != nil {
+		t.Fatalf("Create(source native) error = %v", err)
+	}
+	if err := routeRepo.Create(sourceConversion); err != nil {
+		t.Fatalf("Create(source conversion) error = %v", err)
+	}
+
+	// Target project starts with a stale conversion route that should be updated.
+	targetProject := &domain.Project{
+		TenantID: domain.DefaultTenantID,
+		Name:     "sync-target",
+		Slug:     "sync-target",
+	}
+	if err := projectRepo.Create(targetProject); err != nil {
+		t.Fatalf("Create(project) error = %v", err)
+	}
+
+	staleTarget := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  targetProject.ID,
+		Position:   9,
+		Weight:     9,
+		IsEnabled:  false,
+		IsNative:   true,
+	}
+	if err := routeRepo.Create(staleTarget); err != nil {
+		t.Fatalf("Create(stale target) error = %v", err)
+	}
+
+	result, err := svc.SyncRoutesFromProject(domain.DefaultTenantID, domain.RouteSyncRequest{
+		SourceProjectID: 0,
+		TargetProjectID: targetProject.ID,
+		ClientType:      domain.ClientTypeCodex,
+		Mode:            domain.RouteSyncModeOverwrite,
+	})
+	if err != nil {
+		t.Fatalf("SyncRoutesFromProject() error = %v", err)
+	}
+	if result.CreatedCount != 1 || result.UpdatedCount != 1 {
+		t.Fatalf("result created/updated = %d/%d, want 1/1: %+v", result.CreatedCount, result.UpdatedCount, result)
+	}
+	if len(result.Routes) != 2 {
+		t.Fatalf("result.Routes len = %d, want 2", len(result.Routes))
+	}
+
+	byProvider := make(map[uint64]*domain.Route, len(result.Routes))
+	for _, route := range result.Routes {
+		byProvider[route.ProviderID] = route
+	}
+	if got := byProvider[codexProvider.ID]; got == nil || !got.IsNative {
+		t.Fatalf("synced codex route IsNative = %v, want true", got)
+	}
+	if got := byProvider[openaiProvider.ID]; got == nil || got.IsNative {
+		t.Fatalf("synced openai→codex route IsNative = %v, want false", got)
+	}
+
+	// Persist layer must also hold recomputed snapshots.
+	targetRoutes, err := routeRepo.List(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("List(routes) error = %v", err)
+	}
+	var codexTarget, openaiTarget *domain.Route
+	for _, route := range targetRoutes {
+		if route.ProjectID != targetProject.ID || route.ClientType != domain.ClientTypeCodex {
+			continue
+		}
+		switch route.ProviderID {
+		case codexProvider.ID:
+			codexTarget = route
+		case openaiProvider.ID:
+			openaiTarget = route
+		}
+	}
+	if codexTarget == nil || !codexTarget.IsNative {
+		t.Fatalf("persisted codex target = %+v, want IsNative true", codexTarget)
+	}
+	if openaiTarget == nil || openaiTarget.IsNative {
+		t.Fatalf("persisted openai target = %+v, want IsNative false", openaiTarget)
+	}
+}

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -56,6 +56,7 @@ func NewBackupService(
 // importContext holds ID mappings during import
 type importContext struct {
 	providerNameToID    map[string]uint64
+	providerByName      map[string]*domain.Provider
 	projectSlugToID     map[string]uint64
 	retryConfigNameToID map[string]uint64
 	apiTokenNameToID    map[string]uint64
@@ -68,6 +69,7 @@ type importContext struct {
 func newImportContext() *importContext {
 	return &importContext{
 		providerNameToID:    make(map[string]uint64),
+		providerByName:      make(map[string]*domain.Provider),
 		projectSlugToID:     make(map[string]uint64),
 		retryConfigNameToID: make(map[string]uint64),
 		apiTokenNameToID:    make(map[string]uint64),
@@ -86,6 +88,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 
 	// Build lookup maps for ID to name conversion
 	providerIDToName := make(map[uint64]string)
+	providerByID := make(map[uint64]*domain.Provider)
 	projectIDToSlug := make(map[uint64]string)
 	retryConfigIDToName := make(map[uint64]string)
 	apiTokenIDToName := make(map[uint64]string)
@@ -108,6 +111,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 		return nil, fmt.Errorf("failed to export providers: %w", err)
 	}
 	for _, p := range providers {
+		providerByID[p.ID] = p
 		if p.ExcludeFromExport || p.BlackBox {
 			continue
 		}
@@ -175,7 +179,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 	for _, r := range routes {
 		backup.Data.Routes = append(backup.Data.Routes, domain.BackupRoute{
 			IsEnabled:       r.IsEnabled,
-			IsNative:        r.IsNative,
+			IsNative:        domain.RouteIsNative(providerByID[r.ProviderID], r),
 			ProjectSlug:     projectIDToSlug[r.ProjectID],
 			ClientType:      r.ClientType,
 			ProviderName:    providerIDToName[r.ProviderID],
@@ -324,6 +328,7 @@ func (s *BackupService) loadExistingMappings(tenantID uint64, ctx *importContext
 	}
 	for _, p := range providers {
 		ctx.providerNameToID[p.Name] = p.ID
+		ctx.providerByName[p.Name] = p
 	}
 	providerIDToName := make(map[uint64]string, len(providers))
 	for _, p := range providers {
@@ -533,6 +538,7 @@ func (s *BackupService) importProviders(tenantID uint64, providers []domain.Back
 			SupportedClientTypes: bp.SupportedClientTypes,
 			SupportModels:        bp.SupportModels,
 		}
+		domain.NormalizeProviderSupportedClientTypes(p)
 
 		if !opts.DryRun {
 			if err := s.providerRepo.Create(p); err != nil {
@@ -540,10 +546,13 @@ func (s *BackupService) importProviders(tenantID uint64, providers []domain.Back
 				continue
 			}
 			ctx.providerNameToID[bp.Name] = p.ID
+			ctx.providerByName[bp.Name] = p
 			// Refresh adapter
 			if s.adapterRefresher != nil {
 				s.adapterRefresher.RefreshAdapter(p)
 			}
+		} else {
+			ctx.providerByName[bp.Name] = p
 		}
 		summary.Imported++
 	}
@@ -698,10 +707,20 @@ func (s *BackupService) importRoutes(tenantID uint64, routes []domain.BackupRout
 		if weight <= 0 {
 			weight = 1
 		}
+
+		// Prefer in-memory provider capability (covers dry-run and just-imported
+		// providers). Fall back to repo lookup for providers that already existed.
+		provider := ctx.providerByName[br.ProviderName]
+		if provider == nil {
+			if existing, err := s.providerRepo.GetByID(tenantID, providerID); err == nil {
+				provider = existing
+			}
+		}
+
 		r := &domain.Route{
 			TenantID:      tenantID,
 			IsEnabled:     br.IsEnabled,
-			IsNative:      br.IsNative,
+			IsNative:      domain.ProviderNativelySupports(provider, br.ClientType),
 			ProjectID:     projectID,
 			ClientType:    br.ClientType,
 			ProviderID:    providerID,

--- a/tests/e2e/codex_websocket_proxy_test.go
+++ b/tests/e2e/codex_websocket_proxy_test.go
@@ -174,6 +174,191 @@ func TestCodexWebSocketE2E_DeltaThenCloseSendsTerminalError(t *testing.T) {
 	}
 }
 
+// Client-supplied isNative is ignored; server derives true for native Codex providers.
+func TestCodexWebSocketDirectsThroughCanonicalNativeRoute(t *testing.T) {
+	var websocketConnections atomic.Int32
+	var codexHTTPPosts atomic.Int32
+	upstreamFrames := make(chan []byte, 1)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !websocket.IsWebSocketUpgrade(r) {
+			codexHTTPPosts.Add(1)
+			http.Error(w, "HTTP fallback is forbidden", http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path != "/v1/responses" {
+			t.Errorf("upstream path = %q, want /v1/responses", r.URL.Path)
+		}
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade upstream: %v", err)
+			return
+		}
+		defer conn.Close()
+		websocketConnections.Add(1)
+		messageType, frame, readErr := conn.ReadMessage()
+		if readErr != nil {
+			t.Errorf("read upstream: %v", readErr)
+			return
+		}
+		if messageType != websocket.TextMessage {
+			t.Errorf("upstream message type = %d, want text", messageType)
+			return
+		}
+		upstreamFrames <- bytes.Clone(frame)
+		response := `{"type":"response.completed","response":{"id":"resp_canonical","model":"gpt-test","output":[]}}`
+		if writeErr := conn.WriteMessage(websocket.TextMessage, []byte(response)); writeErr != nil {
+			t.Errorf("write upstream: %v", writeErr)
+		}
+	}))
+	defer upstream.Close()
+
+	var openaiHTTPCalls atomic.Int32
+	openaiHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openaiHTTPCalls.Add(1)
+		http.Error(w, "OpenAI conversion route must not be selected", http.StatusInternalServerError)
+	}))
+	defer openaiHTTP.Close()
+
+	env := NewProxyTestEnv(t)
+	codexProviderID := createCodexProvider(t, env, map[string]any{
+		"accessToken": "static-token",
+		"baseURL":     upstream.URL + "/v1",
+	})
+	// Deliberately submit isNative=false; server must recompute to true for codex→codex.
+	createResp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   false,
+		"clientType": "codex",
+		"providerID": codexProviderID,
+		"position":   1,
+	})
+	if createResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		createResp.Body.Close()
+		t.Fatalf("create route with isNative=false: status=%d body=%s", createResp.StatusCode, body)
+	}
+	var created struct {
+		ID       uint64 `json:"id"`
+		IsNative bool   `json:"isNative"`
+	}
+	DecodeJSON(t, createResp, &created)
+	if !created.IsNative {
+		t.Fatalf("create response isNative = false, want true (server-derived)")
+	}
+
+	getResp := env.AdminGet("/api/admin/routes/" + itoa(created.ID))
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResp.Body)
+		getResp.Body.Close()
+		t.Fatalf("GET route: status=%d body=%s", getResp.StatusCode, body)
+	}
+	var fetched struct {
+		ID       uint64 `json:"id"`
+		IsNative bool   `json:"isNative"`
+	}
+	DecodeJSON(t, getResp, &fetched)
+	if !fetched.IsNative {
+		t.Fatalf("GET route isNative = false, want true")
+	}
+
+	// Competing non-native conversion candidate must not receive traffic.
+	openaiProviderID := createProvider(t, env, "OpenAI conversion candidate", openaiHTTP.URL, []string{"openai"})
+	createNativeRoute(t, env, "codex", openaiProviderID, 2)
+
+	downstreamURL := "ws" + strings.TrimPrefix(env.Server.URL, "http") + "/v1/responses"
+	downstream, response, err := websocket.DefaultDialer.Dial(downstreamURL, nil)
+	if err != nil {
+		if response != nil && response.Body != nil {
+			body, _ := io.ReadAll(response.Body)
+			response.Body.Close()
+			t.Fatalf("dial downstream: %v: %s", err, body)
+		}
+		t.Fatalf("dial downstream: %v", err)
+	}
+	defer downstream.Close()
+
+	frame := []byte(`{"type":"response.create","model":"gpt-test","stream":true,"store":true,"input":[]}`)
+	if err := downstream.WriteMessage(websocket.TextMessage, frame); err != nil {
+		t.Fatalf("write downstream: %v", err)
+	}
+	messageType, event, err := downstream.ReadMessage()
+	if err != nil {
+		t.Fatalf("read downstream: %v", err)
+	}
+	if messageType != websocket.TextMessage || !bytes.Contains(event, []byte(`"type":"response.completed"`)) {
+		t.Fatalf("downstream event = %s", event)
+	}
+	if got := <-upstreamFrames; !bytes.Equal(got, frame) {
+		t.Fatalf("upstream frame mutated:\n got %s\nwant %s", got, frame)
+	}
+	if got := websocketConnections.Load(); got != 1 {
+		t.Fatalf("upstream websocket connections = %d, want 1", got)
+	}
+	if got := codexHTTPPosts.Load(); got != 0 {
+		t.Fatalf("Codex HTTP POST calls = %d, want 0", got)
+	}
+	if got := openaiHTTPCalls.Load(); got != 0 {
+		t.Fatalf("OpenAI conversion HTTP calls = %d, want 0", got)
+	}
+}
+
+// OpenAI HTTP conversion routes are never eligible for Responses WebSocket.
+func TestCodexWebSocketRejectsOpenAIConversionRoute(t *testing.T) {
+	var openaiHTTPCalls atomic.Int32
+	openaiHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		openaiHTTPCalls.Add(1)
+		http.Error(w, "OpenAI HTTP upstream must not be called for WS", http.StatusInternalServerError)
+	}))
+	defer openaiHTTP.Close()
+
+	env := NewProxyTestEnv(t)
+	openaiProviderID := createProvider(t, env, "OpenAI conversion only", openaiHTTP.URL, []string{"openai"})
+	// Codex client route targeting an OpenAI-only provider is non-native conversion.
+	routeResp := env.AdminPost("/api/admin/routes", map[string]any{
+		"isEnabled":  true,
+		"isNative":   true, // client claim ignored; server derives false
+		"clientType": "codex",
+		"providerID": openaiProviderID,
+		"position":   1,
+	})
+	if routeResp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(routeResp.Body)
+		routeResp.Body.Close()
+		t.Fatalf("create conversion route: status=%d body=%s", routeResp.StatusCode, body)
+	}
+	var route struct {
+		ID       uint64 `json:"id"`
+		IsNative bool   `json:"isNative"`
+	}
+	DecodeJSON(t, routeResp, &route)
+	if route.IsNative {
+		t.Fatalf("conversion route isNative = true, want false")
+	}
+
+	downstreamURL := "ws" + strings.TrimPrefix(env.Server.URL, "http") + "/v1/responses"
+	downstream, _, err := websocket.DefaultDialer.Dial(downstreamURL, nil)
+	if err != nil {
+		t.Fatalf("dial downstream: %v", err)
+	}
+	defer downstream.Close()
+	_ = downstream.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if err = downstream.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)); err != nil {
+		t.Fatalf("write downstream: %v", err)
+	}
+	_, event, err := downstream.ReadMessage()
+	if err != nil {
+		t.Fatalf("read downstream error event: %v", err)
+	}
+	if !bytes.Contains(event, []byte(`"type":"error"`)) ||
+		!bytes.Contains(event, []byte(`"code":"websocket_transport_unavailable"`)) {
+		t.Fatalf("downstream event = %s, want websocket_transport_unavailable", event)
+	}
+	if got := openaiHTTPCalls.Load(); got != 0 {
+		t.Fatalf("OpenAI HTTP upstream calls = %d, want 0", got)
+	}
+}
+
 func createNativeRoute(t *testing.T, env *ProxyTestEnv, clientType string, providerID uint64, position int) uint64 {
 	t.Helper()
 	resp := env.AdminPost("/api/admin/routes", map[string]any{

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/testutil/mockserver"
 	"github.com/tidwall/gjson"
 )
@@ -1148,15 +1149,25 @@ func TestProxyNoMatchingRoute(t *testing.T) {
 func TestProxyRouteWithoutConfiguredProviderRecordsRejectedRequest(t *testing.T) {
 	env := NewProxyTestEnv(t)
 
+	// Route create requires a resolvable provider (IsNative is server-derived).
+	// Put that provider into cooldown so Match skips every candidate and returns
+	// no_available_provider — equivalent to the old dangling providerID case.
+	providerID := createProvider(t, env, "cooldown-only-provider", "http://127.0.0.1:1", []string{"openai"})
 	routeResp := env.AdminPost("/api/admin/routes", map[string]any{
 		"isEnabled":  true,
-		"isNative":   false,
 		"clientType": "openai",
-		"providerID": 999999,
+		"providerID": providerID,
 		"projectID":  0,
 		"position":   1,
 	})
 	AssertStatus(t, routeResp, http.StatusCreated)
+
+	cooldown.Default().UpdateCooldown(providerID, "openai", "", time.Now().Add(time.Hour))
+	cooldown.Default().UpdateCooldown(providerID, "openai", "gpt-4o", time.Now().Add(time.Hour))
+	cooldown.Default().UpdateCooldown(providerID, "", "", time.Now().Add(time.Hour))
+	t.Cleanup(func() {
+		cooldown.Default().ClearCooldown(providerID, "", "")
+	})
 
 	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
 	AssertStatus(t, resp, http.StatusServiceUnavailable)

--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -255,7 +255,6 @@ function routesForScope(routes: Route[] | undefined, projectID: number, clientTy
 function routeConfigDiffers(target: Route, source: Route, position: number): boolean {
   return (
     target.isEnabled !== source.isEnabled ||
-    target.isNative !== source.isNative ||
     target.position !== position ||
     (target.weight || 1) !== (source.weight || 1) ||
     target.retryConfigID !== source.retryConfigID
@@ -591,7 +590,8 @@ function ClientTypeRoutesContentInner({
     for (const route of clientRoutes) {
       const provider = providerById.get(Number(route.providerID));
       if (!provider) continue;
-      const isNative = (provider.supportedClientTypes || []).includes(clientType);
+      // Existing routes: trust server-derived route.isNative only.
+      const isNative = route.isNative;
       allItems.push({
         id: `${clientType}-provider-${provider.id}`,
         provider,
@@ -774,7 +774,6 @@ function ClientTypeRoutesContentInner({
     } else {
       createRoute.mutate({
         isEnabled: true,
-        isNative: item.isNative,
         projectID,
         clientType,
         providerID: item.provider.id,
@@ -863,7 +862,6 @@ function ClientTypeRoutesContentInner({
       targetProviders.map((provider, index) =>
         createRoute.mutateAsync({
           isEnabled: true,
-          isNative: (provider.supportedClientTypes || []).includes(clientType),
           projectID,
           clientType,
           providerID: provider.id,

--- a/web/src/hooks/queries/use-routes.ts
+++ b/web/src/hooks/queries/use-routes.ts
@@ -5,8 +5,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getTransport,
-  type Route,
   type CreateRouteData,
+  type UpdateRouteData,
   type ClaudeProviderBatchRequest,
   type RouteBulkDeleteRequest,
   type RouteSyncRequest,
@@ -56,7 +56,7 @@ export function useUpdateRoute() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: number; data: Partial<Route> }) =>
+    mutationFn: ({ id, data }: { id: number; data: UpdateRouteData }) =>
       getTransport().updateRoute(id, data),
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: routeKeys.detail(id) });

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -16,6 +16,7 @@ import type {
   Session,
   Route,
   CreateRouteData,
+  UpdateRouteData,
   RetryConfig,
   CreateRetryConfigData,
   RoutingStrategy,
@@ -363,7 +364,7 @@ export class HttpTransport implements Transport {
     return data;
   }
 
-  async updateRoute(id: number, payload: Partial<Route>): Promise<Route> {
+  async updateRoute(id: number, payload: UpdateRouteData): Promise<Route> {
     const { data } = await this.client.put<Route>(`/routes/${id}`, payload);
     return data;
   }

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -24,6 +24,7 @@ export type {
   Session,
   Route,
   CreateRouteData,
+  UpdateRouteData,
   RoutePositionUpdate,
   RouteBulkDeleteRequest,
   RouteBulkDeleteResult,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -14,6 +14,7 @@ import type {
   Session,
   Route,
   CreateRouteData,
+  UpdateRouteData,
   RetryConfig,
   CreateRetryConfigData,
   RoutingStrategy,
@@ -125,7 +126,7 @@ export interface Transport {
   getRoutes(): Promise<Route[]>;
   getRoute(id: number): Promise<Route>;
   createRoute(data: CreateRouteData): Promise<Route>;
-  updateRoute(id: number, data: Partial<Route>): Promise<Route>;
+  updateRoute(id: number, data: UpdateRouteData): Promise<Route>;
   deleteRoute(id: number): Promise<void>;
   bulkDeleteRoutes(data: RouteBulkDeleteRequest): Promise<RouteBulkDeleteResult>;
   syncRoutesFromProject(data: RouteSyncRequest): Promise<RouteSyncResult>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -249,7 +249,8 @@ export interface Route {
   createdAt: string;
   updatedAt: string;
   isEnabled: boolean;
-  isNative: boolean; // 是否为原生支持（自动创建），false 表示转换支持（手动创建）
+  /** Server-derived: target provider natively supports clientType. Read-only. */
+  readonly isNative: boolean;
   projectID: number;
   clientType: ClientType;
   providerID: number;
@@ -271,7 +272,9 @@ export interface ProviderBulkDeleteResult {
   modelMappingDeletedCount: number;
 }
 
-export type CreateRouteData = Omit<Route, 'id' | 'createdAt' | 'updatedAt'>;
+export type CreateRouteData = Omit<Route, 'id' | 'createdAt' | 'updatedAt' | 'isNative'>;
+
+export type UpdateRouteData = Partial<CreateRouteData>;
 
 export interface RoutePositionUpdate {
   id: number;

--- a/web/src/pages/routes/form.tsx
+++ b/web/src/pages/routes/form.tsx
@@ -70,7 +70,6 @@ export function RouteForm({ route, onClose, isGlobal, projectId }: RouteFormProp
       position: Number(position),
       weight: Number.isFinite(parsedWeight) && parsedWeight > 0 ? parsedWeight : 1,
       isEnabled,
-      isNative: route?.isNative ?? false, // 手动创建的 Route 默认为转换路由
       retryConfigID: route?.retryConfigID ?? 0,
       modelMapping: Object.keys(modelMapping).length > 0 ? modelMapping : undefined,
     };


### PR DESCRIPTION
## Summary
- Make `Route.IsNative` a server-derived, read-only field from provider native ClientType capability (`domain.RouteIsNative` / `CanonicalSupportedClientTypes`).
- Ignore client-submitted `isNative` on route create/update/patch; recompute on sync, backup import/export; backfill snapshots in migration v21.
- Route Codex Responses WebSocket with canonical native + `ResponsesWebSocketAdapter` checks, execute only the first matched provider, and remove cross-provider fallback (`CanTryNextProvider` / multi-candidate dispatch).
- UI/CLI: show native as read-only; stop writing `isNative` from forms and `--native` flag.

## Root cause
UI/API showed or wrote inconsistent `is_native` snapshots while Router trusted the DB flag, so Codex→Codex native WebSocket routes could be filtered with 503 even when the adapter supported WS.

## Test plan
- [x] `go test ./internal/domain ./internal/service ./internal/router ./internal/executor ./internal/handler ./internal/adapter/provider/codex ./internal/repository/sqlite`
- [x] `go test ./tests/e2e -run 'CodexWebSocket|TestProxyRouteWithoutConfiguredProvider'`
- [ ] CI full suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 路由的原生能力现由服务端根据提供方与客户端类型自动判定，并在创建、更新、同步及导入导出时保持一致。
  * Codex Responses WebSocket 请求仅使用首个符合条件的提供方，避免跨提供方回退。
  * 更新路由时支持字段范围更明确，原生标志不再接受客户端设置。

* **问题修复**
  * 提供方配置变更后会重新评估相关路由能力。
  * 改善 WebSocket 不可用、冷却及协议字段处理，并保留必要错误信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->