### PR TITLE
fix(requests): refresh cleanup failed count on errors

### DIFF
--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -41,6 +41,9 @@ export const requestKeys = {
     ] as const,
   errorStats: (params?: CursorPaginationParams) =>
     [...requestKeys.all, 'error-stats', params] as const,
+  cleanupFailedCount: (params?: CursorPaginationParams) =>
+    [...requestKeys.all, 'cleanup-failed-count', params] as const,
+  cleanupFailedCounts: () => [...requestKeys.all, 'cleanup-failed-count'] as const,
   details: () => [...requestKeys.all, 'detail'] as const,
   detail: (id: number) => [...requestKeys.details(), id] as const,
   attempts: (id: number) => [...requestKeys.detail(id), 'attempts'] as const,
@@ -236,7 +239,7 @@ export function useCleanupFailedProxyRequestsCount(
   enabled = true,
 ) {
   return useQuery({
-    queryKey: [...requestKeys.all, 'cleanup-failed-count', params] as const,
+    queryKey: requestKeys.cleanupFailedCount(params),
     queryFn: () => getTransport().getCleanupFailedProxyRequestsCount(params),
     enabled,
     staleTime: 5_000,
@@ -455,6 +458,7 @@ export function useProxyRequestUpdates() {
       let invalidateDashboard = false;
       let invalidateProviderStats = false;
       let invalidateCooldowns = false;
+      let refetchCleanupFailedCount = false;
 
       for (const updatedRequest of updates) {
         const requestId = updatedRequest.id;
@@ -713,6 +717,9 @@ export function useProxyRequestUpdates() {
           invalidateProviderStats = true;
           invalidateCooldowns = true;
         }
+        if (isProxyRequestError(updatedRequest)) {
+          refetchCleanupFailedCount = true;
+        }
       }
 
       if (invalidateDashboard) {
@@ -725,6 +732,12 @@ export function useProxyRequestUpdates() {
         queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
       }
       queryClient.invalidateQueries({ queryKey: [...requestKeys.all, 'error-stats'] });
+      if (refetchCleanupFailedCount) {
+        void queryClient.refetchQueries({
+          queryKey: requestKeys.cleanupFailedCounts(),
+          type: 'active',
+        });
+      }
 
       flushAttempts();
     };
@@ -779,6 +792,10 @@ export function useProxyRequestUpdates() {
       });
       void queryClient.refetchQueries({ queryKey: requestKeys.details(), type: 'active' });
       void queryClient.refetchQueries({ queryKey: ['requestsCount'], type: 'active' });
+      void queryClient.refetchQueries({
+        queryKey: requestKeys.cleanupFailedCounts(),
+        type: 'active',
+      });
       void queryClient.refetchQueries({ queryKey: ['dashboard'], type: 'active' });
       void queryClient.refetchQueries({ queryKey: ['providers', 'stats'], type: 'active' });
       void queryClient.refetchQueries({ queryKey: ['cooldowns'], type: 'active' });


### PR DESCRIPTION
## Summary
- refresh the cleanup-failed request count when live request updates report an error record
- refetch cleanup-failed counts after WebSocket reconnects so the cleanup button state catches up after missed events
- route cleanup-failed count queries through the request query key factory

## Validation
- `git diff --check`
- `npm --prefix web test -- src/hooks/queries/use-requests.test.ts`
- `npm --prefix web run typecheck`
- `npm --prefix web run build`

## Notes
- Scope is limited to the Requests tab cleanup-failed count/button state.
- CodeRabbit was not checked or triggered because this task did not authorize CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化清理失败请求计数的刷新机制，确保相关数据在请求状态更新后及时同步。
  - 修复网络断线重连后清理失败计数可能未更新的问题。
  - 批量处理代理请求错误时，自动刷新清理失败请求计数，提升界面数据准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->