### PR TITLE
fix(routes): remove TTFT sort button

### DIFF
--- a/web/src/components/routes/ClientTypeRoutesContent.tsx
+++ b/web/src/components/routes/ClientTypeRoutesContent.tsx
@@ -13,8 +13,6 @@ import {
   Trash2,
   Zap,
   Workflow,
-  Gauge,
-  ArrowUpDown,
   Settings2,
   Pin,
 } from 'lucide-react';
@@ -105,12 +103,6 @@ import {
   type ProviderTypeKey,
 } from '@/pages/providers/types';
 import { invertVisibleProviderSelection } from '@/pages/providers/utils/selection';
-import {
-  buildTtftRoutePositionUpdates,
-  summarizeTtftProbeResults,
-  type RouteTtftProbeResult,
-} from '@/pages/client-routes/utils/ttft-sort';
-import { probeRoutesTtft } from '@/pages/client-routes/utils/ttft-probe';
 
 function isSameProviderStats(a: ProviderStats, b: ProviderStats): boolean {
   return (
@@ -484,7 +476,6 @@ function ClientTypeRoutesContentInner({
   clientType,
   projectID,
   searchQuery = '',
-  isActive = true,
 }: ClientTypeRoutesContentProps) {
   const { t } = useTranslation();
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -495,9 +486,6 @@ function ClientTypeRoutesContentInner({
   const [bulkAddError, setBulkAddError] = useState<string | null>(null);
   const [bulkAddFailures, setBulkAddFailures] = useState<BulkAddRouteFailure[]>([]);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
-  const [ttftSortMessage, setTtftSortMessage] = useState<string | null>(null);
-  const [ttftProbeResults, setTtftProbeResults] = useState<RouteTtftProbeResult[]>([]);
-  const [isTtftProbing, setIsTtftProbing] = useState(false);
   const { data: providerStats = {} } = useProviderStats(clientType, projectID || undefined);
   const stableProviderStats = useStableProviderStats(providerStats);
   const queryClient = useQueryClient();
@@ -657,15 +645,6 @@ function ClientTypeRoutesContentInner({
     visibleRouteIds.length > 0 && selectedRouteIds.size === visibleRouteIds.length;
   const someVisibleSelected = selectedRouteIds.size > 0 && !allVisibleSelected;
 
-  const hasTtftSortCandidates =
-    isActive && clientRoutes.filter((route) => route.isEnabled).length > 1;
-  const canApplyTtftSort = hasTtftSortCandidates && !isTtftProbing && !updatePositions.isPending;
-
-  useEffect(() => {
-    setTtftSortMessage(null);
-    setTtftProbeResults([]);
-  }, [clientType, projectID]);
-
   const availableProviders = useMemo(() => {
     return providers.filter((p) => !routeByProviderId.has(Number(p.id)));
   }, [providers, routeByProviderId]);
@@ -813,77 +792,6 @@ function ClientTypeRoutesContentInner({
     setBulkAddError(null);
     setBulkAddFailures([]);
     setSelectedAvailableProviderIds(new Set());
-  };
-
-  const handleSortByTtft = async () => {
-    if (!canApplyTtftSort) return;
-
-    const probeInputs = clientRoutes
-      .filter((route) => route.isEnabled && providerById.has(route.providerID))
-      .map((route) => ({ route, clientType, projectID }));
-
-    if (probeInputs.length <= 1) {
-      setTtftSortMessage(t('routes.sortByTtftNoCandidates'));
-      setTtftProbeResults([]);
-      return;
-    }
-
-    const controller = new AbortController();
-    setIsTtftProbing(true);
-    setTtftProbeResults([]);
-    setTtftSortMessage(t('routes.sortByTtftRunning', { count: probeInputs.length }));
-
-    try {
-      const results = await probeRoutesTtft(probeInputs, {
-        concurrency: 4,
-        signal: controller.signal,
-        onResult: (result) => {
-          setTtftProbeResults((prev) => [...prev, result]);
-        },
-      });
-      const summary = summarizeTtftProbeResults(results);
-      const ttftSortUpdates = buildTtftRoutePositionUpdates(clientRoutes, results);
-
-      if (summary.successful === 0) {
-        setTtftSortMessage(t('routes.sortByTtftNoSuccessfulProbe', { count: summary.failed }));
-        return;
-      }
-
-      if (ttftSortUpdates.length === 0) {
-        setTtftSortMessage(
-          t('routes.sortByTtftNoChangesAfterProbe', {
-            success: summary.successful,
-            failed: summary.failed,
-          }),
-        );
-        return;
-      }
-
-      const updates = Object.fromEntries(
-        ttftSortUpdates.map((update) => [update.id, update.position]),
-      ) as Record<number, number>;
-
-      updatePositions.mutate(updates, {
-        onSuccess: () => {
-          setTtftSortMessage(
-            t('routes.sortByTtftApplied', {
-              count: ttftSortUpdates.length,
-              success: summary.successful,
-              failed: summary.failed,
-            }),
-          );
-        },
-        onError: (error) => {
-          console.error('Failed to sort routes by measured TTFT:', error);
-          setTtftSortMessage(t('routes.sortByTtftFailed'));
-        },
-      });
-    } catch (error) {
-      console.error('Failed to probe routes by TTFT:', error);
-      setTtftSortMessage(t('routes.sortByTtftFailed'));
-    } finally {
-      setIsTtftProbing(false);
-    }
   };
 
   const handleBulkAddRoutes = async () => {
@@ -1047,22 +955,6 @@ function ClientTypeRoutesContentInner({
               />
             </div>
             <div className="flex shrink-0 flex-wrap items-center gap-2">
-              {hasTtftSortCandidates && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleSortByTtft}
-                  disabled={!canApplyTtftSort}
-                  title={t('routes.sortByTtftHint')}
-                  className="h-7 shrink-0 text-xs"
-                >
-                  <Gauge className="mr-1.5 h-3.5 w-3.5" />
-                  {isTtftProbing ? t('routes.sortByTtftRunningShort') : t('routes.sortByTtft')}
-                  {(updatePositions.isPending || isTtftProbing) && (
-                    <ArrowUpDown className="ml-1.5 h-3.5 w-3.5 animate-pulse" />
-                  )}
-                </Button>
-              )}
               {clientType === 'claude' && (
                 <ClaudeProviderBatchTestDialog
                   providers={providers}
@@ -1078,36 +970,6 @@ function ClientTypeRoutesContentInner({
               />
             </div>
           </div>
-
-          {ttftSortMessage && <p className="text-xs text-muted-foreground">{ttftSortMessage}</p>}
-
-          {ttftProbeResults.length > 0 && (
-            <div
-              className="rounded-xl border border-border/60 bg-background/80 px-4 py-3 text-xs shadow-sm"
-              data-testid="ttft-probe-results"
-            >
-              <div className="mb-2 font-medium text-foreground">
-                {t('routes.sortByTtftProbeResults')}
-              </div>
-              <div className="space-y-1 text-muted-foreground">
-                {ttftProbeResults.map((result) => (
-                  <div
-                    key={`${result.routeID}-${result.providerID}`}
-                    className="flex flex-wrap items-center gap-2"
-                  >
-                    <span className="font-medium text-foreground">{result.providerName}</span>
-                    {result.ok ? (
-                      <Badge variant="success">{result.ttftMs} ms</Badge>
-                    ) : (
-                      <Badge variant="danger">{result.status}</Badge>
-                    )}
-                    {result.httpStatus && <span>HTTP {result.httpStatus}</span>}
-                    {result.error && <span className="truncate">{result.error}</span>}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
 
           {items.length > 0 && (
             <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/60 bg-background/80 px-4 py-3 shadow-sm">


### PR DESCRIPTION
## Summary
- remove the TTFT probe/sort button from the client routes page
- remove the now-unused frontend state, handler, and probe result panel from `ClientTypeRoutesContent`

## Validation
- `git diff --check`
- `npm --prefix web run typecheck`
- `npm --prefix web run build`

## Notes
- Scope is intentionally limited to removing the button/interaction entry point.
- CodeRabbit was not checked or triggered because this task did not authorize CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能调整**
  * 移除客户端路由管理中的 TTFT 探测与按测量结果排序功能。
  * 路由管理仍支持拖拽排序、批量添加和删除等操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->