### PR TITLE
feat(providers): support custom reasoning policy

### DIFF
--- a/internal/reqpolicy/reqpolicy.go
+++ b/internal/reqpolicy/reqpolicy.go
@@ -80,9 +80,9 @@ type codec struct {
 
 func identity(s string) string { return s }
 
-// codecFor returns the effort codec for an outbound protocol, or nil when the
-// protocol has no simple string effort field this phase handles (e.g. Claude,
-// whose depth is a thinking-token budget).
+// codecFor returns the effort codec for outbound protocols that expose a simple
+// string effort field. Claude is handled separately because its thinking depth
+// is represented as a token budget.
 func codecFor(protocol domain.ClientType) *codec {
 	switch protocol {
 	case domain.ClientTypeOpenAI:
@@ -125,6 +125,126 @@ func (c *codec) write(body []byte, rank int) []byte {
 		return body
 	}
 	return out
+}
+
+func rankForClaudeThinkingBudget(budget int64) (int, bool) {
+	switch {
+	case budget < 0:
+		return 0, false
+	case budget == 0:
+		return rankNone, true
+	case budget <= 1024:
+		return rankLow, true
+	case budget <= 8192:
+		return rankMedium, true
+	default:
+		return rankHigh, true
+	}
+}
+
+func claudeThinkingBudgetForRank(rank int) int64 {
+	switch rank {
+	case rankMinimal, rankLow:
+		return 1024
+	case rankMedium:
+		return 8192
+	case rankHigh:
+		return 16000
+	default:
+		return 0
+	}
+}
+
+func readClaudeEffort(body []byte) effortValue {
+	if v := gjson.GetBytes(body, "output_config.effort"); v.Type == gjson.String {
+		s := v.String()
+		if strings.TrimSpace(s) == "" {
+			return effortValue{}
+		}
+		if isAuto(s) {
+			return effortValue{present: true, auto: true}
+		}
+		if rank, ok := parseRank(s); ok {
+			return effortValue{present: true, hasRank: true, rank: rank}
+		}
+		return effortValue{present: true}
+	}
+
+	thinkingType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "thinking.type").String()))
+	switch thinkingType {
+	case "disabled":
+		return effortValue{present: true, hasRank: true, rank: rankNone}
+	case "adaptive":
+		return effortValue{present: true, auto: true}
+	case "enabled":
+		budget := gjson.GetBytes(body, "thinking.budget_tokens")
+		if !budget.Exists() {
+			return effortValue{present: true, auto: true}
+		}
+		if budget.Type != gjson.Number {
+			return effortValue{present: true}
+		}
+		if rank, ok := rankForClaudeThinkingBudget(budget.Int()); ok {
+			return effortValue{present: true, hasRank: true, rank: rank}
+		}
+		return effortValue{present: true}
+	default:
+		return effortValue{}
+	}
+}
+
+func writeClaudeEffort(body []byte, rank int) []byte {
+	if rank == rankNone {
+		out, err := sjson.SetBytes(body, "thinking.type", "disabled")
+		if err != nil {
+			return body
+		}
+		if out, err = sjson.DeleteBytes(out, "thinking.budget_tokens"); err == nil {
+			return out
+		}
+		return body
+	}
+
+	budget := claudeThinkingBudgetForRank(rank)
+	if budget <= 0 {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "thinking.type", "enabled")
+	if err != nil {
+		return body
+	}
+	out, err = sjson.SetBytes(out, "thinking.budget_tokens", budget)
+	if err != nil {
+		return body
+	}
+	return ensureClaudeMaxTokensExceedsThinkingBudget(out, budget)
+}
+
+func ensureClaudeMaxTokensExceedsThinkingBudget(body []byte, budget int64) []byte {
+	maxTokens := gjson.GetBytes(body, "max_tokens")
+	if !maxTokens.Exists() || maxTokens.Type != gjson.Number || maxTokens.Int() > budget {
+		return body
+	}
+	out, err := sjson.SetBytes(body, "max_tokens", budget+1)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func applyClaude(body []byte, eff Effective) []byte {
+	v := readClaudeEffort(body)
+	if !v.present && eff.hasDefault {
+		body = writeClaudeEffort(body, eff.defaultRank)
+		v = effortValue{present: true, hasRank: true, rank: eff.defaultRank}
+	}
+	if eff.hasMax && v.present {
+		exceeds := v.auto || !v.hasRank || v.rank > eff.maxRank
+		if exceeds {
+			body = writeClaudeEffort(body, eff.maxRank)
+		}
+	}
+	return body
 }
 
 // Effective is a resolved policy: the composed ceiling and default a single
@@ -190,6 +310,9 @@ func globDefault(p *domain.ReasoningPolicy) string {
 func Apply(body []byte, protocol domain.ClientType, eff Effective) []byte {
 	if eff.IsZero() {
 		return body
+	}
+	if protocol == domain.ClientTypeClaude {
+		return applyClaude(body, eff)
 	}
 	c := codecFor(protocol)
 	if c == nil {

--- a/internal/reqpolicy/reqpolicy_test.go
+++ b/internal/reqpolicy/reqpolicy_test.go
@@ -105,12 +105,48 @@ func TestApply_GeminiUpperCaseWire(t *testing.T) {
 	}
 }
 
+func TestApply_ClaudeDefaultWritesThinkingBudget(t *testing.T) {
+	eff := Resolve(nil, mustPolicy("", "medium"), "")
+	out := Apply([]byte(`{"model":"claude-sonnet","max_tokens":4096}`), domain.ClientTypeClaude, eff)
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want enabled; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "thinking.budget_tokens").Int(); got != 8192 {
+		t.Fatalf("thinking.budget_tokens = %d, want 8192; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 8193 {
+		t.Fatalf("max_tokens = %d, want bumped above thinking budget; body=%s", got, out)
+	}
+}
+
+func TestApply_ClaudeClampsExistingThinkingBudget(t *testing.T) {
+	eff := Resolve(nil, mustPolicy("low", ""), "")
+	out := Apply([]byte(`{"thinking":{"type":"enabled","budget_tokens":20000},"max_tokens":30000}`), domain.ClientTypeClaude, eff)
+	if got := gjson.GetBytes(out, "thinking.budget_tokens").Int(); got != 1024 {
+		t.Fatalf("thinking.budget_tokens = %d, want 1024; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 30000 {
+		t.Fatalf("max_tokens = %d, want unchanged above budget; body=%s", got, out)
+	}
+}
+
+func TestApply_ClaudeNoneDisablesThinking(t *testing.T) {
+	eff := Resolve(nil, mustPolicy("none", ""), "")
+	out := Apply([]byte(`{"thinking":{"type":"enabled","budget_tokens":2048}}`), domain.ClientTypeClaude, eff)
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "disabled" {
+		t.Fatalf("thinking.type = %q, want disabled; body=%s", got, out)
+	}
+	if gjson.GetBytes(out, "thinking.budget_tokens").Exists() {
+		t.Fatalf("thinking.budget_tokens should be removed; body=%s", out)
+	}
+}
+
 func TestApply_UnsupportedProtocolNoOp(t *testing.T) {
 	eff := Resolve(nil, mustPolicy("low", "low"), "")
-	in := []byte(`{"thinking":{"type":"enabled","budget_tokens":20000}}`)
-	out := Apply(in, domain.ClientTypeClaude, eff)
+	in := []byte(`{"reasoning_effort":"high"}`)
+	out := Apply(in, domain.ClientType("future"), eff)
 	if string(out) != string(in) {
-		t.Fatalf("claude body mutated: %s", out)
+		t.Fatalf("unsupported protocol mutated body: %s", out)
 	}
 }
 

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -10,6 +10,7 @@ export type {
   ProviderRuntimeModelsResult,
   ProviderRuntimeModelsPreviewRequest,
   ProviderConfig,
+  ReasoningPolicy,
   ProviderConfigCustom,
   ProviderConfigCustomDisguise,
   DisguiseClaudeCodeOptions,

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -34,6 +34,11 @@ export interface ProviderConfigCustomDisguise {
   claudeCode?: DisguiseClaudeCodeOptions;
 }
 
+export interface ReasoningPolicy {
+  maxEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+  defaultEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+}
+
 export interface ProviderConfigCustom {
   baseURL: string;
   backend?: 'ollama';
@@ -178,6 +183,7 @@ export interface ProviderConfig {
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
+  reasoning?: ReasoningPolicy;
   custom?: ProviderConfigCustom;
   antigravity?: ProviderConfigAntigravity;
   bedrock?: ProviderConfigBedrock;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1745,7 +1745,21 @@
     "excludeFromExport": "Do not export this provider",
     "excludeFromExportDesc": "When enabled, this provider and its configuration will not be included in provider exports or system backups, and saved API endpoints and provider secrets will not be revealed on the edit page. Enter a new value to rotate one.",
     "cloneExcludeFromExportDesc": "Applies only to the newly cloned provider. When enabled, the clone will not be exported, and saved API endpoints and provider secrets will not be revealed on the edit page.",
-    "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly."
+    "excludeFromExportLockedDesc": "This provider is already in hidden-secret mode. To avoid exposing the old secret by toggling this off, the switch cannot be disabled directly.",
+    "reasoningPolicy": "Reasoning Policy",
+    "reasoningPolicyDesc": "Control outbound reasoning/thinking depth for this provider. Defaults fill only when the client omits a value; maximum clamps values that exceed the provider limit.",
+    "reasoningDefaultEffort": "Default effort",
+    "reasoningDefaultEffortDesc": "Used only when the client request does not specify reasoning or thinking depth.",
+    "reasoningMaxEffort": "Maximum effort",
+    "reasoningMaxEffortDesc": "Caps client-supplied values above this level. Leave unset to allow the request value through.",
+    "reasoningUnset": "Not set",
+    "reasoningEffort": {
+      "none": "None",
+      "minimal": "Minimal",
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High"
+    }
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1742,7 +1742,21 @@
     "excludeFromExport": "不导出此提供商配置",
     "excludeFromExportDesc": "开启后，此提供商及其配置不会被包含在提供商导出或系统备份中；保存后的 API 端点和提供商密钥也不会在编辑页回显，只能重新输入轮换。",
     "cloneExcludeFromExportDesc": "仅用于新克隆出的提供商。开启后，克隆出的提供商不会被导出，且保存后的 API 端点和提供商密钥不会在编辑页回显。",
-    "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。"
+    "excludeFromExportLockedDesc": "该提供商已进入密钥隐藏模式。为了避免通过关闭开关读回旧密钥，当前开关不可直接关闭。",
+    "reasoningPolicy": "思考程度策略",
+    "reasoningPolicyDesc": "控制该提供商出站请求的 reasoning / thinking 程度。默认值只在客户端未指定时填充；最大值会钳制超过上限的请求。",
+    "reasoningDefaultEffort": "默认思考程度",
+    "reasoningDefaultEffortDesc": "仅当客户端请求没有指定 reasoning 或 thinking 程度时生效。",
+    "reasoningMaxEffort": "最大思考程度",
+    "reasoningMaxEffortDesc": "限制客户端请求中超过该级别的思考程度；留空表示不限制。",
+    "reasoningUnset": "不设置",
+    "reasoningEffort": {
+      "none": "关闭",
+      "minimal": "极低",
+      "low": "低",
+      "medium": "中",
+      "high": "高"
+    }
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -39,6 +39,7 @@ import { useProviderNavigation } from '../hooks/use-provider-navigation';
 import { buildDisguisePayload } from '../utils/disguise';
 import { buildProviderRuntimeModelOptions } from './provider-model-mappings';
 import { SmartMappingRetrySettings } from './smart-mapping-retry-settings';
+import { ReasoningPolicySettings } from './reasoning-policy-settings';
 import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
@@ -144,6 +145,7 @@ export function CustomConfigStep() {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
+          reasoning: formData.reasoning,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -374,6 +376,10 @@ export function CustomConfigStep() {
               mappingTargetCount={mappingTargetCount}
               onEnabledChange={(checked) => updateFormData({ smartMappingRetryEnabled: checked })}
               onRetryLimitChange={(limit) => updateFormData({ smartMappingRetryLimit: limit })}
+            />
+            <ReasoningPolicySettings
+              value={formData.reasoning}
+              onChange={(reasoning) => updateFormData({ reasoning })}
             />
             <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
               <div className="pr-4">

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -50,6 +50,7 @@ import { OllamaProviderView } from './ollama-provider-view';
 import { GrokProviderView } from './grok-provider-view';
 import { ProviderModelMappings } from './provider-model-mappings';
 import { SmartMappingRetrySettings } from './smart-mapping-retry-settings';
+import { ReasoningPolicySettings } from './reasoning-policy-settings';
 import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
@@ -443,6 +444,7 @@ type EditFormData = {
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
+  reasoning?: NonNullable<Provider['config']>['reasoning'];
   maxConcurrency: number;
   excludeFromExport: boolean;
   blackBox: boolean;
@@ -518,6 +520,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
       smartMappingRetryEnabled: provider.config?.smartMappingRetryEnabled ?? false,
       smartMappingRetryLimit: provider.config?.smartMappingRetryLimit ?? 1,
+      reasoning: provider.config?.reasoning,
       maxConcurrency: normalizeMaxConcurrency(provider.maxConcurrency),
       excludeFromExport: !!provider.excludeFromExport || !!provider.blackBox,
       blackBox: !!provider.blackBox,
@@ -632,6 +635,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
+          reasoning: formData.reasoning,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -704,6 +708,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
+          reasoning: formData.reasoning,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -1216,6 +1221,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                 onRetryLimitChange={(limit) =>
                   setFormData((prev) => ({ ...prev, smartMappingRetryLimit: limit }))
                 }
+              />
+              <ReasoningPolicySettings
+                value={formData.reasoning}
+                onChange={(reasoning) => setFormData((prev) => ({ ...prev, reasoning }))}
               />
               <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
                 <div className="pr-4">

--- a/web/src/pages/providers/components/reasoning-policy-settings.tsx
+++ b/web/src/pages/providers/components/reasoning-policy-settings.tsx
@@ -1,0 +1,111 @@
+import type { ReasoningPolicy } from '@/lib/transport';
+import { useTranslation } from 'react-i18next';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const EFFORTS = ['none', 'minimal', 'low', 'medium', 'high'] as const;
+const UNSET_VALUE = '__unset__';
+
+type ReasoningEffort = (typeof EFFORTS)[number];
+
+interface ReasoningPolicySettingsProps {
+  value?: ReasoningPolicy;
+  onChange: (value: ReasoningPolicy | undefined) => void;
+}
+
+function normalizePolicy(policy?: ReasoningPolicy): ReasoningPolicy {
+  return {
+    defaultEffort: policy?.defaultEffort || undefined,
+    maxEffort: policy?.maxEffort || undefined,
+  };
+}
+
+function compactPolicy(policy: ReasoningPolicy): ReasoningPolicy | undefined {
+  const next = normalizePolicy(policy);
+  return next.defaultEffort || next.maxEffort ? next : undefined;
+}
+
+export function ReasoningPolicySettings({ value, onChange }: ReasoningPolicySettingsProps) {
+  const { t } = useTranslation();
+  const policy = normalizePolicy(value);
+
+  const update = (patch: Partial<ReasoningPolicy>) => {
+    onChange(compactPolicy({ ...policy, ...patch }));
+  };
+
+  const effortLabel = (effort: ReasoningEffort) => t(`provider.reasoningEffort.${effort}`);
+
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-card p-4">
+      <div>
+        <div className="text-sm font-medium text-foreground">{t('provider.reasoningPolicy')}</div>
+        <p className="mt-1 text-xs text-muted-foreground">{t('provider.reasoningPolicyDesc')}</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <label className="mb-2 block text-xs font-medium text-muted-foreground">
+            {t('provider.reasoningDefaultEffort')}
+          </label>
+          <Select
+            value={policy.defaultEffort || UNSET_VALUE}
+            onValueChange={(selected) =>
+              update({
+                defaultEffort: selected === UNSET_VALUE ? undefined : (selected as ReasoningEffort),
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNSET_VALUE}>{t('provider.reasoningUnset')}</SelectItem>
+              {EFFORTS.map((effort) => (
+                <SelectItem key={effort} value={effort}>
+                  {effortLabel(effort)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('provider.reasoningDefaultEffortDesc')}
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-xs font-medium text-muted-foreground">
+            {t('provider.reasoningMaxEffort')}
+          </label>
+          <Select
+            value={policy.maxEffort || UNSET_VALUE}
+            onValueChange={(selected) =>
+              update({
+                maxEffort: selected === UNSET_VALUE ? undefined : (selected as ReasoningEffort),
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={UNSET_VALUE}>{t('provider.reasoningUnset')}</SelectItem>
+              {EFFORTS.map((effort) => (
+                <SelectItem key={effort} value={effort}>
+                  {effortLabel(effort)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('provider.reasoningMaxEffortDesc')}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/context/provider-form-context.tsx
+++ b/web/src/pages/providers/context/provider-form-context.tsx
@@ -45,6 +45,7 @@ const initialFormData: ProviderFormData = {
   disableErrorCooldown: false,
   smartMappingRetryEnabled: false,
   smartMappingRetryLimit: 1,
+  reasoning: undefined,
   maxConcurrency: 0,
   excludeFromExport: false,
   blackBox: false,

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -1,4 +1,4 @@
-import type { ClientType, DisguiseType, Provider } from '@/lib/transport';
+import type { ClientType, DisguiseType, Provider, ReasoningPolicy } from '@/lib/transport';
 import { getProviderColorVar } from '@/lib/theme';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -365,6 +365,7 @@ export type ProviderFormData = {
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
+  reasoning?: ReasoningPolicy;
   maxConcurrency?: number;
   excludeFromExport?: boolean;
   blackBox?: boolean;


### PR DESCRIPTION
## Summary
- expose provider-level reasoning policy controls for custom providers
- apply reasoning defaults/ceilings to Claude thinking budgets in the shared outbound policy layer
- add regression coverage for Claude reasoning policy behavior

## Validation
- `git diff --check`
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- `go test ./...`

## Notes
- CodeRabbit was not checked or triggered in this flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 自定义提供商现支持配置推理策略，可分别设置默认和最大思考程度。
  * 支持关闭、极低、低、中、高等推理努力等级。
  * 创建、编辑及克隆提供商时会保存并沿用推理策略。
  * Claude 请求会根据策略自动调整思考预算，并确保输出令牌数满足要求。
* **界面与文案**
  * 新增中英文推理策略配置说明和选项。
* **兼容性**
  * 不支持的协议请求保持原样，不会被修改。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->