### PR TITLE
fix(cooldowns): make manual unfreeze update immediately

### DIFF
--- a/web/src/contexts/cooldowns-context.tsx
+++ b/web/src/contexts/cooldowns-context.tsx
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { getTransport } from '@/lib/transport';
 import type { Cooldown, ProviderHealthLevel } from '@/lib/transport';
 import { subscribeCooldownUpdates } from '@/lib/cooldown-update-subscription';
+import { removeClearedCooldowns } from '@/lib/cooldown-cache';
 
 /** Get provider health level from its cooldowns */
 function computeHealthLevel(cooldowns: Cooldown[]): ProviderHealthLevel {
@@ -80,7 +81,21 @@ export function CooldownsProvider({ children }: CooldownsProviderProps) {
   const clearCooldownMutation = useMutation({
     mutationFn: ({ providerId, options }: { providerId: number; options?: { clientType?: string; model?: string } }) =>
       getTransport().clearCooldown(providerId, options),
-    onSuccess: () => {
+    onMutate: async ({ providerId, options }) => {
+      await queryClient.cancelQueries({ queryKey: ['cooldowns'] });
+      const previousCooldowns = queryClient.getQueryData<Cooldown[]>(['cooldowns']);
+      queryClient.setQueryData<Cooldown[]>(['cooldowns'], (current = []) =>
+        removeClearedCooldowns(current, providerId, options),
+      );
+      return { previousCooldowns };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousCooldowns) {
+        queryClient.setQueryData(['cooldowns'], context.previousCooldowns);
+      }
+      console.error('Failed to clear cooldown:', error);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
     },
   });

--- a/web/src/hooks/use-cooldowns.ts
+++ b/web/src/hooks/use-cooldowns.ts
@@ -3,6 +3,7 @@ import { getTransport } from '@/lib/transport';
 import type { Cooldown, ProviderHealthLevel } from '@/lib/transport';
 import { useEffect, useState, useCallback } from 'react';
 import { subscribeCooldownUpdates } from '@/lib/cooldown-update-subscription';
+import { removeClearedCooldowns } from '@/lib/cooldown-cache';
 
 /** Get provider health level from its cooldowns */
 function computeHealthLevel(cooldowns: Cooldown[]): ProviderHealthLevel {
@@ -60,7 +61,21 @@ export function useCooldowns() {
   const clearCooldownMutation = useMutation({
     mutationFn: ({ providerId, options }: { providerId: number; options?: { clientType?: string; model?: string } }) =>
       getTransport().clearCooldown(providerId, options),
-    onSuccess: () => {
+    onMutate: async ({ providerId, options }) => {
+      await queryClient.cancelQueries({ queryKey: ['cooldowns'] });
+      const previousCooldowns = queryClient.getQueryData<Cooldown[]>(['cooldowns']);
+      queryClient.setQueryData<Cooldown[]>(['cooldowns'], (current = []) =>
+        removeClearedCooldowns(current, providerId, options),
+      );
+      return { previousCooldowns };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousCooldowns) {
+        queryClient.setQueryData(['cooldowns'], context.previousCooldowns);
+      }
+      console.error('Failed to clear cooldown:', error);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
     },
   });

--- a/web/src/lib/cooldown-cache.test.ts
+++ b/web/src/lib/cooldown-cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Cooldown } from './transport/types';
+import { removeClearedCooldowns } from './cooldown-cache';
+
+const baseCooldown = {
+  until: '2099-01-01T00:00:00Z',
+  reason: 'manual',
+  providerName: 'provider',
+} satisfies Omit<Cooldown, 'providerID'>;
+
+function cooldown(providerID: number, clientType?: string, model?: string): Cooldown {
+  return {
+    ...baseCooldown,
+    providerID,
+    clientType,
+    model,
+  };
+}
+
+describe('removeClearedCooldowns', () => {
+  it('removes all cooldowns for a provider when no scope is given', () => {
+    const result = removeClearedCooldowns([
+      cooldown(1),
+      cooldown(1, 'openai'),
+      cooldown(1, 'openai', 'gpt-5'),
+      cooldown(2),
+    ], 1);
+
+    expect(result).toEqual([cooldown(2)]);
+  });
+
+  it('removes only the matching client cooldown', () => {
+    const providerLevel = cooldown(1);
+    const openAI = cooldown(1, 'openai');
+    const claude = cooldown(1, 'claude');
+    const modelLevel = cooldown(1, 'openai', 'gpt-5');
+
+    const result = removeClearedCooldowns([providerLevel, openAI, claude, modelLevel], 1, {
+      clientType: 'openai',
+    });
+
+    expect(result).toEqual([providerLevel, claude, modelLevel]);
+  });
+
+  it('removes only the matching model cooldown', () => {
+    const providerLevel = cooldown(1);
+    const keyLevel = cooldown(1, 'openai');
+    const targetModel = cooldown(1, 'openai', 'gpt-5');
+    const otherModel = cooldown(1, 'openai', 'gpt-4');
+
+    const result = removeClearedCooldowns([providerLevel, keyLevel, targetModel, otherModel], 1, {
+      clientType: 'openai',
+      model: 'gpt-5',
+    });
+
+    expect(result).toEqual([providerLevel, keyLevel, otherModel]);
+  });
+});

--- a/web/src/lib/cooldown-cache.ts
+++ b/web/src/lib/cooldown-cache.ts
@@ -1,0 +1,28 @@
+import type { Cooldown } from './transport/types';
+
+export type CooldownClearOptions = {
+  clientType?: string;
+  model?: string;
+};
+
+function normalizeScopeValue(value: string | undefined): string {
+  return value ?? '';
+}
+
+export function removeClearedCooldowns(
+  cooldowns: Cooldown[],
+  providerId: number,
+  options?: CooldownClearOptions,
+): Cooldown[] {
+  const clearAllForProvider = !options?.clientType && !options?.model;
+
+  return cooldowns.filter((cooldown) => {
+    if (cooldown.providerID !== providerId) return true;
+    if (clearAllForProvider) return false;
+
+    return !(
+      normalizeScopeValue(cooldown.clientType) === normalizeScopeValue(options?.clientType) &&
+      normalizeScopeValue(cooldown.model) === normalizeScopeValue(options?.model)
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- make manual cooldown clear update the UI optimistically instead of appearing inert while waiting for refetch
- roll back the cooldown cache if the clear request fails
- share scoped cooldown-removal logic between cooldown hooks and add regression coverage

## Validation
- cd web && pnpm vitest run src/lib/cooldown-cache.test.ts
- cd web && pnpm typecheck
- cd web && pnpm lint
- cd web && pnpm test
- cd web && pnpm build

CodeRabbit not checked/triggered in this flow unless explicitly requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 清除冷却时间后，界面会立即移除对应的冷却记录，减少等待刷新时间。
  * 支持按服务提供方、客户端类型或模型范围精准清除冷却记录。

* **错误修复**
  * 清除操作失败时自动恢复原有冷却数据，确保界面状态准确。
  * 操作完成后自动同步最新服务端数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->