### PR TITLE
fix(proxy-access): remove duplicate kill switch from client routes

### DIFF
--- a/web/src/pages/client-routes/index.tsx
+++ b/web/src/pages/client-routes/index.tsx
@@ -16,7 +16,6 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react';
-import { ProxyKillSwitchCard } from '@/components/settings/proxy-kill-switch-card';
 import { ClientIcon, getClientName } from '@/components/icons/client-icons';
 import { PageHeader } from '@/components/layout/page-header';
 import type { ClientType } from '@/lib/transport';
@@ -27,7 +26,6 @@ import { useProjects, useUpdateProject, useRoutes, useProviders, routeKeys } fro
 import { useTransport } from '@/lib/transport/context';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
-import { useAuth } from '@/lib/auth-context';
 
 const SCROLL_STEP = 200;
 
@@ -136,9 +134,7 @@ function ProjectTabBar({
 
 export function ClientRoutesPage() {
   const { t } = useTranslation();
-  const { user } = useAuth();
   const { clientType } = useParams<{ clientType: string }>();
-  const isAdmin = user?.role === 'admin';
   const activeClientType = (clientType as ClientType) || 'claude';
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedProjectId, setSelectedProjectId] = useState<string>('0'); // '0' = Global
@@ -290,15 +286,6 @@ export function ClientRoutesPage() {
           </div>
         }
       />
-
-      {isAdmin && (
-        <div className="border-b border-border bg-background px-6 py-4">
-          <div className="mx-auto max-w-[1400px]">
-            <ProxyKillSwitchCard />
-          </div>
-        </div>
-      )}
-
       {/* Tabs for Global / Projects */}
       <Tabs
         value={selectedProjectId}


### PR DESCRIPTION
## Summary
- Remove the duplicate proxy kill switch card from the Client Routes page.
- Keep proxy access controls centralized on the Proxy Access admin page.

## Validation
- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm test` (29 files / 137 tests)
- `cd web && pnpm build`
- User-view browser check against local server on `:9890`:
  - `/routes/claude` no longer shows the proxy kill switch card.
  - `/proxy-access` still shows proxy access controls.
  - Browser console/page errors: 0

## Notes
- Invite code display/storage behavior is intentionally unchanged in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能调整**
  * 客户端路由页面不再显示管理专用的代理终止开关卡片。
  * 保留全局与项目路由、搜索、排序及自定义路由开关等现有功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->