### PR TITLE
fix(ui): polish invite usage and routing layout

### DIFF
--- a/web/e2e/invite-routing-layout-regression.spec.ts
+++ b/web/e2e/invite-routing-layout-regression.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+async function installCommonMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+
+  await page.route('**/api/settings', (route) =>
+    json(route, {
+      api_token_auth_enabled: 'true',
+      force_project_binding: 'false',
+      ui_multitenant_enabled: 'true',
+    }),
+  );
+  await page.route('**/api/admin/settings', (route) =>
+    json(route, {
+      api_token_auth_enabled: 'true',
+      force_project_binding: 'false',
+      ui_multitenant_enabled: 'true',
+    }),
+  );
+  await page.route('**/api/admin/auth/status', (route) =>
+    json(route, {
+      authEnabled: true,
+      user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
+    }),
+  );
+  await page.route('**/api/proxy-status', (route) =>
+    json(route, { running: true, address: '127.0.0.1', port: 9880, version: 'e2e' }),
+  );
+  await page.route('**/api/admin/proxy-status', (route) =>
+    json(route, { running: true, address: '127.0.0.1', port: 9880, version: 'e2e' }),
+  );
+  await page.route('**/api/admin/provider-stats**', (route) => json(route, []));
+  await page.route('**/api/admin/streaming-requests/counts**', (route) => json(route, {}));
+}
+
+test.use({ viewport: { width: 1440, height: 1000 }, locale: 'zh-CN' });
+
+test.describe('Invite code and routing strategy UI regressions', () => {
+  test('invite code usages dialog removes the prefix placeholder while keeping the code visible', async ({
+    page,
+  }) => {
+    await installCommonMocks(page);
+    await page.route('**/api/admin/invite-codes', (route) =>
+      json(route, [
+        {
+          id: 1,
+          createdAt: '2026-07-29T00:00:00Z',
+          updatedAt: '2026-07-29T00:00:00Z',
+          tenantID: 1,
+          codePrefix: 'BKAX2GFJ',
+          status: 'active',
+          maxUses: 1,
+          usedCount: 1,
+          createdByUserID: 1,
+          note: '',
+        },
+      ]),
+    );
+    await page.route('**/api/admin/invite-codes/1/usages', (route) =>
+      json(route, [
+        {
+          id: 11,
+          createdAt: '2026-07-29T00:00:00Z',
+          updatedAt: '2026-07-29T00:00:00Z',
+          tenantID: 1,
+          inviteCodeID: 1,
+          userID: 2,
+          username: 'tester',
+          usedAt: '2026-07-29T00:00:00Z',
+          ip: '127.0.0.1',
+          userAgent: 'playwright',
+          result: 'success',
+        },
+      ]),
+    );
+
+    await page.goto('/invite-codes');
+    await page.getByRole('button', { name: '查看使用记录' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('heading', { name: '邀请码 BKAX2GFJ 的使用记录' })).toBeVisible();
+    await expect(dialog.getByText('前缀: BKAX2GFJ')).toHaveCount(0);
+    await expect(dialog.getByText('tester')).toBeVisible();
+  });
+
+  test('routing strategy content aligns to the shared page padding instead of an extra centered wrapper', async ({
+    page,
+  }) => {
+    await installCommonMocks(page);
+    await page.route('**/api/admin/projects', (route) => json(route, []));
+    await page.route('**/api/admin/routing-strategies', (route) =>
+      json(route, [
+        {
+          id: 1,
+          createdAt: '2026-07-29T00:00:00Z',
+          updatedAt: '2026-07-29T00:00:00Z',
+          tenantID: 1,
+          projectID: 0,
+          type: 'priority',
+          config: null,
+        },
+      ]),
+    );
+
+    await page.goto('/routing-strategies');
+
+    const scroller = page.locator('.flex-1.overflow-auto.p-4.md\\:p-6');
+    const card = page.getByText('全部策略').locator('xpath=ancestor::*[contains(@class, "rounded")][1]');
+    await expect(card).toBeVisible();
+
+    const scrollerBox = await scroller.boundingBox();
+    const cardBox = await card.boundingBox();
+    expect(scrollerBox).not.toBeNull();
+    expect(cardBox).not.toBeNull();
+    expect(Math.round(cardBox!.x - scrollerBox!.x)).toBe(24);
+  });
+});

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1144,6 +1144,7 @@
     "createdDescription": "Copy these codes now. They will only be shown once.",
     "copyAll": "Copy All Codes",
     "usagesTitle": "Invite Code Usages",
+    "usagesTitleWithCode": "Invite code {{codePrefix}} usages",
     "usageUser": "User",
     "usageTime": "Used At",
     "usageIP": "IP Address"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1141,6 +1141,7 @@
     "createdDescription": "请立即复制，邀请码仅显示一次。",
     "copyAll": "复制全部",
     "usagesTitle": "邀请码使用记录",
+    "usagesTitleWithCode": "邀请码 {{codePrefix}} 的使用记录",
     "usageUser": "用户",
     "usageTime": "使用时间",
     "usageIP": "IP 地址"

--- a/web/src/pages/invite-codes/index.tsx
+++ b/web/src/pages/invite-codes/index.tsx
@@ -339,12 +339,11 @@ export function InviteCodesPage() {
       <Dialog open={!!usageDialogCode} onOpenChange={() => setUsageDialogCode(null)}>
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>{t('inviteCodes.usagesTitle')}</DialogTitle>
-            <DialogDescription>
+            <DialogTitle>
               {usageDialogCode
-                ? `${t('inviteCodes.codePrefix')}: ${usageDialogCode.codePrefix}`
-                : ''}
-            </DialogDescription>
+                ? t('inviteCodes.usagesTitleWithCode', { codePrefix: usageDialogCode.codePrefix })
+                : t('inviteCodes.usagesTitle')}
+            </DialogTitle>
           </DialogHeader>
           <div className="max-h-80 overflow-auto">
             {usagesLoading ? (

--- a/web/src/pages/invite-codes/invite-code-usage-dialog-copy.test.ts
+++ b/web/src/pages/invite-codes/invite-code-usage-dialog-copy.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/pages/invite-codes/index.tsx'), 'utf8');
+const zh = readFileSync(join(process.cwd(), 'src/locales/zh.json'), 'utf8');
+const en = readFileSync(join(process.cwd(), 'src/locales/en.json'), 'utf8');
+
+describe('invite code usage dialog copy', () => {
+  it('shows the selected invite code in the title without the prefix placeholder label', () => {
+    expect(source).toContain("t('inviteCodes.usagesTitleWithCode'");
+    expect(source).not.toContain("`${t('inviteCodes.codePrefix')}: ${usageDialogCode.codePrefix}`");
+    expect(zh).toContain('"usagesTitleWithCode": "邀请码 {{codePrefix}} 的使用记录"');
+    expect(en).toContain('"usagesTitleWithCode": "Invite code {{codePrefix}} usages"');
+  });
+});

--- a/web/src/pages/routing-strategies/index.tsx
+++ b/web/src/pages/routing-strategies/index.tsx
@@ -129,7 +129,7 @@ export function RoutingStrategiesPage() {
       />
 
       <div className="flex-1 overflow-auto p-4 md:p-6">
-        <div className="space-y-6 max-w-7xl mx-auto">
+        <div className="space-y-6">
           {showForm && (
             <Card>
               <CardHeader>

--- a/web/src/pages/routing-strategies/routing-strategy-page-layout.test.ts
+++ b/web/src/pages/routing-strategies/routing-strategy-page-layout.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/pages/routing-strategies/index.tsx'), 'utf8');
+
+describe('routing strategies page layout', () => {
+  it('uses the shared page padding without an extra centered max-width wrapper', () => {
+    expect(source).toContain('flex-1 overflow-auto p-4 md:p-6');
+    expect(source).toContain('className="space-y-6"');
+    expect(source).not.toContain('space-y-6 max-w-7xl mx-auto');
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the invite code usages dialog placeholder-style `Prefix: ...` copy and show the selected code in the dialog title.
- Align the routing strategies page content with the shared page padding by removing its extra centered max-width wrapper.
- Add source-level and Playwright regressions for the invite dialog copy and routing strategy page layout.

## Verification
- `cd web && pnpm test src/pages/invite-codes/invite-code-usage-dialog-copy.test.ts src/pages/routing-strategies/routing-strategy-page-layout.test.ts`
- `cd web && pnpm exec playwright test e2e/invite-routing-layout-regression.spec.ts`
- `cd web && pnpm test`
- `cd web && pnpm typecheck`
- `cd web && pnpm build` (passes; existing Vite large chunk warning only)
- `go test ./...`

## Notes
- CodeRabbit was not checked or triggered because this task did not explicitly authorize CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化邀请码使用记录弹窗标题，直接显示完整邀请码内容，不再出现多余的前缀占位符。
  * 调整“路由策略”页面布局，使页面内容与统一的页面内边距保持对齐。

* **测试**
  * 新增邀请码弹窗与路由策略页面布局的自动化回归测试，覆盖中英文文案和视觉对齐。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->