### PR TITLE
fix(requests): move column visibility into settings

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -280,12 +280,11 @@
     "cacheWrite": "Cache Write",
     "cacheWShort": "CacheW",
     "columns": {
-      "action": "Columns",
-      "title": "Visible columns",
-      "hint": "Toggle visibility, drag to reorder; drag header edges to resize.",
+      "action": "Columns display & order",
+      "title": "Columns display & order",
+      "hint": "Toggle columns here, drag to reorder, and drag header edges to resize. At least one column must remain visible.",
       "reset": "Reset",
-      "resize": "Resize {{column}} column",
-      "hide": "Hide {{column}} column"
+      "resize": "Resize {{column}} column"
     },
     "page": "Page {{current}}",
     "pageInfo": "Page {{page}}, showing {{count}} items of {{total}} total",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -284,7 +284,8 @@
       "title": "Visible columns",
       "hint": "Toggle visibility, drag to reorder; drag header edges to resize.",
       "reset": "Reset",
-      "resize": "Resize {{column}} column"
+      "resize": "Resize {{column}} column",
+      "hide": "Hide {{column}} column"
     },
     "page": "Page {{current}}",
     "pageInfo": "Page {{page}}, showing {{count}} items of {{total}} total",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -279,12 +279,11 @@
     "cacheWrite": "缓存写入",
     "cacheWShort": "缓存写",
     "columns": {
-      "action": "列设置",
-      "title": "显示列",
-      "hint": "勾选显示、拖拽排序；表头边缘可拖拽调整宽度。",
+      "action": "列显示与排序",
+      "title": "列显示与排序",
+      "hint": "在这里勾选显示列、拖拽排序；表头边缘仍可调整列宽。至少保留一列可见。",
       "reset": "重置",
-      "resize": "调整{{column}}列宽",
-      "hide": "隐藏{{column}}整列"
+      "resize": "调整{{column}}列宽"
     },
     "page": "第 {{current}} 页",
     "pageInfo": "第 {{page}} 页，显示 {{count}} 条，共 {{total}} 条",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -283,7 +283,8 @@
       "title": "显示列",
       "hint": "勾选显示、拖拽排序；表头边缘可拖拽调整宽度。",
       "reset": "重置",
-      "resize": "调整{{column}}列宽"
+      "resize": "调整{{column}}列宽",
+      "hide": "隐藏{{column}}整列"
     },
     "page": "第 {{current}} 页",
     "pageInfo": "第 {{page}} 页，显示 {{count}} 条，共 {{total}} 条",

--- a/web/src/pages/requests/column-settings.tsx
+++ b/web/src/pages/requests/column-settings.tsx
@@ -40,12 +40,14 @@ function SortableColumnRow({
   id,
   checked,
   disabled,
+  toggleDisabled,
   label,
   onToggle,
 }: {
   id: RequestColumnId;
   checked: boolean;
   disabled: boolean;
+  toggleDisabled: boolean;
   label: string;
   onToggle: (id: RequestColumnId, next: boolean) => void;
 }) {
@@ -84,7 +86,7 @@ function SortableColumnRow({
           type="checkbox"
           className="size-3.5 accent-primary shrink-0"
           checked={checked}
-          disabled={disabled}
+          disabled={toggleDisabled}
           onChange={(event) => onToggle(id, event.target.checked)}
         />
         <span className="text-sm truncate">{label}</span>
@@ -103,6 +105,10 @@ export function RequestsColumnSettings({ prefs, availability, onChange }: Column
   const configurableIds = useMemo(
     () => prefs.order.filter((id) => isColumnAvailable(id, availability)),
     [availability, prefs.order],
+  );
+  const visibleCount = useMemo(
+    () => configurableIds.filter((id) => prefs.visibility[id] !== false).length,
+    [configurableIds, prefs.visibility],
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -179,6 +185,7 @@ export function RequestsColumnSettings({ prefs, availability, onChange }: Column
                   id={id}
                   checked={prefs.visibility[id] !== false}
                   disabled={false}
+                  toggleDisabled={prefs.visibility[id] !== false && visibleCount <= 1}
                   label={t(columnLabelKey(id))}
                   onToggle={handleToggle}
                 />

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -36,7 +36,6 @@ import {
   Clock,
   BarChart3,
   Trash2,
-  EyeOff,
 } from 'lucide-react';
 import {
   type RequestColumnId,
@@ -433,28 +432,6 @@ export function RequestsPage() {
     setColumnPrefs(next);
   }, []);
 
-  const handleHideColumn = useCallback(
-    (columnId: RequestColumnId) => {
-      setColumnPrefs((prev) => {
-        if (prev.visibility[columnId] === false) {
-          return prev;
-        }
-        const remainingVisibleColumns = visibleColumns.filter((id) => id !== columnId);
-        if (remainingVisibleColumns.length === 0) {
-          return prev;
-        }
-        return {
-          ...prev,
-          visibility: {
-            ...prev.visibility,
-            [columnId]: false,
-          },
-        };
-      });
-    },
-    [visibleColumns],
-  );
-
   const handleColumnResizeStart = useCallback(
     (columnId: RequestColumnId, event: ReactMouseEvent<HTMLSpanElement>) => {
       event.preventDefault();
@@ -842,31 +819,14 @@ export function RequestsPage() {
             <TableHead
               key={columnId}
               className={cn(
-                'group relative font-medium select-none',
+                'relative font-medium select-none',
                 isCenteredColumn(columnId) && 'text-center',
                 columnId === 'client' && 'pr-4',
               )}
               style={{ width, minWidth: width, maxWidth: width }}
               title={fullLabel}
             >
-              <div className="flex min-w-0 items-center gap-1 pr-2">
-                <span className="block min-w-0 flex-1 truncate">{displayLabel}</span>
-                {visibleColumns.length > 1 && (
-                  <button
-                    type="button"
-                    className="shrink-0 rounded p-0.5 text-muted-foreground/60 opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    aria-label={t('requests.columns.hide', { column: fullLabel })}
-                    title={t('requests.columns.hide', { column: fullLabel })}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleHideColumn(columnId);
-                    }}
-                    onMouseDown={(event) => event.stopPropagation()}
-                  >
-                    <EyeOff className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </div>
+              <span className="block truncate pr-2">{displayLabel}</span>
               <span
                 role="separator"
                 aria-orientation="vertical"

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -36,6 +36,7 @@ import {
   Clock,
   BarChart3,
   Trash2,
+  EyeOff,
 } from 'lucide-react';
 import {
   type RequestColumnId,
@@ -127,7 +128,11 @@ const REQUEST_PROJECT_FILTER_STORAGE_KEY = 'maxx-requests-project-filter';
 const REQUESTS_VIRTUALIZE_THRESHOLD = 40;
 const DEFAULT_DESKTOP_ROW_HEIGHT = 38;
 
-function ProtocolBadge({ request }: { request: Pick<ProxyRequest, 'protocol' | 'isStream' | 'statusCode'> }) {
+function ProtocolBadge({
+  request,
+}: {
+  request: Pick<ProxyRequest, 'protocol' | 'isStream' | 'statusCode'>;
+}) {
   const { t } = useTranslation();
   const protocol = resolveRequestProtocol(request);
   const label = t(requestProtocolLabelKey(protocol));
@@ -427,6 +432,28 @@ export function RequestsPage() {
   const handleColumnPrefsChange = useCallback((next: RequestColumnPrefs) => {
     setColumnPrefs(next);
   }, []);
+
+  const handleHideColumn = useCallback(
+    (columnId: RequestColumnId) => {
+      setColumnPrefs((prev) => {
+        if (prev.visibility[columnId] === false) {
+          return prev;
+        }
+        const remainingVisibleColumns = visibleColumns.filter((id) => id !== columnId);
+        if (remainingVisibleColumns.length === 0) {
+          return prev;
+        }
+        return {
+          ...prev,
+          visibility: {
+            ...prev.visibility,
+            [columnId]: false,
+          },
+        };
+      });
+    },
+    [visibleColumns],
+  );
 
   const handleColumnResizeStart = useCallback(
     (columnId: RequestColumnId, event: ReactMouseEvent<HTMLSpanElement>) => {
@@ -809,26 +836,37 @@ export function RequestsPage() {
         {visibleColumns.map((columnId) => {
           const width = columnPrefs.widths[columnId];
           const shortKey = columnShortLabelKey(columnId);
-          const fullLabel =
-            columnId === 'ttft' ? 'TTFT' : t(columnLabelKey(columnId));
-          const displayLabel =
-            columnId === 'ttft'
-              ? 'TTFT'
-              : shortKey
-                ? t(shortKey)
-                : fullLabel;
+          const fullLabel = columnId === 'ttft' ? 'TTFT' : t(columnLabelKey(columnId));
+          const displayLabel = columnId === 'ttft' ? 'TTFT' : shortKey ? t(shortKey) : fullLabel;
           return (
             <TableHead
               key={columnId}
               className={cn(
-                'relative font-medium select-none',
+                'group relative font-medium select-none',
                 isCenteredColumn(columnId) && 'text-center',
                 columnId === 'client' && 'pr-4',
               )}
               style={{ width, minWidth: width, maxWidth: width }}
               title={fullLabel}
             >
-              <span className="block truncate pr-2">{displayLabel}</span>
+              <div className="flex min-w-0 items-center gap-1 pr-2">
+                <span className="block min-w-0 flex-1 truncate">{displayLabel}</span>
+                {visibleColumns.length > 1 && (
+                  <button
+                    type="button"
+                    className="shrink-0 rounded p-0.5 text-muted-foreground/60 opacity-0 transition hover:bg-muted hover:text-foreground group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    aria-label={t('requests.columns.hide', { column: fullLabel })}
+                    title={t('requests.columns.hide', { column: fullLabel })}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleHideColumn(columnId);
+                    }}
+                    onMouseDown={(event) => event.stopPropagation()}
+                  >
+                    <EyeOff className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </div>
               <span
                 role="separator"
                 aria-orientation="vertical"


### PR DESCRIPTION
## Summary
- Add a hover/focus hide-column control directly in the Requests table header.
- Keep the existing column settings popover as the recovery path for hidden columns.
- Preserve the existing guard that prevents hiding the last visible column.
- Add English and Chinese labels for the new hide-column action.

## Validation
- `pnpm --dir web typecheck`
- `pnpm --dir web exec vitest run src/pages/requests/column-prefs.test.ts`
- `pnpm --dir web exec prettier --check src/pages/requests/index.tsx src/locales/en.json src/locales/zh.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 请求列表桌面端表头新增隐藏列按钮。
  * 隐藏列后会保留至少一列可见，避免表格无列显示。
  * 新增中英文“隐藏列”提示文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->