### PR TITLE
fix(requests): preserve column prefs after auth hydration

### DIFF
--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -299,6 +299,7 @@ export function RequestsPage() {
   const [columnPrefs, setColumnPrefs] = useState<RequestColumnPrefs>(() =>
     readColumnPrefs(columnPrefsStorageKey),
   );
+  const skipNextColumnPrefsWriteRef = useRef(false);
 
   // 过滤维度（默认令牌）
   const [filterMode, setFilterMode] = useState<RequestFilterMode>(() =>
@@ -421,10 +422,15 @@ export function RequestsPage() {
   );
 
   useEffect(() => {
+    skipNextColumnPrefsWriteRef.current = true;
     setColumnPrefs(readColumnPrefs(columnPrefsStorageKey));
   }, [columnPrefsStorageKey]);
 
   useEffect(() => {
+    if (skipNextColumnPrefsWriteRef.current) {
+      skipNextColumnPrefsWriteRef.current = false;
+      return;
+    }
     writeColumnPrefs(columnPrefsStorageKey, columnPrefs);
   }, [columnPrefs, columnPrefsStorageKey]);
 


### PR DESCRIPTION
## Summary
- prevent request table column preferences from being overwritten when the storage key switches after auth/user hydration
- keep column visibility, order, and width preferences loaded from the scoped user key instead of writing the initial default/anonymous state into that key

## Validation
- `git diff --check`
- `npm --prefix web test -- src/pages/requests/column-prefs.test.ts`
- `npm --prefix web run typecheck`
- `npm --prefix web run build`

## Notes
- Scope is limited to the request table column preference persistence path.
- CodeRabbit was not checked or triggered because this task did not authorize CodeRabbit.
