### PR TITLE
fix(codex): accurate 426 pre-check for WebSocket→SSE fallback

### DIFF
--- a/.github/workflows/ci-docker-build.yml
+++ b/.github/workflows/ci-docker-build.yml
@@ -37,14 +37,26 @@ jobs:
 
       - name: Set image name
         id: image
+        env:
+          # Pass via env to avoid Actions template injection into the shell script.
+          RAW_TAG: ${{ inputs.tag || github.event.inputs.tag || github.ref_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REGISTRY: ${{ env.REGISTRY }}
         run: |
-          echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+          NAME="${GITHUB_REPOSITORY,,}"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
           # workflow_call / workflow_dispatch may pass inputs.tag; otherwise use ref name.
           # Sanitize branch names so tags are valid docker references.
-          RAW="${{ inputs.tag || github.event.inputs.tag || github.ref_name }}"
+          RAW="$RAW_TAG"
           TAG=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | sed 's#/#-#g' | sed 's/[^a-z0-9._-]/-/g')
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "raw=${RAW}" >> "$GITHUB_OUTPUT"
+          TAGS="${REGISTRY}/${NAME}:${TAG}"
+          # Only default-branch builds should retag :latest (not fix/** deploy probes).
+          if [ "$REF_NAME" = "main" ] || [ "$REF_NAME" = "master" ]; then
+            TAGS="${TAGS},${REGISTRY}/${NAME}:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -114,6 +126,4 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:latest
+          tags: ${{ steps.image.outputs.tags }}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -78,12 +78,13 @@ func (e *Executor) CloseResponsesWebSocketConnection(connectionID string) {
 }
 
 // HasResponsesWebSocketProvider reports whether any Codex route can serve
-// Responses WebSocket. Used to reject upgrades with HTTP 426 for Codex fallback.
-func (e *Executor) HasResponsesWebSocketProvider(tenantID uint64) bool {
+// Responses WebSocket for the given project scope (same rules as Match).
+// Used to reject upgrades with HTTP 426 for Codex fallback.
+func (e *Executor) HasResponsesWebSocketProvider(tenantID, projectID uint64) bool {
 	if e == nil || e.router == nil {
 		return false
 	}
-	return e.router.HasResponsesWebSocketProvider(tenantID)
+	return e.router.HasResponsesWebSocketProvider(tenantID, projectID)
 }
 
 // Execute runs the executor middleware chain with a new flow context.

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -94,20 +94,25 @@ func (h *ProxyHandler) SetRequestTracker(tracker RequestTracker) {
 func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if isResponsesWebSocketUpgrade(r) {
 		tenantID := domain.DefaultTenantID
+		var projectID uint64
 		if h.tokenAuth != nil {
 			apiToken, err := h.tokenAuth.ValidateRequest(r, domain.ClientTypeCodex)
 			if err != nil {
 				writeError(w, http.StatusUnauthorized, err.Error())
 				return
 			}
-			if apiToken != nil && apiToken.TenantID > 0 {
-				tenantID = apiToken.TenantID
+			if apiToken != nil {
+				if apiToken.TenantID > 0 {
+					tenantID = apiToken.TenantID
+				}
+				// Token-bound project is known before upgrade; session binding is not.
+				projectID = apiToken.ProjectID
 			}
 		}
 
 		// Codex only immediately falls back to HTTP/SSE when the WebSocket
 		// handshake fails with 426 Upgrade Required (not after 101 + JSON error).
-		if h.executor == nil || !h.executor.HasResponsesWebSocketProvider(tenantID) {
+		if h.executor == nil || !h.executor.HasResponsesWebSocketProvider(tenantID, projectID) {
 			writeResponsesWebSocketUpgradeRequired(w)
 			return
 		}

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -146,26 +146,52 @@ func (wsRouterStrategyRepo) GetByProjectID(uint64, uint64) (*domain.RoutingStrat
 }
 func (wsRouterStrategyRepo) List(uint64) ([]*domain.RoutingStrategy, error) { return nil, nil }
 
-type wsRouterProjectRepo struct{}
+type wsRouterProjectRepo struct{ projects []*domain.Project }
 
-func (wsRouterProjectRepo) Create(*domain.Project) error { return nil }
-func (wsRouterProjectRepo) Update(*domain.Project) error { return nil }
-func (wsRouterProjectRepo) Delete(uint64, uint64) error  { return nil }
-func (wsRouterProjectRepo) GetByID(uint64, uint64) (*domain.Project, error) {
+func (r *wsRouterProjectRepo) Create(p *domain.Project) error {
+	r.projects = append(r.projects, p)
+	return nil
+}
+func (r *wsRouterProjectRepo) Update(*domain.Project) error { return nil }
+func (r *wsRouterProjectRepo) Delete(uint64, uint64) error  { return nil }
+func (r *wsRouterProjectRepo) GetByID(tenantID, id uint64) (*domain.Project, error) {
+	for _, p := range r.projects {
+		if p.TenantID == tenantID && p.ID == id {
+			return p, nil
+		}
+	}
 	return nil, domain.ErrNotFound
 }
-func (wsRouterProjectRepo) GetBySlug(uint64, string) (*domain.Project, error) {
+func (r *wsRouterProjectRepo) GetBySlug(uint64, string) (*domain.Project, error) {
 	return nil, domain.ErrNotFound
 }
-func (wsRouterProjectRepo) List(uint64) ([]*domain.Project, error) { return nil, nil }
+func (r *wsRouterProjectRepo) List(tenantID uint64) ([]*domain.Project, error) {
+	var out []*domain.Project
+	for _, p := range r.projects {
+		if tenantID == domain.TenantIDAll || p.TenantID == tenantID {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
 
 func newResponsesWebSocketTestRouter(t *testing.T, routes []*domain.Route, providers []*domain.Provider) *Router {
+	t.Helper()
+	return newResponsesWebSocketTestRouterWithProjects(t, routes, providers, nil)
+}
+
+func newResponsesWebSocketTestRouterWithProjects(
+	t *testing.T,
+	routes []*domain.Route,
+	providers []*domain.Provider,
+	projects []*domain.Project,
+) *Router {
 	t.Helper()
 	routeRepo := cached.NewRouteRepository(&wsRouterRouteRepo{routes: routes})
 	providerRepo := cached.NewProviderRepository(&wsRouterProviderRepo{providers: providers})
 	retryRepo := cached.NewRetryConfigRepository(wsRouterRetryRepo{})
 	strategyRepo := cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{})
-	projectRepo := cached.NewProjectRepository(wsRouterProjectRepo{})
+	projectRepo := cached.NewProjectRepository(&wsRouterProjectRepo{projects: projects})
 	for name, load := range map[string]func() error{
 		"routes":     routeRepo.Load,
 		"providers":  providerRepo.Load,
@@ -204,7 +230,7 @@ func TestHasResponsesWebSocketProvider(t *testing.T) {
 			{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
 		},
 	)
-	if !r.HasResponsesWebSocketProvider(1) {
+	if !r.HasResponsesWebSocketProvider(1, 0) {
 		t.Fatal("expected HasResponsesWebSocketProvider true for native WS adapter")
 	}
 
@@ -216,13 +242,50 @@ func TestHasResponsesWebSocketProvider(t *testing.T) {
 			{ID: 201, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "http-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
 		},
 	)
-	if rHTTPOnly.HasResponsesWebSocketProvider(1) {
+	if rHTTPOnly.HasResponsesWebSocketProvider(1, 0) {
 		t.Fatal("HTTP-only adapter should not count as WebSocket-capable")
 	}
 
 	rEmpty := newResponsesWebSocketTestRouter(t, nil, nil)
-	if rEmpty.HasResponsesWebSocketProvider(1) {
+	if rEmpty.HasResponsesWebSocketProvider(1, 0) {
 		t.Fatal("empty routes should not report WebSocket capability")
+	}
+
+	// Project-only WS routes must not make the global (projectID=0) pre-check pass.
+	// Otherwise upgrade succeeds (101) and Codex will not auto-fallback to SSE.
+	rProjectOnly := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProjectID: 9, ProviderID: 301, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+		},
+		[]*domain.Provider{
+			{ID: 301, TenantID: 1, Type: wsRouterNativeType, Name: "project-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	if rProjectOnly.HasResponsesWebSocketProvider(1, 0) {
+		t.Fatal("project-only WS route must not satisfy global projectID=0 check")
+	}
+
+	// Project custom Codex routes exist but are HTTP-only, while global is WS.
+	// Match uses only project routes → no WS. Pre-check must be false so callers
+	// return 426 (not 101 + later failure).
+	rProjectHTTPOnlyWithGlobalWS := newResponsesWebSocketTestRouterWithProjects(t,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProjectID: 9, ProviderID: 401, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 2, TenantID: 1, ProjectID: 0, ProviderID: 402, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 401, TenantID: 1, Type: wsRouterHTTPOnlyType, Name: "project-http", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: 402, TenantID: 1, Type: wsRouterNativeType, Name: "global-ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+		[]*domain.Project{
+			{ID: 9, TenantID: 1, EnabledCustomRoutes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	if rProjectHTTPOnlyWithGlobalWS.HasResponsesWebSocketProvider(1, 9) {
+		t.Fatal("project HTTP-only custom routes must force 426 even when global WS exists")
+	}
+	if !rProjectHTTPOnlyWithGlobalWS.HasResponsesWebSocketProvider(1, 0) {
+		t.Fatal("global projectID=0 should still see the global WS route")
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -406,11 +406,15 @@ func adapterSupportsResponsesWebSocket(adapter provider.ProviderAdapter) bool {
 	return ok
 }
 
-// HasResponsesWebSocketProvider reports whether any enabled Codex route can
-// currently serve Responses over WebSocket (native + adapter + opt-in flag).
-// Used to reject the WebSocket upgrade with HTTP 426 so Codex clients fall
-// back to HTTP/SSE immediately (see codex-rs core websocket_fallback tests).
-func (r *Router) HasResponsesWebSocketProvider(tenantID uint64) bool {
+// HasResponsesWebSocketProvider reports whether Match would find any Codex route
+// that can serve Responses over WebSocket (native + adapter + opt-in flag).
+//
+// Route scope MUST match Match exactly: when the project enables custom Codex
+// routes and has project-scoped Codex routes, only those are considered;
+// otherwise only global (ProjectID == 0) routes. A false positive here lets the
+// upgrade succeed (101) and Codex will not auto-fallback to HTTP/SSE — only an
+// immediate 426 Upgrade Required triggers FallbackToHttp in official Codex.
+func (r *Router) HasResponsesWebSocketProvider(tenantID, projectID uint64) bool {
 	if r == nil {
 		return false
 	}
@@ -418,16 +422,60 @@ func (r *Router) HasResponsesWebSocketProvider(tenantID uint64) bool {
 	if err != nil {
 		return false
 	}
+
+	// Mirror Match's project custom-route gate for ClientTypeCodex.
+	useProjectRoutes := false
+	if projectID != 0 && r.projectRepo != nil {
+		project, err := r.projectRepo.GetByID(tenantID, projectID)
+		if err == nil && project != nil && len(project.EnabledCustomRoutes) > 0 {
+			for _, ct := range project.EnabledCustomRoutes {
+				if ct == domain.ClientTypeCodex {
+					useProjectRoutes = true
+					break
+				}
+			}
+		}
+	}
+
+	// Select the same candidate set Match would use before capability filters.
+	var candidates []*domain.Route
+	if useProjectRoutes {
+		for _, route := range routes {
+			if route == nil || !route.IsEnabled {
+				continue
+			}
+			if tenantID > 0 && route.TenantID != tenantID {
+				continue
+			}
+			if route.ClientType != domain.ClientTypeCodex {
+				continue
+			}
+			if route.ProjectID == projectID && projectID != 0 {
+				candidates = append(candidates, route)
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		for _, route := range routes {
+			if route == nil || !route.IsEnabled {
+				continue
+			}
+			if tenantID > 0 && route.TenantID != tenantID {
+				continue
+			}
+			if route.ClientType != domain.ClientTypeCodex {
+				continue
+			}
+			if route.ProjectID == 0 {
+				candidates = append(candidates, route)
+			}
+		}
+	}
+
 	providers := r.providerRepo.GetAll()
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for _, route := range routes {
-		if route == nil || !route.IsEnabled || route.ClientType != domain.ClientTypeCodex {
-			continue
-		}
-		if tenantID > 0 && route.TenantID != tenantID {
-			continue
-		}
+	for _, route := range candidates {
 		prov, ok := providers[route.ProviderID]
 		if !ok || prov == nil {
 			continue


### PR DESCRIPTION
## Summary
- **Root cause for Codex fallback:** official Codex only auto-switches to HTTP/SSE when the **WebSocket handshake returns 426** (`UPGRADE_REQUIRED`). A false-positive "WS available" pre-check lets the upgrade succeed (101); later route failures do **not** trigger FallbackToHttp.
- Align `HasResponsesWebSocketProvider(tenantID, projectID)` candidate selection with `Match`: if the project enables custom Codex routes and has project-scoped Codex routes, only those are considered; otherwise only global (`ProjectID == 0`) routes. Project HTTP-only custom routes no longer pass the pre-check just because a global WS route exists.
- Pass token-bound `projectID` into the upgrade pre-check when available.
- CI: avoid Actions template injection for image tags; do not retag `:latest` from `fix/**` / non-main builds.

## Test plan
- [x] `go test ./internal/router/ -run HasResponsesWebSocket`
- [x] `go test ./internal/handler/ ./internal/executor/ ./internal/router/`
- [ ] PR CI on awsl-project/maxx

Follow-up to #728 CodeRabbit review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - Codex Responses WebSocket 能力检测现支持按项目范围判断。
  - 项目自定义路由将优先使用对应项目配置，避免错误匹配全局路由。
  - 不支持 WebSocket 的项目会自动引导使用 HTTP/SSE，提升连接兼容性。

- **构建改进**
  - Docker 镜像仅在主分支构建时自动添加 `latest` 标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->