### PR TITLE
fix(proxy): retry stalled streaming providers

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -576,6 +576,26 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 	return nil
 }
 
+func streamTimeoutFromFlow(c *flow.Ctx, key string, fallback time.Duration) time.Duration {
+	if c == nil {
+		return fallback
+	}
+	value, ok := c.Get(key)
+	if !ok {
+		return fallback
+	}
+	duration, ok := value.(time.Duration)
+	if !ok || duration <= 0 {
+		return fallback
+	}
+	return duration
+}
+
+type streamReadResult struct {
+	n   int
+	err error
+}
+
 func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, clientType domain.ClientType, isOAuthToken bool) error {
 	// Decompress response body if needed
 	reader, err := decompressResponse(resp)
@@ -728,6 +748,8 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 	buf := make([]byte, 4096)
 	firstChunkSent := false // Track TTFT
 	sawTerminalSSEEvent := false
+	streamFirstEventTimeout := streamTimeoutFromFlow(c, "stream_first_event_timeout", 20*time.Second)
+	streamIdleTimeout := streamTimeoutFromFlow(c, "stream_idle_timeout", 45*time.Second)
 
 	processStreamLine := func(line string) error {
 		processedLine := line
@@ -811,7 +833,41 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 		default:
 		}
 
-		n, err := reader.Read(buf)
+		readTimeout := streamIdleTimeout
+		timeoutErr := domain.ErrStreamIdleTimeout
+		timeoutMessage := "upstream stream idle timeout after response started"
+		if !firstChunkSent {
+			readTimeout = streamFirstEventTimeout
+			timeoutErr = domain.ErrFirstByteTimeout
+			timeoutMessage = "upstream stream idle timeout before response started"
+		}
+
+		readResultCh := make(chan streamReadResult, 1)
+		go func() {
+			n, readErr := reader.Read(buf)
+			readResultCh <- streamReadResult{n: n, err: readErr}
+		}()
+
+		var n int
+		var err error
+		select {
+		case <-ctx.Done():
+			sendFinalEvents()
+			proxyErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
+			proxyErr.Scope = domain.ScopeRequest
+			return proxyErr
+		case result := <-readResultCh:
+			n = result.n
+			err = result.err
+		case <-time.After(readTimeout):
+			sendFinalEvents()
+			proxyErr := domain.NewProxyErrorWithMessage(timeoutErr, !firstChunkSent, timeoutMessage)
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonNetworkError
+			proxyErr.HTTPStatusCode = http.StatusGatewayTimeout
+			return proxyErr
+		}
+
 		if n > 0 {
 			lineBuffer.Write(buf[:n])
 

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -748,8 +748,8 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 	buf := make([]byte, 4096)
 	firstChunkSent := false // Track TTFT
 	sawTerminalSSEEvent := false
-	streamFirstEventTimeout := streamTimeoutFromFlow(c, "stream_first_event_timeout", 20*time.Second)
-	streamIdleTimeout := streamTimeoutFromFlow(c, "stream_idle_timeout", 45*time.Second)
+	streamFirstEventTimeout := streamTimeoutFromFlow(c, "stream_first_event_timeout", 0)
+	streamIdleTimeout := streamTimeoutFromFlow(c, "stream_idle_timeout", 0)
 
 	processStreamLine := func(line string) error {
 		processedLine := line
@@ -842,30 +842,34 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 			timeoutMessage = "upstream stream idle timeout before response started"
 		}
 
-		readResultCh := make(chan streamReadResult, 1)
-		go func() {
-			n, readErr := reader.Read(buf)
-			readResultCh <- streamReadResult{n: n, err: readErr}
-		}()
-
 		var n int
 		var err error
-		select {
-		case <-ctx.Done():
-			sendFinalEvents()
-			proxyErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
-			proxyErr.Scope = domain.ScopeRequest
-			return proxyErr
-		case result := <-readResultCh:
-			n = result.n
-			err = result.err
-		case <-time.After(readTimeout):
-			sendFinalEvents()
-			proxyErr := domain.NewProxyErrorWithMessage(timeoutErr, !firstChunkSent, timeoutMessage)
-			proxyErr.Scope = domain.ScopeProvider
-			proxyErr.Reason = domain.CooldownReasonNetworkError
-			proxyErr.HTTPStatusCode = http.StatusGatewayTimeout
-			return proxyErr
+		if readTimeout <= 0 {
+			n, err = reader.Read(buf)
+		} else {
+			readResultCh := make(chan streamReadResult, 1)
+			go func() {
+				n, readErr := reader.Read(buf)
+				readResultCh <- streamReadResult{n: n, err: readErr}
+			}()
+
+			select {
+			case <-ctx.Done():
+				sendFinalEvents()
+				proxyErr := domain.NewProxyErrorWithMessage(ctx.Err(), false, "client disconnected")
+				proxyErr.Scope = domain.ScopeRequest
+				return proxyErr
+			case result := <-readResultCh:
+				n = result.n
+				err = result.err
+			case <-time.After(readTimeout):
+				sendFinalEvents()
+				proxyErr := domain.NewProxyErrorWithMessage(timeoutErr, !firstChunkSent, timeoutMessage)
+				proxyErr.Scope = domain.ScopeProvider
+				proxyErr.Reason = domain.CooldownReasonNetworkError
+				proxyErr.HTTPStatusCode = http.StatusGatewayTimeout
+				return proxyErr
+			}
 		}
 
 		if n > 0 {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -961,6 +961,8 @@ const (
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"
 	SettingKeyReasoningPolicy                      = "reasoning_policy"                         // 全局出站 reasoning-effort 策略（JSON 对象 {maxEffort,defaultEffort}）
 	SettingKeyForceRetryUpstreamErrors             = "force_retry_upstream_errors"              // 是否强制上游/provider 错误按路由重试策略重试，"true" 或 "false"，默认 "false"
+	SettingKeyStreamFirstEventTimeoutMS            = "stream_first_event_timeout_ms"            // 普通 HTTP/SSE 上游首事件超时毫秒数，默认 20000
+	SettingKeyStreamIdleTimeoutMS                  = "stream_idle_timeout_ms"                   // 普通 HTTP/SSE 上游事件间 idle 超时毫秒数，默认 45000
 	SettingKeyRequestFailureDetailsEnabled         = "request_failure_details_enabled"          // 是否在请求详情 Metadata 中展示增强失败详情，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRequestsDisabled                = "proxy_requests_disabled"                  // 是否全局禁用代理请求，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"      // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -961,8 +961,9 @@ const (
 	SettingKeyCodexInstructionsEnabled             = "codex_instructions_enabled"               // 是否启用 Codex 官方 instructions，"true" 或 "false"
 	SettingKeyReasoningPolicy                      = "reasoning_policy"                         // 全局出站 reasoning-effort 策略（JSON 对象 {maxEffort,defaultEffort}）
 	SettingKeyForceRetryUpstreamErrors             = "force_retry_upstream_errors"              // 是否强制上游/provider 错误按路由重试策略重试，"true" 或 "false"，默认 "false"
-	SettingKeyStreamFirstEventTimeoutMS            = "stream_first_event_timeout_ms"            // 普通 HTTP/SSE 上游首事件超时毫秒数，默认 20000
-	SettingKeyStreamIdleTimeoutMS                  = "stream_idle_timeout_ms"                   // 普通 HTTP/SSE 上游事件间 idle 超时毫秒数，默认 45000
+	SettingKeyStreamTimeoutsEnabled                = "stream_timeouts_enabled"                  // 是否启用普通 HTTP/SSE 上游流式超时，"true" 或 "false"，默认 "false"
+	SettingKeyStreamFirstEventTimeoutMS            = "stream_first_event_timeout_ms"            // 普通 HTTP/SSE 上游首事件超时毫秒数，默认 20000，仅启用 stream_timeouts_enabled 时生效
+	SettingKeyStreamIdleTimeoutMS                  = "stream_idle_timeout_ms"                   // 普通 HTTP/SSE 上游事件间 idle 超时毫秒数，默认 45000，仅启用 stream_timeouts_enabled 时生效
 	SettingKeyRequestFailureDetailsEnabled         = "request_failure_details_enabled"          // 是否在请求详情 Metadata 中展示增强失败详情，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRequestsDisabled                = "proxy_requests_disabled"                  // 是否全局禁用代理请求，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"      // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -234,6 +234,9 @@ routeLoop:
 
 			originalWriter := c.Writer
 			c.Writer = responseWriter
+			c.Set(flowKeyStreamFirstEventTimeout, e.streamFirstEventTimeout())
+			c.Set(flowKeyStreamIdleTimeout, e.streamIdleTimeout())
+
 			err := executeWithProviderSlot(releaseProvider, func() error {
 				return matchedRoute.ProviderAdapter.Execute(c, matchedRoute.Provider)
 			})

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -234,8 +234,10 @@ routeLoop:
 
 			originalWriter := c.Writer
 			c.Writer = responseWriter
-			c.Set(flowKeyStreamFirstEventTimeout, e.streamFirstEventTimeout())
-			c.Set(flowKeyStreamIdleTimeout, e.streamIdleTimeout())
+			if e.streamTimeoutsEnabled() {
+				c.Set(flowKeyStreamFirstEventTimeout, e.streamFirstEventTimeout())
+				c.Set(flowKeyStreamIdleTimeout, e.streamIdleTimeout())
+			}
 
 			err := executeWithProviderSlot(releaseProvider, func() error {
 				return matchedRoute.ProviderAdapter.Execute(c, matchedRoute.Provider)

--- a/internal/executor/stream_timeout_settings.go
+++ b/internal/executor/stream_timeout_settings.go
@@ -16,6 +16,17 @@ const (
 	defaultStreamIdleTimeout       = 45 * time.Second
 )
 
+func (e *Executor) streamTimeoutsEnabled() bool {
+	if e == nil || e.settingsRepo == nil {
+		return false
+	}
+	value, err := e.settingsRepo.Get(domain.SettingKeyStreamTimeoutsEnabled)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(strings.ToLower(value)) == "true"
+}
+
 func (e *Executor) streamFirstEventTimeout() time.Duration {
 	return e.streamTimeoutSetting(domain.SettingKeyStreamFirstEventTimeoutMS, defaultStreamFirstEventTimeout)
 }

--- a/internal/executor/stream_timeout_settings.go
+++ b/internal/executor/stream_timeout_settings.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+const (
+	flowKeyStreamFirstEventTimeout = "stream_first_event_timeout"
+	flowKeyStreamIdleTimeout       = "stream_idle_timeout"
+
+	defaultStreamFirstEventTimeout = 20 * time.Second
+	defaultStreamIdleTimeout       = 45 * time.Second
+)
+
+func (e *Executor) streamFirstEventTimeout() time.Duration {
+	return e.streamTimeoutSetting(domain.SettingKeyStreamFirstEventTimeoutMS, defaultStreamFirstEventTimeout)
+}
+
+func (e *Executor) streamIdleTimeout() time.Duration {
+	return e.streamTimeoutSetting(domain.SettingKeyStreamIdleTimeoutMS, defaultStreamIdleTimeout)
+}
+
+func (e *Executor) streamTimeoutSetting(key string, fallback time.Duration) time.Duration {
+	if e == nil || e.settingsRepo == nil {
+		return fallback
+	}
+	value, err := e.settingsRepo.Get(key)
+	if err != nil {
+		return fallback
+	}
+	milliseconds, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || milliseconds < 1000 || milliseconds > 600000 {
+		return fallback
+	}
+	return time.Duration(milliseconds) * time.Millisecond
+}

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -17,6 +17,8 @@ func validateSystemSettingValue(key, value string) error {
 		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)
+	case domain.SettingKeyStreamFirstEventTimeoutMS, domain.SettingKeyStreamIdleTimeoutMS:
+		return validateStreamTimeoutMilliseconds(key, value)
 	default:
 		return nil
 	}
@@ -39,6 +41,18 @@ func validateRateLimitCooldownDefaultSeconds(value string) error {
 	seconds, err := strconv.Atoi(trimmed)
 	if err != nil || seconds < 1 || seconds > 86400 {
 		return fmt.Errorf("%w: %s must be an integer between 1 and 86400", domain.ErrInvalidInput, domain.SettingKeyRateLimitCooldownDefaultSeconds)
+	}
+	return nil
+}
+
+func validateStreamTimeoutMilliseconds(key, value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%w: %s cannot be empty", domain.ErrInvalidInput, key)
+	}
+	milliseconds, err := strconv.Atoi(trimmed)
+	if err != nil || milliseconds < 1000 || milliseconds > 600000 {
+		return fmt.Errorf("%w: %s must be an integer between 1000 and 600000", domain.ErrInvalidInput, key)
 	}
 	return nil
 }

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -13,7 +13,7 @@ func validateSystemSettingValue(key, value string) error {
 	switch key {
 	case domain.SettingKeyReasoningPolicy:
 		return reqpolicy.ValidatePolicyJSON(value)
-	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyProxyRequestsDisabled:
+	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyProxyRequestsDisabled:
 		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)

--- a/internal/service/system_setting_validation_test.go
+++ b/internal/service/system_setting_validation_test.go
@@ -114,3 +114,27 @@ func TestAdminServiceDeleteSettingInvalidatesProxyBooleanCache(t *testing.T) {
 		t.Fatal("expected cache invalidation to expose deleted false value")
 	}
 }
+
+func TestValidateStreamTimeoutMilliseconds(t *testing.T) {
+	validKeys := []string{
+		domain.SettingKeyStreamFirstEventTimeoutMS,
+		domain.SettingKeyStreamIdleTimeoutMS,
+	}
+	for _, key := range validKeys {
+		t.Run(key+" valid", func(t *testing.T) {
+			if err := validateSystemSettingValue(key, "45000"); err != nil {
+				t.Fatalf("validateSystemSettingValue() error = %v", err)
+			}
+		})
+		t.Run(key+" too low", func(t *testing.T) {
+			if err := validateSystemSettingValue(key, "999"); err == nil {
+				t.Fatal("validateSystemSettingValue() error = nil, want error")
+			}
+		})
+		t.Run(key+" too high", func(t *testing.T) {
+			if err := validateSystemSettingValue(key, "600001"); err == nil {
+				t.Fatal("validateSystemSettingValue() error = nil, want error")
+			}
+		})
+	}
+}

--- a/internal/service/system_setting_validation_test.go
+++ b/internal/service/system_setting_validation_test.go
@@ -40,6 +40,7 @@ func (r *stubSystemSettingRepo) Delete(key string) error {
 func TestValidateSystemSettingValueBooleanSettings(t *testing.T) {
 	keys := []string{
 		domain.SettingKeyForceRetryUpstreamErrors,
+		domain.SettingKeyStreamTimeoutsEnabled,
 		domain.SettingKeyRequestFailureDetailsEnabled,
 		domain.SettingKeyProxyRequestsDisabled,
 	}

--- a/web/e2e/stream-timeouts.spec.ts
+++ b/web/e2e/stream-timeouts.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+const SETTINGS = [
+  'stream_timeouts_enabled',
+  'stream_first_event_timeout_ms',
+  'stream_idle_timeout_ms',
+];
+
+async function resetStreamTimeoutSettings(request: Parameters<typeof test>[0]['request']) {
+  for (const key of SETTINGS) {
+    await request.delete(`/api/admin/settings/${key}`);
+  }
+}
+
+test.describe('stream timeout settings', () => {
+  test.beforeEach(async ({ request }) => {
+    await resetStreamTimeoutSettings(request);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await resetStreamTimeoutSettings(request);
+  });
+
+  test('keeps upstream stream timeouts opt-in and persists user values', async ({ page }) => {
+    await page.goto('/settings');
+
+    await expect(page.getByText('Stream timeouts', { exact: true })).toBeVisible();
+    const enabledSwitch = page.getByRole('switch', { name: 'Enable upstream stream timeouts' });
+    const firstEventInput = page.getByLabel('First event timeout');
+    const idleInput = page.getByLabel('Event idle timeout');
+
+    await expect(enabledSwitch).not.toBeChecked();
+    await expect(firstEventInput).toBeDisabled();
+    await expect(idleInput).toBeDisabled();
+    await expect(firstEventInput).toHaveValue('20000');
+    await expect(idleInput).toHaveValue('45000');
+
+    await enabledSwitch.click();
+    await expect(firstEventInput).toBeEnabled();
+    await expect(idleInput).toBeEnabled();
+
+    await firstEventInput.fill('15000');
+    await idleInput.fill('55000');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect
+      .poll(async () => {
+        return page.evaluate(async () => {
+          const resp = await fetch('/api/admin/settings');
+          const settings = await resp.json();
+          return {
+            enabled: settings.stream_timeouts_enabled,
+            first: settings.stream_first_event_timeout_ms,
+            idle: settings.stream_idle_timeout_ms,
+          };
+        });
+      })
+      .toEqual({ enabled: 'true', first: '15000', idle: '55000' });
+
+    await page.reload();
+    await expect(enabledSwitch).toBeChecked();
+    await expect(firstEventInput).toHaveValue('15000');
+    await expect(idleInput).toHaveValue('55000');
+
+    await firstEventInput.fill('999');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(
+      page.getByText('Timeouts must be integers between 1000 and 600000 ms.'),
+    ).toBeVisible();
+  });
+});

--- a/web/e2e/stream-timeouts.spec.ts
+++ b/web/e2e/stream-timeouts.spec.ts
@@ -41,7 +41,9 @@ test.describe('stream timeout settings', () => {
 
     await firstEventInput.fill('15000');
     await idleInput.fill('55000');
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
 
     await expect
       .poll(async () => {
@@ -63,7 +65,7 @@ test.describe('stream timeout settings', () => {
     await expect(idleInput).toHaveValue('55000');
 
     await firstEventInput.fill('999');
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await saveButton.click();
     await expect(
       page.getByText('Timeouts must be integers between 1000 and 600000 ms.'),
     ).toBeVisible();

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1428,13 +1428,15 @@
     "forceRetryUpstreamErrorsDesc": "When enabled, provider/upstream/network/server failures that were classified as non-retryable are still retried according to the matched route retry policy.",
     "forceRetryUpstreamErrorsHint": "Request errors, invalid credentials, canceled request contexts, unsafe committed responses, and exhausted retry budgets are still not retried.",
     "streamTimeouts": "Stream timeouts",
-    "streamTimeoutsDesc": "Control how long Maxx waits for upstream streaming events before retrying or failing over.",
+    "streamTimeoutsDesc": "Optionally control how long Maxx waits for upstream streaming events before retrying or failing over.",
     "streamFirstEventTimeout": "First event timeout",
     "streamFirstEventTimeoutDesc": "Maximum wait for the first upstream streaming event before treating the provider as stalled.",
     "streamIdleTimeout": "Event idle timeout",
     "streamIdleTimeoutDesc": "Maximum gap between upstream streaming events before treating the provider as stalled.",
     "streamTimeoutInvalid": "Timeouts must be integers between 1000 and 600000 ms.",
-    "streamTimeoutsHint": "Keep the idle timeout below client-side stall protection such as the AI SDK 60000 ms watchdog so Maxx can retry first."
+    "streamTimeoutsHint": "Default is off for compatibility. Enable it and keep the idle timeout below client-side stall protection such as the AI SDK 60000 ms watchdog so Maxx can retry first.",
+    "enableStreamTimeouts": "Enable upstream stream timeouts",
+    "enableStreamTimeoutsDesc": "Default off. When disabled, Maxx keeps waiting for upstream streaming data like before."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1426,7 +1426,15 @@
     "retryBehaviorDesc": "Controls how provider and upstream failures are retried.",
     "forceRetryUpstreamErrors": "Force retry upstream errors",
     "forceRetryUpstreamErrorsDesc": "When enabled, provider/upstream/network/server failures that were classified as non-retryable are still retried according to the matched route retry policy.",
-    "forceRetryUpstreamErrorsHint": "Request errors, invalid credentials, canceled request contexts, unsafe committed responses, and exhausted retry budgets are still not retried."
+    "forceRetryUpstreamErrorsHint": "Request errors, invalid credentials, canceled request contexts, unsafe committed responses, and exhausted retry budgets are still not retried.",
+    "streamTimeouts": "Stream timeouts",
+    "streamTimeoutsDesc": "Control how long Maxx waits for upstream streaming events before retrying or failing over.",
+    "streamFirstEventTimeout": "First event timeout",
+    "streamFirstEventTimeoutDesc": "Maximum wait for the first upstream streaming event before treating the provider as stalled.",
+    "streamIdleTimeout": "Event idle timeout",
+    "streamIdleTimeoutDesc": "Maximum gap between upstream streaming events before treating the provider as stalled.",
+    "streamTimeoutInvalid": "Timeouts must be integers between 1000 and 600000 ms.",
+    "streamTimeoutsHint": "Keep the idle timeout below client-side stall protection such as the AI SDK 60000 ms watchdog so Maxx can retry first."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1425,13 +1425,15 @@
     "forceRetryUpstreamErrorsDesc": "开启后，被误分类为不可重试的 provider / 上游 / 网络 / 服务端错误仍会按命中的路由重试策略重试。",
     "forceRetryUpstreamErrorsHint": "请求错误、无效凭据、请求上下文取消、不安全的已提交响应，以及已耗尽的重试预算仍不会被重试。",
     "streamTimeouts": "流式超时",
-    "streamTimeoutsDesc": "控制 Maxx 等待上游流式事件的时间，超时后触发重试或故障转移。",
+    "streamTimeoutsDesc": "可选控制 Maxx 等待上游流式事件的时间，超时后触发重试或故障转移。",
     "streamFirstEventTimeout": "首事件超时",
     "streamFirstEventTimeoutDesc": "等待上游第一个流式事件的最长时间，超过后视为 provider 卡死。",
     "streamIdleTimeout": "事件间空闲超时",
     "streamIdleTimeoutDesc": "上游流式事件之间允许的最长间隔，超过后视为 provider 卡死。",
     "streamTimeoutInvalid": "超时时间必须是 1000 到 600000 ms 之间的整数。",
-    "streamTimeoutsHint": "建议让 idle timeout 小于 AI SDK 60000 ms 这类客户端保护阈值，这样 Maxx 能先触发重试。"
+    "streamTimeoutsHint": "默认关闭以保持兼容。开启后建议让 idle timeout 小于 AI SDK 60000 ms 这类客户端保护阈值，这样 Maxx 能先触发重试。",
+    "enableStreamTimeouts": "启用上游流式超时",
+    "enableStreamTimeoutsDesc": "默认关闭。关闭时 Maxx 保持旧行为，继续相对无限等待上游流式数据。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1423,7 +1423,15 @@
     "retryBehaviorDesc": "控制 provider 与上游失败如何重试。",
     "forceRetryUpstreamErrors": "强制重试上游错误",
     "forceRetryUpstreamErrorsDesc": "开启后，被误分类为不可重试的 provider / 上游 / 网络 / 服务端错误仍会按命中的路由重试策略重试。",
-    "forceRetryUpstreamErrorsHint": "请求错误、无效凭据、请求上下文取消、不安全的已提交响应，以及已耗尽的重试预算仍不会被重试。"
+    "forceRetryUpstreamErrorsHint": "请求错误、无效凭据、请求上下文取消、不安全的已提交响应，以及已耗尽的重试预算仍不会被重试。",
+    "streamTimeouts": "流式超时",
+    "streamTimeoutsDesc": "控制 Maxx 等待上游流式事件的时间，超时后触发重试或故障转移。",
+    "streamFirstEventTimeout": "首事件超时",
+    "streamFirstEventTimeoutDesc": "等待上游第一个流式事件的最长时间，超过后视为 provider 卡死。",
+    "streamIdleTimeout": "事件间空闲超时",
+    "streamIdleTimeoutDesc": "上游流式事件之间允许的最长间隔，超过后视为 provider 卡死。",
+    "streamTimeoutInvalid": "超时时间必须是 1000 到 600000 ms 之间的整数。",
+    "streamTimeoutsHint": "建议让 idle timeout 小于 AI SDK 60000 ms 这类客户端保护阈值，这样 Maxx 能先触发重试。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -818,6 +818,8 @@ export function RequestStreamTimeoutSection() {
   const [idleDraft, setIdleDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState('');
+  const firstEventInputId = useId();
+  const idleInputId = useId();
 
   useEffect(() => {
     if (!isLoading && !initialized) {
@@ -912,11 +914,12 @@ export function RequestStreamTimeoutSection() {
 
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
-            <Label className="text-sm font-medium text-foreground">
+            <Label htmlFor={firstEventInputId} className="text-sm font-medium text-foreground">
               {t('settings.streamFirstEventTimeout')}
             </Label>
             <div className="flex items-center gap-2">
               <Input
+                id={firstEventInputId}
                 type="number"
                 value={firstEventDraft}
                 onChange={(event) => setFirstEventDraft(event.target.value)}
@@ -933,11 +936,12 @@ export function RequestStreamTimeoutSection() {
           </div>
 
           <div className="space-y-2">
-            <Label className="text-sm font-medium text-foreground">
+            <Label htmlFor={idleInputId} className="text-sm font-medium text-foreground">
               {t('settings.streamIdleTimeout')}
             </Label>
             <div className="flex items-center gap-2">
               <Input
+                id={idleInputId}
                 type="number"
                 value={idleDraft}
                 onChange={(event) => setIdleDraft(event.target.value)}

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -66,6 +66,10 @@ function parseRetentionInteger(value: string): number | null {
 }
 
 const REQUEST_FAILURE_DETAILS_SETTING_KEY = 'request_failure_details_enabled';
+const STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY = 'stream_first_event_timeout_ms';
+const STREAM_IDLE_TIMEOUT_SETTING_KEY = 'stream_idle_timeout_ms';
+const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = '20000';
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = '45000';
 const MULTITENANT_UI_LAYOUT_SETTING_KEY = 'ui_multitenant_layout';
 type MultiTenantUILayout = 'current' | 'user_panel';
 
@@ -130,6 +134,7 @@ export function SettingsPage() {
             <>
               <MultiTenantUISection />
               <TimezoneSection />
+              <RequestStreamTimeoutSection />
             </>
           )}
         </div>
@@ -792,6 +797,140 @@ export function ForceProjectSection() {
             <span className="text-xs text-muted-foreground">{t('settings.waitTimeoutRange')}</span>
           </div>
         )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function RequestStreamTimeoutSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+
+  const firstEventTimeout = settings?.[STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY] || DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS;
+  const idleTimeout = settings?.[STREAM_IDLE_TIMEOUT_SETTING_KEY] || DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+
+  const [firstEventDraft, setFirstEventDraft] = useState('');
+  const [idleDraft, setIdleDraft] = useState('');
+  const [initialized, setInitialized] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!isLoading && !initialized) {
+      setFirstEventDraft(firstEventTimeout);
+      setIdleDraft(idleTimeout);
+      setInitialized(true);
+    }
+  }, [firstEventTimeout, idleTimeout, initialized, isLoading]);
+
+  useEffect(() => {
+    if (initialized) {
+      setFirstEventDraft(firstEventTimeout);
+      setIdleDraft(idleTimeout);
+    }
+  }, [firstEventTimeout, idleTimeout, initialized]);
+
+  const hasChanges =
+    initialized && (firstEventDraft !== firstEventTimeout || idleDraft !== idleTimeout);
+
+  const validateTimeout = (value: string) => {
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed >= 1000 && parsed <= 600000;
+  };
+
+  const handleSave = async () => {
+    if (!validateTimeout(firstEventDraft) || !validateTimeout(idleDraft)) {
+      setError(t('settings.streamTimeoutInvalid'));
+      return;
+    }
+
+    setError('');
+    if (firstEventDraft !== firstEventTimeout) {
+      await updateSetting.mutateAsync({
+        key: STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY,
+        value: firstEventDraft,
+      });
+    }
+    if (idleDraft !== idleTimeout) {
+      await updateSetting.mutateAsync({
+        key: STREAM_IDLE_TIMEOUT_SETTING_KEY,
+        value: idleDraft,
+      });
+    }
+  };
+
+  if (isLoading || !initialized) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <CardTitle className="text-base font-medium flex items-center gap-2">
+              <Activity className="h-4 w-4 text-muted-foreground" />
+              {t('settings.streamTimeouts')}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.streamTimeoutsDesc')}
+            </p>
+          </div>
+          <Button onClick={handleSave} disabled={!hasChanges || updateSetting.isPending} size="sm">
+            {updateSetting.isPending ? t('common.saving') : t('common.save')}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="p-6 space-y-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-foreground">
+              {t('settings.streamFirstEventTimeout')}
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                value={firstEventDraft}
+                onChange={(event) => setFirstEventDraft(event.target.value)}
+                min={1000}
+                max={600000}
+                step={1000}
+                disabled={updateSetting.isPending}
+              />
+              <span className="text-xs text-muted-foreground">ms</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t('settings.streamFirstEventTimeoutDesc')}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-sm font-medium text-foreground">
+              {t('settings.streamIdleTimeout')}
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                value={idleDraft}
+                onChange={(event) => setIdleDraft(event.target.value)}
+                min={1000}
+                max={600000}
+                step={1000}
+                disabled={updateSetting.isPending}
+              />
+              <span className="text-xs text-muted-foreground">ms</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t('settings.streamIdleTimeoutDesc')}
+            </p>
+          </div>
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <div className="flex items-start gap-2 p-3 rounded-md bg-blue-500/10 border border-blue-500/20">
+          <AlertTriangle className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-blue-600 dark:text-blue-400">
+            {t('settings.streamTimeoutsHint')}
+          </p>
+        </div>
       </CardContent>
     </Card>
   );

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -885,9 +885,7 @@ export function RequestStreamTimeoutSection() {
               <Activity className="h-4 w-4 text-muted-foreground" />
               {t('settings.streamTimeouts')}
             </CardTitle>
-            <p className="text-xs text-muted-foreground mt-1">
-              {t('settings.streamTimeoutsDesc')}
-            </p>
+            <p className="text-xs text-muted-foreground mt-1">{t('settings.streamTimeoutsDesc')}</p>
           </div>
           <Button onClick={handleSave} disabled={!hasChanges || updateSetting.isPending} size="sm">
             {updateSetting.isPending ? t('common.saving') : t('common.save')}
@@ -950,9 +948,7 @@ export function RequestStreamTimeoutSection() {
               />
               <span className="text-xs text-muted-foreground">ms</span>
             </div>
-            <p className="text-xs text-muted-foreground">
-              {t('settings.streamIdleTimeoutDesc')}
-            </p>
+            <p className="text-xs text-muted-foreground">{t('settings.streamIdleTimeoutDesc')}</p>
           </div>
         </div>
 

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -66,6 +66,7 @@ function parseRetentionInteger(value: string): number | null {
 }
 
 const REQUEST_FAILURE_DETAILS_SETTING_KEY = 'request_failure_details_enabled';
+const STREAM_TIMEOUTS_ENABLED_SETTING_KEY = 'stream_timeouts_enabled';
 const STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY = 'stream_first_event_timeout_ms';
 const STREAM_IDLE_TIMEOUT_SETTING_KEY = 'stream_idle_timeout_ms';
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = '20000';
@@ -807,9 +808,12 @@ export function RequestStreamTimeoutSection() {
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();
 
-  const firstEventTimeout = settings?.[STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY] || DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS;
+  const streamTimeoutsEnabled = settings?.[STREAM_TIMEOUTS_ENABLED_SETTING_KEY] === 'true';
+  const firstEventTimeout =
+    settings?.[STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY] || DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS;
   const idleTimeout = settings?.[STREAM_IDLE_TIMEOUT_SETTING_KEY] || DEFAULT_STREAM_IDLE_TIMEOUT_MS;
 
+  const [enabledDraft, setEnabledDraft] = useState(false);
   const [firstEventDraft, setFirstEventDraft] = useState('');
   const [idleDraft, setIdleDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
@@ -817,21 +821,26 @@ export function RequestStreamTimeoutSection() {
 
   useEffect(() => {
     if (!isLoading && !initialized) {
+      setEnabledDraft(streamTimeoutsEnabled);
       setFirstEventDraft(firstEventTimeout);
       setIdleDraft(idleTimeout);
       setInitialized(true);
     }
-  }, [firstEventTimeout, idleTimeout, initialized, isLoading]);
+  }, [firstEventTimeout, idleTimeout, initialized, isLoading, streamTimeoutsEnabled]);
 
   useEffect(() => {
     if (initialized) {
+      setEnabledDraft(streamTimeoutsEnabled);
       setFirstEventDraft(firstEventTimeout);
       setIdleDraft(idleTimeout);
     }
-  }, [firstEventTimeout, idleTimeout, initialized]);
+  }, [firstEventTimeout, idleTimeout, initialized, streamTimeoutsEnabled]);
 
   const hasChanges =
-    initialized && (firstEventDraft !== firstEventTimeout || idleDraft !== idleTimeout);
+    initialized &&
+    (enabledDraft !== streamTimeoutsEnabled ||
+      firstEventDraft !== firstEventTimeout ||
+      idleDraft !== idleTimeout);
 
   const validateTimeout = (value: string) => {
     const parsed = parseInt(value, 10);
@@ -845,6 +854,12 @@ export function RequestStreamTimeoutSection() {
     }
 
     setError('');
+    if (enabledDraft !== streamTimeoutsEnabled) {
+      await updateSetting.mutateAsync({
+        key: STREAM_TIMEOUTS_ENABLED_SETTING_KEY,
+        value: enabledDraft ? 'true' : 'false',
+      });
+    }
     if (firstEventDraft !== firstEventTimeout) {
       await updateSetting.mutateAsync({
         key: STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY,
@@ -880,6 +895,23 @@ export function RequestStreamTimeoutSection() {
         </div>
       </CardHeader>
       <CardContent className="p-6 space-y-4">
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/20 p-4">
+          <div>
+            <Label className="text-sm font-medium text-foreground">
+              {t('settings.enableStreamTimeouts')}
+            </Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.enableStreamTimeoutsDesc')}
+            </p>
+          </div>
+          <Switch
+            aria-label={t('settings.enableStreamTimeouts')}
+            checked={enabledDraft}
+            onCheckedChange={setEnabledDraft}
+            disabled={updateSetting.isPending}
+          />
+        </div>
+
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <Label className="text-sm font-medium text-foreground">
@@ -893,7 +925,7 @@ export function RequestStreamTimeoutSection() {
                 min={1000}
                 max={600000}
                 step={1000}
-                disabled={updateSetting.isPending}
+                disabled={updateSetting.isPending || !enabledDraft}
               />
               <span className="text-xs text-muted-foreground">ms</span>
             </div>
@@ -914,7 +946,7 @@ export function RequestStreamTimeoutSection() {
                 min={1000}
                 max={600000}
                 step={1000}
-                disabled={updateSetting.isPending}
+                disabled={updateSetting.isPending || !enabledDraft}
               />
               <span className="text-xs text-muted-foreground">ms</span>
             </div>

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, Fragment, useId } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Settings,
   Monitor,
@@ -39,7 +40,7 @@ import {
 import { PageHeader } from '@/components/layout/page-header';
 import { ProxyKillSwitchCard } from '@/components/settings/proxy-kill-switch-card';
 import { BackendAddressControl } from '@/components/backend-address-control';
-import { useSettings, useUpdateSetting, useDeleteSetting } from '@/hooks/queries';
+import { settingsKeys, useSettings, useUpdateSetting, useDeleteSetting } from '@/hooks/queries';
 import { useAuth } from '@/lib/auth-context';
 import { buildPprofUrl } from '@/lib/backend-config';
 import { useTransport } from '@/lib/transport/context';
@@ -805,7 +806,8 @@ export function ForceProjectSection() {
 
 export function RequestStreamTimeoutSection() {
   const { data: settings, isLoading } = useSettings();
-  const updateSetting = useUpdateSetting();
+  const { transport } = useTransport();
+  const queryClient = useQueryClient();
   const { t } = useTranslation();
 
   const streamTimeoutsEnabled = settings?.[STREAM_TIMEOUTS_ENABLED_SETTING_KEY] === 'true';
@@ -818,6 +820,7 @@ export function RequestStreamTimeoutSection() {
   const [idleDraft, setIdleDraft] = useState('');
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
   const firstEventInputId = useId();
   const idleInputId = useId();
 
@@ -856,23 +859,26 @@ export function RequestStreamTimeoutSection() {
     }
 
     setError('');
-    if (enabledDraft !== streamTimeoutsEnabled) {
-      await updateSetting.mutateAsync({
-        key: STREAM_TIMEOUTS_ENABLED_SETTING_KEY,
-        value: enabledDraft ? 'true' : 'false',
+    setIsSaving(true);
+    try {
+      await transport.updateSetting(
+        STREAM_TIMEOUTS_ENABLED_SETTING_KEY,
+        enabledDraft ? 'true' : 'false',
+      );
+      await transport.updateSetting(STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY, firstEventDraft);
+      await transport.updateSetting(STREAM_IDLE_TIMEOUT_SETTING_KEY, idleDraft);
+      queryClient.setQueryData<Record<string, string>>(settingsKeys.all, {
+        ...(settings || {}),
+        [STREAM_TIMEOUTS_ENABLED_SETTING_KEY]: enabledDraft ? 'true' : 'false',
+        [STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY]: firstEventDraft,
+        [STREAM_IDLE_TIMEOUT_SETTING_KEY]: idleDraft,
       });
-    }
-    if (firstEventDraft !== firstEventTimeout) {
-      await updateSetting.mutateAsync({
-        key: STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY,
-        value: firstEventDraft,
-      });
-    }
-    if (idleDraft !== idleTimeout) {
-      await updateSetting.mutateAsync({
-        key: STREAM_IDLE_TIMEOUT_SETTING_KEY,
-        value: idleDraft,
-      });
+      await queryClient.invalidateQueries({ queryKey: settingsKeys.all });
+      await queryClient.invalidateQueries({ queryKey: settingsKeys.public });
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : String(saveError));
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -889,8 +895,8 @@ export function RequestStreamTimeoutSection() {
             </CardTitle>
             <p className="text-xs text-muted-foreground mt-1">{t('settings.streamTimeoutsDesc')}</p>
           </div>
-          <Button onClick={handleSave} disabled={!hasChanges || updateSetting.isPending} size="sm">
-            {updateSetting.isPending ? t('common.saving') : t('common.save')}
+          <Button onClick={handleSave} disabled={!hasChanges || isSaving} size="sm">
+            {isSaving ? t('common.saving') : t('common.save')}
           </Button>
         </div>
       </CardHeader>
@@ -908,7 +914,7 @@ export function RequestStreamTimeoutSection() {
             aria-label={t('settings.enableStreamTimeouts')}
             checked={enabledDraft}
             onCheckedChange={setEnabledDraft}
-            disabled={updateSetting.isPending}
+            disabled={isSaving}
           />
         </div>
 
@@ -926,7 +932,7 @@ export function RequestStreamTimeoutSection() {
                 min={1000}
                 max={600000}
                 step={1000}
-                disabled={updateSetting.isPending || !enabledDraft}
+                disabled={isSaving || !enabledDraft}
               />
               <span className="text-xs text-muted-foreground">ms</span>
             </div>
@@ -948,7 +954,7 @@ export function RequestStreamTimeoutSection() {
                 min={1000}
                 max={600000}
                 step={1000}
-                disabled={updateSetting.isPending || !enabledDraft}
+                disabled={isSaving || !enabledDraft}
               />
               <span className="text-xs text-muted-foreground">ms</span>
             </div>


### PR DESCRIPTION
## Summary
- add an opt-in `stream_timeouts_enabled` setting for ordinary HTTP/SSE upstream streams
- add configurable first-event and idle timeout values that apply only when the switch is enabled
- classify enabled upstream SSE timeout stalls as provider network failures so retry/failover can run before clients hit their own stall watchdog
- expose the switch and timeout inputs in Settings with English/Chinese copy
- save all three stream-timeout settings reliably from the UI, fixing the regression found during user-flow recording
- add a Playwright regression covering default-off behavior, enabling, persistence, reload, and invalid timeout validation

## Validation
- `go test ./internal/domain ./internal/service ./internal/executor ./internal/adapter/provider/custom`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`
- `pnpm --dir web exec playwright test e2e/stream-timeouts.spec.ts --project=chromium --workers=1`

## Evidence
- User-flow recording and screenshot sequence were generated locally for the Settings UI changes.

## Notes
- Default behavior stays compatible: when the switch is off, Maxx keeps waiting for ordinary SSE upstream data as before.
- This does not change the manual cancel interaction discussed earlier.