### PR TITLE
fix(requests): persist column preferences

### DIFF
--- a/web/e2e/requests-reasoning-effort.spec.ts
+++ b/web/e2e/requests-reasoning-effort.spec.ts
@@ -6,7 +6,10 @@ async function json(route: Route, body: unknown) {
 
 async function installRequestPageMocks(
   page: Page,
-  options: { cleanupFailedCount?: number | (() => number) } = {},
+  options: {
+    cleanupFailedCount?: number | (() => number);
+    adminSettings?: Record<string, string>;
+  } = {},
 ) {
   await page.addInitScript(() => {
     localStorage.setItem('maxx-admin-token', 'mock-token');
@@ -58,6 +61,8 @@ async function installRequestPageMocks(
       user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
     }),
   );
+  const adminSettings = options.adminSettings ?? {};
+
   await page.route('**/api/settings', (route) =>
     json(route, {
       api_token_auth_enabled: 'false',
@@ -65,6 +70,16 @@ async function installRequestPageMocks(
       ui_multitenant_enabled: 'false',
     }),
   );
+  await page.route('**/api/admin/settings', (route) => json(route, adminSettings));
+  await page.route(/\/api\/admin\/settings\/[^/]+$/, async (route) => {
+    const key = decodeURIComponent(new URL(route.request().url()).pathname.split('/').pop() ?? '');
+    if (route.request().method() === 'PUT' || route.request().method() === 'POST') {
+      const body = route.request().postDataJSON() as { value?: string };
+      adminSettings[key] = body.value ?? '';
+      return json(route, { key, value: adminSettings[key] });
+    }
+    return json(route, { key, value: adminSettings[key] ?? '' });
+  });
   await page.route('**/api/providers', (route) => json(route, []));
   await page.route('**/api/projects', (route) => json(route, []));
   await page.route('**/api/api-tokens', (route) => json(route, []));
@@ -125,4 +140,23 @@ test('refresh enables cleanup failed button when failed records already exist wi
   await page.getByRole('button', { name: '刷新' }).click();
 
   await expect(cleanupButton).toBeEnabled();
+});
+
+test('request column visibility survives page restart from backend settings', async ({ page }) => {
+  const adminSettings: Record<string, string> = {};
+  await installRequestPageMocks(page, { adminSettings });
+  await page.goto('/requests');
+
+  await expect(page.getByRole('columnheader', { name: /费用/ })).toBeVisible();
+  await page.getByRole('button', { name: '列显示与排序' }).click();
+  await page.getByRole('checkbox', { name: '费用' }).uncheck();
+  await expect(page.getByRole('columnheader', { name: /费用/ })).toBeHidden();
+  await expect
+    .poll(() => adminSettings['ui.requests.table.columns.tenant-1.user-1'])
+    .toContain('"cost":false');
+
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+
+  await expect(page.getByRole('columnheader', { name: /费用/ })).toBeHidden();
 });

--- a/web/src/pages/requests/column-prefs.test.ts
+++ b/web/src/pages/requests/column-prefs.test.ts
@@ -6,8 +6,10 @@ import {
   createDefaultColumnPrefs,
   migrateColumnPrefs,
   normalizeColumnPrefs,
+  parseColumnPrefs,
   readColumnPrefs,
   resolveVisibleColumns,
+  serializeColumnPrefs,
   writeColumnPrefs,
 } from './column-prefs';
 
@@ -78,6 +80,17 @@ describe('column-prefs', () => {
     expect(stored.order.slice(0, 2)).toEqual(['model', 'time']);
     expect(stored.visibility.provider).toBe(false);
     expect(stored.widths.model).toBe(220);
+  });
+
+  it('serializes and parses prefs for backend persistence', () => {
+    const prefs = createDefaultColumnPrefs();
+    prefs.visibility.cost = false;
+    prefs.widths.model = 210;
+
+    const parsed = parseColumnPrefs(serializeColumnPrefs(prefs));
+
+    expect(parsed?.visibility.cost).toBe(false);
+    expect(parsed?.widths.model).toBe(210);
   });
 
   it('migrates anonymous column prefs to the scoped user key', () => {

--- a/web/src/pages/requests/column-prefs.ts
+++ b/web/src/pages/requests/column-prefs.ts
@@ -110,6 +110,7 @@ export const DEFAULT_COLUMN_VISIBILITY: Readonly<Record<RequestColumnId, boolean
 };
 
 export const REQUEST_COLUMNS_STORAGE_KEY = 'maxx-requests-table-columns';
+export const REQUEST_COLUMNS_SETTING_KEY = 'ui.requests.table.columns';
 
 export type RequestColumnPrefs = {
   order: RequestColumnId[];
@@ -191,19 +192,27 @@ export function normalizeColumnPrefs(raw: unknown): RequestColumnPrefs {
   return { order, widths, visibility };
 }
 
+export function parseColumnPrefs(value: string | null | undefined): RequestColumnPrefs | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return normalizeColumnPrefs(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
+}
+
+export function serializeColumnPrefs(prefs: RequestColumnPrefs): string {
+  return JSON.stringify(normalizeColumnPrefs(prefs));
+}
+
 export function readColumnPrefs(storageKey: string): RequestColumnPrefs {
   if (typeof window === 'undefined') {
     return createDefaultColumnPrefs();
   }
-  try {
-    const raw = window.localStorage.getItem(storageKey);
-    if (!raw) {
-      return createDefaultColumnPrefs();
-    }
-    return normalizeColumnPrefs(JSON.parse(raw));
-  } catch {
-    return createDefaultColumnPrefs();
-  }
+  const prefs = parseColumnPrefs(window.localStorage.getItem(storageKey));
+  return prefs ?? createDefaultColumnPrefs();
 }
 
 /**
@@ -231,7 +240,7 @@ export function migrateColumnPrefs(storageKey: string, legacyKeys: readonly stri
     }
     try {
       const prefs = normalizeColumnPrefs(JSON.parse(raw));
-      window.localStorage.setItem(storageKey, JSON.stringify(prefs));
+      window.localStorage.setItem(storageKey, serializeColumnPrefs(prefs));
       window.localStorage.removeItem(legacyKey);
       return;
     } catch {
@@ -244,7 +253,7 @@ export function writeColumnPrefs(storageKey: string, prefs: RequestColumnPrefs):
   if (typeof window === 'undefined') {
     return;
   }
-  window.localStorage.setItem(storageKey, JSON.stringify(normalizeColumnPrefs(prefs)));
+  window.localStorage.setItem(storageKey, serializeColumnPrefs(prefs));
 }
 
 export type ColumnAvailability = {

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -22,6 +22,8 @@ import {
   useProviders,
   usePublicSettings,
   useProjects,
+  useSettings,
+  useUpdateSetting,
   useVisibleAPITokens,
 } from '@/hooks/queries';
 import {
@@ -42,13 +44,16 @@ import {
   type RequestColumnPrefs,
   MIN_COLUMN_WIDTHS,
   MAX_COLUMN_WIDTH,
+  REQUEST_COLUMNS_SETTING_KEY,
   REQUEST_COLUMNS_STORAGE_KEY,
   columnLabelKey,
   columnShortLabelKey,
   isCenteredColumn,
   migrateColumnPrefs,
+  parseColumnPrefs,
   readColumnPrefs,
   resolveVisibleColumns,
+  serializeColumnPrefs,
   writeColumnPrefs,
 } from './column-prefs';
 import { RequestsColumnSettings } from './column-settings';
@@ -256,6 +261,13 @@ function buildScopedStorageKey(baseKey: string, tenantID?: number, userID?: numb
   return `${baseKey}:tenant-${tenantID}:user-${userID}`;
 }
 
+function buildScopedSettingKey(baseKey: string, tenantID?: number, userID?: number): string {
+  if (!tenantID || !userID) {
+    return `${baseKey}.anonymous`;
+  }
+  return `${baseKey}.tenant-${tenantID}.user-${userID}`;
+}
+
 function buildColumnPrefsLegacyKeys(storageKey: string): string[] {
   return [REQUEST_COLUMNS_STORAGE_KEY, `${REQUEST_COLUMNS_STORAGE_KEY}:anonymous`].filter(
     (key) => key !== storageKey,
@@ -302,11 +314,17 @@ export function RequestsPage() {
     () => buildScopedStorageKey(REQUEST_COLUMNS_STORAGE_KEY, user?.tenantID, user?.id),
     [user?.id, user?.tenantID],
   );
+  const columnPrefsSettingKey = useMemo(
+    () => buildScopedSettingKey(REQUEST_COLUMNS_SETTING_KEY, user?.tenantID, user?.id),
+    [user?.id, user?.tenantID],
+  );
 
   const [columnPrefs, setColumnPrefs] = useState<RequestColumnPrefs>(() =>
     readColumnPrefs(columnPrefsStorageKey),
   );
   const skipNextColumnPrefsWriteRef = useRef(false);
+  const lastSavedColumnPrefsRef = useRef<string | null>(null);
+  const hydratedColumnPrefsSettingKeyRef = useRef<string | null>(null);
 
   // 过滤维度（默认令牌）
   const [filterMode, setFilterMode] = useState<RequestFilterMode>(() =>
@@ -349,6 +367,8 @@ export function RequestsPage() {
   const { data: projects = [], isSuccess: projectsIsSuccess } = useProjects();
   const { data: apiTokens = [], isSuccess: apiTokensIsSuccess } = useVisibleAPITokens();
   const { data: settings } = usePublicSettings();
+  const { data: adminSettings, isSuccess: adminSettingsIsSuccess } = useSettings();
+  const { mutate: updateSetting } = useUpdateSetting();
 
   const waitingProviderFilterValidation =
     filterMode === 'provider' && selectedProviderId !== undefined && !providersIsSuccess;
@@ -431,16 +451,69 @@ export function RequestsPage() {
   useEffect(() => {
     migrateColumnPrefs(columnPrefsStorageKey, buildColumnPrefsLegacyKeys(columnPrefsStorageKey));
     skipNextColumnPrefsWriteRef.current = true;
+    lastSavedColumnPrefsRef.current = null;
+    hydratedColumnPrefsSettingKeyRef.current = null;
     setColumnPrefs(readColumnPrefs(columnPrefsStorageKey));
   }, [columnPrefsStorageKey]);
+
+  useEffect(() => {
+    if (
+      !adminSettingsIsSuccess ||
+      hydratedColumnPrefsSettingKeyRef.current === columnPrefsSettingKey
+    ) {
+      return;
+    }
+    hydratedColumnPrefsSettingKeyRef.current = columnPrefsSettingKey;
+
+    const remotePrefs = parseColumnPrefs(adminSettings?.[columnPrefsSettingKey]);
+    if (remotePrefs) {
+      const serialized = serializeColumnPrefs(remotePrefs);
+      lastSavedColumnPrefsRef.current = serialized;
+      writeColumnPrefs(columnPrefsStorageKey, remotePrefs);
+      skipNextColumnPrefsWriteRef.current = true;
+      setColumnPrefs(remotePrefs);
+      return;
+    }
+
+    const localPrefs = readColumnPrefs(columnPrefsStorageKey);
+    const serialized = serializeColumnPrefs(localPrefs);
+    lastSavedColumnPrefsRef.current = serialized;
+    updateSetting({ key: columnPrefsSettingKey, value: serialized });
+  }, [
+    adminSettings,
+    adminSettingsIsSuccess,
+    columnPrefsSettingKey,
+    columnPrefsStorageKey,
+    updateSetting,
+  ]);
 
   useEffect(() => {
     if (skipNextColumnPrefsWriteRef.current) {
       skipNextColumnPrefsWriteRef.current = false;
       return;
     }
+
     writeColumnPrefs(columnPrefsStorageKey, columnPrefs);
-  }, [columnPrefs, columnPrefsStorageKey]);
+
+    if (!adminSettingsIsSuccess) {
+      return;
+    }
+    const serialized = serializeColumnPrefs(columnPrefs);
+    if (lastSavedColumnPrefsRef.current === serialized) {
+      return;
+    }
+    lastSavedColumnPrefsRef.current = serialized;
+    const timeout = window.setTimeout(() => {
+      updateSetting({ key: columnPrefsSettingKey, value: serialized });
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [
+    adminSettingsIsSuccess,
+    columnPrefs,
+    columnPrefsSettingKey,
+    columnPrefsStorageKey,
+    updateSetting,
+  ]);
 
   const handleColumnPrefsChange = useCallback((next: RequestColumnPrefs) => {
     setColumnPrefs(next);


### PR DESCRIPTION
## Summary
- persist Requests table column visibility/order/width preferences to backend settings scoped by tenant/user
- keep localStorage as a fallback and migration cache
- guard backend hydration so stale settings refetches do not overwrite later user changes
- add regression coverage for column visibility surviving localStorage loss/page restart

## Validation
- `cd web && pnpm exec playwright test e2e/requests-reasoning-effort.spec.ts --project=chromium`
- `cd web && pnpm run typecheck`
- `cd web && pnpm run lint`
- `cd web && pnpm test`
