### PR TITLE
fix(codex): stop WebSocket 1012 replay reconnect loops

### DIFF
--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -548,17 +549,32 @@ func (s *codexWebSocketSession) executeTurn(
 				if readErr == nil {
 					readErr = io.ErrUnexpectedEOF
 				}
-				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, "Codex websocket closed before terminal event")
+				message := "Codex websocket closed before terminal event"
+				var closeErr *websocket.CloseError
+				if errors.As(readErr, &closeErr) {
+					if strings.TrimSpace(closeErr.Text) != "" {
+						message = "Codex websocket closed: " + strings.TrimSpace(closeErr.Text)
+					}
+					if closeErr.Code == websocket.CloseServiceRestart || closeErr.Code == websocket.CloseTryAgainLater {
+						provideradapter.MarkResponsesWebSocketTransportUnavailable(providerID)
+					}
+				}
+				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, message)
 				proxyErr.Scope = domain.ScopeProvider
 				proxyErr.Reason = domain.CooldownReasonNetworkError
 				proxyErr.Code = "upstream_websocket_closed_before_terminal"
 				proxyErr.HTTPStatusCode = http.StatusBadGateway
-				return result, &domain.ResponsesWebSocketAttemptError{
+				attemptErr := &domain.ResponsesWebSocketAttemptError{
 					Err:                         proxyErr,
 					RequestFrameMayHaveBeenSent: true,
 					FirstEventReceived:          result.FirstEventReceived,
 					ClientEventSent:             result.ClientEventSent,
 				}
+				if closeErr != nil {
+					attemptErr.UpstreamCloseCode = closeErr.Code
+					attemptErr.UpstreamCloseReason = strings.TrimSpace(closeErr.Text)
+				}
+				return result, attemptErr
 			}
 			if read.messageType != websocket.TextMessage || !gjson.ValidBytes(read.payload) || !gjson.ParseBytes(read.payload).IsObject() {
 				proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "invalid Codex websocket application frame")

--- a/internal/adapter/provider/codex/websocket.go
+++ b/internal/adapter/provider/codex/websocket.go
@@ -550,14 +550,9 @@ func (s *codexWebSocketSession) executeTurn(
 					readErr = io.ErrUnexpectedEOF
 				}
 				message := "Codex websocket closed before terminal event"
-				var closeErr *websocket.CloseError
-				if errors.As(readErr, &closeErr) {
-					if strings.TrimSpace(closeErr.Text) != "" {
-						message = "Codex websocket closed: " + strings.TrimSpace(closeErr.Text)
-					}
-					if closeErr.Code == websocket.CloseServiceRestart || closeErr.Code == websocket.CloseTryAgainLater {
-						provideradapter.MarkResponsesWebSocketTransportUnavailable(providerID)
-					}
+				closeCode, closeReason, hasClose := provideradapter.ClassifyUpstreamResponsesWebSocketClose(readErr, providerID)
+				if hasClose && closeReason != "" {
+					message = "Codex websocket closed: " + closeReason
 				}
 				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, message)
 				proxyErr.Scope = domain.ScopeProvider
@@ -570,9 +565,9 @@ func (s *codexWebSocketSession) executeTurn(
 					FirstEventReceived:          result.FirstEventReceived,
 					ClientEventSent:             result.ClientEventSent,
 				}
-				if closeErr != nil {
-					attemptErr.UpstreamCloseCode = closeErr.Code
-					attemptErr.UpstreamCloseReason = strings.TrimSpace(closeErr.Text)
+				if hasClose {
+					attemptErr.UpstreamCloseCode = closeCode
+					attemptErr.UpstreamCloseReason = closeReason
 				}
 				return result, attemptErr
 			}

--- a/internal/adapter/provider/custom/websocket.go
+++ b/internal/adapter/provider/custom/websocket.go
@@ -447,14 +447,9 @@ func (s *customWebSocketSession) executeTurn(
 					readErr = io.ErrUnexpectedEOF
 				}
 				message := "custom Codex websocket closed before terminal event"
-				var closeErr *websocket.CloseError
-				if errors.As(readErr, &closeErr) {
-					if strings.TrimSpace(closeErr.Text) != "" {
-						message = "custom Codex websocket closed: " + strings.TrimSpace(closeErr.Text)
-					}
-					if closeErr.Code == websocket.CloseServiceRestart || closeErr.Code == websocket.CloseTryAgainLater {
-						provideradapter.MarkResponsesWebSocketTransportUnavailable(providerID)
-					}
+				closeCode, closeReason, hasClose := provideradapter.ClassifyUpstreamResponsesWebSocketClose(readErr, providerID)
+				if hasClose && closeReason != "" {
+					message = "custom Codex websocket closed: " + closeReason
 				}
 				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, message)
 				proxyErr.Scope = domain.ScopeProvider
@@ -467,9 +462,9 @@ func (s *customWebSocketSession) executeTurn(
 					FirstEventReceived:          result.FirstEventReceived,
 					ClientEventSent:             result.ClientEventSent,
 				}
-				if closeErr != nil {
-					attemptErr.UpstreamCloseCode = closeErr.Code
-					attemptErr.UpstreamCloseReason = strings.TrimSpace(closeErr.Text)
+				if hasClose {
+					attemptErr.UpstreamCloseCode = closeCode
+					attemptErr.UpstreamCloseReason = closeReason
 				}
 				return result, attemptErr
 			}

--- a/internal/adapter/provider/custom/websocket.go
+++ b/internal/adapter/provider/custom/websocket.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -447,20 +448,30 @@ func (s *customWebSocketSession) executeTurn(
 				}
 				message := "custom Codex websocket closed before terminal event"
 				var closeErr *websocket.CloseError
-				if errors.As(readErr, &closeErr) && strings.TrimSpace(closeErr.Text) != "" {
-					message = "custom Codex websocket closed: " + strings.TrimSpace(closeErr.Text)
+				if errors.As(readErr, &closeErr) {
+					if strings.TrimSpace(closeErr.Text) != "" {
+						message = "custom Codex websocket closed: " + strings.TrimSpace(closeErr.Text)
+					}
+					if closeErr.Code == websocket.CloseServiceRestart || closeErr.Code == websocket.CloseTryAgainLater {
+						provideradapter.MarkResponsesWebSocketTransportUnavailable(providerID)
+					}
 				}
 				proxyErr := domain.NewProxyErrorWithMessage(readErr, false, message)
 				proxyErr.Scope = domain.ScopeProvider
 				proxyErr.Reason = domain.CooldownReasonNetworkError
 				proxyErr.Code = "upstream_websocket_closed_before_terminal"
 				proxyErr.HTTPStatusCode = http.StatusBadGateway
-				return result, &domain.ResponsesWebSocketAttemptError{
+				attemptErr := &domain.ResponsesWebSocketAttemptError{
 					Err:                         proxyErr,
 					RequestFrameMayHaveBeenSent: true,
 					FirstEventReceived:          result.FirstEventReceived,
 					ClientEventSent:             result.ClientEventSent,
 				}
+				if closeErr != nil {
+					attemptErr.UpstreamCloseCode = closeErr.Code
+					attemptErr.UpstreamCloseReason = strings.TrimSpace(closeErr.Text)
+				}
+				return result, attemptErr
 			}
 			if read.messageType != websocket.TextMessage || !gjson.ValidBytes(read.payload) || !gjson.ParseBytes(read.payload).IsObject() {
 				proxyErr := domain.NewProxyErrorWithMessage(domain.ErrResponsesWebSocketProtocol, false, "invalid custom Codex websocket application frame")

--- a/internal/adapter/provider/custom/websocket_test.go
+++ b/internal/adapter/provider/custom/websocket_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/domain"
@@ -134,6 +135,63 @@ func TestExecuteResponsesWebSocket_CustomCodexGateway(t *testing.T) {
 	adapter.CloseResponsesWebSocketConnection(connectionID)
 	if releasedSlots.Load() != 1 {
 		t.Fatalf("released slots after close = %d, want 1", releasedSlots.Load())
+	}
+}
+
+func TestExecuteResponsesWebSocket_PreservesServiceRestart(t *testing.T) {
+	const (
+		providerID = uint64(43)
+		reason     = "upstream requires HTTP replay"
+	)
+	provideradapter.ClearResponsesWebSocketTransportCooldown(providerID)
+	t.Cleanup(func() { provideradapter.ClearResponsesWebSocketTransportCooldown(providerID) })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 4096, 4096)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read: %v", err)
+			return
+		}
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseServiceRestart, reason),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	provider := &domain.Provider{
+		ID:                   providerID,
+		Type:                 "custom",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL:            upstream.URL + "/v1",
+			APIKey:             "sk-live",
+			ResponsesWebSocket: boolPtr(true),
+		}},
+	}
+	adapter := &CustomAdapter{provider: provider}
+	_, err := adapter.ExecuteResponsesWebSocket(newCustomWSTestContext(t), provider, &domain.ResponsesWebSocketExchange{
+		ConnectionID: uuid.NewString(),
+		Frame:        []byte(`{"type":"response.create","model":"gpt-test","stream":true,"input":[]}`),
+		Sink:         &recordingCustomWSSink{},
+	})
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	if !errors.As(err, &wsErr) {
+		t.Fatalf("error = %#v, want ResponsesWebSocketAttemptError", err)
+	}
+	if wsErr.UpstreamCloseCode != websocket.CloseServiceRestart || wsErr.UpstreamCloseReason != reason {
+		t.Fatalf("upstream close = (%d, %q), want (%d, %q)", wsErr.UpstreamCloseCode, wsErr.UpstreamCloseReason, websocket.CloseServiceRestart, reason)
+	}
+	if provideradapter.ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("provider remained websocket-available after upstream 1012")
 	}
 }
 

--- a/internal/adapter/provider/responses_websocket_close.go
+++ b/internal/adapter/provider/responses_websocket_close.go
@@ -1,0 +1,23 @@
+package provider
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+// ClassifyUpstreamResponsesWebSocketClose extracts structured close metadata
+// and applies transport-only cooldown policy for restart/retry signals.
+func ClassifyUpstreamResponsesWebSocketClose(err error, providerID uint64) (code int, reason string, ok bool) {
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		return 0, "", false
+	}
+	code = closeErr.Code
+	reason = strings.TrimSpace(closeErr.Text)
+	if code == websocket.CloseServiceRestart || code == websocket.CloseTryAgainLater {
+		MarkResponsesWebSocketTransportUnavailable(providerID)
+	}
+	return code, reason, true
+}

--- a/internal/adapter/provider/responses_websocket_close_test.go
+++ b/internal/adapter/provider/responses_websocket_close_test.go
@@ -1,0 +1,31 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestClassifyUpstreamResponsesWebSocketClose(t *testing.T) {
+	const providerID = uint64(99103)
+	ClearResponsesWebSocketTransportCooldown(providerID)
+	t.Cleanup(func() { ClearResponsesWebSocketTransportCooldown(providerID) })
+
+	code, reason, ok := ClassifyUpstreamResponsesWebSocketClose(
+		&websocket.CloseError{Code: websocket.CloseServiceRestart, Text: " replay over HTTP "},
+		providerID,
+	)
+	if !ok || code != websocket.CloseServiceRestart || reason != "replay over HTTP" {
+		t.Fatalf("classified close = (%d, %q, %v)", code, reason, ok)
+	}
+	if ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("1012 did not trigger websocket transport cooldown")
+	}
+}
+
+func TestClassifyUpstreamResponsesWebSocketCloseIgnoresOrdinaryErrors(t *testing.T) {
+	if code, reason, ok := ClassifyUpstreamResponsesWebSocketClose(errors.New("read failed"), 99104); ok || code != 0 || reason != "" {
+		t.Fatalf("ordinary error classified as close = (%d, %q, %v)", code, reason, ok)
+	}
+}

--- a/internal/adapter/provider/responses_websocket_cooldown.go
+++ b/internal/adapter/provider/responses_websocket_cooldown.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+const responsesWebSocketTransportCooldownTTL = 30 * time.Second
+
+type responsesWebSocketTransportCooldownStore struct {
+	mu      sync.Mutex
+	entries map[uint64]time.Time
+}
+
+var responsesWebSocketTransportCooldowns = &responsesWebSocketTransportCooldownStore{
+	entries: make(map[uint64]time.Time),
+}
+
+// MarkResponsesWebSocketTransportUnavailable temporarily removes a provider
+// from Responses WebSocket routing without affecting its HTTP/SSE traffic.
+func MarkResponsesWebSocketTransportUnavailable(providerID uint64) {
+	if providerID == 0 {
+		return
+	}
+	responsesWebSocketTransportCooldowns.mu.Lock()
+	responsesWebSocketTransportCooldowns.entries[providerID] = time.Now().Add(responsesWebSocketTransportCooldownTTL)
+	responsesWebSocketTransportCooldowns.mu.Unlock()
+}
+
+// ResponsesWebSocketTransportAvailable reports whether a provider may accept
+// a new upstream Responses WebSocket session.
+func ResponsesWebSocketTransportAvailable(providerID uint64) bool {
+	if providerID == 0 {
+		return false
+	}
+	now := time.Now()
+	responsesWebSocketTransportCooldowns.mu.Lock()
+	defer responsesWebSocketTransportCooldowns.mu.Unlock()
+	expiresAt, ok := responsesWebSocketTransportCooldowns.entries[providerID]
+	if !ok {
+		return true
+	}
+	if !now.Before(expiresAt) {
+		delete(responsesWebSocketTransportCooldowns.entries, providerID)
+		return true
+	}
+	return false
+}
+
+// ClearResponsesWebSocketTransportCooldown allows a refreshed provider
+// configuration to probe its WebSocket endpoint immediately.
+func ClearResponsesWebSocketTransportCooldown(providerID uint64) {
+	responsesWebSocketTransportCooldowns.mu.Lock()
+	delete(responsesWebSocketTransportCooldowns.entries, providerID)
+	responsesWebSocketTransportCooldowns.mu.Unlock()
+}

--- a/internal/adapter/provider/responses_websocket_cooldown_test.go
+++ b/internal/adapter/provider/responses_websocket_cooldown_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"testing"
+	"time"
+)
+
+func TestResponsesWebSocketTransportCooldown(t *testing.T) {
+	const providerID = uint64(99101)
+	ClearResponsesWebSocketTransportCooldown(providerID)
+	t.Cleanup(func() { ClearResponsesWebSocketTransportCooldown(providerID) })
+
+	if !ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("provider unexpectedly unavailable before cooldown")
+	}
+	MarkResponsesWebSocketTransportUnavailable(providerID)
+	if ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("provider remained available during websocket transport cooldown")
+	}
+	ClearResponsesWebSocketTransportCooldown(providerID)
+	if !ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("provider remained unavailable after cooldown clear")
+	}
+}
+
+func TestResponsesWebSocketTransportCooldownExpires(t *testing.T) {
+	const providerID = uint64(99102)
+	ClearResponsesWebSocketTransportCooldown(providerID)
+	t.Cleanup(func() { ClearResponsesWebSocketTransportCooldown(providerID) })
+
+	responsesWebSocketTransportCooldowns.mu.Lock()
+	responsesWebSocketTransportCooldowns.entries[providerID] = time.Now().Add(-time.Second)
+	responsesWebSocketTransportCooldowns.mu.Unlock()
+
+	if !ResponsesWebSocketTransportAvailable(providerID) {
+		t.Fatal("expired websocket transport cooldown was not removed")
+	}
+}

--- a/internal/domain/responses_websocket.go
+++ b/internal/domain/responses_websocket.go
@@ -53,6 +53,8 @@ type ResponsesWebSocketAttemptError struct {
 	FirstEventReceived          bool
 	ClientEventSent             bool
 	TerminalErrorEventSent      bool
+	UpstreamCloseCode           int
+	UpstreamCloseReason         string
 
 	// CapabilityFailure is used only for cooldown/unsupported cache.
 	// It must never trigger cross-provider fallback.

--- a/internal/handler/responses_websocket.go
+++ b/internal/handler/responses_websocket.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
@@ -75,7 +76,7 @@ func (c *responsesWebSocketClient) close(code int, reason string) {
 	c.closeOnce.Do(func() {
 		close(c.done)
 		if c.conn != nil {
-			_ = c.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, reason), time.Now().Add(10*time.Second))
+			_ = c.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(code, sanitizeResponsesWebSocketCloseReason(reason)), time.Now().Add(10*time.Second))
 			_ = c.conn.Close()
 		}
 	})
@@ -213,6 +214,10 @@ func (h *ProxyHandler) serveResponsesWebSocket(w http.ResponseWriter, r *http.Re
 			if flowCtx.Err == nil {
 				continue
 			}
+			if code, reason, ok := responsesWebSocketForwardedClose(flowCtx.Err); ok {
+				client.close(code, reason)
+				return
+			}
 			if responsesWebSocketErrorAlreadySent(flowCtx.Err) {
 				continue
 			}
@@ -338,6 +343,31 @@ func (h *ProxyHandler) runResponsesWebSocketTurn(
 func responsesWebSocketErrorAlreadySent(err error) bool {
 	var wsErr *domain.ResponsesWebSocketAttemptError
 	return errors.As(err, &wsErr) && wsErr.TerminalErrorEventSent
+}
+
+func responsesWebSocketForwardedClose(err error) (int, string, bool) {
+	var wsErr *domain.ResponsesWebSocketAttemptError
+	if !errors.As(err, &wsErr) {
+		return 0, "", false
+	}
+	switch wsErr.UpstreamCloseCode {
+	case websocket.CloseMessageTooBig, websocket.CloseServiceRestart, websocket.CloseTryAgainLater:
+		return wsErr.UpstreamCloseCode, sanitizeResponsesWebSocketCloseReason(wsErr.UpstreamCloseReason), true
+	default:
+		return 0, "", false
+	}
+}
+
+func sanitizeResponsesWebSocketCloseReason(reason string) string {
+	reason = strings.ToValidUTF8(strings.TrimSpace(reason), "")
+	if len(reason) <= 123 {
+		return reason
+	}
+	truncated := []byte(reason)[:123]
+	for len(truncated) > 0 && !utf8.Valid(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return string(truncated)
 }
 
 func responsesWebSocketTurnCommitted(err error) bool {

--- a/internal/handler/responses_websocket_test.go
+++ b/internal/handler/responses_websocket_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	maxxctx "github.com/awsl-project/maxx/internal/context"
 	"github.com/awsl-project/maxx/internal/domain"
@@ -202,5 +204,40 @@ func TestResponsesWebSocketErrorAlreadySentRequiresTerminalError(t *testing.T) {
 	}
 	if !responsesWebSocketErrorAlreadySent(terminal) {
 		t.Fatal("forwarded terminal error event was not recognized")
+	}
+}
+
+func TestResponsesWebSocketForwardedClose(t *testing.T) {
+	for _, code := range []int{
+		websocket.CloseMessageTooBig,
+		websocket.CloseServiceRestart,
+		websocket.CloseTryAgainLater,
+	} {
+		err := &domain.ResponsesWebSocketAttemptError{
+			Err:                 errors.New("upstream closed"),
+			UpstreamCloseCode:   code,
+			UpstreamCloseReason: " upstream close reason ",
+		}
+		gotCode, gotReason, ok := responsesWebSocketForwardedClose(err)
+		if !ok || gotCode != code || gotReason != "upstream close reason" {
+			t.Fatalf("forwarded close = (%d, %q, %v), want (%d, %q, true)", gotCode, gotReason, ok, code, "upstream close reason")
+		}
+	}
+	if _, _, ok := responsesWebSocketForwardedClose(&domain.ResponsesWebSocketAttemptError{
+		Err:               errors.New("upstream closed"),
+		UpstreamCloseCode: websocket.CloseInternalServerErr,
+	}); ok {
+		t.Fatal("unsafe upstream close code 1011 was forwarded")
+	}
+}
+
+func TestSanitizeResponsesWebSocketCloseReason(t *testing.T) {
+	reason := "  " + strings.Repeat("中", 100) + string([]byte{0xff}) + "  "
+	got := sanitizeResponsesWebSocketCloseReason(reason)
+	if len(got) > 123 {
+		t.Fatalf("sanitized close reason length = %d, want <= 123", len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("sanitized close reason is not valid UTF-8")
 	}
 }

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -289,6 +289,79 @@ func TestHasResponsesWebSocketProvider(t *testing.T) {
 	}
 }
 
+func TestResponsesWebSocketTransportCooldownAffectsOnlyWebSocket(t *testing.T) {
+	const providerID = uint64(501)
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: providerID, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+		},
+		[]*domain.Provider{
+			{ID: providerID, TenantID: 1, Type: wsRouterNativeType, Name: "ws", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	provideradapter.MarkResponsesWebSocketTransportUnavailable(providerID)
+	t.Cleanup(func() { provideradapter.ClearResponsesWebSocketTransportCooldown(providerID) })
+
+	if r.HasResponsesWebSocketProvider(1, 0) {
+		t.Fatal("websocket handshake pre-check ignored transport cooldown")
+	}
+	_, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+	})
+	if !errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
+		t.Fatalf("websocket Match error = %v, want ErrNoResponsesWebSocketProviders", err)
+	}
+	result, err := r.Match(&MatchContext{
+		TenantID:     1,
+		ClientType:   domain.ClientTypeCodex,
+		RequestModel: "gpt-test",
+	})
+	if err != nil {
+		t.Fatalf("HTTP/SSE Match: %v", err)
+	}
+	if ids := matchedProviderIDs(result); len(ids) != 1 || ids[0] != providerID {
+		t.Fatalf("HTTP/SSE matched provider IDs = %v, want %d", ids, providerID)
+	}
+}
+
+func TestResponsesWebSocketTransportCooldownKeepsOtherProviderAvailable(t *testing.T) {
+	const (
+		cooledProviderID = uint64(511)
+		readyProviderID  = uint64(512)
+	)
+	r := newResponsesWebSocketTestRouter(t,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: cooledProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 2, TenantID: 1, ProviderID: readyProviderID, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: cooledProviderID, TenantID: 1, Type: wsRouterNativeType, Name: "cooled", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+			{ID: readyProviderID, TenantID: 1, Type: wsRouterNativeType, Name: "ready", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+		},
+	)
+	provideradapter.MarkResponsesWebSocketTransportUnavailable(cooledProviderID)
+	t.Cleanup(func() { provideradapter.ClearResponsesWebSocketTransportCooldown(cooledProviderID) })
+
+	if !r.HasResponsesWebSocketProvider(1, 0) {
+		t.Fatal("ready websocket provider was hidden by another provider's cooldown")
+	}
+	result, err := r.Match(&MatchContext{
+		TenantID:                  1,
+		ClientType:                domain.ClientTypeCodex,
+		RequestModel:              "gpt-test",
+		RequireResponsesWebSocket: true,
+	})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if ids := matchedProviderIDs(result); len(ids) != 1 || ids[0] != readyProviderID {
+		t.Fatalf("matched provider IDs = %v, want only %d", ids, readyProviderID)
+	}
+}
+
 // Only providers that natively support Codex and whose adapter implements
 // ResponsesWebSocketAdapter are eligible. Stale is_native=false is ignored.
 func TestMatch_ResponsesWebSocketOnlyNativeCapableAdaptersEligible(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -143,6 +143,7 @@ func (r *Router) RefreshAdapter(p *domain.Provider) error {
 		return err
 	}
 	r.injectProviderUpdate(a, p)
+	provider.ClearResponsesWebSocketTransportCooldown(p.ID)
 	r.mu.Lock()
 	r.adapters[p.ID] = a
 	r.mu.Unlock()
@@ -151,6 +152,7 @@ func (r *Router) RefreshAdapter(p *domain.Provider) error {
 
 // RemoveAdapter removes the adapter for a provider
 func (r *Router) RemoveAdapter(providerID uint64) {
+	provider.ClearResponsesWebSocketTransportCooldown(providerID)
 	r.mu.Lock()
 	delete(r.adapters, providerID)
 	r.mu.Unlock()
@@ -302,6 +304,10 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		// the historical routes.is_native snapshot for WebSocket eligibility.
 		native := domain.RouteIsNative(prov, route)
 		if ctx.RequireResponsesWebSocket {
+			if !provider.ResponsesWebSocketTransportAvailable(prov.ID) {
+				sawTransientSkip = true
+				continue
+			}
 			wsAdapter := adapterSupportsResponsesWebSocket(adp)
 			wsEnabled := domain.ProviderResponsesWebSocketEnabled(prov)
 			if !native || !wsAdapter || !wsEnabled {
@@ -503,6 +509,9 @@ func (r *Router) HasResponsesWebSocketProvider(tenantID, projectID uint64) bool 
 			continue
 		}
 		if !domain.ProviderResponsesWebSocketEnabled(prov) {
+			continue
+		}
+		if !provider.ResponsesWebSocketTransportAvailable(prov.ID) {
 			continue
 		}
 		return true
@@ -748,6 +757,7 @@ func (r *Router) GetCooldowns() ([]*domain.Cooldown, error) {
 // Clears all cooldowns (global + per-client-type) for the provider
 func (r *Router) ClearCooldown(providerID uint64) error {
 	r.cooldownManager.ClearCooldown(providerID, "", "")
+	provider.ClearResponsesWebSocketTransportCooldown(providerID)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- preserve upstream Responses WebSocket close code and reason in structured attempt errors
- forward safe upstream close codes 1009, 1012, and 1013 before emitting a JSON error frame
- add a 30-second WebSocket-only provider transport cooldown for upstream 1012/1013
- make route matching and handshake preflight use the same WebSocket transport availability state
- keep HTTP/SSE routing available while the WebSocket transport is cooling down
- sanitize close reasons to valid UTF-8 within the 123-byte control-frame limit

## Why

An upstream CPA 1012 Service Restart was converted into a JSON 502 plus downstream 1011. Codex then reconnected, while the handshake preflight still treated the provider as WebSocket-capable. That allowed repeated upgrade/replay cycles and elevated CPU usage.

After this change, the original 1012 reaches the client, the affected provider is temporarily excluded only from WebSocket routing, and the next handshake returns HTTP 426 when no other WebSocket provider is available so Codex can fall back to HTTP/SSE.

## Validation

- `go vet ./cmd/... ./internal/...`
- `go test ./internal/adapter/provider ./internal/adapter/provider/custom ./internal/adapter/provider/codex ./internal/domain ./internal/handler ./internal/router -count=1`
- `go build -o /tmp/maxx-ci-build ./cmd/maxx`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 上游 WebSocket 触发“服务重启/稍后重试”时，自动进行短暂传输冷却，并可按需立即清理以恢复可用性。
  * 上游 WebSocket 关闭码与关闭原因会被更准确记录，并在符合条件时转发给客户端。
* **问题修复**
  * 路由选择更智能：冷却期间仅影响 WebSocket 升级路径，不影响其他连接方式。
  * 关闭原因在转发前进行 UTF-8 校验与长度限制，避免异常/超长内容。
* **测试/保障**
  * 新增覆盖冷却、关闭分类与转发行为的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->