### PR TITLE
fix(requests): migrate column preference cache

### DIFF
--- a/web/src/pages/requests/column-prefs.test.ts
+++ b/web/src/pages/requests/column-prefs.test.ts
@@ -1,14 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_COLUMN_ORDER,
   DEFAULT_COLUMN_VISIBILITY,
   DEFAULT_COLUMN_WIDTHS,
   createDefaultColumnPrefs,
+  migrateColumnPrefs,
   normalizeColumnPrefs,
+  readColumnPrefs,
   resolveVisibleColumns,
+  writeColumnPrefs,
 } from './column-prefs';
 
 describe('column-prefs', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('returns defaults for empty input', () => {
     const prefs = normalizeColumnPrefs(null);
     expect(prefs.order).toEqual([...DEFAULT_COLUMN_ORDER]);
@@ -57,5 +64,53 @@ describe('column-prefs', () => {
     expect(visible).toContain('protocol');
     expect(visible).not.toContain('project');
     expect(visible).not.toContain('token');
+  });
+
+  it('persists column visibility, order, and widths in localStorage', () => {
+    const prefs = createDefaultColumnPrefs();
+    prefs.order = ['model', 'time', ...prefs.order.filter((id) => id !== 'model' && id !== 'time')];
+    prefs.visibility.provider = false;
+    prefs.widths.model = 220;
+
+    writeColumnPrefs('scoped-columns', prefs);
+
+    const stored = readColumnPrefs('scoped-columns');
+    expect(stored.order.slice(0, 2)).toEqual(['model', 'time']);
+    expect(stored.visibility.provider).toBe(false);
+    expect(stored.widths.model).toBe(220);
+  });
+
+  it('migrates anonymous column prefs to the scoped user key', () => {
+    const prefs = createDefaultColumnPrefs();
+    prefs.order = ['cost', 'time', ...prefs.order.filter((id) => id !== 'cost' && id !== 'time')];
+    prefs.visibility.cacheRead = false;
+    prefs.widths.cost = 144;
+    localStorage.setItem('maxx-requests-table-columns:anonymous', JSON.stringify(prefs));
+
+    migrateColumnPrefs('maxx-requests-table-columns:tenant-1:user-1', [
+      'maxx-requests-table-columns',
+      'maxx-requests-table-columns:anonymous',
+    ]);
+
+    const migrated = readColumnPrefs('maxx-requests-table-columns:tenant-1:user-1');
+    expect(migrated.order.slice(0, 2)).toEqual(['cost', 'time']);
+    expect(migrated.visibility.cacheRead).toBe(false);
+    expect(migrated.widths.cost).toBe(144);
+    expect(localStorage.getItem('maxx-requests-table-columns:anonymous')).toBeNull();
+  });
+
+  it('does not overwrite existing scoped column prefs during migration', () => {
+    const scoped = createDefaultColumnPrefs();
+    scoped.visibility.model = false;
+    const legacy = createDefaultColumnPrefs();
+    legacy.visibility.provider = false;
+    localStorage.setItem('scoped-columns', JSON.stringify(scoped));
+    localStorage.setItem('legacy-columns', JSON.stringify(legacy));
+
+    migrateColumnPrefs('scoped-columns', ['legacy-columns']);
+
+    expect(readColumnPrefs('scoped-columns').visibility.model).toBe(false);
+    expect(readColumnPrefs('scoped-columns').visibility.provider).toBe(true);
+    expect(localStorage.getItem('legacy-columns')).not.toBeNull();
   });
 });

--- a/web/src/pages/requests/column-prefs.ts
+++ b/web/src/pages/requests/column-prefs.ts
@@ -206,6 +206,40 @@ export function readColumnPrefs(storageKey: string): RequestColumnPrefs {
   }
 }
 
+/**
+ * Moves column prefs from older/unscoped keys to the active scoped key.
+ *
+ * Requests filters already migrated when storage became tenant/user scoped, but
+ * column prefs did not. That made existing column visibility/order appear to
+ * vanish after auth/bootstrap switched the page from anonymous to scoped keys.
+ */
+export function migrateColumnPrefs(storageKey: string, legacyKeys: readonly string[]): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (window.localStorage.getItem(storageKey) !== null) {
+    return;
+  }
+
+  for (const legacyKey of legacyKeys) {
+    if (!legacyKey || legacyKey === storageKey) {
+      continue;
+    }
+    const raw = window.localStorage.getItem(legacyKey);
+    if (raw === null) {
+      continue;
+    }
+    try {
+      const prefs = normalizeColumnPrefs(JSON.parse(raw));
+      window.localStorage.setItem(storageKey, JSON.stringify(prefs));
+      window.localStorage.removeItem(legacyKey);
+      return;
+    } catch {
+      window.localStorage.removeItem(legacyKey);
+    }
+  }
+}
+
 export function writeColumnPrefs(storageKey: string, prefs: RequestColumnPrefs): void {
   if (typeof window === 'undefined') {
     return;

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -46,6 +46,7 @@ import {
   columnLabelKey,
   columnShortLabelKey,
   isCenteredColumn,
+  migrateColumnPrefs,
   readColumnPrefs,
   resolveVisibleColumns,
   writeColumnPrefs,
@@ -255,6 +256,12 @@ function buildScopedStorageKey(baseKey: string, tenantID?: number, userID?: numb
   return `${baseKey}:tenant-${tenantID}:user-${userID}`;
 }
 
+function buildColumnPrefsLegacyKeys(storageKey: string): string[] {
+  return [REQUEST_COLUMNS_STORAGE_KEY, `${REQUEST_COLUMNS_STORAGE_KEY}:anonymous`].filter(
+    (key) => key !== storageKey,
+  );
+}
+
 /** Maps each proxy request status to its corresponding badge variant. */
 export const statusVariant: Record<
   ProxyRequestStatus,
@@ -422,6 +429,7 @@ export function RequestsPage() {
   );
 
   useEffect(() => {
+    migrateColumnPrefs(columnPrefsStorageKey, buildColumnPrefsLegacyKeys(columnPrefsStorageKey));
     skipNextColumnPrefsWriteRef.current = true;
     setColumnPrefs(readColumnPrefs(columnPrefsStorageKey));
   }, [columnPrefsStorageKey]);


### PR DESCRIPTION
## Summary
- migrate Requests column preferences from legacy/unscoped and anonymous localStorage keys into the active tenant/user-scoped key
- preserve existing scoped prefs and avoid overwriting a user-specific cache
- add regression coverage for column order, visibility, width persistence, and anonymous-to-scoped migration

## Validation
- `npm --prefix web run test -- src/pages/requests/column-prefs.test.ts` ✅ 8 tests
- `npm --prefix web run test` ✅ 27 files / 125 tests
- `npm --prefix web run lint` ✅
- `npm --prefix web run typecheck` ✅
- `npm --prefix web run build` ✅
- `git diff --check` ✅
