### PR TITLE
feat(settings): split data and proxy access pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,8 @@ import { RetryConfigsPage } from '@/pages/retry-configs';
 import { RoutingStrategiesPage } from '@/pages/routing-strategies';
 import { ConsolePage } from '@/pages/console';
 import { SettingsPage } from '@/pages/settings';
+import { DataManagementPage } from '@/pages/data-management';
+import { ProxyAccessPage } from '@/pages/proxy-access';
 import { DiagnosticsPage } from '@/pages/diagnostics';
 import { DocumentationPage } from '@/pages/documentation';
 import { LoginPage } from '@/pages/login';
@@ -150,6 +152,22 @@ function AppRoutes() {
           />
           <Route path="stats" element={<StatsPage />} />
           <Route path="settings" element={<SettingsPage />} />
+          <Route
+            path="data-management"
+            element={
+              <AdminRoute>
+                <DataManagementPage />
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="proxy-access"
+            element={
+              <AdminRoute>
+                <ProxyAccessPage />
+              </AdminRoute>
+            }
+          />
           <Route
             path="diagnostics"
             element={

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -16,6 +16,8 @@ import {
   Workflow,
   Gauge,
   Activity,
+  ShieldCheck,
+  Database,
 } from 'lucide-react';
 import type { SidebarConfig } from '@/types/sidebar';
 import { RequestsNavItem } from './requests-nav-item';
@@ -170,6 +172,22 @@ export const sidebarConfig: SidebarConfig = {
           to: '/api-token-limits',
           icon: Gauge,
           labelKey: 'nav.apiTokenLimits',
+          adminOnly: true,
+        },
+        {
+          type: 'standard',
+          key: 'proxy-access',
+          to: '/proxy-access',
+          icon: ShieldCheck,
+          labelKey: 'nav.proxyAccess',
+          adminOnly: true,
+        },
+        {
+          type: 'standard',
+          key: 'data-management',
+          to: '/data-management',
+          icon: Database,
+          labelKey: 'nav.dataManagement',
           adminOnly: true,
         },
         {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -109,7 +109,9 @@
     "users": "Users",
     "changePassword": "Change Password",
     "managePasskeys": "Manage Passkeys",
-    "apiTokenLimits": "API Token Limits"
+    "apiTokenLimits": "API Token Limits",
+    "dataManagement": "Data Management",
+    "proxyAccess": "Proxy Access"
   },
   "userPanel": {
     "title": "User Console",
@@ -1982,5 +1984,13 @@
     "autoCooldownSeconds": "Default cooldown duration",
     "autoCooldownHint": "When upstream 429 / concurrency limits do not return Retry-After, or upstream connection errors exhaust retries and need automatic cooldown, use this value as the cooldown duration. Upstream Retry-After or explicit CooldownUntil still takes priority.",
     "autoCooldownInvalid": "Default auto-cooldown duration must be an integer between 1 and 86400."
+  },
+  "dataManagement": {
+    "title": "Data Management",
+    "description": "Control request retention, session retention, detail storage, backup export, and backup import."
+  },
+  "proxyAccess": {
+    "title": "Proxy Access",
+    "description": "Control global proxy availability, project binding, visible proxy endpoints, and route-adjacent quota refresh behavior."
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -109,7 +109,9 @@
     "users": "用户管理",
     "changePassword": "修改密码",
     "managePasskeys": "管理 Passkey",
-    "apiTokenLimits": "API Token 限流"
+    "apiTokenLimits": "API Token 限流",
+    "dataManagement": "数据管理",
+    "proxyAccess": "代理访问控制"
   },
   "userPanel": {
     "title": "用户控制台",
@@ -1978,5 +1980,13 @@
     "autoCooldownSeconds": "默认冻结时长",
     "autoCooldownHint": "当上游 429 / 并发限制没有返回 Retry-After，或上游连接错误在重试耗尽后需要自动冻结时，使用此秒数作为冻结时长；上游返回 Retry-After 或显式 CooldownUntil 时仍优先使用上游时间。",
     "autoCooldownInvalid": "自动冻结默认时长必须是 1 到 86400 之间的整数。"
+  },
+  "dataManagement": {
+    "title": "数据管理",
+    "description": "管理请求保留、会话保留、详情存储、备份导出与备份导入。"
+  },
+  "proxyAccess": {
+    "title": "代理访问控制",
+    "description": "管理全局代理可用性、强制项目绑定、可见代理入口和路由相关 quota 刷新行为。"
   }
 }

--- a/web/src/pages/data-management/index.tsx
+++ b/web/src/pages/data-management/index.tsx
@@ -1,0 +1,28 @@
+import { Database } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PageHeader } from '@/components/layout/page-header';
+import { BackupSection, DataRetentionSection } from '@/pages/settings';
+
+export function DataManagementPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <PageHeader
+        icon={Database}
+        iconClassName="text-zinc-500"
+        title={t('dataManagement.title')}
+        description={t('dataManagement.description')}
+      />
+
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="space-y-6">
+          <DataRetentionSection />
+          <BackupSection />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DataManagementPage;

--- a/web/src/pages/proxy-access/index.tsx
+++ b/web/src/pages/proxy-access/index.tsx
@@ -1,0 +1,35 @@
+import { ShieldCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PageHeader } from '@/components/layout/page-header';
+import {
+  AntigravitySection,
+  ForceProjectSection,
+  ProxyKillSwitchSection,
+  ProxyRouteExposureSection,
+} from '@/pages/settings';
+
+export function ProxyAccessPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <PageHeader
+        icon={ShieldCheck}
+        iconClassName="text-zinc-500"
+        title={t('proxyAccess.title')}
+        description={t('proxyAccess.description')}
+      />
+
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="space-y-6">
+          <ProxyKillSwitchSection />
+          <ForceProjectSection />
+          <ProxyRouteExposureSection />
+          <AntigravitySection />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProxyAccessPage;

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -130,12 +130,6 @@ export function SettingsPage() {
             <>
               <MultiTenantUISection />
               <TimezoneSection />
-              <DataRetentionSection />
-              <ProxyKillSwitchSection />
-              <ForceProjectSection />
-              <ProxyRouteExposureSection />
-              <AntigravitySection />
-              <BackupSection />
             </>
           )}
         </div>
@@ -387,7 +381,7 @@ function TimezoneSection() {
   );
 }
 
-function DataRetentionSection() {
+export function DataRetentionSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
@@ -729,7 +723,7 @@ function DataRetentionSection() {
   );
 }
 
-function ForceProjectSection() {
+export function ForceProjectSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
@@ -851,11 +845,11 @@ export function RequestDiagnosticsSection() {
   );
 }
 
-function ProxyKillSwitchSection() {
+export function ProxyKillSwitchSection() {
   return <ProxyKillSwitchCard />;
 }
 
-function ProxyRouteExposureSection() {
+export function ProxyRouteExposureSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
@@ -943,7 +937,7 @@ function ProxyRouteExposureSection() {
   );
 }
 
-function AntigravitySection() {
+export function AntigravitySection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
@@ -1322,7 +1316,7 @@ export function PprofSection() {
   );
 }
 
-function BackupSection() {
+export function BackupSection() {
   const { t } = useTranslation();
   const { transport } = useTransport();
   const fileInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary
- split data lifecycle controls into a new Data Management page
- split proxy availability and route exposure controls into a new Proxy Access page
- keep General Settings focused on general preferences, backend address, multi-tenant UI, and timezone
- add sidebar routes and English/Chinese labels for the new pages

## User-perspective validation
- visited General Settings and confirmed Data Retention / Backup / Proxy Access controls are no longer present there
- visited Proxy Access from the sidebar and confirmed request kill switch, force project binding, public proxy routes, and quota settings render together
- toggled the first proxy access switch in a temp local backend and confirmed the UI/API interaction path responds
- visited Data Management from the sidebar and confirmed Data Retention plus Backup & Restore render together
- returned to General Settings from the sidebar to confirm navigation remains stable

## Validation
- cd web && pnpm typecheck
- cd web && pnpm test (29 files / 137 tests)
- cd web && pnpm build
- cd web && pnpm lint

## Evidence
MP4 walkthrough and screenshots were generated locally from the PR branch against a temporary local Maxx backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“数据管理”页面，集中提供数据保留、备份及导入导出设置。
  - 新增“代理访问”页面，提供代理开关、项目绑定、路由可见性及配额相关设置。
  - 管理员可通过侧边栏访问上述页面。

- **改进**
  - 将相关设置从“设置”页面独立为专属页面，优化管理入口。
  - 新增中英文导航、标题与说明文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->