### PR TITLE
fix(providers): route custom provider card to create form

### DIFF
--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -23,42 +23,12 @@ import { useProviderNavigation } from '../hooks/use-provider-navigation';
 
 export function SelectTypeStep() {
   const { formData, updateFormData } = useProviderForm();
-  const {
-    goToCustomConfig,
-    goToAntigravity,
-    goToKiro,
-    goToCodex,
-    goToClaude,
-    goToBedrock,
-    goToOpenRouter,
-    goToNewApi,
-    goToOllama,
-    goToGrok,
-    goToProviders,
-  } = useProviderNavigation();
+  const { goToCustomConfig, goToProviderConfig, goToProviders } = useProviderNavigation();
   const { t } = useTranslation();
 
   const handleSelectType = (type: ProviderFormData['type']) => {
     updateFormData({ type });
-    if (type === 'antigravity') {
-      goToAntigravity();
-    } else if (type === 'bedrock') {
-      goToBedrock();
-    } else if (type === 'openrouter') {
-      goToOpenRouter();
-    } else if (type === 'kiro') {
-      goToKiro();
-    } else if (type === 'grok') {
-      goToGrok();
-    } else if (type === 'codex') {
-      goToCodex();
-    } else if (type === 'claude') {
-      goToClaude();
-    } else if (type === 'newapi') {
-      goToNewApi();
-    } else if (type === 'ollama') {
-      goToOllama();
-    }
+    goToProviderConfig(type);
   };
 
   const handleApplyTemplate = (templateId: string) => {

--- a/web/src/pages/providers/hooks/use-provider-navigation.test.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getProviderCreatePath, PROVIDER_CREATE_PATHS } from './use-provider-navigation';
+import { PROVIDER_TYPE_CONFIGS, PROVIDER_TYPE_ORDER } from '../types';
+
+describe('provider create navigation', () => {
+  it('routes every configured provider type to a create step', () => {
+    for (const type of PROVIDER_TYPE_ORDER) {
+      expect(getProviderCreatePath(type)).toBe(PROVIDER_CREATE_PATHS[type]);
+      expect(getProviderCreatePath(type)).toMatch(/^\/providers\/create\//);
+    }
+  });
+
+  it('routes the visible Custom Provider card to the custom configuration step', () => {
+    expect(PROVIDER_TYPE_CONFIGS.custom.hidden).toBeFalsy();
+    expect(getProviderCreatePath('custom')).toBe('/providers/create/custom');
+  });
+});

--- a/web/src/pages/providers/hooks/use-provider-navigation.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.ts
@@ -1,20 +1,39 @@
 import { useNavigate } from 'react-router-dom';
+import type { ProviderTypeKey } from '../types';
+
+export const PROVIDER_CREATE_PATHS: Record<ProviderTypeKey, string> = {
+  custom: '/providers/create/custom',
+  antigravity: '/providers/create/antigravity',
+  kiro: '/providers/create/kiro',
+  codex: '/providers/create/codex',
+  claude: '/providers/create/claude',
+  bedrock: '/providers/create/bedrock',
+  openrouter: '/providers/create/openrouter',
+  newapi: '/providers/create/newapi',
+  ollama: '/providers/create/ollama',
+  grok: '/providers/create/grok',
+};
+
+export function getProviderCreatePath(type: ProviderTypeKey): string {
+  return PROVIDER_CREATE_PATHS[type];
+}
 
 export function useProviderNavigation() {
   const navigate = useNavigate();
 
   return {
     goToSelectType: () => navigate('/providers/create'),
-    goToCustomConfig: () => navigate('/providers/create/custom'),
-    goToAntigravity: () => navigate('/providers/create/antigravity'),
-    goToKiro: () => navigate('/providers/create/kiro'),
-    goToCodex: () => navigate('/providers/create/codex'),
-    goToClaude: () => navigate('/providers/create/claude'),
-    goToBedrock: () => navigate('/providers/create/bedrock'),
-    goToOpenRouter: () => navigate('/providers/create/openrouter'),
-    goToNewApi: () => navigate('/providers/create/newapi'),
-    goToOllama: () => navigate('/providers/create/ollama'),
-    goToGrok: () => navigate('/providers/create/grok'),
+    goToCustomConfig: () => navigate(PROVIDER_CREATE_PATHS.custom),
+    goToAntigravity: () => navigate(PROVIDER_CREATE_PATHS.antigravity),
+    goToKiro: () => navigate(PROVIDER_CREATE_PATHS.kiro),
+    goToCodex: () => navigate(PROVIDER_CREATE_PATHS.codex),
+    goToClaude: () => navigate(PROVIDER_CREATE_PATHS.claude),
+    goToBedrock: () => navigate(PROVIDER_CREATE_PATHS.bedrock),
+    goToOpenRouter: () => navigate(PROVIDER_CREATE_PATHS.openrouter),
+    goToNewApi: () => navigate(PROVIDER_CREATE_PATHS.newapi),
+    goToOllama: () => navigate(PROVIDER_CREATE_PATHS.ollama),
+    goToGrok: () => navigate(PROVIDER_CREATE_PATHS.grok),
+    goToProviderConfig: (type: ProviderTypeKey) => navigate(getProviderCreatePath(type)),
     goToProviders: () => navigate('/providers'),
     goBack: () => navigate(-1),
   };


### PR DESCRIPTION
## Summary
- centralize provider create-step paths in `use-provider-navigation`
- route the visible Custom Provider card to `/providers/create/custom`
- add regression coverage so every configured provider type has a create route

## Verification
- `cd web && pnpm test -- src/pages/providers/hooks/use-provider-navigation.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm build`
- User-view Playwright smoke on local `:9892` with clean data:
  - all Add Provider provider-type cards route to their expected create pages
  - Custom Provider card creates a provider and returns to `/providers`
  - Empty Template creates a provider and returns to `/providers`
  - OpenRouter creates a provider and returns to `/providers`
  - Ollama creates a provider and returns to `/providers`
  - all quick preset templates create successfully and return to `/providers`: `88 Code`, `AI Code Mirror`, `DuckCoding`, `Free Duck`, `NVIDIA NIM`, `Zhipu AI`, `DeepSeek`
  - browser page errors / console errors: 0
