### PR TITLE
fix(providers): align edit visibility section order

### DIFF
--- a/web/e2e/provider-visibility-order-regression.spec.ts
+++ b/web/e2e/provider-visibility-order-regression.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+async function sectionTop(section: Locator) {
+  const box = await section.boundingBox();
+  expect(box).not.toBeNull();
+  return box!.y;
+}
+
+function heading(page: Page, name: RegExp) {
+  return page.getByRole('heading', { name }).first();
+}
+
+async function expectCustomProviderSectionOrder(page: Page) {
+  const clientConfig = heading(page, /Client Configuration|客户端配置/);
+  const errorCooldown = heading(page, /Automatic Error Freeze|错误自动冻结/);
+  const visibilityAndExport = heading(page, /Visibility and Export|可见性与导出/);
+
+  await expect(clientConfig).toBeVisible();
+  await expect(errorCooldown).toBeVisible();
+  await expect(visibilityAndExport).toBeVisible();
+
+  expect(await sectionTop(errorCooldown)).toBeGreaterThan(await sectionTop(clientConfig));
+  expect(await sectionTop(visibilityAndExport)).toBeGreaterThan(await sectionTop(errorCooldown));
+}
+
+test.use({ viewport: { width: 1440, height: 1800 }, locale: 'zh-CN' });
+
+test.describe('Custom provider visibility/export section order', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('maxx-admin-token', 'mock-token');
+      localStorage.setItem('maxx-ui-language', 'zh');
+    });
+  });
+
+  test('edit flow keeps visibility/export in the same position as create flow', async ({ page }) => {
+    await page.goto('/providers/create/custom');
+    await expectCustomProviderSectionOrder(page);
+
+    await page.goto('/providers/1/edit');
+    await expectCustomProviderSectionOrder(page);
+  });
+});

--- a/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
+++ b/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const editFlowSource = readFileSync(
+  join(process.cwd(), 'src/pages/providers/components/provider-edit-flow.tsx'),
+  'utf8',
+);
+
+describe('ProviderEditFlow section layout', () => {
+  it('keeps visibility and export in the same relative position as custom provider creation', () => {
+    const clientConfig = editFlowSource.indexOf("t('provider.clientConfig')");
+    const errorCooldown = editFlowSource.indexOf("t('provider.errorCooldownTitle')");
+    const visibilityAndExport = editFlowSource.indexOf("t('provider.visibilityAndExport')");
+    const supportModels = editFlowSource.indexOf('<ProviderSupportModels');
+
+    expect(clientConfig).toBeGreaterThan(-1);
+    expect(errorCooldown).toBeGreaterThan(clientConfig);
+    expect(visibilityAndExport).toBeGreaterThan(errorCooldown);
+    expect(supportModels).toBeGreaterThan(visibilityAndExport);
+  });
+});

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -1153,54 +1153,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
 
             <div className="space-y-6">
               <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
-                {t('provider.visibilityAndExport')}
-              </h3>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.blackBox')}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {t('provider.blackBoxDesc')}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={!!formData.blackBox}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        blackBox: checked,
-                        excludeFromExport: checked ? true : prev.excludeFromExport,
-                      }))
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.excludeFromExport')}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {excludeFromExportLocked
-                        ? t('provider.excludeFromExportLockedDesc')
-                        : t('provider.excludeFromExportDesc')}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={effectiveExcludeFromExport}
-                    disabled={excludeFromExportLocked || !!formData.blackBox}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-6">
-              <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
                 {t('provider.clientConfig')}
               </h3>
               <ClientsConfigSection
@@ -1280,6 +1232,54 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                     setFormData((prev) => ({ ...prev, responsesPassthrough: checked }))
                   }
                 />
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+                {t('provider.visibilityAndExport')}
+              </h3>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.blackBox')}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t('provider.blackBoxDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={!!formData.blackBox}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        blackBox: checked,
+                        excludeFromExport: checked ? true : prev.excludeFromExport,
+                      }))
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.excludeFromExport')}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {excludeFromExportLocked
+                        ? t('provider.excludeFromExportLockedDesc')
+                        : t('provider.excludeFromExportDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={effectiveExcludeFromExport}
+                    disabled={excludeFromExportLocked || !!formData.blackBox}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
+                    }
+                  />
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Move the custom provider edit flow "Visibility and Export" section to match the create flow position.
- Add a source-order regression test for the edit flow layout.
- Add a Playwright user-flow regression covering create/edit section order.

## Verification
- `cd web && pnpm test src/pages/providers/components/provider-edit-flow-layout.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm build` (passes; existing Vite large chunk warning only)
- `cd web && pnpm exec playwright test e2e/provider-visibility-order-regression.spec.ts`
- `cd web && pnpm test`
- `go test ./...`

## Notes
- CodeRabbit was not checked or triggered because this task did not explicitly authorize CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 调整自定义提供者编辑页面的分区顺序，使客户端配置、错误自动冻结、可见性与导出按一致顺序展示。
  - 优化客户端配置相关选项的展示位置与交互。

- **测试**
  - 新增回归测试，验证创建和编辑自定义提供者时各分区的垂直顺序保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->