### PR TITLE
fix(stats): backfill usage stats after restart

### DIFF
--- a/internal/repository/sqlite/usage_stats.go
+++ b/internal/repository/sqlite/usage_stats.go
@@ -20,7 +20,7 @@ type UsageStatsRepository struct {
 	db *DB
 }
 
-const providerStatsRawBackfillWindow = 2 * time.Hour
+const usageStatsRawBackfillWindow = 2 * time.Hour
 
 func NewUsageStatsRepository(db *DB) *UsageStatsRepository {
 	return &UsageStatsRepository{db: db}
@@ -200,10 +200,12 @@ func (r *UsageStatsRepository) Query(tenantID uint64, filter repository.UsageSta
 	currentHour := truncateToHourInLocation(now, loc)
 	currentMinute := now.Truncate(time.Minute)
 	twoMinutesAgo := currentMinute.Add(-time.Minute)
+	realtimeStart := r.rawBackfillStart(tenantID, loc, currentMinute)
 
-	// 判断是否需要补全实时数据（仅当查询范围包含最近 2 分钟内的数据）
-	// 如果 EndTime 在 2 分钟之前，说明是纯历史查询，预聚合数据已完整覆盖
-	needRealtimeData := filter.EndTime == nil || !filter.EndTime.Before(twoMinutesAgo)
+	// 判断是否需要补全实时数据（查询范围触及 raw backfill 窗口）。
+	// raw backfill 窗口会从最新已聚合 minute 往前 overlap 2 分钟开始；如果尚无 minute 聚合,
+	// 最多回扫 2 小时,避免服务重启后统计页在后台聚合前误显示空数据。
+	needRealtimeData := filter.EndTime == nil || !filter.EndTime.Before(realtimeStart)
 
 	// 1. 查询历史数据（使用目标粒度的预聚合数据）
 	// 如果需要补全实时数据，则排除当前时间桶（避免查出会被替换的数据）
@@ -271,14 +273,17 @@ func (r *UsageStatsRepository) Query(tenantID uint64, filter repository.UsageSta
 		})
 	}
 
-	// 2c. 查询当前小时内已完成的分钟数据（不包括最近 2 分钟）
+	// 2c. 查询当前小时内已完成的分钟数据（不包括 raw backfill 窗口）
 	minuteStart := currentHour
 	if currentBucket.After(currentHour) {
 		minuteStart = currentBucket
 	}
-	if twoMinutesAgo.After(minuteStart) {
+	if realtimeStart.After(twoMinutesAgo) {
+		realtimeStart = twoMinutesAgo
+	}
+	if realtimeStart.After(minuteStart) {
 		g.Go(func() error {
-			minuteStats, err := r.queryStatsInRange(tenantID, domain.GranularityMinute, minuteStart, twoMinutesAgo, filter)
+			minuteStats, err := r.queryStatsInRange(tenantID, domain.GranularityMinute, minuteStart, realtimeStart, filter)
 			if err != nil {
 				return err
 			}
@@ -289,9 +294,13 @@ func (r *UsageStatsRepository) Query(tenantID uint64, filter repository.UsageSta
 		})
 	}
 
-	// 2d. 查询最近 2 分钟的实时数据
+	// 2d. 查询 raw backfill 窗口内的实时数据
+	rawStart := realtimeStart
+	if filter.StartTime != nil && filter.StartTime.After(rawStart) {
+		rawStart = *filter.StartTime
+	}
 	g.Go(func() error {
-		realtimeStats, err := r.queryRecentMinutesStats(tenantID, twoMinutesAgo, filter)
+		realtimeStats, err := r.queryRecentMinutesStats(tenantID, rawStart, filter)
 		if err != nil {
 			return err
 		}
@@ -662,13 +671,7 @@ func (r *UsageStatsRepository) GetProviderStats(tenantID uint64, clientType stri
 
 	loc := r.getConfiguredTimezone()
 	now := time.Now().In(loc)
-	backfillStart := now.Add(-providerStatsRawBackfillWindow).Truncate(time.Minute)
-	if latestMinute, err := r.GetLatestTimeBucket(tenantID, domain.GranularityMinute); err == nil && latestMinute != nil {
-		candidate := latestMinute.In(loc).Add(-2 * time.Minute)
-		if candidate.After(backfillStart) {
-			backfillStart = candidate
-		}
-	}
+	backfillStart := r.rawBackfillStart(tenantID, loc, now.Truncate(time.Minute))
 
 	result, err := r.queryPersistedProviderStatsBefore(tenantID, filter, backfillStart)
 	if err != nil {
@@ -681,6 +684,17 @@ func (r *UsageStatsRepository) GetProviderStats(tenantID uint64, clientType stri
 	}
 	mergeProviderStats(result, rawStats)
 	return result, nil
+}
+
+func (r *UsageStatsRepository) rawBackfillStart(tenantID uint64, loc *time.Location, currentMinute time.Time) time.Time {
+	backfillStart := currentMinute.In(loc).Add(-usageStatsRawBackfillWindow).Truncate(time.Minute)
+	if latestMinute, err := r.GetLatestTimeBucket(tenantID, domain.GranularityMinute); err == nil && latestMinute != nil {
+		candidate := latestMinute.In(loc).Add(-2 * time.Minute)
+		if candidate.After(backfillStart) {
+			backfillStart = candidate
+		}
+	}
+	return backfillStart
 }
 
 func mergeProviderStats(dst, src map[uint64]*domain.ProviderStats) {

--- a/internal/repository/sqlite/usage_stats_test.go
+++ b/internal/repository/sqlite/usage_stats_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
 )
 
 // TestQueryDashboardHistoricalDays_GroupsByDimensions 锁住 PR573 R2 修复的"GROUP BY 下推"合约:
@@ -220,6 +221,61 @@ func TestGetProviderStatsIncludesPersistedRawBackfillAfterRestart(t *testing.T) 
 	}
 	if ps.SuccessRate != 50 {
 		t.Fatalf("successRate = %v, want 50", ps.SuccessRate)
+	}
+}
+
+func TestQueryIncludesPersistedRawBackfillAfterRestart(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewUsageStatsRepository(db)
+	now := time.Now().UTC().Truncate(time.Minute)
+	recent := now.Add(-10 * time.Minute)
+	request := &ProxyRequest{TenantID: 1, ClientType: "openai", ProjectID: 20, Status: "COMPLETED"}
+	if err := db.gorm.Create(request).Error; err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+	attempt := &ProxyUpstreamAttempt{
+		TenantID:         1,
+		ProxyRequestID:   request.ID,
+		ProviderID:       10,
+		Status:           "COMPLETED",
+		EndTime:          toTimestamp(recent),
+		ResponseModel:    "glm-5.2",
+		InputTokenCount:  1234,
+		OutputTokenCount: 567,
+		CacheReadCount:   11,
+		CacheWriteCount:  22,
+		Cost:             890,
+	}
+	if err := db.gorm.Create(attempt).Error; err != nil {
+		t.Fatalf("seed attempt: %v", err)
+	}
+
+	start := now.Add(-30 * time.Minute)
+	got, err := repo.Query(1, repository.UsageStatsFilter{
+		Granularity: domain.GranularityMinute,
+		StartTime:   &start,
+	})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+
+	var found *domain.UsageStats
+	for _, s := range got {
+		if s.ProviderID == 10 && s.Model == "glm-5.2" {
+			found = s
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("missing raw backfill stats in query result: %+v", got)
+	}
+	if found.TotalRequests != 1 || found.InputTokens != 1234 || found.OutputTokens != 567 || found.CacheRead != 11 || found.CacheWrite != 22 || found.Cost != 890 {
+		t.Fatalf("raw query stats = %+v, want persisted raw attempt values", found)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extend the bounded raw-attempt backfill from provider stats to the `/usage-stats` query path used by the Stats tab.
- Avoid the restart gap where persisted `proxy_upstream_attempts` exist but `usage_stats` has not yet been rebuilt, causing the Stats tab to show empty/no records.
- Keep the same performance guard as #734: raw backfill is capped to 2 hours and starts from the latest aggregated minute minus a 2-minute overlap when aggregated data exists.

## Validation
- `go test ./internal/repository/sqlite -count=1`
- `go test ./internal/service -run Test -count=1`
- `go test ./internal/handler -run 'Test.*UsageStats|Test.*ProviderStats' -count=1`
- `go build -o /tmp/maxx-usage-stats-e2e ./cmd/maxx`
- `git diff --check`
- Restart E2E with isolated data dir: start maxx, create custom provider, stop service, seed completed persisted request/attempt, restart maxx, verify `/api/admin/usage-stats` returns the raw-backfilled minute row, then open the Stats tab and verify token data is visible instead of an empty state.

## Evidence
- Restart E2E screenshots captured locally under `/home/moltbot/clawd-wechat/tmp/maxx-usage-stats-tab-e2e/`.
