### PR TITLE
feat(providers): enforce per-provider concurrency limits

### DIFF
--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -56,9 +56,18 @@ type codexWebSocketSession struct {
 	fingerprint     string
 	lastUsedAt      atomic.Int64
 	activeTurns     atomic.Int32
+	releaseProvider func()
 }
 
-func newCodexWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header, fingerprint string) *codexWebSocketSession {
+func newCodexWebSocketSession(
+	conn *websocket.Conn,
+	handshakeHeader http.Header,
+	fingerprint string,
+	releaseProvider func(),
+) *codexWebSocketSession {
+	if releaseProvider == nil {
+		releaseProvider = func() {}
+	}
 	session := &codexWebSocketSession{
 		conn:            conn,
 		handshakeHeader: handshakeHeader.Clone(),
@@ -66,6 +75,7 @@ func newCodexWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header,
 		done:            make(chan struct{}),
 		maxQueuedBytes:  codexResponsesWebSocketMaxQueuedBytes,
 		fingerprint:     fingerprint,
+		releaseProvider: releaseProvider,
 	}
 	session.touch()
 	conn.SetReadLimit(codexResponsesWebSocketMaxFrameBytes)
@@ -133,6 +143,9 @@ func (s *codexWebSocketSession) close() {
 		close(s.done)
 		if s.conn != nil {
 			_ = s.conn.Close()
+		}
+		if s.releaseProvider != nil {
+			s.releaseProvider()
 		}
 	})
 }
@@ -337,10 +350,25 @@ func (a *CodexAdapter) ExecuteResponsesWebSocket(
 
 	reused := session != nil
 	if session == nil {
-		session, err = a.dialResponsesWebSocketSession(ctx, provider, config, target, headers, fingerprint, accessToken)
+		releaseProvider, acquired := exchange.AcquireProviderSlot()
+		if !acquired {
+			proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached")
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Code = "websocket_transport_unavailable"
+			proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+			return nil, newCodexWebSocketAttemptError(proxyErr, false)
+		}
+		slotOwnedBySession := false
+		defer func() {
+			if !slotOwnedBySession {
+				releaseProvider()
+			}
+		}()
+		session, err = a.dialResponsesWebSocketSession(ctx, provider, config, target, headers, fingerprint, accessToken, releaseProvider)
 		if err != nil {
 			return nil, err
 		}
+		slotOwnedBySession = true
 		session.activeTurns.Add(1)
 		if !globalCodexWebSocketSessions.put(key, session) {
 			session.activeTurns.Add(-1)
@@ -376,8 +404,9 @@ func (a *CodexAdapter) dialResponsesWebSocketSession(
 	headers http.Header,
 	fingerprint string,
 	accessToken string,
+	releaseProvider func(),
 ) (*codexWebSocketSession, error) {
-	session, response, err := dialCodexWebSocket(ctx, target, headers, fingerprint)
+	session, response, err := dialCodexWebSocket(ctx, target, headers, fingerprint, releaseProvider)
 	if err != nil && response != nil && response.StatusCode == http.StatusUnauthorized && canRefreshCodexAccessToken(config) {
 		body := readCodexWebSocketHandshakeBody(response)
 		_ = body
@@ -388,7 +417,7 @@ func (a *CodexAdapter) dialResponsesWebSocketSession(
 		}
 		headers.Set("Authorization", "Bearer "+refreshed)
 		fingerprint = codexWebSocketFingerprint(provider.ID, target, headers)
-		session, response, err = dialCodexWebSocket(ctx, target, headers, fingerprint)
+		session, response, err = dialCodexWebSocket(ctx, target, headers, fingerprint, releaseProvider)
 	}
 	if err == nil {
 		return session, nil
@@ -728,7 +757,13 @@ func codexWebSocketFingerprint(providerID uint64, target string, headers http.He
 	return fmt.Sprintf("%x", sum[:])
 }
 
-func dialCodexWebSocket(ctx context.Context, target string, headers http.Header, fingerprint string) (*codexWebSocketSession, *http.Response, error) {
+func dialCodexWebSocket(
+	ctx context.Context,
+	target string,
+	headers http.Header,
+	fingerprint string,
+	releaseProvider func(),
+) (*codexWebSocketSession, *http.Response, error) {
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
 		HandshakeTimeout:  codexResponsesWebSocketHandshake,
@@ -749,7 +784,7 @@ func dialCodexWebSocket(ctx context.Context, target string, headers http.Header,
 			_ = response.Body.Close()
 		}
 	}
-	return newCodexWebSocketSession(conn, responseHeaders, fingerprint), response, nil
+	return newCodexWebSocketSession(conn, responseHeaders, fingerprint, releaseProvider), response, nil
 }
 
 func readCodexWebSocketHandshakeBody(response *http.Response) []byte {

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -87,15 +87,22 @@ func TestExecuteResponsesWebSocket_PreservesOfficialWirePayload(t *testing.T) {
 		httpClient: newUpstreamHTTPClient(),
 	}
 	connectionID := uuid.NewString()
+	var acquiredSlots atomic.Int32
+	var releasedSlots atomic.Int32
+	acquireSlot := func() (func(), bool) {
+		acquiredSlots.Add(1)
+		return func() { releasedSlots.Add(1) }, true
+	}
 	t.Cleanup(func() { adapter.CloseResponsesWebSocketConnection(connectionID) })
 	sink := &recordingWebSocketSink{}
 
 	firstRaw := []byte(`{"type":"response.create","model":"gpt-test","generate":false,"stream":true,"store":true,"background":true,"stream_options":{"include_usage":true},"client_metadata":{"source":"test"},"unknown_field":"preserve","input":[]}`)
 	firstCtx := newCodexWebSocketTestContext(t)
 	firstExchange := &domain.ResponsesWebSocketExchange{
-		ConnectionID: connectionID,
-		Frame:        firstRaw,
-		Sink:         sink,
+		ConnectionID:           connectionID,
+		Frame:                  firstRaw,
+		Sink:                   sink,
+		TryAcquireProviderSlot: acquireSlot,
 	}
 	result, err := adapter.ExecuteResponsesWebSocket(firstCtx, provider, firstExchange)
 	if err != nil {
@@ -113,14 +120,18 @@ func TestExecuteResponsesWebSocket_PreservesOfficialWirePayload(t *testing.T) {
 			t.Fatalf("field %q was removed: %s", field, firstUpstream)
 		}
 	}
+	if acquiredSlots.Load() != 1 || releasedSlots.Load() != 0 {
+		t.Fatalf("slot lifecycle after first turn: acquired=%d released=%d", acquiredSlots.Load(), releasedSlots.Load())
+	}
 
 	secondRaw := []byte(`{"type":"response.create","model":"gpt-test","previous_response_id":"resp_1","generate":true,"input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`)
 	secondExchange := &domain.ResponsesWebSocketExchange{
-		ConnectionID:       connectionID,
-		Frame:              secondRaw,
-		PreviousResponseID: "resp_1",
-		PinnedProviderID:   provider.ID,
-		Sink:               sink,
+		ConnectionID:           connectionID,
+		Frame:                  secondRaw,
+		PreviousResponseID:     "resp_1",
+		PinnedProviderID:       provider.ID,
+		Sink:                   sink,
+		TryAcquireProviderSlot: acquireSlot,
 	}
 	result, err = adapter.ExecuteResponsesWebSocket(newCodexWebSocketTestContext(t), provider, secondExchange)
 	if err != nil {
@@ -138,6 +149,13 @@ func TestExecuteResponsesWebSocket_PreservesOfficialWirePayload(t *testing.T) {
 	}
 	if len(sink.frames) != 2 {
 		t.Fatalf("forwarded frames = %d, want 2", len(sink.frames))
+	}
+	if got := acquiredSlots.Load(); got != 1 {
+		t.Fatalf("acquired provider slots = %d, want 1 for one reused session", got)
+	}
+	adapter.CloseResponsesWebSocketConnection(connectionID)
+	if got := releasedSlots.Load(); got != 1 {
+		t.Fatalf("released provider slots after session close = %d, want 1", got)
 	}
 }
 

--- a/internal/adapter/provider/custom/websocket.go
+++ b/internal/adapter/provider/custom/websocket.go
@@ -64,6 +64,7 @@ type customWebSocketSession struct {
 	fingerprint     string
 	lastUsedAt      atomic.Int64
 	activeTurns     atomic.Int32
+	releaseProvider func()
 }
 
 type customWebSocketSessionKey struct {
@@ -82,7 +83,15 @@ var globalCustomWebSocketSessions = &customWebSocketSessionStore{
 	maxEntries: customResponsesWebSocketMaxSessions,
 }
 
-func newCustomWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header, fingerprint string) *customWebSocketSession {
+func newCustomWebSocketSession(
+	conn *websocket.Conn,
+	handshakeHeader http.Header,
+	fingerprint string,
+	releaseProvider func(),
+) *customWebSocketSession {
+	if releaseProvider == nil {
+		releaseProvider = func() {}
+	}
 	session := &customWebSocketSession{
 		conn:            conn,
 		handshakeHeader: handshakeHeader.Clone(),
@@ -90,6 +99,7 @@ func newCustomWebSocketSession(conn *websocket.Conn, handshakeHeader http.Header
 		done:            make(chan struct{}),
 		maxQueuedBytes:  customResponsesWebSocketMaxQueuedBytes,
 		fingerprint:     fingerprint,
+		releaseProvider: releaseProvider,
 	}
 	session.touch()
 	conn.SetReadLimit(customResponsesWebSocketMaxFrameBytes)
@@ -120,7 +130,12 @@ func (s *customWebSocketSession) isClosed() bool {
 func (s *customWebSocketSession) close() {
 	s.closeOnce.Do(func() {
 		close(s.done)
-		_ = s.conn.Close()
+		if s.conn != nil {
+			_ = s.conn.Close()
+		}
+		if s.releaseProvider != nil {
+			s.releaseProvider()
+		}
 	})
 }
 
@@ -305,7 +320,21 @@ func (a *CustomAdapter) ExecuteResponsesWebSocket(
 
 	reused := session != nil
 	if session == nil {
-		session, err = dialCustomResponsesWebSocket(ctx, target, headers, fingerprint)
+		releaseProvider, acquired := exchange.AcquireProviderSlot()
+		if !acquired {
+			proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached")
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Code = "websocket_transport_unavailable"
+			proxyErr.HTTPStatusCode = http.StatusServiceUnavailable
+			return nil, newCustomWebSocketAttemptError(proxyErr, false)
+		}
+		slotOwnedBySession := false
+		defer func() {
+			if !slotOwnedBySession {
+				releaseProvider()
+			}
+		}()
+		session, err = dialCustomResponsesWebSocket(ctx, target, headers, fingerprint, releaseProvider)
 		if err != nil {
 			proxyErr := domain.NewProxyErrorWithMessage(err, true, "failed to upgrade custom Codex websocket connection")
 			proxyErr.Scope = domain.ScopeProvider
@@ -315,6 +344,7 @@ func (a *CustomAdapter) ExecuteResponsesWebSocket(
 			log.Printf("[CustomWS] provider=%d dial %s failed: %v", provider.ID, target, err)
 			return nil, newCustomWebSocketAttemptError(proxyErr, false)
 		}
+		slotOwnedBySession = true
 		session.activeTurns.Add(1)
 		if !globalCustomWebSocketSessions.put(key, session) {
 			session.activeTurns.Add(-1)
@@ -626,7 +656,13 @@ func customWebSocketFingerprint(providerID uint64, target string, headers http.H
 	return fmt.Sprintf("%x", sum[:])
 }
 
-func dialCustomResponsesWebSocket(ctx context.Context, target string, headers http.Header, fingerprint string) (*customWebSocketSession, error) {
+func dialCustomResponsesWebSocket(
+	ctx context.Context,
+	target string,
+	headers http.Header,
+	fingerprint string,
+	releaseProvider func(),
+) (*customWebSocketSession, error) {
 	dialer := &websocket.Dialer{
 		Proxy:             http.ProxyFromEnvironment,
 		HandshakeTimeout:  customResponsesWebSocketHandshake,
@@ -651,7 +687,7 @@ func dialCustomResponsesWebSocket(ctx context.Context, target string, headers ht
 			_ = response.Body.Close()
 		}
 	}
-	return newCustomWebSocketSession(conn, responseHeaders, fingerprint), nil
+	return newCustomWebSocketSession(conn, responseHeaders, fingerprint, releaseProvider), nil
 }
 
 func validateOutboundCustomCodexWebSocketFrame(frame []byte) error {

--- a/internal/adapter/provider/custom/websocket_test.go
+++ b/internal/adapter/provider/custom/websocket_test.go
@@ -11,8 +11,8 @@ import (
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
-	"github.com/gorilla/websocket"
 	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
 )
 
 type recordingCustomWSSink struct {
@@ -61,6 +61,7 @@ func TestJoinCustomResponsesWebSocketURL(t *testing.T) {
 
 func TestExecuteResponsesWebSocket_CustomCodexGateway(t *testing.T) {
 	var dials atomic.Int32
+	keepUpstreamOpen := make(chan struct{})
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		dials.Add(1)
 		if r.Header.Get("Authorization") != "Bearer sk-live" {
@@ -85,8 +86,10 @@ func TestExecuteResponsesWebSocket_CustomCodexGateway(t *testing.T) {
 			t.Error("empty frame")
 		}
 		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.completed","response":{"id":"resp_1","model":"gpt-test","output":[]}}`))
+		<-keepUpstreamOpen
 	}))
 	defer upstream.Close()
+	defer close(keepUpstreamOpen)
 
 	provider := &domain.Provider{
 		ID:                   42,
@@ -100,12 +103,18 @@ func TestExecuteResponsesWebSocket_CustomCodexGateway(t *testing.T) {
 	}
 	adapter := &CustomAdapter{provider: provider}
 	connectionID := uuid.NewString()
+	var acquiredSlots atomic.Int32
+	var releasedSlots atomic.Int32
 	t.Cleanup(func() { adapter.CloseResponsesWebSocketConnection(connectionID) })
 	sink := &recordingCustomWSSink{}
 	result, err := adapter.ExecuteResponsesWebSocket(newCustomWSTestContext(t), provider, &domain.ResponsesWebSocketExchange{
 		ConnectionID: connectionID,
 		Frame:        []byte(`{"type":"response.create","model":"gpt-test","stream":true,"input":[]}`),
 		Sink:         sink,
+		TryAcquireProviderSlot: func() (func(), bool) {
+			acquiredSlots.Add(1)
+			return func() { releasedSlots.Add(1) }, true
+		},
 	})
 	if err != nil {
 		t.Fatalf("execute: %v", err)
@@ -118,6 +127,13 @@ func TestExecuteResponsesWebSocket_CustomCodexGateway(t *testing.T) {
 	}
 	if len(sink.frames) != 1 {
 		t.Fatalf("frames = %d", len(sink.frames))
+	}
+	if acquiredSlots.Load() != 1 || releasedSlots.Load() != 0 {
+		t.Fatalf("slot lifecycle before close: acquired=%d released=%d", acquiredSlots.Load(), releasedSlots.Load())
+	}
+	adapter.CloseResponsesWebSocketConnection(connectionID)
+	if releasedSlots.Load() != 1 {
+		t.Fatalf("released slots after close = %d, want 1", releasedSlots.Load())
 	}
 }
 
@@ -166,4 +182,3 @@ func TestExecuteResponsesWebSocket_RejectsWhenFlagDisabled(t *testing.T) {
 		t.Fatalf("err = %#v, want capability failure when flag disabled", err)
 	}
 }
-

--- a/internal/domain/backup.go
+++ b/internal/domain/backup.go
@@ -40,6 +40,7 @@ type BackupProvider struct {
 	Config               *ProviderConfig `json:"config,omitempty"`
 	SupportedClientTypes []ClientType    `json:"supportedClientTypes,omitempty"`
 	SupportModels        []string        `json:"supportModels,omitempty"`
+	MaxConcurrency       int             `json:"maxConcurrency,omitempty"`
 }
 
 // BackupProject represents a project for backup (using slug as identifier)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -450,6 +450,9 @@ type Provider struct {
 	// 空数组表示支持所有模型
 	SupportModels []string `json:"supportModels,omitempty"`
 
+	// Maximum number of upstream sessions allowed at once. Zero means unlimited.
+	MaxConcurrency int `json:"maxConcurrency,omitempty"`
+
 	// 为 true 时，该 provider 不参与导出/备份
 	ExcludeFromExport bool `json:"excludeFromExport,omitempty"`
 

--- a/internal/domain/responses_websocket.go
+++ b/internal/domain/responses_websocket.go
@@ -14,6 +14,19 @@ type ResponsesWebSocketExchange struct {
 	PreviousResponseID string
 	PinnedProviderID   uint64
 	Sink               ResponsesWebSocketFrameSink
+	// TryAcquireProviderSlot is called only when an adapter creates a new
+	// persistent upstream session. The returned release function belongs to
+	// that session and must run exactly once when the session closes.
+	TryAcquireProviderSlot func() (release func(), acquired bool)
+}
+
+// AcquireProviderSlot reserves a slot for a new persistent upstream session.
+// A nil callback means the caller does not use provider concurrency limiting.
+func (e *ResponsesWebSocketExchange) AcquireProviderSlot() (func(), bool) {
+	if e == nil || e.TryAcquireProviderSlot == nil {
+		return func() {}, true
+	}
+	return e.TryAcquireProviderSlot()
 }
 
 type ResponsesWebSocketResult struct {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -54,6 +54,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 		wg.Wait()
 	}
 
+routeLoop:
 	for _, matchedRoute := range state.routes {
 		if ctx.Err() != nil {
 			state.lastErr = ctx.Err()
@@ -156,6 +157,18 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 			}
 
 			attemptStartTime := time.Now()
+			releaseProvider := func() {}
+			if e.router != nil {
+				var acquired bool
+				releaseProvider, acquired = e.router.TryAcquireProvider(matchedRoute.Provider)
+				if !acquired {
+					log.Printf("[Executor] Provider %d is at its concurrency limit; trying the next route", matchedRoute.Provider.ID)
+					proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached")
+					proxyErr.Scope = domain.ScopeProvider
+					state.lastErr = proxyErr
+					continue routeLoop
+				}
+			}
 			attemptRecord := &domain.ProxyUpstreamAttempt{
 				TenantID:       proxyReq.TenantID,
 				ProxyRequestID: proxyReq.ID,
@@ -221,7 +234,9 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 
 			originalWriter := c.Writer
 			c.Writer = responseWriter
-			err := matchedRoute.ProviderAdapter.Execute(c, matchedRoute.Provider)
+			err := executeWithProviderSlot(releaseProvider, func() error {
+				return matchedRoute.ProviderAdapter.Execute(c, matchedRoute.Provider)
+			})
 			c.Writer = originalWriter
 
 			if needsConversion && convertingWriter != nil && !state.isStream {
@@ -521,6 +536,11 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 	}
 	state.ctx = ctx
 	c.Err = state.lastErr
+}
+
+func executeWithProviderSlot(release func(), execute func() error) error {
+	defer release()
+	return execute()
 }
 
 func shouldDeferNetworkErrorCooldown(proxyErr *domain.ProxyError, attempt int, retryConfig *domain.RetryConfig) bool {

--- a/internal/executor/middleware_dispatch_websocket.go
+++ b/internal/executor/middleware_dispatch_websocket.go
@@ -47,8 +47,8 @@ func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
 		return
 	}
 
-	// Router returns at most one candidate for WebSocket; execute that route only.
-	// No cross-provider fallback and no second pass on Route.IsNative snapshot.
+	// Execute the first ordered WebSocket candidate. A later candidate is tried
+	// only when this unpinned first turn loses the provider-slot race before dial.
 	matched := state.routes[0]
 	if matched == nil || matched.Route == nil || matched.Provider == nil || matched.ProviderAdapter == nil {
 		proxyErr := domain.NewProxyErrorWithMessage(
@@ -107,6 +107,11 @@ func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
 	outboundFrame = e.applyOutboundParamPolicy(outboundFrame, domain.ClientTypeCodex, mappedModel, matched.Provider)
 	turnExchange := *exchange
 	turnExchange.Frame = outboundFrame
+	if e.router != nil {
+		turnExchange.TryAcquireProviderSlot = func() (func(), bool) {
+			return e.router.TryAcquireProvider(matched.Provider)
+		}
+	}
 
 	proxyReq.RouteID = matched.Route.ID
 	proxyReq.ProviderID = matched.Provider.ID
@@ -225,6 +230,16 @@ func (e *Executor) dispatchResponsesWebSocket(c *flow.Ctx) {
 	pricing.MirrorCostToRequest(proxyReq, attempt)
 	proxyReq.TTFT = attempt.TTFT
 	_ = e.proxyRequestRepo.Update(proxyReq)
+
+	// Slot acquisition happens before dialing or writing an upstream frame. If
+	// it loses the race after routing, an unpinned first turn may safely try the
+	// next ordered candidate. All other WebSocket failures remain pinned and do
+	// not fall back across providers.
+	if errors.Is(execErr, domain.ErrNoAvailableProviders) && exchange.PinnedProviderID == 0 && len(state.routes) > 1 {
+		state.routes = state.routes[1:]
+		e.dispatchResponsesWebSocket(c)
+		return
+	}
 
 	var wsErr *domain.ResponsesWebSocketAttemptError
 	errors.As(execErr, &wsErr)

--- a/internal/executor/middleware_dispatch_websocket_test.go
+++ b/internal/executor/middleware_dispatch_websocket_test.go
@@ -44,6 +44,15 @@ func (a *recordingWSAdapter) ExecuteResponsesWebSocket(
 	if exchange != nil {
 		a.lastFrame = append([]byte(nil), exchange.Frame...)
 	}
+	if exchange != nil && exchange.TryAcquireProviderSlot != nil {
+		release, acquired := exchange.AcquireProviderSlot()
+		if !acquired {
+			proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached")
+			proxyErr.Scope = domain.ScopeProvider
+			return nil, &domain.ResponsesWebSocketAttemptError{Err: proxyErr}
+		}
+		defer release()
+	}
 	if len(a.errSequence) > 0 {
 		err := a.errSequence[0]
 		a.errSequence = a.errSequence[1:]
@@ -210,6 +219,41 @@ func TestDispatch_ResponsesWebSocketExecutesFirstProviderOnly(t *testing.T) {
 		t.Fatalf("attempt provider = %d, want 21", attemptRepo.created[0].ProviderID)
 	}
 	_ = proxyRepo
+}
+
+func TestDispatch_ResponsesWebSocketTriesNextProviderAfterSlotRace(t *testing.T) {
+	first := &recordingWSAdapter{resultModel: "gpt-test"}
+	second := &recordingWSAdapter{resultModel: "gpt-test"}
+	firstRoute := wsMatchedRoute(1, 31, first, true)
+	firstRoute.Provider.MaxConcurrency = 1
+	secondRoute := wsMatchedRoute(2, 32, second, true)
+	secondRoute.Provider.MaxConcurrency = 1
+	frame := []byte(`{"type":"response.create","model":"gpt-test","input":[]}`)
+	c, proxyRepo, attemptRepo := newWSDispatchCtx(t, frame, nil, []*router.MatchedRoute{firstRoute, secondRoute})
+	r := router.NewRouter(nil, nil, nil, nil, nil)
+	release, acquired := r.TryAcquireProvider(firstRoute.Provider)
+	if !acquired {
+		t.Fatal("failed to occupy first provider slot")
+	}
+	defer release()
+	e := newWSDispatchExecutor(proxyRepo, attemptRepo)
+	e.router = r
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error: %v", c.Err)
+	}
+	if first.wsCalls != 1 || second.wsCalls != 1 {
+		t.Fatalf("WS calls first=%d second=%d, want 1/1", first.wsCalls, second.wsCalls)
+	}
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	}
+	state, ok := getExecState(c)
+	if !ok || state.wsExchange.PinnedProviderID != secondRoute.Provider.ID {
+		t.Fatalf("pinned provider = %d, want %d", state.wsExchange.PinnedProviderID, secondRoute.Provider.ID)
+	}
 }
 
 func TestDispatch_ResponsesWebSocketRecordsCooldownWithoutSecondProvider(t *testing.T) {

--- a/internal/executor/provider_slot_test.go
+++ b/internal/executor/provider_slot_test.go
@@ -1,0 +1,18 @@
+package executor
+
+import (
+	"testing"
+)
+
+func TestExecuteWithProviderSlotReleasesAfterPanic(t *testing.T) {
+	released := false
+	func() {
+		defer func() { _ = recover() }()
+		_ = executeWithProviderSlot(func() { released = true }, func() error {
+			panic("adapter panic")
+		})
+	}()
+	if !released {
+		t.Fatal("HTTP provider slot was not released after panic")
+	}
+}

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -95,6 +95,7 @@ type Provider struct {
 	Config               LongText
 	SupportedClientTypes LongText
 	SupportModels        LongText
+	MaxConcurrency       int `gorm:"default:0"`
 	ExcludeFromExport    int `gorm:"default:0"`
 	BlackBox             int `gorm:"default:0"`
 }

--- a/internal/repository/sqlite/provider.go
+++ b/internal/repository/sqlite/provider.go
@@ -209,6 +209,7 @@ func (r *ProviderRepository) toModel(p *domain.Provider) *Provider {
 		Config:               LongText(toJSON(p.Config)),
 		SupportedClientTypes: LongText(toJSON(p.SupportedClientTypes)),
 		SupportModels:        LongText(toJSON(p.SupportModels)),
+		MaxConcurrency:       p.MaxConcurrency,
 		ExcludeFromExport:    boolToInt(p.ExcludeFromExport),
 		BlackBox:             boolToInt(p.BlackBox),
 	}
@@ -228,6 +229,7 @@ func (r *ProviderRepository) toDomain(m *Provider) *domain.Provider {
 		Config:               fromJSON[*domain.ProviderConfig](string(m.Config)),
 		SupportedClientTypes: fromJSON[[]domain.ClientType](string(m.SupportedClientTypes)),
 		SupportModels:        fromJSON[[]string](string(m.SupportModels)),
+		MaxConcurrency:       m.MaxConcurrency,
 		ExcludeFromExport:    m.ExcludeFromExport != 0,
 		BlackBox:             m.BlackBox != 0,
 	}

--- a/internal/router/provider_limiter.go
+++ b/internal/router/provider_limiter.go
@@ -1,0 +1,49 @@
+package router
+
+import "sync"
+
+// ProviderLimiter tracks upstream sessions for one gateway process.
+type ProviderLimiter struct {
+	mu       sync.Mutex
+	inflight map[uint64]int
+}
+
+func NewProviderLimiter() *ProviderLimiter {
+	return &ProviderLimiter{inflight: make(map[uint64]int)}
+}
+
+// TryAcquire reserves one upstream session. A non-positive limit is unlimited.
+func (l *ProviderLimiter) TryAcquire(providerID uint64, limit int) (release func(), ok bool) {
+	if l == nil {
+		return func() {}, true
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if limit > 0 && l.inflight[providerID] >= limit {
+		return nil, false
+	}
+	l.inflight[providerID]++
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			l.mu.Lock()
+			defer l.mu.Unlock()
+			if l.inflight[providerID] <= 1 {
+				delete(l.inflight, providerID)
+				return
+			}
+			l.inflight[providerID]--
+		})
+	}, true
+}
+
+func (l *ProviderLimiter) IsAtLimit(providerID uint64, limit int) bool {
+	if l == nil || limit <= 0 {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inflight[providerID] >= limit
+}

--- a/internal/router/provider_limiter_test.go
+++ b/internal/router/provider_limiter_test.go
@@ -1,0 +1,82 @@
+package router
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestProviderLimiterHardLimitAndRelease(t *testing.T) {
+	limiter := NewProviderLimiter()
+	release, ok := limiter.TryAcquire(42, 1)
+	if !ok {
+		t.Fatal("first acquire should succeed")
+	}
+	if _, ok := limiter.TryAcquire(42, 1); ok {
+		t.Fatal("second acquire must not exceed the hard limit")
+	}
+	if !limiter.IsAtLimit(42, 1) {
+		t.Fatal("provider should report at limit")
+	}
+
+	release()
+	release()
+	if _, ok := limiter.TryAcquire(42, 1); !ok {
+		t.Fatal("slot should be reusable after release")
+	}
+}
+
+func TestProviderLimiterTracksProvidersSeparately(t *testing.T) {
+	limiter := NewProviderLimiter()
+	if _, ok := limiter.TryAcquire(1, 1); !ok {
+		t.Fatal("provider 1 acquire failed")
+	}
+	if _, ok := limiter.TryAcquire(2, 1); !ok {
+		t.Fatal("provider 2 should have an independent slot")
+	}
+}
+
+func TestProviderLimiterConcurrentAcquireHonorsLimit(t *testing.T) {
+	limiter := NewProviderLimiter()
+	start := make(chan struct{})
+	var acquired atomic.Int32
+	var wg sync.WaitGroup
+
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, ok := limiter.TryAcquire(7, 1); ok {
+				acquired.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := acquired.Load(); got != 1 {
+		t.Fatalf("successful acquires = %d, want 1", got)
+	}
+}
+
+func TestProviderLimiterZeroMeansUnlimited(t *testing.T) {
+	limiter := NewProviderLimiter()
+	releases := make([]func(), 0, 100)
+	for range 100 {
+		release, ok := limiter.TryAcquire(9, 0)
+		if !ok {
+			t.Fatal("zero limit should be unlimited")
+		}
+		releases = append(releases, release)
+	}
+	if _, ok := limiter.TryAcquire(9, 100); ok {
+		t.Fatal("existing unlimited sessions must count after changing to a positive limit")
+	}
+	releases[0]()
+	if release, ok := limiter.TryAcquire(9, 100); !ok {
+		t.Fatal("a slot should become available after an existing session ends")
+	} else {
+		release()
+	}
+}

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -327,7 +327,7 @@ func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T)
 	}
 }
 
-func TestMatch_ResponsesWebSocketReturnsOneProvider(t *testing.T) {
+func TestMatch_ResponsesWebSocketReturnsOrderedProviders(t *testing.T) {
 	const (
 		providerA = uint64(401)
 		providerB = uint64(402)
@@ -353,8 +353,79 @@ func TestMatch_ResponsesWebSocketReturnsOneProvider(t *testing.T) {
 		t.Fatalf("Match: %v", err)
 	}
 	ids := matchedProviderIDs(result)
-	if len(ids) != 1 || ids[0] != providerA {
-		t.Fatalf("matched provider IDs = %v, want single first provider %d", ids, providerA)
+	if len(ids) != 2 || ids[0] != providerA || ids[1] != providerB {
+		t.Fatalf("matched provider IDs = %v, want [%d %d]", ids, providerA, providerB)
+	}
+}
+
+func TestMatch_ProviderConcurrencyLimitSkipsFullProvider(t *testing.T) {
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 71, TenantID: 1, ProviderID: 701, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 72, TenantID: 1, ProviderID: 702, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 701, TenantID: 1, Type: wsRouterNativeType, Name: "full", MaxConcurrency: 1, SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: 702, TenantID: 1, Type: wsRouterNativeType, Name: "available", MaxConcurrency: 1, SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	release, ok := r.TryAcquireProvider(&domain.Provider{ID: 701, MaxConcurrency: 1})
+	if !ok {
+		t.Fatal("failed to occupy provider slot")
+	}
+	defer release()
+
+	result, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "gpt-test"})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	ids := matchedProviderIDs(result)
+	if len(ids) != 1 || ids[0] != 702 {
+		t.Fatalf("matched provider IDs = %v, want [702]", ids)
+	}
+}
+
+func TestMatch_ResponsesWebSocketSkipsProviderAtConcurrencyLimit(t *testing.T) {
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 51, TenantID: 1, ProviderID: 501, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 52, TenantID: 1, ProviderID: 502, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 501, TenantID: 1, Type: wsRouterNativeType, Name: "full", MaxConcurrency: 1, SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: 502, TenantID: 1, Type: wsRouterNativeType, Name: "available", MaxConcurrency: 1, SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	release, ok := r.TryAcquireProvider(&domain.Provider{ID: 501, MaxConcurrency: 1})
+	if !ok {
+		t.Fatal("failed to occupy provider slot")
+	}
+	defer release()
+
+	result, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "gpt-test", RequireResponsesWebSocket: true})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	ids := matchedProviderIDs(result)
+	if len(ids) != 1 || ids[0] != 502 {
+		t.Fatalf("matched provider IDs = %v, want [502]", ids)
+	}
+}
+
+func TestMatch_ResponsesWebSocketRejectsWhenOnlyProviderIsAtConcurrencyLimit(t *testing.T) {
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{{ID: 61, TenantID: 1, ProviderID: 601, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1}},
+		[]*domain.Provider{{ID: 601, TenantID: 1, Type: wsRouterNativeType, Name: "full", MaxConcurrency: 1, SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}}},
+	)
+	release, ok := r.TryAcquireProvider(&domain.Provider{ID: 601, MaxConcurrency: 1})
+	if !ok {
+		t.Fatal("failed to occupy provider slot")
+	}
+	defer release()
+
+	_, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "gpt-test", RequireResponsesWebSocket: true})
+	if !errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
+		t.Fatalf("Match error = %v, want ErrNoResponsesWebSocketProviders", err)
 	}
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -73,6 +73,7 @@ type Router struct {
 	// Adapter cache
 	adapters map[uint64]provider.ProviderAdapter
 	mu       sync.RWMutex
+	limiter  *ProviderLimiter
 
 	// Cooldown manager
 	cooldownManager *cooldown.Manager
@@ -93,8 +94,21 @@ func NewRouter(
 		retryConfigRepo:     retryConfigRepo,
 		projectRepo:         projectRepo,
 		adapters:            make(map[uint64]provider.ProviderAdapter),
+		limiter:             NewProviderLimiter(),
 		cooldownManager:     cooldown.Default(),
 	}
+}
+
+// TryAcquireProvider reserves an upstream session slot for a provider.
+func (r *Router) TryAcquireProvider(p *domain.Provider) (func(), bool) {
+	if r == nil || p == nil {
+		return nil, false
+	}
+	return r.limiter.TryAcquire(p.ID, p.MaxConcurrency)
+}
+
+func (r *Router) isProviderAtConcurrencyLimit(p *domain.Provider) bool {
+	return r != nil && p != nil && r.limiter.IsAtLimit(p.ID, p.MaxConcurrency)
 }
 
 // InitAdapters initializes adapters for all providers
@@ -266,6 +280,10 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if !ok {
 			continue
 		}
+		if r.isProviderAtConcurrencyLimit(prov) {
+			sawTransientSkip = true
+			continue
+		}
 
 		// Skip providers in cooldown (checks provider, key, and model-level cooldowns)
 		if r.cooldownManager.IsInCooldown(route.ProviderID, string(clientType), requestModel) {
@@ -380,12 +398,6 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		stickyCancel()
 	}
 
-	// Codex Responses WebSocket turns execute exactly one provider: no
-	// cross-provider fallback is allowed after match.
-	if ctx.RequireResponsesWebSocket && len(matched) > 1 {
-		matched = matched[:1]
-	}
-
 	return &MatchResult{Routes: matched, Sticky: stickyWrite}, nil
 }
 
@@ -477,7 +489,7 @@ func (r *Router) HasResponsesWebSocketProvider(tenantID, projectID uint64) bool 
 	defer r.mu.RUnlock()
 	for _, route := range candidates {
 		prov, ok := providers[route.ProviderID]
-		if !ok || prov == nil {
+		if !ok || prov == nil || r.isProviderAtConcurrencyLimit(prov) {
 			continue
 		}
 		adp, ok := r.adapters[route.ProviderID]

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -143,6 +143,7 @@ func (s *AdminService) GetProvider(tenantID uint64, id uint64) (*domain.Provider
 
 func (s *AdminService) CreateProvider(tenantID uint64, provider *domain.Provider) error {
 	provider.TenantID = tenantID
+	provider.MaxConcurrency = max(provider.MaxConcurrency, 0)
 	if provider.BlackBox {
 		provider.ExcludeFromExport = true
 	}
@@ -168,6 +169,7 @@ func (s *AdminService) UpdateProvider(tenantID uint64, provider *domain.Provider
 	if existing.BlackBox {
 		return ErrProviderBlackBoxLocked
 	}
+	provider.MaxConcurrency = max(provider.MaxConcurrency, 0)
 	if provider.BlackBox {
 		provider.ExcludeFromExport = true
 	}
@@ -926,8 +928,8 @@ func filterRoutesByScope(routes []*domain.Route, projectID uint64, clientType do
 
 func cloneRouteForTarget(source *domain.Route, tenantID, targetProjectID uint64, position int) *domain.Route {
 	return &domain.Route{
-		TenantID:      tenantID,
-		IsEnabled:     source.IsEnabled,
+		TenantID:  tenantID,
+		IsEnabled: source.IsEnabled,
 		// IsNative is always recomputed from provider capability before save.
 		IsNative:      false,
 		ProjectID:     targetProjectID,

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
 )
 
+func TestAdminServiceProviderMaxConcurrencyIsPersistedAndNormalized(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := sqlite.NewProviderRepository(db)
+	svc := NewAdminService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+	provider := &domain.Provider{Name: "limited", Type: "custom", MaxConcurrency: -3}
+	if err := svc.CreateProvider(domain.DefaultTenantID, provider); err != nil {
+		t.Fatalf("CreateProvider() error = %v", err)
+	}
+	created, err := repo.GetByID(domain.DefaultTenantID, provider.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if created.MaxConcurrency != 0 {
+		t.Fatalf("created max concurrency = %d, want 0", created.MaxConcurrency)
+	}
+
+	created.MaxConcurrency = 4
+	if err := svc.UpdateProvider(domain.DefaultTenantID, created); err != nil {
+		t.Fatalf("UpdateProvider() error = %v", err)
+	}
+	updated, err := repo.GetByID(domain.DefaultTenantID, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID() after update error = %v", err)
+	}
+	if updated.MaxConcurrency != 4 {
+		t.Fatalf("updated max concurrency = %d, want 4", updated.MaxConcurrency)
+	}
+}
+
 func TestAdminServiceDeleteProviderCleansRoutesAndProviderModelMappings(t *testing.T) {
 	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -123,6 +123,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 			Config:               p.Config,
 			SupportedClientTypes: p.SupportedClientTypes,
 			SupportModels:        p.SupportModels,
+			MaxConcurrency:       p.MaxConcurrency,
 		})
 	}
 
@@ -537,6 +538,10 @@ func (s *BackupService) importProviders(tenantID uint64, providers []domain.Back
 			Config:               bp.Config,
 			SupportedClientTypes: bp.SupportedClientTypes,
 			SupportModels:        bp.SupportModels,
+			MaxConcurrency:       bp.MaxConcurrency,
+		}
+		if p.MaxConcurrency < 0 {
+			p.MaxConcurrency = 0
 		}
 		domain.NormalizeProviderSupportedClientTypes(p)
 

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -70,6 +70,7 @@ func seedBackupRoundtripData(t *testing.T, db *sqlite.DB) {
 		},
 		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeClaude},
 		SupportModels:        []string{"gpt-4o*", "claude-*"},
+		MaxConcurrency:       7,
 	}
 	if err := providerRepo.Create(provider); err != nil {
 		t.Fatalf("seed provider: %v", err)
@@ -203,6 +204,9 @@ func TestBackupService_ExportImportRoundtrip_PreservesCoreConfig(t *testing.T) {
 	if roundtrip.Data.Providers[0].Logo != "https://example.com/logo.png" {
 		t.Fatalf("provider logo = %q, want preserved", roundtrip.Data.Providers[0].Logo)
 	}
+	if roundtrip.Data.Providers[0].MaxConcurrency != 7 {
+		t.Fatalf("provider max concurrency = %d, want 7", roundtrip.Data.Providers[0].MaxConcurrency)
+	}
 
 	if len(roundtrip.Data.ModelPrices) != 1 {
 		t.Fatalf("modelPrices count = %d, want 1", len(roundtrip.Data.ModelPrices))
@@ -230,6 +234,35 @@ func TestBackupService_ExportImportRoundtrip_PreservesCoreConfig(t *testing.T) {
 	}
 	if foundCustomMapping != 1 {
 		t.Fatalf("custom model mapping count = %d, want 1", foundCustomMapping)
+	}
+}
+
+func TestBackupService_ImportNormalizesNegativeProviderMaxConcurrency(t *testing.T) {
+	sourceDB := newBackupServiceTestDB(t, "source-negative-concurrency.db")
+	seedBackupRoundtripData(t, sourceDB)
+
+	backup, err := newBackupServiceForTest(t, sourceDB).Export(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("export backup: %v", err)
+	}
+	backup.Data.Providers[0].MaxConcurrency = -3
+
+	targetDB := newBackupServiceTestDB(t, "target-negative-concurrency.db")
+	targetSvc := newBackupServiceForTest(t, targetDB)
+	result, err := targetSvc.Import(domain.DefaultTenantID, backup, domain.ImportOptions{ConflictStrategy: "skip"})
+	if err != nil {
+		t.Fatalf("import backup: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("import result success=false, errors=%v", result.Errors)
+	}
+
+	roundtrip, err := targetSvc.Export(domain.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("re-export backup: %v", err)
+	}
+	if got := roundtrip.Data.Providers[0].MaxConcurrency; got != 0 {
+		t.Fatalf("provider max concurrency = %d, want 0", got)
 	}
 }
 

--- a/internal/service/claude_provider_batch.go
+++ b/internal/service/claude_provider_batch.go
@@ -455,6 +455,7 @@ func (s *AdminService) persistClaudeBatchResults(tenantID uint64, req ClaudeProv
 			provider.ID = item.duplicate.ID
 			provider.TenantID = tenantID
 			provider.CreatedAt = item.duplicate.CreatedAt
+			preserveClaudeBatchOverwriteSettings(provider, item.duplicate)
 			if err := s.UpdateProvider(tenantID, provider); err != nil {
 				result.Status = ClaudeProviderBatchStatusPersistenceFailed
 				result.OK = false
@@ -648,6 +649,13 @@ func maskURL(raw string) string {
 	}
 	parsed.User = nil
 	return parsed.String()
+}
+
+func preserveClaudeBatchOverwriteSettings(candidate, existing *domain.Provider) {
+	if candidate == nil || existing == nil {
+		return
+	}
+	candidate.MaxConcurrency = existing.MaxConcurrency
 }
 
 func cloneProviderForBatch(provider *domain.Provider) *domain.Provider {

--- a/internal/service/claude_provider_batch_test.go
+++ b/internal/service/claude_provider_batch_test.go
@@ -1,0 +1,18 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestPreserveClaudeBatchOverwriteSettingsKeepsMaxConcurrency(t *testing.T) {
+	candidate := &domain.Provider{MaxConcurrency: 0}
+	existing := &domain.Provider{MaxConcurrency: 6}
+
+	preserveClaudeBatchOverwriteSettings(candidate, existing)
+
+	if candidate.MaxConcurrency != 6 {
+		t.Fatalf("max concurrency = %d, want 6", candidate.MaxConcurrency)
+	}
+}

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -198,6 +198,7 @@ export interface Provider {
   config: ProviderConfig | null;
   supportedClientTypes: ClientType[];
   supportModels?: string[]; // 支持的模型列表（通配符模式），空数组表示支持所有模型
+  maxConcurrency?: number; // 最大并发上游会话数，0 表示不限制
   excludeFromExport?: boolean; // 为 true 时不参与导出/备份
   blackBox?: boolean; // 为 true 时不可编辑且不向 UI/API 暴露配置细节
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1650,6 +1650,8 @@
     "cloakSensitiveWordsDesc": "Words will be obfuscated with zero-width characters (comma or newline separated).",
     "cloakSensitiveWordsPlaceholder": "e.g. secret, internal-project",
     "displayName": "Display Name",
+    "maxConcurrency": "Max concurrency",
+    "maxConcurrencyDesc": "Active upstream sessions cap. 0 = unlimited.",
     "customBackend": "Backend",
     "customBackendHttp": "HTTP relay (pass-through)",
     "customBackendHttpDesc": "Forward requests to an upstream that already speaks the selected client protocol.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1647,6 +1647,8 @@
     "cloakSensitiveWordsDesc": "将以零宽字符混淆（逗号或换行分隔）。",
     "cloakSensitiveWordsPlaceholder": "例如：secret, internal-project",
     "displayName": "显示名称",
+    "maxConcurrency": "最大并发",
+    "maxConcurrencyDesc": "上游会话并发上限，0 表示不限制。",
     "customBackend": "后端类型",
     "customBackendHttp": "HTTP 中转（原样转发）",
     "customBackendHttpDesc": "转发到已经支持所选客户端协议的上游服务。",

--- a/web/src/pages/providers/components/antigravity-provider-view.tsx
+++ b/web/src/pages/providers/components/antigravity-provider-view.tsx
@@ -22,6 +22,10 @@ import { ANTIGRAVITY_COLOR } from '../types';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  ProviderMaxConcurrencyField,
+  useProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface AntigravityProviderViewProps {
   provider: Provider;
@@ -138,6 +142,8 @@ export function AntigravityProviderView({
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     () => provider.config?.disableErrorCooldown ?? false,
   );
+  const { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency } =
+    useProviderMaxConcurrencyField(provider, updateProvider);
 
   useEffect(() => {
     setUseCLIProxyAPI(provider.config?.antigravity?.useCLIProxyAPI ?? false);
@@ -334,7 +340,13 @@ export function AntigravityProviderView({
               </div>
             </div>
 
-            <div className="mt-4">
+            <div className="mt-4 space-y-3">
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+                onCommit={handleCommitMaxConcurrency}
+                disabled={updateProvider.isPending}
+              />
               <div className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border">
                 <div className="pr-4">
                   <div className="text-sm font-medium text-foreground">

--- a/web/src/pages/providers/components/antigravity-token-import.tsx
+++ b/web/src/pages/providers/components/antigravity-token-import.tsx
@@ -23,14 +23,20 @@ import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/layout/page-header';
 import { cn } from '@/lib/utils';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { useProviderForm } from '../context/provider-form-context';
 import { useCreateProvider } from '@/hooks/queries';
 import { useTranslation } from 'react-i18next';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 type ImportMode = 'oauth' | 'token';
 type OAuthStatus = 'idle' | 'waiting' | 'success' | 'error';
 
 export function AntigravityTokenImport() {
+  const { formData, updateFormData } = useProviderForm();
   const { t } = useTranslation();
   const { goToSelectType, goToProviders } = useProviderNavigation();
   const createProvider = useCreateProvider();
@@ -174,6 +180,7 @@ export function AntigravityTokenImport() {
       const providerData: CreateProviderData = {
         type: 'antigravity',
         name: finalEmail || 'Antigravity Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           antigravity: {
             email: finalEmail,
@@ -213,6 +220,7 @@ export function AntigravityTokenImport() {
       const providerData: CreateProviderData = {
         type: 'antigravity',
         name: oauthResult.email || 'Antigravity Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           antigravity: {
             email: oauthResult.email || '',
@@ -261,6 +269,11 @@ export function AntigravityTokenImport() {
 
           {/* CLIProxyAPI Switch */}
           <CLIProxyAPISwitch checked={useCLIProxyAPI} onChange={setUseCLIProxyAPI} />
+
+          <ProviderMaxConcurrencyField
+            value={normalizeMaxConcurrency(formData.maxConcurrency)}
+            onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+          />
 
           {/* Mode Selector */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/web/src/pages/providers/components/bedrock-config-step.tsx
+++ b/web/src/pages/providers/components/bedrock-config-step.tsx
@@ -8,6 +8,10 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 const BEDROCK_REGIONS = [
   'us-east-1',
@@ -34,6 +38,7 @@ export function BedrockConfigStep() {
   const [modelPrefix, setModelPrefix] = useState('us');
   const [showSecret, setShowSecret] = useState(false);
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [maxConcurrency, setMaxConcurrency] = useState(0);
   const [blackBox, setBlackBox] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -51,6 +56,7 @@ export function BedrockConfigStep() {
       const data: CreateProviderData = {
         type: 'bedrock',
         name: name.trim(),
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           bedrock: {
@@ -119,6 +125,11 @@ export function BedrockConfigStep() {
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
             </div>
           </div>
 

--- a/web/src/pages/providers/components/bedrock-provider-view.tsx
+++ b/web/src/pages/providers/components/bedrock-provider-view.tsx
@@ -22,6 +22,10 @@ import { Button, Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { BEDROCK_COLOR } from '../types';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import {
+  ProviderMaxConcurrencyField,
+  useProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface BedrockProviderViewProps {
   provider: Provider;
@@ -99,6 +103,9 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
     setCopied(key);
     setTimeout(() => setCopied(null), 2000);
   };
+
+  const { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency } =
+    useProviderMaxConcurrencyField(provider, updateProvider);
 
   const handleToggleCooldown = async (checked: boolean) => {
     await updateProvider.mutateAsync({
@@ -330,6 +337,13 @@ export function BedrockProviderView({ provider, onDelete, onClose }: BedrockProv
               </p>
             )}
           </div>
+
+          <ProviderMaxConcurrencyField
+            value={maxConcurrency}
+            onChange={setMaxConcurrency}
+            onCommit={handleCommitMaxConcurrency}
+            disabled={updateProvider.isPending}
+          />
 
           {/* Error Cooldown */}
           <div className="space-y-4">

--- a/web/src/pages/providers/components/claude-provider-view.tsx
+++ b/web/src/pages/providers/components/claude-provider-view.tsx
@@ -23,6 +23,10 @@ import { Button, Switch } from '@/components/ui';
 import { CLAUDE_COLOR } from '../types';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  ProviderMaxConcurrencyField,
+  useProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface ClaudeProviderViewProps {
   provider: Provider;
@@ -85,6 +89,8 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     () => provider.config?.disableErrorCooldown ?? false,
   );
+  const { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency } =
+    useProviderMaxConcurrencyField(provider, updateProvider);
 
   const handleToggleDisableErrorCooldown = async (checked: boolean) => {
     if (!config) return;
@@ -214,7 +220,13 @@ export function ClaudeProviderView({ provider, onDelete, onClose }: ClaudeProvid
               </div>
             )}
 
-            <div className="mt-4">
+            <div className="mt-4 space-y-3">
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+                onCommit={handleCommitMaxConcurrency}
+                disabled={updateProvider.isPending}
+              />
               <div className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border">
                 <div className="pr-4">
                   <div className="text-sm font-medium text-foreground">

--- a/web/src/pages/providers/components/claude-token-import.tsx
+++ b/web/src/pages/providers/components/claude-token-import.tsx
@@ -26,13 +26,19 @@ import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/layout/page-header';
 import { cn } from '@/lib/utils';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { useProviderForm } from '../context/provider-form-context';
 import { useCreateProvider } from '@/hooks/queries';
 import { useTranslation } from 'react-i18next';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 type ImportMode = 'oauth' | 'token';
 type OAuthStatus = 'idle' | 'waiting' | 'success' | 'error';
 
 export function ClaudeTokenImport() {
+  const { formData, updateFormData } = useProviderForm();
   const { t } = useTranslation();
   const { goToSelectType, goToProviders } = useProviderNavigation();
   const createProvider = useCreateProvider();
@@ -41,7 +47,9 @@ export function ClaudeTokenImport() {
   const [token, setToken] = useState('');
   const [validating, setValidating] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [validationResult, setValidationResult] = useState<ClaudeTokenValidationResult | null>(null);
+  const [validationResult, setValidationResult] = useState<ClaudeTokenValidationResult | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   // OAuth state
@@ -254,6 +262,7 @@ export function ClaudeTokenImport() {
       const providerData: CreateProviderData = {
         type: 'claude',
         name: oauthResult.email || 'Claude Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           claude: {
             email: oauthResult.email || '',
@@ -290,6 +299,7 @@ export function ClaudeTokenImport() {
       const providerData: CreateProviderData = {
         type: 'claude',
         name: finalEmail || 'Claude Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           claude: {
             email: finalEmail,
@@ -322,9 +332,7 @@ export function ClaudeTokenImport() {
         <div className="container max-w-2xl mx-auto py-8 px-6 space-y-8">
           {/* Hero Section */}
           <div className="text-center space-y-2 mb-8">
-            <div
-              className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-inner bg-provider-claude/15"
-            >
+            <div className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-4 shadow-inner bg-provider-claude/15">
               <Sparkles size={32} className="text-provider-claude" />
             </div>
             <h1 className="text-2xl font-bold text-foreground">
@@ -334,6 +342,11 @@ export function ClaudeTokenImport() {
               {t('providers.claudeTokenImport.connectDescription')}
             </p>
           </div>
+
+          <ProviderMaxConcurrencyField
+            value={normalizeMaxConcurrency(formData.maxConcurrency)}
+            onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+          />
 
           {/* Mode Tabs */}
           <div className="flex gap-2 p-1 bg-muted rounded-lg">

--- a/web/src/pages/providers/components/codex-provider-view.tsx
+++ b/web/src/pages/providers/components/codex-provider-view.tsx
@@ -28,6 +28,10 @@ import { useCodexBatchQuotas } from '@/hooks/queries';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  ProviderMaxConcurrencyField,
+  useProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface CodexProviderViewProps {
   provider: Provider;
@@ -209,6 +213,8 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     () => provider.config?.disableErrorCooldown ?? false,
   );
+  const { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency } =
+    useProviderMaxConcurrencyField(provider, updateProvider);
   const [reasoning, setReasoning] = useState(() => config?.reasoning ?? '');
   const [serviceTier, setServiceTier] = useState(() => config?.serviceTier ?? '');
   // undefined/true = 默认透传;仅显式 false 关闭。
@@ -552,6 +558,12 @@ export function CodexProviderView({ provider, onDelete, onClose }: CodexProvider
             )}
 
             <div className="mt-4 space-y-3">
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+                onCommit={handleCommitMaxConcurrency}
+                disabled={updateProvider.isPending}
+              />
               <div className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border">
                 <div className="pr-4">
                   <div className="text-sm font-medium text-foreground">

--- a/web/src/pages/providers/components/codex-token-import.tsx
+++ b/web/src/pages/providers/components/codex-token-import.tsx
@@ -26,14 +26,20 @@ import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/layout/page-header';
 import { cn } from '@/lib/utils';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { useProviderForm } from '../context/provider-form-context';
 import { useCreateProvider } from '@/hooks/queries';
 import { useTranslation } from 'react-i18next';
 import { CLIProxyAPISwitch } from './cliproxyapi-switch';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 type ImportMode = 'oauth' | 'token';
 type OAuthStatus = 'idle' | 'waiting' | 'success' | 'error';
 
 export function CodexTokenImport() {
+  const { formData, updateFormData } = useProviderForm();
   const { t } = useTranslation();
   const { goToSelectType, goToProviders } = useProviderNavigation();
   const createProvider = useCreateProvider();
@@ -236,6 +242,7 @@ export function CodexTokenImport() {
       const providerData: CreateProviderData = {
         type: 'codex',
         name: oauthResult.email || 'Codex Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           codex: {
             email: oauthResult.email || '',
@@ -279,6 +286,7 @@ export function CodexTokenImport() {
       const providerData: CreateProviderData = {
         type: 'codex',
         name: finalEmail || 'Codex Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           codex: {
             email: finalEmail,
@@ -334,6 +342,11 @@ export function CodexTokenImport() {
 
           {/* CLIProxyAPI Switch */}
           <CLIProxyAPISwitch checked={useCLIProxyAPI} onChange={setUseCLIProxyAPI} />
+
+          <ProviderMaxConcurrencyField
+            value={normalizeMaxConcurrency(formData.maxConcurrency)}
+            onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+          />
 
           {/* Mode Tabs */}
           <div className="flex gap-2 p-1 bg-muted rounded-lg">

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -39,6 +39,10 @@ import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import { buildDisguisePayload } from '../utils/disguise';
 import { buildProviderRuntimeModelOptions } from './provider-model-mappings';
 import { SmartMappingRetrySettings } from './smart-mapping-retry-settings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 export function CustomConfigStep() {
   const [showApiKey, setShowApiKey] = useState(false);
@@ -135,6 +139,7 @@ export function CustomConfigStep() {
         type: 'custom',
         name: formData.name,
         logo: formData.logo,
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
@@ -223,6 +228,11 @@ export function CustomConfigStep() {
                   className="w-full"
                 />
               </div>
+              <ProviderMaxConcurrencyField
+                value={formData.maxConcurrency ?? 0}
+                onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+              />
+
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">
                   {t('provider.customBackend')}

--- a/web/src/pages/providers/components/grok-provider-view.tsx
+++ b/web/src/pages/providers/components/grok-provider-view.tsx
@@ -9,6 +9,10 @@ import { useUpdateProvider } from '@/hooks/queries';
 import type { ClientType, CreateProviderData, Provider } from '@/lib/transport';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface GrokProviderViewProps {
   provider: Provider;
@@ -29,6 +33,9 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [maxConcurrency, setMaxConcurrency] = useState(
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
   const [blackBox, setBlackBox] = useState(!!provider.blackBox || !!provider.excludeFromExport);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -43,6 +50,7 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
       const data: Partial<CreateProviderData> = {
         name: name.trim(),
         type: 'grok',
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           grok: {
@@ -122,6 +130,10 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
                 </label>
                 <Input value={name} onChange={(event) => setName(event.target.value)} />
               </div>
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
               <div>
                 <label className="mb-2 block text-sm font-medium text-foreground">
                   {t('addProvider.grok.email')}

--- a/web/src/pages/providers/components/grok-token-import.tsx
+++ b/web/src/pages/providers/components/grok-token-import.tsx
@@ -11,6 +11,11 @@ import { PageHeader } from '@/components/layout/page-header';
 import { useCreateModelMapping, useCreateProvider } from '@/hooks/queries';
 import type { ClientType, CreateProviderData } from '@/lib/transport';
 import type { ProviderConfigGrok } from '@/lib/transport/types';
+import { useProviderForm } from '../context/provider-form-context';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 export interface CPAxAIExportJSON {
   type?: string;
@@ -299,6 +304,7 @@ async function parseImportItemsFromFiles(files: FileList): Promise<GrokImportIte
 
 export function GrokTokenImport() {
   const { t } = useTranslation();
+  const { formData, updateFormData } = useProviderForm();
   const navigate = useNavigate();
   const createProvider = useCreateProvider();
   const createModelMapping = useCreateModelMapping();
@@ -339,6 +345,7 @@ export function GrokTokenImport() {
         const data: CreateProviderData = {
           type: 'grok',
           name: providerName(grok, item.source),
+          maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
           config: { disableErrorCooldown, grok },
           supportedClientTypes: [...GROK_CLIENT_TYPES],
           excludeFromExport: blackBox,
@@ -437,6 +444,10 @@ export function GrokTokenImport() {
               }}
               placeholder='{"type":"xai","auth_kind":"oauth",...}'
               className="min-h-64 font-mono text-xs"
+            />
+            <ProviderMaxConcurrencyField
+              value={normalizeMaxConcurrency(formData.maxConcurrency)}
+              onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
             />
           </div>
 

--- a/web/src/pages/providers/components/kiro-provider-view.tsx
+++ b/web/src/pages/providers/components/kiro-provider-view.tsx
@@ -9,6 +9,10 @@ import { Switch } from '@/components/ui';
 import { KIRO_COLOR } from '../types';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  ProviderMaxConcurrencyField,
+  useProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface KiroProviderViewProps {
   provider: Provider;
@@ -122,6 +126,8 @@ export function KiroProviderView({ provider, onDelete, onClose }: KiroProviderVi
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     () => provider.config?.disableErrorCooldown ?? false,
   );
+  const { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency } =
+    useProviderMaxConcurrencyField(provider, updateProvider);
 
   useEffect(() => {
     setDisableErrorCooldown(provider.config?.disableErrorCooldown ?? false);
@@ -241,7 +247,13 @@ export function KiroProviderView({ provider, onDelete, onClose }: KiroProviderVi
               </div>
             </div>
 
-            <div className="mt-4">
+            <div className="mt-4 space-y-3">
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+                onCommit={handleCommitMaxConcurrency}
+                disabled={updateProvider.isPending}
+              />
               <div className="flex items-center justify-between p-3 bg-muted rounded-lg border border-border">
                 <div className="pr-4">
                   <div className="text-sm font-medium text-foreground">

--- a/web/src/pages/providers/components/kiro-token-import.tsx
+++ b/web/src/pages/providers/components/kiro-token-import.tsx
@@ -17,9 +17,15 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useTranslation } from 'react-i18next';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import { useProviderForm } from '../context/provider-form-context';
 import { useCreateProvider } from '@/hooks/queries';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 export function KiroTokenImport() {
+  const { formData, updateFormData } = useProviderForm();
   const { t } = useTranslation();
   const { goToSelectType, goToProviders } = useProviderNavigation();
   const createProvider = useCreateProvider();
@@ -76,6 +82,7 @@ export function KiroTokenImport() {
       const providerData: CreateProviderData = {
         type: 'kiro',
         name: finalEmail || 'Kiro Account',
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           kiro: {
             authMethod: 'social',
@@ -132,6 +139,11 @@ export function KiroTokenImport() {
               {t('providers.kiroTokenImport.importDescription')}
             </p>
           </div>
+
+          <ProviderMaxConcurrencyField
+            value={normalizeMaxConcurrency(formData.maxConcurrency)}
+            onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+          />
 
           {/* Token Input Form */}
           <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">

--- a/web/src/pages/providers/components/newapi-config-step.tsx
+++ b/web/src/pages/providers/components/newapi-config-step.tsx
@@ -9,6 +9,10 @@ import { Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import { OpenRouterModelMappings } from './openrouter-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 // new-api / one-api style relays serve multiple client protocols under a single
 // base URL. Default to OpenAI (the image-generation path this type is built for);
@@ -33,13 +37,13 @@ export function NewApiConfigStep() {
   });
   const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [maxConcurrency, setMaxConcurrency] = useState(0);
   const [blackBox, setBlackBox] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
   const enabledClients = NEWAPI_CLIENT_TYPES.filter((c) => clients[c]);
-  const isValid = () =>
-    name.trim() !== '' && baseURL.trim() !== '' && enabledClients.length > 0;
+  const isValid = () => name.trim() !== '' && baseURL.trim() !== '' && enabledClients.length > 0;
 
   const toggleClient = (client: ClientType) =>
     setClients((prev) => ({ ...prev, [client]: !prev[client] }));
@@ -54,6 +58,7 @@ export function NewApiConfigStep() {
       const data: CreateProviderData = {
         type: 'newapi',
         name: name.trim(),
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           custom: {
@@ -132,6 +137,11 @@ export function NewApiConfigStep() {
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">

--- a/web/src/pages/providers/components/newapi-provider-view.tsx
+++ b/web/src/pages/providers/components/newapi-provider-view.tsx
@@ -9,6 +9,10 @@ import { Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 const NEWAPI_CLIENT_TYPES = ['openai', 'claude', 'gemini'] as const;
 
@@ -44,6 +48,9 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [maxConcurrency, setMaxConcurrency] = useState(
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
@@ -63,6 +70,7 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
       const data: Partial<CreateProviderData> = {
         name: name.trim(),
         type: 'newapi',
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           custom: {
@@ -134,6 +142,11 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               {!secretsAreWriteOnly && (
                 <div>

--- a/web/src/pages/providers/components/ollama-config-step.tsx
+++ b/web/src/pages/providers/components/ollama-config-step.tsx
@@ -9,6 +9,10 @@ import { Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import { OpenRouterModelMappings } from './openrouter-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 export function OllamaConfigStep() {
   const { t } = useTranslation();
@@ -22,6 +26,7 @@ export function OllamaConfigStep() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [maxConcurrency, setMaxConcurrency] = useState(0);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
@@ -37,6 +42,7 @@ export function OllamaConfigStep() {
       const data: CreateProviderData = {
         type: 'ollama',
         name: name.trim(),
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           custom: {
@@ -112,6 +118,11 @@ export function OllamaConfigStep() {
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">

--- a/web/src/pages/providers/components/ollama-provider-view.tsx
+++ b/web/src/pages/providers/components/ollama-provider-view.tsx
@@ -9,6 +9,10 @@ import { Switch } from '@/components/ui';
 import { PageHeader } from '@/components/layout/page-header';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface OllamaProviderViewProps {
   provider: Provider;
@@ -31,6 +35,9 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [maxConcurrency, setMaxConcurrency] = useState(
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
@@ -46,6 +53,7 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
       const data: Partial<CreateProviderData> = {
         name: name.trim(),
         type: 'ollama',
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           custom: {
@@ -116,6 +124,11 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               {!secretsAreWriteOnly && (
                 <div>

--- a/web/src/pages/providers/components/openrouter-config-step.tsx
+++ b/web/src/pages/providers/components/openrouter-config-step.tsx
@@ -10,6 +10,10 @@ import { PageHeader } from '@/components/layout/page-header';
 import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import openrouterLogo from '@/assets/icons/openrouter.svg';
 import { OpenRouterModelMappings, OPENROUTER_CLIENT_TYPES } from './openrouter-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 export function OpenRouterConfigStep() {
   const { t } = useTranslation();
@@ -29,6 +33,7 @@ export function OpenRouterConfigStep() {
   });
   const [modelMapping, setModelMapping] = useState<Record<string, string>>({});
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [maxConcurrency, setMaxConcurrency] = useState(0);
   const [blackBox, setBlackBox] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
@@ -50,6 +55,7 @@ export function OpenRouterConfigStep() {
         type: 'openrouter',
         name: name.trim(),
         logo: openrouterLogo,
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           openrouter: {
@@ -128,6 +134,11 @@ export function OpenRouterConfigStep() {
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">

--- a/web/src/pages/providers/components/openrouter-provider-view.tsx
+++ b/web/src/pages/providers/components/openrouter-provider-view.tsx
@@ -10,6 +10,10 @@ import { PageHeader } from '@/components/layout/page-header';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { OPENROUTER_CLIENT_TYPES } from './openrouter-model-mappings';
 import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 
 interface OpenRouterProviderViewProps {
   provider: Provider;
@@ -45,6 +49,9 @@ export function OpenRouterProviderView({
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [maxConcurrency, setMaxConcurrency] = useState(
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
@@ -64,6 +71,7 @@ export function OpenRouterProviderView({
       const data: Partial<CreateProviderData> = {
         name: name.trim(),
         type: 'openrouter',
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
           openrouter: {
@@ -134,6 +142,11 @@ export function OpenRouterProviderView({
                   className="w-full"
                 />
               </div>
+
+              <ProviderMaxConcurrencyField
+                value={maxConcurrency}
+                onChange={setMaxConcurrency}
+              />
 
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -50,6 +50,10 @@ import { OllamaProviderView } from './ollama-provider-view';
 import { GrokProviderView } from './grok-provider-view';
 import { ProviderModelMappings } from './provider-model-mappings';
 import { SmartMappingRetrySettings } from './smart-mapping-retry-settings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui';
@@ -300,6 +304,7 @@ type EditFormData = {
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
+  maxConcurrency: number;
   // undefined = 默认透传;false = 旧的硬编码 /responses。
   responsesPassthrough?: boolean;
   // false/undefined = 不启用 Codex Responses WebSocket；true = 允许 WS 上游。
@@ -368,6 +373,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
       smartMappingRetryEnabled: provider.config?.smartMappingRetryEnabled ?? false,
       smartMappingRetryLimit: provider.config?.smartMappingRetryLimit ?? 1,
+      maxConcurrency: normalizeMaxConcurrency(provider.maxConcurrency),
       responsesPassthrough: provider.config?.custom?.responsesPassthrough,
       responsesWebSocket: provider.config?.custom?.responsesWebSocket === true,
     };
@@ -471,6 +477,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       const data: Partial<CreateProviderData> = {
         name: formData.name,
         type: provider.type || 'custom', // Preserve the provider type
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
@@ -539,6 +546,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         type: provider.type || 'custom',
         name: cloneName,
         logo: provider.logo,
+        maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
@@ -861,6 +869,13 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                     className="w-full"
                   />
                 </div>
+
+                <ProviderMaxConcurrencyField
+                  value={formData.maxConcurrency}
+                  onChange={(maxConcurrency) =>
+                    setFormData((prev) => ({ ...prev, maxConcurrency }))
+                  }
+                />
 
                 <div>
                   <label className="text-sm font-medium text-foreground block mb-2">

--- a/web/src/pages/providers/components/provider-max-concurrency-field.test.ts
+++ b/web/src/pages/providers/components/provider-max-concurrency-field.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMaxConcurrency } from './provider-max-concurrency-field';
+
+describe('normalizeMaxConcurrency', () => {
+  it('treats empty/nullish as unlimited (0)', () => {
+    expect(normalizeMaxConcurrency('')).toBe(0);
+    expect(normalizeMaxConcurrency(null)).toBe(0);
+    expect(normalizeMaxConcurrency(undefined)).toBe(0);
+  });
+
+  it('truncates positives to non-negative integers', () => {
+    expect(normalizeMaxConcurrency(3.9)).toBe(3);
+    expect(normalizeMaxConcurrency('12')).toBe(12);
+    expect(normalizeMaxConcurrency(' 7 ')).toBe(7);
+    expect(normalizeMaxConcurrency(0)).toBe(0);
+  });
+
+  it('clamps invalid and negative values to 0', () => {
+    expect(normalizeMaxConcurrency(-1)).toBe(0);
+    expect(normalizeMaxConcurrency('-3')).toBe(0);
+    expect(normalizeMaxConcurrency('abc')).toBe(0);
+    expect(normalizeMaxConcurrency(Number.NaN)).toBe(0);
+    expect(normalizeMaxConcurrency(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});

--- a/web/src/pages/providers/components/provider-max-concurrency-field.tsx
+++ b/web/src/pages/providers/components/provider-max-concurrency-field.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import type { Provider } from '@/lib/transport';
+
+type ProviderUpdater = {
+  mutateAsync: (variables: { id: number; data: Partial<Provider> }) => Promise<unknown>;
+};
+
+/** Clamp provider maxConcurrency for API payloads. 0 = unlimited. */
+export function normalizeMaxConcurrency(value: unknown): number {
+  if (value === '' || value === null || value === undefined) return 0;
+  const n =
+    typeof value === 'number' ? value : Number.parseInt(String(value).trim(), 10);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.trunc(n);
+}
+
+export function useProviderMaxConcurrencyField(
+  provider: Provider,
+  updateProvider: ProviderUpdater,
+) {
+  const [maxConcurrency, setMaxConcurrency] = useState(() =>
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
+
+  useEffect(() => {
+    setMaxConcurrency(normalizeMaxConcurrency(provider.maxConcurrency));
+  }, [provider.maxConcurrency]);
+
+  const handleCommitMaxConcurrency = async (next: number) => {
+    const normalized = normalizeMaxConcurrency(next);
+    const previous = normalizeMaxConcurrency(provider.maxConcurrency);
+    if (normalized === previous) return;
+
+    setMaxConcurrency(normalized);
+    try {
+      await updateProvider.mutateAsync({
+        id: provider.id,
+        data: { maxConcurrency: normalized },
+      });
+    } catch {
+      setMaxConcurrency(previous);
+    }
+  };
+
+  return { maxConcurrency, setMaxConcurrency, handleCommitMaxConcurrency };
+}
+
+type ProviderMaxConcurrencyFieldProps = {
+  value: number;
+  onChange: (value: number) => void;
+  /** Called after blur with the normalized value (for immediate-save UIs). */
+  onCommit?: (value: number) => void;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+};
+
+/**
+ * Compact controlled concurrency field. Allows temporary empty text while
+ * editing; blur normalizes empty/invalid input to 0 (unlimited).
+ */
+export function ProviderMaxConcurrencyField({
+  value,
+  onChange,
+  onCommit,
+  disabled,
+  className,
+  id,
+}: ProviderMaxConcurrencyFieldProps) {
+  const { t } = useTranslation();
+  const autoId = useId();
+  const fieldId = id ?? autoId;
+  const helperId = `${fieldId}-desc`;
+  const [text, setText] = useState(() => String(normalizeMaxConcurrency(value)));
+
+  useEffect(() => {
+    setText(String(normalizeMaxConcurrency(value)));
+  }, [value]);
+
+  const commit = () => {
+    const next = normalizeMaxConcurrency(text);
+    setText(String(next));
+    if (next !== value) {
+      onChange(next);
+    }
+    onCommit?.(next);
+  };
+
+  return (
+    <div className={cn(className)}>
+      <label htmlFor={fieldId} className="mb-2 block text-sm font-medium text-foreground">
+        {t('provider.maxConcurrency')}
+      </label>
+      <Input
+        id={fieldId}
+        type="number"
+        inputMode="numeric"
+        min={0}
+        step={1}
+        disabled={disabled}
+        value={text}
+        onChange={(event) => {
+          const raw = event.target.value;
+          // Allow temporary empty while editing; do not coerce to 0 yet.
+          if (raw === '') {
+            setText('');
+            return;
+          }
+          // Digits only (type=number can still emit e/./- in some browsers).
+          if (!/^\d+$/.test(raw)) return;
+          setText(raw);
+          onChange(normalizeMaxConcurrency(raw));
+        }}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            (event.target as HTMLInputElement).blur();
+          }
+        }}
+        aria-describedby={helperId}
+        className="w-full sm:w-32"
+      />
+      <p id={helperId} className="mt-1 text-xs text-muted-foreground">
+        {t('provider.maxConcurrencyDesc')}
+      </p>
+    </div>
+  );
+}

--- a/web/src/pages/providers/context/provider-form-context.tsx
+++ b/web/src/pages/providers/context/provider-form-context.tsx
@@ -45,6 +45,7 @@ const initialFormData: ProviderFormData = {
   disableErrorCooldown: false,
   smartMappingRetryEnabled: false,
   smartMappingRetryLimit: 1,
+  maxConcurrency: 0,
   excludeFromExport: false,
   blackBox: false,
 };

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -365,6 +365,7 @@ export type ProviderFormData = {
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
+  maxConcurrency?: number;
   excludeFromExport?: boolean;
   blackBox?: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
@@ -168,6 +168,35 @@ describe('custom provider share command builder', () => {
     });
   });
 
+  it('round-trips provider max concurrency', () => {
+    const parsed = parseBulkCustomProviderCommands(
+      'provider add --name Limited --base-url https://api.example.com/v1 --api-key sk-test --clients openai --max-concurrency 7',
+    );
+
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.commands[0].maxConcurrency).toBe(7);
+    expect(toCreateProviderData(parsed.commands[0]).maxConcurrency).toBe(7);
+
+    const command = buildCustomProviderShareCommand({ ...baseProvider, maxConcurrency: 7 });
+    expect(command).toContain('--max-concurrency 7');
+    expect(parseBulkCustomProviderCommands(command ?? '').commands[0].maxConcurrency).toBe(7);
+  });
+
+  it.each(['1.5', '2foo', '-1', '9007199254740992'])(
+    'rejects invalid provider max concurrency %s',
+    (value) => {
+      const parsed = parseBulkCustomProviderCommands(
+        `provider add --name Limited --base-url https://api.example.com/v1 --api-key sk-test --clients openai --max-concurrency ${value}`,
+      );
+
+      expect(parsed.commands).toEqual([]);
+      expect(parsed.errors).toContainEqual({
+        lineNumber: 1,
+        message: 'Max concurrency must be 0 or greater',
+      });
+    },
+  );
+
   it('rejects smart mapping retry without disabled error cooldown', () => {
     const parsed = parseBulkCustomProviderCommands(
       'provider add --name Smart --base-url https://api.example.com/v1 --api-key sk-test --clients openai --smart-mapping-retry',

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.ts
@@ -14,6 +14,7 @@ export type BulkCustomProviderCommand = {
   disableErrorCooldown: boolean;
   smartMappingRetryEnabled: boolean;
   smartMappingRetryLimit?: number;
+  maxConcurrency: number;
   excludeFromExport: boolean;
   responsesPassthrough?: boolean;
 };
@@ -44,6 +45,7 @@ const VALUE_FLAGS = new Set([
   'backend',
   'logo',
   'smart-mapping-retry-limit',
+  'max-concurrency',
 ]);
 const BOOLEAN_FLAGS = new Set([
   'disable-error-cooldown',
@@ -182,6 +184,9 @@ export function buildCustomProviderShareCommand(
   if (provider.logo) {
     appendValue('--logo', provider.logo);
   }
+  if ((provider.maxConcurrency ?? 0) > 0) {
+    appendValue('--max-concurrency', String(provider.maxConcurrency));
+  }
   if (provider.config?.disableErrorCooldown) {
     command.push('--disable-error-cooldown');
     if (provider.config.smartMappingRetryEnabled) {
@@ -288,6 +293,7 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
     disableErrorCooldown: false,
     smartMappingRetryEnabled: false,
     smartMappingRetryLimit: undefined as number | undefined,
+    maxConcurrency: 0,
     excludeFromExport: false,
     responsesPassthrough: undefined as boolean | undefined,
   };
@@ -379,6 +385,15 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
         }
         break;
       }
+      case 'max-concurrency': {
+        const maxConcurrency = Number(value);
+        if (!/^\d+$/.test(value) || !Number.isSafeInteger(maxConcurrency)) {
+          errors.push({ lineNumber, message: 'Max concurrency must be 0 or greater' });
+        } else {
+          parsed.maxConcurrency = maxConcurrency;
+        }
+        break;
+      }
     }
   }
 
@@ -425,6 +440,7 @@ export function toCreateProviderData(command: BulkCustomProviderCommand): Create
     type: 'custom',
     name: command.name,
     logo: command.logo,
+    maxConcurrency: command.maxConcurrency,
     config: {
       disableErrorCooldown: command.disableErrorCooldown,
       smartMappingRetryEnabled: command.disableErrorCooldown && command.smartMappingRetryEnabled,


### PR DESCRIPTION
## Summary

- persist a per-provider `maxConcurrency` setting (`0` means unlimited)
- enforce the limit for HTTP and WebSocket upstream sessions with panic-safe release
- preserve the setting through backup, batch update, clone, import, and provider editing flows
- expose compact localized controls in existing provider forms without adding a global banner

## Behavior

The limiter tracks active upstream sessions per provider. Runtime changes take effect without restarting, including transitions from unlimited (`0`) to a finite limit. Saturated providers are skipped so routing can continue to another eligible provider.

## Validation

- `go test ./internal/router ./internal/executor ./internal/service`
- `go vet ./...`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (129 tests)
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持为各类提供方配置最大并发数，限制活跃上游会话数量；设置为 0 表示不限制。
  * 并发达到上限时，系统会自动跳过繁忙提供方并尝试其他可用选项。
  * 提供方创建、编辑、克隆、备份导入及批量分享命令均支持该配置。
* **改进**
  * 输入值会自动规范化为非负整数，异常值按“不限制”处理。
  * 优化连接失败和异常场景下的并发资源释放，提升请求稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->