### PR TITLE
fix(providers): expose visibility controls in edit flow

### DIFF
--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -444,6 +444,8 @@ type EditFormData = {
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
   maxConcurrency: number;
+  excludeFromExport: boolean;
+  blackBox: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。
   responsesPassthrough?: boolean;
   // false/undefined = 不启用 Codex Responses WebSocket；true = 允许 WS 上游。
@@ -517,11 +519,16 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       smartMappingRetryEnabled: provider.config?.smartMappingRetryEnabled ?? false,
       smartMappingRetryLimit: provider.config?.smartMappingRetryLimit ?? 1,
       maxConcurrency: normalizeMaxConcurrency(provider.maxConcurrency),
+      excludeFromExport: !!provider.excludeFromExport || !!provider.blackBox,
+      blackBox: !!provider.blackBox,
       responsesPassthrough: provider.config?.custom?.responsesPassthrough,
       responsesWebSocket: provider.config?.custom?.responsesWebSocket === true,
     };
   });
   const providerConfigIsWriteOnly = !!provider.excludeFromExport;
+  const excludeFromExportLocked = providerConfigIsWriteOnly;
+  const effectiveExcludeFromExport =
+    excludeFromExportLocked || !!formData.blackBox || !!formData.excludeFromExport;
   const runtimeModelsPreview = useMemo<ProviderRuntimeModelsPreviewRequest | undefined>(() => {
     const clientBaseURL: Partial<Record<ClientType, string>> = {};
     formData.clients.forEach((client) => {
@@ -645,7 +652,8 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
         exposedModelsEnabled: formData.exposedModelsEnabled,
         exposedModels: formData.exposedModels.length > 0 ? formData.exposedModels : undefined,
-        excludeFromExport: !!provider.excludeFromExport,
+        excludeFromExport: effectiveExcludeFromExport,
+        blackBox: !!formData.blackBox,
       };
 
       await updateProvider.mutateAsync({ id: Number(provider.id), data });
@@ -719,6 +727,8 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         supportModels: formData.supportModels.length > 0 ? formData.supportModels : undefined,
         exposedModelsEnabled: formData.exposedModelsEnabled,
         exposedModels: formData.exposedModels.length > 0 ? formData.exposedModels : undefined,
+        excludeFromExport: effectiveExcludeFromExport,
+        blackBox: !!formData.blackBox,
       };
 
       const newProvider = await createProvider.mutateAsync(data);
@@ -1137,6 +1147,54 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                       </div>
                     )}
                   </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+                {t('provider.visibilityAndExport')}
+              </h3>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.blackBox')}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t('provider.blackBoxDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={!!formData.blackBox}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        blackBox: checked,
+                        excludeFromExport: checked ? true : prev.excludeFromExport,
+                      }))
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.excludeFromExport')}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {excludeFromExportLocked
+                        ? t('provider.excludeFromExportLockedDesc')
+                        : t('provider.excludeFromExportDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={effectiveExcludeFromExport}
+                    disabled={excludeFromExportLocked || !!formData.blackBox}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
+                    }
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add Visibility and Export controls to the custom provider edit flow
- persist `excludeFromExport` and `blackBox` changes on save
- carry the same visibility choices into clone payloads
- keep already hidden-secret providers locked so old endpoints/secrets cannot be revealed by toggling the setting off

## Validation
- `cd web && pnpm typecheck`
- `cd web && pnpm build` (only existing Vite large chunk warning)
- mocked Playwright user-flow check for normal provider, black-box linkage, and hidden-secret locked state
- `go test ./...`

## Notes
- This only changes the provider edit UI/save/clone path; request routing/provider adapter behavior is untouched.
- CodeRabbit was not checked or requested for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 提供方编辑页面新增“黑箱”设置，可控制提供方的可见性。
  * 新增“导出排除”设置，支持将提供方排除在导出内容之外。
  * 当提供方状态不支持写入或启用“黑箱”时，“导出排除”会自动启用并锁定，同时显示相应说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->