### PR TITLE
fix(api-tokens): add bulk validity reset

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1568,6 +1568,10 @@
       "more": "and {{count}} more token(s)",
       "lastResult": "Last cleanup removed {{count}} expired token(s)."
     },
+    "reactivateExpired": {
+      "button": "Reset validity ({{count}})",
+      "lastResult": "Last reset restored {{count}} expired token(s)."
+    },
     "newTokenDialog": {
       "title": "Token Created Successfully",
       "description": "Copy your new API token now. ",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1565,6 +1565,10 @@
       "more": "以及另外 {{count}} 个令牌",
       "lastResult": "上次已清理 {{count}} 个已过期令牌。"
     },
+    "reactivateExpired": {
+      "button": "一键恢复有效 ({{count}})",
+      "lastResult": "上次已恢复 {{count}} 个已过期令牌。"
+    },
     "newTokenDialog": {
       "title": "令牌创建成功",
       "description": "请立即复制您的新 API 令牌。",

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -90,6 +90,8 @@ export function APITokensPage() {
   const [deletingToken, setDeletingToken] = useState<APIToken | null>(null);
   const [cleanupExpiredDialogOpen, setCleanupExpiredDialogOpen] = useState(false);
   const [lastCleanupCount, setLastCleanupCount] = useState<number | null>(null);
+  const [lastReactivatedCount, setLastReactivatedCount] = useState<number | null>(null);
+  const [isReactivatingExpired, setIsReactivatingExpired] = useState(false);
   const [newTokenDialog, setNewTokenDialog] = useState<{
     token: string;
     name: string;
@@ -204,6 +206,25 @@ export function APITokensPage() {
       id: token.id,
       data: buildAPITokenReactivatePayload(),
     });
+  };
+
+  const handleReactivateExpiredTokens = async () => {
+    if (expiredTokens.length === 0) return;
+
+    setIsReactivatingExpired(true);
+    try {
+      await Promise.all(
+        expiredTokens.map((token) =>
+          updateToken.mutateAsync({
+            id: token.id,
+            data: buildAPITokenReactivatePayload(),
+          }),
+        ),
+      );
+      setLastReactivatedCount(expiredTokens.length);
+    } finally {
+      setIsReactivatingExpired(false);
+    }
   };
 
   const handleDelete = () => {
@@ -424,21 +445,45 @@ export function APITokensPage() {
                         {t('apiTokens.cleanupExpired.lastResult', { count: lastCleanupCount })}
                       </p>
                     )}
-                  </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setCleanupExpiredDialogOpen(true)}
-                    disabled={expiredTokenCount === 0 || cleanupExpiredTokens.isPending}
-                    className="self-start text-destructive hover:text-destructive sm:self-auto"
-                  >
-                    {cleanupExpiredTokens.isPending ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Trash2 className="mr-2 h-4 w-4" />
+                    {lastReactivatedCount !== null && (
+                      <p className="text-xs text-text-muted">
+                        {t('apiTokens.reactivateExpired.lastResult', {
+                          count: lastReactivatedCount,
+                        })}
+                      </p>
                     )}
-                    {t('apiTokens.cleanupExpired.button', { count: expiredTokenCount })}
-                  </Button>
+                  </div>
+                  <div className="flex flex-col gap-2 self-start sm:self-auto md:flex-row">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleReactivateExpiredTokens}
+                      disabled={
+                        expiredTokenCount === 0 || updateToken.isPending || isReactivatingExpired
+                      }
+                    >
+                      {isReactivatingExpired ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                      )}
+                      {t('apiTokens.reactivateExpired.button', { count: expiredTokenCount })}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCleanupExpiredDialogOpen(true)}
+                      disabled={expiredTokenCount === 0 || cleanupExpiredTokens.isPending}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      {cleanupExpiredTokens.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="mr-2 h-4 w-4" />
+                      )}
+                      {t('apiTokens.cleanupExpired.button', { count: expiredTokenCount })}
+                    </Button>
+                  </div>
                 </div>
                 <Table>
                   <TableHeader>
@@ -567,7 +612,7 @@ export function APITokensPage() {
                                 size="sm"
                                 aria-label={t('apiTokens.reactivateToken')}
                                 title={t('apiTokens.reactivateToken')}
-                                disabled={updateToken.isPending}
+                                disabled={updateToken.isPending || isReactivatingExpired}
                                 onClick={() => handleReactivateToken(token)}
                               >
                                 <RotateCcw className="h-4 w-4" />

--- a/web/src/pages/api-tokens/reactivate-expired-actions.test.ts
+++ b/web/src/pages/api-tokens/reactivate-expired-actions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const page = readFileSync(join(process.cwd(), 'src/pages/api-tokens/index.tsx'), 'utf8');
+const zh = readFileSync(join(process.cwd(), 'src/locales/zh.json'), 'utf8');
+const en = readFileSync(join(process.cwd(), 'src/locales/en.json'), 'utf8');
+
+describe('API token expired reactivation actions', () => {
+  it('adds a bulk restore action for all expired tokens', () => {
+    expect(page).toContain('handleReactivateExpiredTokens');
+    expect(page).toContain('expiredTokens.map((token) =>');
+    expect(page).toContain('updateToken.mutateAsync');
+    expect(page).toContain('buildAPITokenReactivatePayload()');
+    expect(page).toContain("t('apiTokens.reactivateExpired.button'");
+  });
+
+  it('disables row restore while bulk restore is running', () => {
+    expect(page).toContain('isReactivatingExpired');
+    expect(page).toContain('disabled={updateToken.isPending || isReactivatingExpired}');
+  });
+
+  it('ships localized bulk restore copy', () => {
+    expect(zh).toContain('一键恢复有效 ({{count}})');
+    expect(zh).toContain('上次已恢复 {{count}} 个已过期令牌。');
+    expect(en).toContain('Reset validity ({{count}})');
+    expect(en).toContain('Last reset restored {{count}} expired token(s).');
+  });
+});


### PR DESCRIPTION
## Summary
- add an API token list action to reset validity for all currently expired tokens
- reuse the existing `resetValidity` update payload so restored tokens are enabled and have expiry/inactivity metadata cleared
- disable per-row restore while the bulk restore action is running and show the last restored count

## Validation
- `cd web && pnpm test src/pages/api-tokens/form-utils.test.ts src/pages/api-tokens/reactivate-expired-actions.test.ts`
- `cd web && pnpm typecheck`
- `cd web && pnpm test`
- `cd web && pnpm build`
- `go test ./...`
- `git diff --check`

CodeRabbit was not checked or triggered by this task.
