### PR TITLE
feat(model-mappings): support reorder controls

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1329,6 +1329,13 @@ type ModelMappingQuery struct {
 	APITokenID   uint64
 }
 
+// ModelMappingReorderRequest reorders mappings inside one sortable scope.
+type ModelMappingReorderRequest struct {
+	Scope      ModelMappingScope `json:"scope"`
+	ProviderID uint64            `json:"providerID,omitempty"`
+	OrderedIDs []uint64          `json:"orderedIDs"`
+}
+
 // ResponseModel 记录所有出现过的 response model
 // 用于快速查询可选的模型列表，避免每次 DISTINCT 查询
 type ResponseModel struct {

--- a/internal/executor/dispatch_test_helpers_test.go
+++ b/internal/executor/dispatch_test_helpers_test.go
@@ -147,6 +147,9 @@ func (r *stubModelMappingRepo) ListByClientType(uint64, domain.ClientType) ([]*d
 func (r *stubModelMappingRepo) ListByQuery(uint64, *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
 	return r.mappings, nil
 }
+func (r *stubModelMappingRepo) Reorder(uint64, domain.ModelMappingReorderRequest) error {
+	return nil
+}
 func (r *stubModelMappingRepo) Count(uint64) (int, error) { return 0, nil }
 func (r *stubModelMappingRepo) DeleteAll(uint64) error    { return nil }
 func (r *stubModelMappingRepo) ClearAll(uint64) error     { return nil }

--- a/internal/executor/format_conversion_dispatch_test.go
+++ b/internal/executor/format_conversion_dispatch_test.go
@@ -369,6 +369,9 @@ type staticModelMappingRepo struct {
 func (r *staticModelMappingRepo) ListByQuery(uint64, *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
 	return r.mappings, nil
 }
+func (r *staticModelMappingRepo) Reorder(uint64, domain.ModelMappingReorderRequest) error {
+	return nil
+}
 
 func newOpenAIClaudeConversionTestExecutor(proxyRepo *recordingProxyRequestRepo, attemptRepo *recordingAttemptRepo) *Executor {
 	return &Executor{

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1941,6 +1941,11 @@ func (h *AdminHandler) handleModelMappings(w http.ResponseWriter, r *http.Reques
 		h.handleResetModelMappingsToDefaults(w, r)
 		return
 	}
+	// Check for reorder endpoint: /admin/model-mappings/reorder
+	if strings.HasSuffix(path, "/reorder") {
+		h.handleReorderModelMappings(w, r)
+		return
+	}
 
 	tenantID := maxxctx.GetTenantID(r.Context())
 
@@ -2041,6 +2046,40 @@ func (h *AdminHandler) handleModelMappings(w http.ResponseWriter, r *http.Reques
 }
 
 // handleClearAllModelMappings handles DELETE /admin/model-mappings/clear-all
+func (h *AdminHandler) handleReorderModelMappings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req domain.ModelMappingReorderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if len(req.OrderedIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "orderedIDs is required"})
+		return
+	}
+	tenantID := maxxctx.GetTenantID(r.Context())
+	if err := h.svc.ReorderModelMappings(tenantID, req); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, domain.ErrInvalidInput) {
+			status = http.StatusBadRequest
+		} else if errors.Is(err, domain.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+	mappings, err := h.svc.GetModelMappings(tenantID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, mappings)
+}
+
 func (h *AdminHandler) handleClearAllModelMappings(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})

--- a/internal/handler/models_test.go
+++ b/internal/handler/models_test.go
@@ -66,6 +66,9 @@ func (f *fakeModelMappingRepo) ListByClientType(tenantID uint64, clientType doma
 func (f *fakeModelMappingRepo) ListByQuery(tenantID uint64, query *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
 	return f.List(tenantID)
 }
+func (f *fakeModelMappingRepo) Reorder(uint64, domain.ModelMappingReorderRequest) error {
+	return nil
+}
 func (f *fakeModelMappingRepo) Count(tenantID uint64) (int, error) { return len(f.mappings), f.err }
 func (f *fakeModelMappingRepo) DeleteAll(tenantID uint64) error    { return nil }
 func (f *fakeModelMappingRepo) ClearAll(tenantID uint64) error     { return nil }

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -185,6 +185,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleClearAllModelMappings(w, r)
 		case len(parts) == 3 && parts[2] == "reset-defaults":
 			h.handleResetModelMappingsToDefaults(w, r)
+		case len(parts) == 3 && parts[2] == "reorder":
+			h.handleReorderModelMappings(w, r)
 		case len(parts) == 3:
 			id, ok := parseSelfServiceID(w, "model mapping", parts[2])
 			if !ok {
@@ -995,6 +997,44 @@ func (h *SelfServiceHandler) handleModelMappings(w http.ResponseWriter, r *http.
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+func (h *SelfServiceHandler) handleReorderModelMappings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	var req domain.ModelMappingReorderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if len(req.OrderedIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "orderedIDs is required"})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	if err := h.svc.ReorderModelMappings(tenantID, req); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, domain.ErrInvalidInput) {
+			status = http.StatusBadRequest
+		} else if errors.Is(err, domain.ErrNotFound) {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+	mappings, err := h.svc.GetModelMappings(tenantID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetModelMappings failed", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, mappings)
 }
 
 func (h *SelfServiceHandler) handleClearAllModelMappings(w http.ResponseWriter, r *http.Request) {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -356,6 +356,9 @@ func (r *selfServiceModelMappingRepo) ListByClientType(tenantID uint64, clientTy
 func (r *selfServiceModelMappingRepo) ListByQuery(tenantID uint64, _ *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
 	return r.List(tenantID)
 }
+func (r *selfServiceModelMappingRepo) Reorder(uint64, domain.ModelMappingReorderRequest) error {
+	return nil
+}
 
 func (r *selfServiceModelMappingRepo) Count(tenantID uint64) (int, error) {
 	list, err := r.List(tenantID)

--- a/internal/repository/cached/model_mapping.go
+++ b/internal/repository/cached/model_mapping.go
@@ -201,6 +201,17 @@ func (r *ModelMappingRepository) ListByQuery(tenantID uint64, query *domain.Mode
 	return result, nil
 }
 
+func (r *ModelMappingRepository) Reorder(tenantID uint64, req domain.ModelMappingReorderRequest) error {
+	if err := r.repo.Reorder(tenantID, req); err != nil {
+		return err
+	}
+	if err := r.Load(); err != nil {
+		return err
+	}
+	r.bc.publish(OpReload, 0)
+	return nil
+}
+
 func (r *ModelMappingRepository) Count(tenantID uint64) (int, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -358,6 +358,7 @@ type ModelMappingRepository interface {
 	ListEnabled(tenantID uint64) ([]*domain.ModelMapping, error)
 	ListByClientType(tenantID uint64, clientType domain.ClientType) ([]*domain.ModelMapping, error)
 	ListByQuery(tenantID uint64, query *domain.ModelMappingQuery) ([]*domain.ModelMapping, error)
+	Reorder(tenantID uint64, req domain.ModelMappingReorderRequest) error
 	Count(tenantID uint64) (int, error)
 	DeleteAll(tenantID uint64) error
 	ClearAll(tenantID uint64) error     // Delete all mappings

--- a/internal/repository/sqlite/model_mapping.go
+++ b/internal/repository/sqlite/model_mapping.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -108,6 +109,56 @@ func (r *ModelMappingRepository) ListByClientType(tenantID uint64, clientType do
 		return nil, err
 	}
 	return r.toDomainList(models), nil
+}
+
+func (r *ModelMappingRepository) Reorder(tenantID uint64, req domain.ModelMappingReorderRequest) error {
+	if req.Scope == "" {
+		req.Scope = domain.ModelMappingScopeGlobal
+	}
+	if len(req.OrderedIDs) == 0 {
+		return fmt.Errorf("%w: orderedIDs is required", domain.ErrInvalidInput)
+	}
+	seen := make(map[uint64]struct{}, len(req.OrderedIDs))
+	for _, id := range req.OrderedIDs {
+		if id == 0 {
+			return fmt.Errorf("%w: orderedIDs must not contain zero", domain.ErrInvalidInput)
+		}
+		if _, exists := seen[id]; exists {
+			return fmt.Errorf("%w: duplicate mapping id %d", domain.ErrInvalidInput, id)
+		}
+		seen[id] = struct{}{}
+	}
+
+	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		var models []ModelMapping
+		if err := tenantScope(tx, tenantID).Where("deleted_at = 0 AND id IN ?", req.OrderedIDs).Find(&models).Error; err != nil {
+			return err
+		}
+		if len(models) != len(req.OrderedIDs) {
+			return fmt.Errorf("%w: one or more mappings not found", domain.ErrNotFound)
+		}
+		for _, model := range models {
+			if domain.ModelMappingScope(model.Scope) != req.Scope {
+				return fmt.Errorf("%w: mapping %d scope mismatch", domain.ErrInvalidInput, model.ID)
+			}
+			if req.Scope == domain.ModelMappingScopeProvider && model.ProviderID != req.ProviderID {
+				return fmt.Errorf("%w: mapping %d provider mismatch", domain.ErrInvalidInput, model.ID)
+			}
+		}
+
+		now := time.Now().UnixMilli()
+		for i, id := range req.OrderedIDs {
+			if err := tenantScope(tx.Model(&ModelMapping{}), tenantID).
+				Where("id = ? AND deleted_at = 0", id).
+				Updates(map[string]any{
+					"priority":   i * 10,
+					"updated_at": now,
+				}).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 func (r *ModelMappingRepository) Count(tenantID uint64) (int, error) {

--- a/internal/repository/sqlite/model_mapping.go
+++ b/internal/repository/sqlite/model_mapping.go
@@ -115,6 +115,12 @@ func (r *ModelMappingRepository) Reorder(tenantID uint64, req domain.ModelMappin
 	if req.Scope == "" {
 		req.Scope = domain.ModelMappingScopeGlobal
 	}
+	if req.Scope != domain.ModelMappingScopeGlobal && req.Scope != domain.ModelMappingScopeProvider && req.Scope != domain.ModelMappingScopeRoute {
+		return fmt.Errorf("%w: unsupported mapping scope %q", domain.ErrInvalidInput, req.Scope)
+	}
+	if req.Scope == domain.ModelMappingScopeProvider && req.ProviderID == 0 {
+		return fmt.Errorf("%w: providerID is required for provider mappings", domain.ErrInvalidInput)
+	}
 	if len(req.OrderedIDs) == 0 {
 		return fmt.Errorf("%w: orderedIDs is required", domain.ErrInvalidInput)
 	}
@@ -130,30 +136,35 @@ func (r *ModelMappingRepository) Reorder(tenantID uint64, req domain.ModelMappin
 	}
 
 	return r.db.gorm.Transaction(func(tx *gorm.DB) error {
+		query := tenantScope(tx, tenantID).Where("deleted_at = 0 AND scope = ?", req.Scope)
+		if req.Scope == domain.ModelMappingScopeProvider {
+			query = query.Where("provider_id = ?", req.ProviderID)
+		}
+
 		var models []ModelMapping
-		if err := tenantScope(tx, tenantID).Where("deleted_at = 0 AND id IN ?", req.OrderedIDs).Find(&models).Error; err != nil {
+		if err := query.Find(&models).Error; err != nil {
 			return err
 		}
 		if len(models) != len(req.OrderedIDs) {
-			return fmt.Errorf("%w: one or more mappings not found", domain.ErrNotFound)
+			return fmt.Errorf("%w: orderedIDs must include every mapping in the requested scope", domain.ErrInvalidInput)
 		}
 		for _, model := range models {
-			if domain.ModelMappingScope(model.Scope) != req.Scope {
-				return fmt.Errorf("%w: mapping %d scope mismatch", domain.ErrInvalidInput, model.ID)
-			}
-			if req.Scope == domain.ModelMappingScopeProvider && model.ProviderID != req.ProviderID {
-				return fmt.Errorf("%w: mapping %d provider mismatch", domain.ErrInvalidInput, model.ID)
+			if _, exists := seen[model.ID]; !exists {
+				return fmt.Errorf("%w: orderedIDs missing mapping id %d", domain.ErrInvalidInput, model.ID)
 			}
 		}
 
 		now := time.Now().UnixMilli()
 		for i, id := range req.OrderedIDs {
-			if err := tenantScope(tx.Model(&ModelMapping{}), tenantID).
-				Where("id = ? AND deleted_at = 0", id).
-				Updates(map[string]any{
-					"priority":   i * 10,
-					"updated_at": now,
-				}).Error; err != nil {
+			update := tenantScope(tx.Model(&ModelMapping{}), tenantID).
+				Where("id = ? AND deleted_at = 0 AND scope = ?", id, req.Scope)
+			if req.Scope == domain.ModelMappingScopeProvider {
+				update = update.Where("provider_id = ?", req.ProviderID)
+			}
+			if err := update.Updates(map[string]any{
+				"priority":   i * 10,
+				"updated_at": now,
+			}).Error; err != nil {
 				return err
 			}
 		}

--- a/internal/repository/sqlite/model_mapping_test.go
+++ b/internal/repository/sqlite/model_mapping_test.go
@@ -49,6 +49,62 @@ func TestModelMappingRepositoryReorderUpdatesPrioritiesAtomically(t *testing.T) 
 	}
 }
 
+func TestModelMappingRepositoryReorderRejectsIncompleteProviderOrder(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewModelMappingRepository(db)
+	mappings := []*domain.ModelMapping{
+		{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "a", Target: "target-a", Priority: 0},
+		{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "b", Target: "target-b", Priority: 10},
+	}
+	for _, mapping := range mappings {
+		if err := repo.Create(mapping); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	if err := repo.Reorder(1, domain.ModelMappingReorderRequest{
+		Scope:      domain.ModelMappingScopeProvider,
+		ProviderID: 101,
+		OrderedIDs: []uint64{mappings[1].ID},
+	}); !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("Reorder() incomplete order error = %v, want ErrInvalidInput", err)
+	}
+
+	got, err := repo.ListByQuery(1, &domain.ModelMappingQuery{ProviderID: 101})
+	if err != nil {
+		t.Fatalf("ListByQuery() error = %v", err)
+	}
+	if got[0].ID != mappings[0].ID || got[0].Priority != 0 || got[1].ID != mappings[1].ID || got[1].Priority != 10 {
+		t.Fatalf("incomplete reorder should not mutate priorities: %#v", got)
+	}
+}
+
+func TestModelMappingRepositoryReorderRejectsMissingProviderID(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewModelMappingRepository(db)
+	mapping := &domain.ModelMapping{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "a", Target: "target-a", Priority: 0}
+	if err := repo.Create(mapping); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := repo.Reorder(1, domain.ModelMappingReorderRequest{
+		Scope:      domain.ModelMappingScopeProvider,
+		OrderedIDs: []uint64{mapping.ID},
+	}); !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("Reorder() missing providerID error = %v, want ErrInvalidInput", err)
+	}
+}
+
 func TestModelMappingRepositoryReorderRejectsScopeOrProviderMismatch(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/internal/repository/sqlite/model_mapping_test.go
+++ b/internal/repository/sqlite/model_mapping_test.go
@@ -1,0 +1,83 @@
+package sqlite
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestModelMappingRepositoryReorderUpdatesPrioritiesAtomically(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewModelMappingRepository(db)
+	mappings := []*domain.ModelMapping{
+		{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "a", Target: "target-a", Priority: 0},
+		{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "b", Target: "target-b", Priority: 10},
+		{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "c", Target: "target-c", Priority: 20},
+	}
+	for _, mapping := range mappings {
+		if err := repo.Create(mapping); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	if err := repo.Reorder(1, domain.ModelMappingReorderRequest{
+		Scope:      domain.ModelMappingScopeProvider,
+		ProviderID: 101,
+		OrderedIDs: []uint64{mappings[2].ID, mappings[0].ID, mappings[1].ID},
+	}); err != nil {
+		t.Fatalf("Reorder() error = %v", err)
+	}
+
+	got, err := repo.ListByQuery(1, &domain.ModelMappingQuery{ProviderID: 101})
+	if err != nil {
+		t.Fatalf("ListByQuery() error = %v", err)
+	}
+	wantIDs := []uint64{mappings[2].ID, mappings[0].ID, mappings[1].ID}
+	for i, wantID := range wantIDs {
+		if got[i].ID != wantID {
+			t.Fatalf("order[%d] = %d, want %d (all: %#v)", i, got[i].ID, wantID, got)
+		}
+		if got[i].Priority != i*10 {
+			t.Fatalf("priority[%d] = %d, want %d", i, got[i].Priority, i*10)
+		}
+	}
+}
+
+func TestModelMappingRepositoryReorderRejectsScopeOrProviderMismatch(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewModelMappingRepository(db)
+	providerMapping := &domain.ModelMapping{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 101, Pattern: "a", Target: "target-a", Priority: 0}
+	otherProviderMapping := &domain.ModelMapping{TenantID: 1, Scope: domain.ModelMappingScopeProvider, ProviderID: 202, Pattern: "b", Target: "target-b", Priority: 10}
+	globalMapping := &domain.ModelMapping{TenantID: 1, Scope: domain.ModelMappingScopeGlobal, Pattern: "c", Target: "target-c", Priority: 20}
+	for _, mapping := range []*domain.ModelMapping{providerMapping, otherProviderMapping, globalMapping} {
+		if err := repo.Create(mapping); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	if err := repo.Reorder(1, domain.ModelMappingReorderRequest{
+		Scope:      domain.ModelMappingScopeProvider,
+		ProviderID: 101,
+		OrderedIDs: []uint64{providerMapping.ID, otherProviderMapping.ID},
+	}); !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("Reorder() provider mismatch error = %v, want ErrInvalidInput", err)
+	}
+	if err := repo.Reorder(1, domain.ModelMappingReorderRequest{
+		Scope:      domain.ModelMappingScopeProvider,
+		ProviderID: 101,
+		OrderedIDs: []uint64{providerMapping.ID, globalMapping.ID},
+	}); !errors.Is(err, domain.ErrInvalidInput) {
+		t.Fatalf("Reorder() scope mismatch error = %v, want ErrInvalidInput", err)
+	}
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1830,6 +1830,11 @@ func (s *AdminService) UpdateModelMapping(tenantID uint64, mapping *domain.Model
 	return s.modelMappingRepo.Update(mapping)
 }
 
+// ReorderModelMappings updates priorities for mappings inside one sortable scope.
+func (s *AdminService) ReorderModelMappings(tenantID uint64, req domain.ModelMappingReorderRequest) error {
+	return s.modelMappingRepo.Reorder(tenantID, req)
+}
+
 // DeleteModelMapping deletes a model mapping by ID
 func (s *AdminService) DeleteModelMapping(tenantID uint64, id uint64) error {
 	return s.modelMappingRepo.Delete(tenantID, id)

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -104,6 +104,7 @@ export {
   useModelMappings,
   useCreateModelMapping,
   useUpdateModelMapping,
+  useReorderModelMappings,
   useDeleteModelMapping,
   useClearAllModelMappings,
   useResetModelMappingsToDefaults,

--- a/web/src/hooks/queries/use-settings.ts
+++ b/web/src/hooks/queries/use-settings.ts
@@ -4,7 +4,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getTransport } from '@/lib/transport';
-import type { ModelMappingInput } from '@/lib/transport';
+import type { ModelMappingInput, ModelMappingReorderInput } from '@/lib/transport';
 
 export const settingsKeys = {
   all: ['settings'] as const,
@@ -129,6 +129,17 @@ export function useUpdateModelMapping() {
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: ModelMappingInput }) =>
       getTransport().updateModelMapping(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.modelMappings });
+    },
+  });
+}
+
+export function useReorderModelMappings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ModelMappingReorderInput) => getTransport().reorderModelMappings(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: settingsKeys.modelMappings });
     },

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -42,6 +42,7 @@ import type {
   ProviderRuntimeModelsPreviewRequest,
   ModelMapping,
   ModelMappingInput,
+  ModelMappingReorderInput,
   ImportResult,
   Cooldown,
   KiroTokenValidationResult,
@@ -780,6 +781,11 @@ export class HttpTransport implements Transport {
   async updateModelMapping(id: number, input: ModelMappingInput): Promise<ModelMapping> {
     const { data } = await this.client.put<ModelMapping>(`/model-mappings/${id}`, input);
     return data;
+  }
+
+  async reorderModelMappings(input: ModelMappingReorderInput): Promise<ModelMapping[]> {
+    const { data } = await this.client.post<ModelMapping[]>('/model-mappings/reorder', input);
+    return this.expectArray<ModelMapping>(data, '/model-mappings/reorder');
   }
 
   async deleteModelMapping(id: number): Promise<void> {

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -79,6 +79,7 @@ export type {
   // Model Mapping
   ModelMapping,
   ModelMappingInput,
+  ModelMappingReorderInput,
   // Kiro
   KiroTokenValidationResult,
   KiroQuotaData,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -39,6 +39,7 @@ import type {
   ProviderRuntimeModelsPreviewRequest,
   ModelMapping,
   ModelMappingInput,
+  ModelMappingReorderInput,
   ImportResult,
   Cooldown,
   KiroTokenValidationResult,
@@ -230,6 +231,7 @@ export interface Transport {
   getModelMappings(): Promise<ModelMapping[]>;
   createModelMapping(data: ModelMappingInput): Promise<ModelMapping>;
   updateModelMapping(id: number, data: ModelMappingInput): Promise<ModelMapping>;
+  reorderModelMappings(data: ModelMappingReorderInput): Promise<ModelMapping[]>;
   deleteModelMapping(id: number): Promise<void>;
   clearAllModelMappings(): Promise<void>;
   resetModelMappingsToDefaults(): Promise<void>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -808,6 +808,12 @@ export interface ModelMappingInput {
   isEnabled?: boolean;
 }
 
+export interface ModelMappingReorderInput {
+  scope: ModelMappingScope;
+  providerID?: number;
+  orderedIDs: number[];
+}
+
 // ===== Kiro 类型 =====
 
 export interface KiroTokenValidationResult {

--- a/web/src/pages/model-mappings/index.tsx
+++ b/web/src/pages/model-mappings/index.tsx
@@ -33,6 +33,7 @@ import {
   useModelMappings,
   useCreateModelMapping,
   useUpdateModelMapping,
+  useReorderModelMappings,
   useDeleteModelMapping,
   useClearAllModelMappings,
   useResetModelMappingsToDefaults,
@@ -134,6 +135,7 @@ export function ModelMappingsPage() {
   const { data: mappings, isLoading } = useModelMappings();
   const createMapping = useCreateModelMapping();
   const updateMapping = useUpdateModelMapping();
+  const reorderMappings = useReorderModelMappings();
   const deleteMapping = useDeleteModelMapping();
   const clearAllMappings = useClearAllModelMappings();
   const resetToDefaults = useResetModelMappingsToDefaults();
@@ -166,21 +168,10 @@ export function ModelMappingsPage() {
 
     if (oldIndex !== -1 && newIndex !== -1) {
       const reordered = arrayMove(rules, oldIndex, newIndex);
-      for (let i = 0; i < reordered.length; i++) {
-        const rule = reordered[i];
-        if (rule.priority !== i * 10) {
-          await updateMapping.mutateAsync({
-            id: rule.id,
-            data: {
-              pattern: rule.pattern,
-              target: rule.target,
-              scope: 'global',
-              priority: i * 10,
-              isEnabled: rule.isEnabled,
-            },
-          });
-        }
-      }
+      await reorderMappings.mutateAsync({
+        scope: 'global',
+        orderedIDs: reordered.map((rule) => rule.id),
+      });
     }
   };
 
@@ -252,6 +243,7 @@ export function ModelMappingsPage() {
   const isPending =
     createMapping.isPending ||
     updateMapping.isPending ||
+    reorderMappings.isPending ||
     deleteMapping.isPending ||
     resetToDefaults.isPending ||
     clearAllMappings.isPending;

--- a/web/src/pages/providers/components/provider-model-mappings.tsx
+++ b/web/src/pages/providers/components/provider-model-mappings.tsx
@@ -1,5 +1,22 @@
 import { useMemo, useState } from 'react';
-import { ArrowRight, Plus, Trash2, Zap } from 'lucide-react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ArrowRight, GripVertical, Plus, Trash2, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   useModelMappings,
@@ -7,6 +24,7 @@ import {
   useProviderRuntimeModelsPreview,
   useCreateModelMapping,
   useUpdateModelMapping,
+  useReorderModelMappings,
   useDeleteModelMapping,
 } from '@/hooks/queries';
 import type {
@@ -45,6 +63,72 @@ export function buildProviderRuntimeModelOptions(
   return options;
 }
 
+interface SortableProviderMappingRowProps {
+  mapping: ModelMapping;
+  index: number;
+  disabled: boolean;
+  extraModels: ReturnType<typeof buildProviderRuntimeModelOptions>;
+  onUpdate: (mapping: ModelMapping, data: Partial<ModelMappingInput>) => void;
+  onDelete: (id: number) => void;
+}
+
+function SortableProviderMappingRow({
+  mapping,
+  index,
+  disabled,
+  extraModels,
+  onUpdate,
+  onDelete,
+}: SortableProviderMappingRowProps) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `mapping-${mapping.id}`,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`flex items-center gap-2 ${isDragging ? 'opacity-50' : ''}`}
+    >
+      <button
+        {...attributes}
+        {...listeners}
+        className="cursor-grab active:cursor-grabbing p-1 hover:bg-accent rounded shrink-0"
+        disabled={disabled}
+      >
+        <GripVertical className="h-4 w-4 text-muted-foreground" />
+      </button>
+      <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
+      <ModelInput
+        value={mapping.pattern}
+        onChange={(pattern) => onUpdate(mapping, { pattern })}
+        placeholder={t('modelMappings.matchPattern')}
+        disabled={disabled}
+        className="flex-1 min-w-0 h-8 text-sm"
+      />
+      <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+      <ModelInput
+        value={mapping.target}
+        onChange={(target) => onUpdate(mapping, { target })}
+        placeholder={t('modelMappings.targetModel')}
+        disabled={disabled}
+        extraModels={extraModels}
+        openSearchValue=""
+        className="flex-1 min-w-0 h-8 text-sm"
+      />
+      <Button variant="ghost" size="sm" onClick={() => onDelete(mapping.id)} disabled={disabled}>
+        <Trash2 className="h-4 w-4 text-destructive" />
+      </Button>
+    </div>
+  );
+}
+
 export function ProviderModelMappings({
   provider,
   runtimeModelsPreview,
@@ -56,6 +140,7 @@ export function ProviderModelMappings({
   const { data: allMappings } = useModelMappings();
   const createMapping = useCreateModelMapping();
   const updateMapping = useUpdateModelMapping();
+  const reorderMappings = useReorderModelMappings();
   const deleteMapping = useDeleteModelMapping();
   const hasPreviewConfig = !!runtimeModelsPreview;
   const { data: savedRuntimeModels } = useProviderRuntimeModels(provider.id, !hasPreviewConfig);
@@ -74,7 +159,18 @@ export function ProviderModelMappings({
     );
   }, [allMappings, provider.id]);
 
-  const isPending = createMapping.isPending || updateMapping.isPending || deleteMapping.isPending;
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const isPending =
+    createMapping.isPending ||
+    updateMapping.isPending ||
+    reorderMappings.isPending ||
+    deleteMapping.isPending;
   const providerRuntimeModelOptions = useMemo(
     () =>
       buildProviderRuntimeModelOptions(
@@ -84,6 +180,27 @@ export function ProviderModelMappings({
       ),
     [provider.supportModels, runtimeModels?.models, t],
   );
+
+  const handleDragStart = () => {
+    document.body.classList.add('is-dragging');
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    document.body.classList.remove('is-dragging');
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = providerMappings.findIndex((m) => `mapping-${m.id}` === active.id);
+    const newIndex = providerMappings.findIndex((m) => `mapping-${m.id}` === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reordered = arrayMove(providerMappings, oldIndex, newIndex);
+    await reorderMappings.mutateAsync({
+      scope: 'provider',
+      providerID: provider.id,
+      orderedIDs: reordered.map((mapping) => mapping.id),
+    });
+  };
 
   const handleAddMapping = async () => {
     if (!newPattern.trim() || !newTarget.trim()) return;
@@ -133,38 +250,31 @@ export function ProviderModelMappings({
         <p className="text-xs text-muted-foreground mb-4">{t('modelMappings.pageDesc')}</p>
 
         {providerMappings.length > 0 && (
-          <div className="space-y-2 mb-4">
-            {providerMappings.map((mapping, index) => (
-              <div key={mapping.id} className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
-                <ModelInput
-                  value={mapping.pattern}
-                  onChange={(pattern) => handleUpdateMapping(mapping, { pattern })}
-                  placeholder={t('modelMappings.matchPattern')}
-                  disabled={isPending}
-                  className="flex-1 min-w-0 h-8 text-sm"
-                />
-                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                <ModelInput
-                  value={mapping.target}
-                  onChange={(target) => handleUpdateMapping(mapping, { target })}
-                  placeholder={t('modelMappings.targetModel')}
-                  disabled={isPending}
-                  extraModels={providerRuntimeModelOptions}
-                  openSearchValue=""
-                  className="flex-1 min-w-0 h-8 text-sm"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleDeleteMapping(mapping.id)}
-                  disabled={isPending}
-                >
-                  <Trash2 className="h-4 w-4 text-destructive" />
-                </Button>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={providerMappings.map((mapping) => `mapping-${mapping.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-2 mb-4">
+                {providerMappings.map((mapping, index) => (
+                  <SortableProviderMappingRow
+                    key={mapping.id}
+                    mapping={mapping}
+                    index={index}
+                    disabled={isPending}
+                    extraModels={providerRuntimeModelOptions}
+                    onUpdate={handleUpdateMapping}
+                    onDelete={handleDeleteMapping}
+                  />
+                ))}
               </div>
-            ))}
-          </div>
+            </SortableContext>
+          </DndContext>
         )}
 
         {providerMappings.length === 0 && (


### PR DESCRIPTION
## Summary
- add an atomic model-mapping reorder API backed by repository/service/handler validation
- update the global model mappings page to persist ordering through the batch reorder endpoint
- add drag-and-drop ordering controls for provider-scoped model mappings
- add regression tests for repository reorder ordering and scope/provider mismatch rejection

## Validation
- `git diff --check`
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- `go test ./...`

## Notes
- CodeRabbit was not checked or triggered in this flow.
