### PR TITLE
feat(providers): add custom provider share command

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1700,7 +1700,14 @@
     "excludeFromExport": "Do not export this provider",
     "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved API endpoints and provider secrets will not be revealed on the edit page. Enter a new value to rotate one.",
     "cloneExcludeFromExportDesc": "Applies only to the newly cloned provider. When enabled, the clone will not be exported, and saved API endpoints and provider secrets will not be revealed on the edit page.",
-    "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly."
+    "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly.",
+    "shareCommand": "Share command",
+    "shareCommandTitle": "Share custom provider command",
+    "shareCommandDesc": "Copy a provider add command that can be pasted into the bulk import dialog.",
+    "copyShareCommand": "Copy command",
+    "shareCommandApiKeyHint": "To avoid leaking secrets, the command uses the <YOUR_API_KEY> placeholder by default.",
+    "shareCommandHiddenSecretHint": "This provider hides secrets or is excluded from exports; the shared command only uses visible config and placeholders.",
+    "shareCommandBlackBoxDisabled": "Black-box providers do not expose config, so a share command cannot be generated."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1697,7 +1697,14 @@
     "excludeFromExport": "不导出此提供商配置",
     "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的 API 端点和提供商密钥也不会在编辑页回显，只能重新输入轮换。",
     "cloneExcludeFromExportDesc": "仅用于新克隆出的提供商。开启后，克隆出的提供商不会被导出，且保存后的 API 端点和提供商密钥不会在编辑页回显。",
-    "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。"
+    "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。",
+    "shareCommand": "分享命令",
+    "shareCommandTitle": "分享自定义提供商命令",
+    "shareCommandDesc": "复制一条可粘贴到批量导入框的 provider add 命令。",
+    "copyShareCommand": "复制命令",
+    "shareCommandApiKeyHint": "为避免泄露密钥，命令中的 API Key 默认使用占位符 <YOUR_API_KEY>。",
+    "shareCommandHiddenSecretHint": "该提供商已启用隐藏密钥/不导出配置；分享命令只会使用可见配置和占位符。",
+    "shareCommandBlackBoxDisabled": "黑盒提供商不暴露配置，不能生成分享命令。"
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -1,7 +1,17 @@
-import type { KeyboardEvent } from 'react';
-import { Activity, Mail, Globe, Snowflake } from 'lucide-react';
+import { useMemo, useState, type KeyboardEvent, type MouseEvent } from 'react';
+import { Activity, Check, Copy, Globe, Mail, Share2, Snowflake } from 'lucide-react';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import { useCooldowns } from '@/hooks/use-cooldowns';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 
 import { ClientIcon } from '@/components/icons/client-icons';
 import { StreamingBadge } from '@/components/ui/streaming-badge';
@@ -12,6 +22,7 @@ import type {
   AntigravityQuotaData,
   KiroQuotaData,
   CodexQuotaData,
+  ModelMapping,
 } from '@/lib/transport';
 import { getProviderTypeConfig } from '../types';
 import { cn } from '@/lib/utils';
@@ -19,6 +30,7 @@ import { useAntigravityQuotaFromContext } from '@/contexts/antigravity-quotas-co
 import { useCodexQuotaFromContext } from '@/contexts/codex-quotas-context';
 import { useKiroQuota } from '@/hooks/queries';
 import { useTranslation } from 'react-i18next';
+import { buildCustomProviderShareCommand } from '../utils/bulk-custom-provider-import';
 
 // 格式化 Token 数量
 function formatTokens(count: number): string {
@@ -48,6 +60,7 @@ interface ProviderRowProps {
   provider: Provider;
   stats?: ProviderStats;
   streamingCount: number;
+  providerModelMappings?: ModelMapping[];
   onClick?: () => void;
   title?: string;
   className?: string;
@@ -207,11 +220,14 @@ export function ProviderRow({
   provider,
   stats,
   streamingCount,
+  providerModelMappings = [],
   onClick,
   title,
   className,
 }: ProviderRowProps) {
   const { t } = useTranslation();
+  const [shareCommandOpen, setShareCommandOpen] = useState(false);
+  const [shareCommandCopied, setShareCommandCopied] = useState(false);
   // 使用通用配置系统
   const typeConfig = getProviderTypeConfig(provider.type);
   const color = typeConfig.color;
@@ -242,6 +258,11 @@ export function ProviderRow({
   const healthLevel = getProviderHealthLevel(provider.id);
   const worstCooldown = providerCooldowns[0];
   const modelCooldowns = providerCooldowns.filter((cd) => cd.model);
+  const shareCommand = useMemo(
+    () => buildCustomProviderShareCommand(provider, { providerModelMappings }),
+    [provider, providerModelMappings],
+  );
+  const canShareCommand = provider.type === 'custom' && !!shareCommand && !provider.blackBox;
 
   const isInteractive = !!onClick;
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -256,6 +277,19 @@ export function ProviderRow({
       event.preventDefault();
       onClick();
     }
+  };
+
+  const stopRowClick = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  const handleCopyShareCommand = async () => {
+    if (!shareCommand || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+    await navigator.clipboard.writeText(shareCommand);
+    setShareCommandCopied(true);
+    window.setTimeout(() => setShareCommandCopied(false), 1200);
   };
 
   return (
@@ -585,6 +619,61 @@ export function ProviderRow({
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Custom Provider Share Command */}
+      {provider.type === 'custom' && (
+        <div className="relative z-10 shrink-0" onClick={stopRowClick} onMouseDown={stopRowClick}>
+          <Dialog open={shareCommandOpen} onOpenChange={setShareCommandOpen}>
+            <DialogTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  disabled={!canShareCommand}
+                  aria-label={t('provider.shareCommand')}
+                  title={
+                    provider.blackBox
+                      ? t('provider.shareCommandBlackBoxDisabled')
+                      : t('provider.shareCommand')
+                  }
+                />
+              }
+            >
+              <Share2 className="h-3.5 w-3.5" />
+            </DialogTrigger>
+            <DialogContent className="grid-cols-[minmax(0,1fr)] sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>{t('provider.shareCommandTitle')}</DialogTitle>
+                <DialogDescription>{t('provider.shareCommandDesc')}</DialogDescription>
+              </DialogHeader>
+              <div className="space-y-3 min-w-0">
+                {provider.excludeFromExport && (
+                  <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                    {t('provider.shareCommandHiddenSecretHint')}
+                  </div>
+                )}
+                <pre className="max-h-64 overflow-auto rounded-lg border bg-muted/50 p-3 text-xs leading-relaxed text-foreground whitespace-pre-wrap break-all">
+                  {shareCommand}
+                </pre>
+                <p className="text-xs text-muted-foreground">
+                  {t('provider.shareCommandApiKeyHint')}
+                </p>
+              </div>
+              <DialogFooter>
+                <Button type="button" className="gap-2" onClick={handleCopyShareCommand}>
+                  {shareCommandCopied ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                  {shareCommandCopied ? t('proxy.copied') : t('provider.copyShareCommand')}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
       )}
 

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -895,6 +895,12 @@ export function ProvidersPage() {
                                   provider={provider}
                                   stats={providerStats[provider.id]}
                                   streamingCount={countsByProvider.get(provider.id) || 0}
+                                  providerModelMappings={(modelMappings ?? []).filter(
+                                    (mapping) =>
+                                      mapping.scope === 'provider' &&
+                                      mapping.providerID === provider.id &&
+                                      mapping.isEnabled !== false,
+                                  )}
                                   className={cn(
                                     canManageProviderSettings && 'pl-12',
                                     isSelected &&

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildCustomProviderShareCommand,
   parseBulkCustomProviderCommands,
   tokenizeProviderCommand,
   toCreateProviderData,
 } from './bulk-custom-provider-import';
+import type { ModelMapping, Provider } from '@/lib/transport';
 
 describe('bulk custom provider import parser', () => {
   it('tokenizes quoted flag values', () => {
@@ -111,5 +113,67 @@ provider add --name bad --base-url https://api.example.com --api-key sk-test --c
       { lineNumber: 3, message: 'Unsupported client "unknown"' },
       { lineNumber: 3, message: 'At least one client is required' },
     ]);
+  });
+});
+
+describe('custom provider share command builder', () => {
+  const baseProvider: Provider = {
+    id: 1,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    type: 'custom',
+    name: 'GLM Share Provider',
+    config: {
+      disableErrorCooldown: true,
+      custom: {
+        baseURL: 'https://api.example.com/v1',
+        apiKey: 'sk-real-secret',
+        modelMapping: { 'glm-5.2': 'z-ai/glm-5.2' },
+        responseModelMapping: { 'z-ai/glm-5.2': 'glm-5.2' },
+        responsesPassthrough: false,
+      },
+    },
+    supportedClientTypes: ['openai', 'claude'],
+    supportModels: ['glm-5.2'],
+  };
+
+  it('builds a bulk-import-compatible command without leaking the api key', () => {
+    const command = buildCustomProviderShareCommand(baseProvider);
+
+    expect(command).toBe(
+      'provider add --name "GLM Share Provider" --base-url https://api.example.com/v1 --api-key "<YOUR_API_KEY>" --clients openai,claude --models glm-5.2 --map glm-5.2=z-ai/glm-5.2 --response-map z-ai/glm-5.2=glm-5.2 --disable-error-cooldown --no-responses-passthrough',
+    );
+    expect(command).not.toContain('sk-real-secret');
+    expect(parseBulkCustomProviderCommands(command ?? '').errors).toEqual([]);
+  });
+
+  it('includes provider-scoped model mappings in the shared command', () => {
+    const mappings: ModelMapping[] = [
+      {
+        id: 10,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        scope: 'provider',
+        clientType: '',
+        providerType: 'custom',
+        providerID: 1,
+        projectID: 0,
+        routeID: 0,
+        apiTokenID: 0,
+        pattern: 'gpt-5',
+        target: 'upstream-gpt-5',
+        priority: 0,
+        isEnabled: true,
+        isBuiltin: false,
+      },
+    ];
+
+    expect(
+      buildCustomProviderShareCommand(baseProvider, { providerModelMappings: mappings }),
+    ).toContain('--map glm-5.2=z-ai/glm-5.2,gpt-5=upstream-gpt-5');
+  });
+
+  it('returns null for non-custom providers', () => {
+    expect(buildCustomProviderShareCommand({ ...baseProvider, type: 'claude' })).toBeNull();
   });
 });

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.ts
@@ -1,4 +1,4 @@
-import type { ClientType, CreateProviderData } from '@/lib/transport';
+import type { ClientType, CreateProviderData, ModelMapping, Provider } from '@/lib/transport';
 
 export type BulkCustomProviderCommand = {
   lineNumber: number;
@@ -24,6 +24,10 @@ export type BulkCustomProviderParseError = {
 export type BulkCustomProviderParseResult = {
   commands: BulkCustomProviderCommand[];
   errors: BulkCustomProviderParseError[];
+};
+
+export type BuildCustomProviderShareCommandOptions = {
+  providerModelMappings?: ModelMapping[];
 };
 
 const CLIENT_TYPES = new Set<ClientType>(['claude', 'codex', 'gemini', 'openai']);
@@ -109,6 +113,84 @@ function splitList(value: string): string[] {
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function quoteCommandValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,*-]+$/.test(value)) {
+    return value;
+  }
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function joinCommandList(values: string[]): string {
+  return values.join(',');
+}
+
+function joinCommandMapping(mapping: Record<string, string>): string {
+  return Object.entries(mapping)
+    .map(([source, target]) => `${source}=${target}`)
+    .join(',');
+}
+
+export function buildCustomProviderShareCommand(
+  provider: Provider,
+  options: BuildCustomProviderShareCommandOptions = {},
+): string | null {
+  if (provider.type !== 'custom') return null;
+
+  const custom = provider.config?.custom;
+  const command = ['provider', 'add'];
+  const appendValue = (flag: string, value: string) => {
+    command.push(flag, quoteCommandValue(value));
+  };
+
+  appendValue('--name', provider.name);
+  appendValue('--base-url', custom?.baseURL || '<BASE_URL>');
+  appendValue('--api-key', '<YOUR_API_KEY>');
+
+  if (provider.supportedClientTypes.length > 0) {
+    appendValue('--clients', joinCommandList(provider.supportedClientTypes));
+  }
+
+  if (provider.supportModels && provider.supportModels.length > 0) {
+    appendValue('--models', joinCommandList(provider.supportModels));
+  }
+
+  const requestMapping: Record<string, string> = {
+    ...(custom?.modelMapping ?? {}),
+  };
+  for (const mapping of options.providerModelMappings ?? []) {
+    if (mapping.isEnabled !== false && mapping.pattern && mapping.target) {
+      requestMapping[mapping.pattern] = mapping.target;
+    }
+  }
+  if (Object.keys(requestMapping).length > 0) {
+    appendValue('--map', joinCommandMapping(requestMapping));
+  }
+
+  if (custom?.responseModelMapping && Object.keys(custom.responseModelMapping).length > 0) {
+    appendValue('--response-map', joinCommandMapping(custom.responseModelMapping));
+  }
+
+  if (custom?.backend === 'ollama') {
+    appendValue('--backend', 'ollama');
+  }
+  if (provider.logo) {
+    appendValue('--logo', provider.logo);
+  }
+  if (provider.config?.disableErrorCooldown) {
+    command.push('--disable-error-cooldown');
+  }
+  if (provider.excludeFromExport) {
+    command.push('--exclude-from-export');
+  }
+  if (custom?.responsesPassthrough === true) {
+    command.push('--responses-passthrough');
+  } else if (custom?.responsesPassthrough === false) {
+    command.push('--no-responses-passthrough');
+  }
+
+  return command.join(' ');
 }
 
 function parseClients(value: string): { clients: ClientType[]; errors: string[] } {


### PR DESCRIPTION
## Summary
- Add a per-row share command action for custom providers in the Providers tab.
- Generate a bulk-import-compatible `provider add` command from the visible provider config.
- Include supported clients, supported models, request/response model mappings, backend/logo, disabled error freeze, export flag, and Responses passthrough flags when present.
- Keep secrets safe by always using the `<YOUR_API_KEY>` placeholder instead of copying the stored API key.
- Include provider-scoped model mappings in the generated command so the shared command can be pasted into Batch Add and previewed/imported.

## Validation
- `pnpm --dir web exec prettier --check src/pages/providers/components/provider-row.tsx src/pages/providers/index.tsx src/pages/providers/utils/bulk-custom-provider-import.ts src/pages/providers/utils/bulk-custom-provider-import.test.ts src/locales/en.json src/locales/zh.json`
- `pnpm --dir web exec vitest run src/pages/providers/utils/bulk-custom-provider-import.test.ts`
- `pnpm --dir web typecheck`
- `pnpm --dir web build`
- `go build -o /tmp/maxx-e2e-share ./cmd/maxx`
- Local E2E with real maxx server + mock custom provider + provider-scoped model mapping: open Providers tab, click share command, verify generated command, copy to clipboard, paste into Batch Add preview, and capture screenshots.

## Evidence
Screenshots were captured locally under `/home/moltbot/clawd-wechat/tmp/maxx-share-command-e2e/`.
