### PR TITLE
fix(workflow): update CLIProxyAPI v7 replace sync

### DIFF
--- a/.github/workflows/cliproxyapi-sync.yml
+++ b/.github/workflows/cliproxyapi-sync.yml
@@ -102,7 +102,7 @@ jobs:
           git fetch origin "$BASE_BRANCH"
           git checkout -B "$BRANCH" "origin/$BASE_BRANCH"
 
-          go mod edit -replace=github.com/router-for-me/CLIProxyAPI/v6=github.com/awsl-project/CLIProxyAPI/v6@latest
+          go mod edit -replace=github.com/router-for-me/CLIProxyAPI/v7=github.com/awsl-project/CLIProxyAPI/v7@latest
           go mod tidy
 
           git add go.mod go.sum
@@ -112,7 +112,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: update CLIProxyAPI replace"
+          git commit -m "chore: update CLIProxyAPI v7 replace"
           git push -f origin "$BRANCH"
 
           PR_NUMBER=$(gh pr list \
@@ -130,8 +130,8 @@ jobs:
           if ! gh pr create \
             --base "$BASE_BRANCH" \
             --head "$BRANCH" \
-            --title "chore: update CLIProxyAPI replace" \
-            --body "Automated dependency update by CLIProxyAPI Sync workflow."; then
+            --title "chore: update CLIProxyAPI v7 replace" \
+            --body "Automated CLIProxyAPI v7 dependency update by CLIProxyAPI Sync workflow."; then
             {
               echo "### PR creation skipped"
               echo "- Branch pushed: $BRANCH"


### PR DESCRIPTION
## Summary
- update the CLIProxyAPI Sync dependency PR step to refresh the active v7 replace directive instead of the stale v6 replace
- align the automated dependency update commit and PR title with CLIProxyAPI v7

## Why
`maxx` currently depends on `github.com/router-for-me/CLIProxyAPI/v7`, but the scheduled workflow only refreshed the v6 replace directive. The daily run could complete successfully without producing a dependency PR because the active v7 replace never changed.

## Validation
- Confirmed `.github/workflows/cliproxyapi-sync.yml` now targets `github.com/router-for-me/CLIProxyAPI/v7 => github.com/awsl-project/CLIProxyAPI/v7@latest`
- Ran the updated `go mod edit ... v7@latest && go mod tidy` command locally and confirmed it produces a v7 dependency diff
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 将 CLIProxyAPI 依赖替换版本更新至 v7。
  * 同步更新自动生成的提交信息及拉取请求描述，明确标注 v7 版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->