### PR TITLE
fix(requests): refresh cleanup failed count

### DIFF
--- a/web/e2e/requests-reasoning-effort.spec.ts
+++ b/web/e2e/requests-reasoning-effort.spec.ts
@@ -4,7 +4,10 @@ async function json(route: Route, body: unknown) {
   await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
 }
 
-async function installRequestPageMocks(page: Page) {
+async function installRequestPageMocks(
+  page: Page,
+  options: { cleanupFailedCount?: number | (() => number) } = {},
+) {
   await page.addInitScript(() => {
     localStorage.setItem('maxx-admin-token', 'mock-token');
     localStorage.setItem('maxx-ui-language', 'zh');
@@ -65,9 +68,10 @@ async function installRequestPageMocks(page: Page) {
   await page.route('**/api/providers', (route) => json(route, []));
   await page.route('**/api/projects', (route) => json(route, []));
   await page.route('**/api/api-tokens', (route) => json(route, []));
-  await page.route(/\/api\/admin\/requests\/cleanup-failed-count(?:\?.*)?$/, (route) =>
-    json(route, 0),
-  );
+  await page.route(/\/api\/admin\/requests\/cleanup-failed-count(?:\?.*)?$/, (route) => {
+    const count = options.cleanupFailedCount;
+    return json(route, typeof count === 'function' ? count() : (count ?? 0));
+  });
   await page.route(/\/api\/admin\/requests\/count(?:\?.*)?$/, (route) => json(route, 1));
   await page.route(/\/api\/admin\/requests(?:\?.*)?$/, (route) =>
     json(route, { items: [request], hasMore: false, firstId: 1, lastId: 1 }),
@@ -82,21 +86,43 @@ test('request table shows reasoning effort beside a compact model column', async
   await installRequestPageMocks(page);
   await page.goto('/requests');
 
-  const modelHeader = page.getByRole('columnheader', { name: '模型', exact: true });
-  const reasoningHeader = page.getByRole('columnheader', { name: '思考深度', exact: true });
+  const modelHeader = page.getByRole('columnheader', { name: /模型/ });
+  const protocolHeader = page.getByRole('columnheader', { name: /协议/ });
+  const reasoningHeader = page.getByRole('columnheader', { name: /思考深度/ });
   const row = page.locator('[data-request-row="true"]');
 
   await expect(modelHeader).toBeVisible();
+  await expect(protocolHeader).toBeVisible();
   await expect(reasoningHeader).toBeVisible();
   await expect(row.getByText('gpt-5.6-sol', { exact: true })).toBeVisible();
+  await expect(row.getByText('SSE', { exact: true })).toBeVisible();
   await expect(row.getByText('high', { exact: true })).toBeVisible();
 
   const modelBox = await modelHeader.boundingBox();
+  const protocolBox = await protocolHeader.boundingBox();
   const reasoningBox = await reasoningHeader.boundingBox();
   expect(modelBox).not.toBeNull();
+  expect(protocolBox).not.toBeNull();
   expect(reasoningBox).not.toBeNull();
   expect(modelBox!.width).toBeLessThan(220);
-  expect(Math.abs(reasoningBox!.x - (modelBox!.x + modelBox!.width))).toBeLessThan(2);
+  expect(protocolBox!.x).toBeGreaterThan(modelBox!.x);
+  expect(reasoningBox!.x).toBeGreaterThan(protocolBox!.x);
 
   await page.screenshot({ path: testInfo.outputPath('requests-reasoning-effort.png') });
+});
+
+test('refresh enables cleanup failed button when failed records already exist without new requests', async ({
+  page,
+}) => {
+  let cleanupFailedCount = 0;
+  await installRequestPageMocks(page, { cleanupFailedCount: () => cleanupFailedCount });
+  await page.goto('/requests');
+
+  const cleanupButton = page.getByRole('button', { name: '清理失败记录' });
+  await expect(cleanupButton).toBeDisabled();
+
+  cleanupFailedCount = 2;
+  await page.getByRole('button', { name: '刷新' }).click();
+
+  await expect(cleanupButton).toBeEnabled();
 });

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -764,6 +764,7 @@ export function RequestsPage() {
     scrollContainerRef.current?.scrollTo({ top: 0 });
     refetch();
     refetchCount();
+    refetchFailedCount();
   };
 
   // 过滤模式变化时重置滚动


### PR DESCRIPTION
## Summary
- refresh the cleanup-failed request count when the Requests page manual refresh button is clicked
- add a user-view regression covering existing failed records becoming cleanable without new request events
- update the existing request table E2E expectations to match the current Model → Protocol → Reasoning column order

## Validation
- `cd web && pnpm exec playwright test e2e/requests-reasoning-effort.spec.ts --project=chromium`
- `cd web && pnpm run typecheck`
- `cd web && pnpm run lint`
- `cd web && pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 手动刷新请求页面时，会同步更新失败请求数量。
  * “清理失败记录”按钮能够根据最新数量正确显示启用或禁用状态。
  * 优化请求列表中协议、思考深度和模型信息的展示校验，确保相关内容清晰可见。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->