### PR TITLE
fix(cooldowns): make manual unfreeze update immediately

### DIFF
--- a/web/src/contexts/cooldowns-context.tsx
+++ b/web/src/contexts/cooldowns-context.tsx
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { getTransport } from '@/lib/transport';
 import type { Cooldown, ProviderHealthLevel } from '@/lib/transport';
 import { subscribeCooldownUpdates } from '@/lib/cooldown-update-subscription';
+import { removeClearedCooldowns } from '@/lib/cooldown-cache';
 
 /** Get provider health level from its cooldowns */
 function computeHealthLevel(cooldowns: Cooldown[]): ProviderHealthLevel {
@@ -80,7 +81,21 @@ export function CooldownsProvider({ children }: CooldownsProviderProps) {
   const clearCooldownMutation = useMutation({
     mutationFn: ({ providerId, options }: { providerId: number; options?: { clientType?: string; model?: string } }) =>
       getTransport().clearCooldown(providerId, options),
-    onSuccess: () => {
+    onMutate: async ({ providerId, options }) => {
+      await queryClient.cancelQueries({ queryKey: ['cooldowns'] });
+      const previousCooldowns = queryClient.getQueryData<Cooldown[]>(['cooldowns']);
+      queryClient.setQueryData<Cooldown[]>(['cooldowns'], (current = []) =>
+        removeClearedCooldowns(current, providerId, options),
+      );
+      return { previousCooldowns };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousCooldowns) {
+        queryClient.setQueryData(['cooldowns'], context.previousCooldowns);
+      }
+      console.error('Failed to clear cooldown:', error);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
     },
   });

--- a/web/src/hooks/use-cooldowns.ts
+++ b/web/src/hooks/use-cooldowns.ts
@@ -3,6 +3,7 @@ import { getTransport } from '@/lib/transport';
 import type { Cooldown, ProviderHealthLevel } from '@/lib/transport';
 import { useEffect, useState, useCallback } from 'react';
 import { subscribeCooldownUpdates } from '@/lib/cooldown-update-subscription';
+import { removeClearedCooldowns } from '@/lib/cooldown-cache';
 
 /** Get provider health level from its cooldowns */
 function computeHealthLevel(cooldowns: Cooldown[]): ProviderHealthLevel {
@@ -60,7 +61,21 @@ export function useCooldowns() {
   const clearCooldownMutation = useMutation({
     mutationFn: ({ providerId, options }: { providerId: number; options?: { clientType?: string; model?: string } }) =>
       getTransport().clearCooldown(providerId, options),
-    onSuccess: () => {
+    onMutate: async ({ providerId, options }) => {
+      await queryClient.cancelQueries({ queryKey: ['cooldowns'] });
+      const previousCooldowns = queryClient.getQueryData<Cooldown[]>(['cooldowns']);
+      queryClient.setQueryData<Cooldown[]>(['cooldowns'], (current = []) =>
+        removeClearedCooldowns(current, providerId, options),
+      );
+      return { previousCooldowns };
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousCooldowns) {
+        queryClient.setQueryData(['cooldowns'], context.previousCooldowns);
+      }
+      console.error('Failed to clear cooldown:', error);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['cooldowns'] });
     },
   });

--- a/web/src/lib/cooldown-cache.test.ts
+++ b/web/src/lib/cooldown-cache.test.ts
@@ -42,7 +42,7 @@ describe('removeClearedCooldowns', () => {
     expect(result).toEqual([providerLevel, claude, modelLevel]);
   });
 
-  it('removes only the matching model cooldown', () => {
+  it('removes only the matching client and model cooldown', () => {
     const providerLevel = cooldown(1);
     const keyLevel = cooldown(1, 'openai');
     const targetModel = cooldown(1, 'openai', 'gpt-5');
@@ -54,5 +54,18 @@ describe('removeClearedCooldowns', () => {
     });
 
     expect(result).toEqual([providerLevel, keyLevel, otherModel]);
+  });
+
+  it('removes only the matching model-only cooldown', () => {
+    const providerLevel = cooldown(1);
+    const keyLevel = cooldown(1, 'openai');
+    const targetModel = cooldown(1, undefined, 'gpt-5');
+    const clientModel = cooldown(1, 'openai', 'gpt-5');
+
+    const result = removeClearedCooldowns([providerLevel, keyLevel, targetModel, clientModel], 1, {
+      model: 'gpt-5',
+    });
+
+    expect(result).toEqual([providerLevel, keyLevel, clientModel]);
   });
 });

--- a/web/src/lib/cooldown-cache.test.ts
+++ b/web/src/lib/cooldown-cache.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Cooldown } from './transport/types';
+import { removeClearedCooldowns } from './cooldown-cache';
+
+const baseCooldown = {
+  until: '2099-01-01T00:00:00Z',
+  reason: 'manual',
+  providerName: 'provider',
+} satisfies Omit<Cooldown, 'providerID'>;
+
+function cooldown(providerID: number, clientType?: string, model?: string): Cooldown {
+  return {
+    ...baseCooldown,
+    providerID,
+    clientType,
+    model,
+  };
+}
+
+describe('removeClearedCooldowns', () => {
+  it('removes all cooldowns for a provider when no scope is given', () => {
+    const result = removeClearedCooldowns([
+      cooldown(1),
+      cooldown(1, 'openai'),
+      cooldown(1, 'openai', 'gpt-5'),
+      cooldown(2),
+    ], 1);
+
+    expect(result).toEqual([cooldown(2)]);
+  });
+
+  it('removes only the matching client cooldown', () => {
+    const providerLevel = cooldown(1);
+    const openAI = cooldown(1, 'openai');
+    const claude = cooldown(1, 'claude');
+    const modelLevel = cooldown(1, 'openai', 'gpt-5');
+
+    const result = removeClearedCooldowns([providerLevel, openAI, claude, modelLevel], 1, {
+      clientType: 'openai',
+    });
+
+    expect(result).toEqual([providerLevel, claude, modelLevel]);
+  });
+
+  it('removes only the matching model cooldown', () => {
+    const providerLevel = cooldown(1);
+    const keyLevel = cooldown(1, 'openai');
+    const targetModel = cooldown(1, 'openai', 'gpt-5');
+    const otherModel = cooldown(1, 'openai', 'gpt-4');
+
+    const result = removeClearedCooldowns([providerLevel, keyLevel, targetModel, otherModel], 1, {
+      clientType: 'openai',
+      model: 'gpt-5',
+    });
+
+    expect(result).toEqual([providerLevel, keyLevel, otherModel]);
+  });
+});

--- a/web/src/lib/cooldown-cache.ts
+++ b/web/src/lib/cooldown-cache.ts
@@ -1,0 +1,28 @@
+import type { Cooldown } from './transport/types';
+
+export type CooldownClearOptions = {
+  clientType?: string;
+  model?: string;
+};
+
+function normalizeScopeValue(value: string | undefined): string {
+  return value ?? '';
+}
+
+export function removeClearedCooldowns(
+  cooldowns: Cooldown[],
+  providerId: number,
+  options?: CooldownClearOptions,
+): Cooldown[] {
+  const clearAllForProvider = !options?.clientType && !options?.model;
+
+  return cooldowns.filter((cooldown) => {
+    if (cooldown.providerID !== providerId) return true;
+    if (clearAllForProvider) return false;
+
+    return !(
+      normalizeScopeValue(cooldown.clientType) === normalizeScopeValue(options?.clientType) &&
+      normalizeScopeValue(cooldown.model) === normalizeScopeValue(options?.model)
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- make manual cooldown clear update the UI optimistically instead of appearing inert while waiting for refetch
- roll back the cooldown cache if the clear request fails
- share scoped cooldown-removal logic between cooldown hooks and add regression coverage, including model-only clears

## Validation
- go test ./internal/cooldown ./internal/handler ./internal/service ./internal/systemsettingcache
- cd web && pnpm vitest run src/lib/cooldown-cache.test.ts
- cd web && pnpm test
- cd web && pnpm typecheck
- cd web && pnpm build
- cd web && pnpm lint

Supersedes #744 because GitHub kept #744's pull head pinned to the old commit after the branch advanced.