### PR TITLE
fix(stats): backfill historical usage stats

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,5 +1,12 @@
 # DEVLOG
 
+## 2026-07-30
+
+- Fixed usage stats initial aggregation so missing/empty `usage_stats` backfills historical raw attempts instead of only scanning the last 2 hours.
+- Fixed realtime raw backfill overlap for non-minute queries so completed historical hour/day buckets are not double-counted into the current bucket.
+- Added repository and admin API regressions proving “this month” diverges from “last 24 hours” when older raw attempts exist.
+- Captured local UI/mock screenshots for month vs. last-24h stats evidence.
+
 ## 2026-07-16
 
 - Implemented available-only model list semantics for maxx model-list endpoints.

--- a/TODO.md
+++ b/TODO.md
@@ -9,4 +9,7 @@
 - [x] Validate layout with targeted tests, typecheck, build, and screenshots.
 - [x] Decouple committed stream read EOF retry from DisableErrorCooldown.
 - [x] Cover committed stream EOF retry budget and custom unexpected EOF classification with regression tests.
+- [x] Fix usage stats historical backfill so this month and last 24h diverge with older raw attempts.
+- [x] Cover usage stats initial aggregation, raw overlap de-dupe, and admin API regression.
+- [x] Capture UI/mock screenshot evidence for stats tab month vs. last-24h behavior.
 - [ ] Open PR after verification.

--- a/internal/repository/sqlite/usage_stats.go
+++ b/internal/repository/sqlite/usage_stats.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -294,8 +295,13 @@ func (r *UsageStatsRepository) Query(tenantID uint64, filter repository.UsageSta
 		})
 	}
 
-	// 2d. 查询 raw backfill 窗口内的实时数据
+	// 2d. 查询 raw backfill 窗口内的实时数据。
+	// 非分钟粒度已经通过 hour/day 预聚合覆盖了已完成的历史桶；raw 只补当前小时，
+	// 避免把 overlap 窗口内的上一小时数据再次聚合进当前桶。
 	rawStart := realtimeStart
+	if filter.Granularity != domain.GranularityMinute && currentHour.After(rawStart) {
+		rawStart = currentHour
+	}
 	if filter.StartTime != nil && filter.StartTime.After(rawStart) {
 		rawStart = *filter.StartTime
 	}
@@ -1003,20 +1009,55 @@ func (r *UsageStatsRepository) queryAllWithRealtime(tenantID uint64, filter repo
 	return allStats, nil
 }
 
+func (r *UsageStatsRepository) scanEarliestTimestamp(query *gorm.DB) (*time.Time, error) {
+	var earliest sql.NullInt64
+	if err := query.Scan(&earliest).Error; err != nil {
+		return nil, err
+	}
+	if !earliest.Valid {
+		return nil, nil
+	}
+
+	t := fromTimestamp(earliest.Int64)
+	return &t, nil
+}
+
+func (r *UsageStatsRepository) getEarliestCompletedAttemptTime(tenantID uint64) (*time.Time, error) {
+	query := r.db.gorm.Model(&ProxyUpstreamAttempt{}).
+		Select("MIN(end_time)").
+		Where("status IN ?", []string{"COMPLETED", "FAILED", "CANCELLED"})
+	if tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	return r.scanEarliestTimestamp(query)
+}
+
+func (r *UsageStatsRepository) getEarliestStatsBucket(tenantID uint64, granularity domain.Granularity) (*time.Time, error) {
+	query := r.db.gorm.Model(&UsageStats{}).
+		Select("MIN(time_bucket)").
+		Where("granularity = ?", granularity)
+	if tenantID > 0 {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	return r.scanEarliestTimestamp(query)
+}
+
 // aggregateMinute 从原始数据聚合到分钟级别（内部方法）
 // 返回：聚合数量、开始时间、结束时间、错误
 func (r *UsageStatsRepository) aggregateMinute(tenantID uint64) (count int, startTime, endTime time.Time, err error) {
 	now := time.Now().UTC()
 	endTime = now.Truncate(time.Minute)
 
-	// 获取最新的聚合分钟
+	// 获取最新的聚合分钟。已有聚合历史时只 overlap 2 分钟，确保补齐延迟数据。
+	// 首次聚合或 usage_stats 被清空时必须从最早 raw attempt 开始，否则已有历史 raw
+	// 会永久落在 2 小时窗口之外，导致“本月”等长时间范围统计只显示最近数据。
 	latestMinute, e := r.GetLatestTimeBucket(tenantID, domain.GranularityMinute)
-	if e != nil || latestMinute == nil {
-		// 如果没有历史数据，从 2 小时前开始
-		startTime = now.Add(-2 * time.Hour).Truncate(time.Minute)
-	} else {
-		// 从最新记录前 2 分钟开始，确保补齐延迟数据
+	if e == nil && latestMinute != nil {
 		startTime = latestMinute.Add(-2 * time.Minute)
+	} else if earliestAttempt, e := r.getEarliestCompletedAttemptTime(tenantID); e == nil && earliestAttempt != nil {
+		startTime = earliestAttempt.In(time.UTC).Truncate(time.Minute)
+	} else {
+		startTime = now.Add(-2 * time.Hour).Truncate(time.Minute)
 	}
 
 	// 查询在时间范围内已完成的 proxy_upstream_attempts
@@ -1195,20 +1236,14 @@ func (r *UsageStatsRepository) rollUp(tenantID uint64, from, to domain.Granulari
 
 	// 获取目标粒度的最新时间桶
 	latestBucket, _ := r.GetLatestTimeBucket(tenantID, to)
-	if latestBucket == nil {
-		// 如果没有历史数据，根据源粒度的保留时间决定
-		switch from {
-		case domain.GranularityMinute:
-			startTime = now.Add(-2 * time.Hour)
-		case domain.GranularityHour:
-			startTime = now.Add(-7 * 24 * time.Hour)
-		case domain.GranularityDay:
-			startTime = now.Add(-90 * 24 * time.Hour)
-		default:
-			startTime = now.AddDate(0, 0, -30)
-		}
-	} else {
+	if latestBucket != nil {
 		startTime = *latestBucket
+	} else if earliestSourceBucket, e := r.getEarliestStatsBucket(tenantID, from); e == nil && earliestSourceBucket != nil {
+		// 首次上卷必须从源粒度最早桶开始。否则首次 minute 聚合出的历史数据会被
+		// 固定窗口裁掉，hour/day/month 统计仍然缺昨天/前天等历史桶。
+		startTime = earliestSourceBucket.In(loc)
+	} else {
+		startTime = endTime
 	}
 
 	// 查询源粒度数据

--- a/internal/repository/sqlite/usage_stats_regression_test.go
+++ b/internal/repository/sqlite/usage_stats_regression_test.go
@@ -1,0 +1,121 @@
+package sqlite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository"
+)
+
+func sumUsageStatsRequests(stats []*domain.UsageStats) uint64 {
+	var total uint64
+	for _, s := range stats {
+		total += s.TotalRequests
+	}
+	return total
+}
+
+func seedUsageStatsRegressionAttempts(t *testing.T, db *DB, now time.Time) {
+	t.Helper()
+
+	request := &ProxyRequest{TenantID: 1, ClientType: "openai", ProjectID: 20, Status: "COMPLETED"}
+	if err := db.gorm.Create(request).Error; err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+
+	attempts := []*ProxyUpstreamAttempt{
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: toTimestamp(now.Add(-48 * time.Hour)), InputTokenCount: 100},
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: toTimestamp(now.Add(-25 * time.Hour)), InputTokenCount: 200},
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: toTimestamp(now.Add(-10 * time.Minute)), InputTokenCount: 300},
+	}
+	if err := db.gorm.Create(&attempts).Error; err != nil {
+		t.Fatalf("seed attempts: %v", err)
+	}
+}
+
+func TestAggregateAndRollUpInitialRunBackfillsHistoricalAttempts(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://" + t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewUsageStatsRepository(db)
+	now := time.Now().UTC().Truncate(time.Minute)
+	seedUsageStatsRegressionAttempts(t, db, now)
+
+	for range repo.AggregateAndRollUp(0) {
+	}
+
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	last24Start := now.Add(-24 * time.Hour)
+	monthStats, err := repo.Query(1, repository.UsageStatsFilter{
+		Granularity: domain.GranularityDay,
+		StartTime:   &monthStart,
+		EndTime:     &now,
+	})
+	if err != nil {
+		t.Fatalf("month query: %v", err)
+	}
+	last24Stats, err := repo.Query(1, repository.UsageStatsFilter{
+		Granularity: domain.GranularityHour,
+		StartTime:   &last24Start,
+		EndTime:     &now,
+	})
+	if err != nil {
+		t.Fatalf("last24 query: %v", err)
+	}
+
+	monthTotal := sumUsageStatsRequests(monthStats)
+	last24Total := sumUsageStatsRequests(last24Stats)
+	if monthTotal <= last24Total {
+		t.Fatalf("month=%d last24=%d, want month to include older historical attempts after first aggregation", monthTotal, last24Total)
+	}
+	if monthTotal != 3 || last24Total != 1 {
+		t.Fatalf("month=%d last24=%d, want 3/1 without realtime overlap double counting", monthTotal, last24Total)
+	}
+}
+
+func TestQueryRealtimeBackfillDoesNotDoubleCountCompletedHour(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://" + t.TempDir() + "/stats.db")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewUsageStatsRepository(db)
+	now := time.Now().UTC().Truncate(time.Minute)
+	seedUsageStatsRegressionAttempts(t, db, now)
+
+	progress := make(chan domain.Progress, 16)
+	if err := repo.ClearAndRecalculateWithProgress(0, progress); err != nil {
+		t.Fatalf("recalculate: %v", err)
+	}
+	close(progress)
+
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	last24Start := now.Add(-24 * time.Hour)
+	monthStats, err := repo.Query(1, repository.UsageStatsFilter{
+		Granularity: domain.GranularityDay,
+		StartTime:   &monthStart,
+		EndTime:     &now,
+	})
+	if err != nil {
+		t.Fatalf("month query: %v", err)
+	}
+	last24Stats, err := repo.Query(1, repository.UsageStatsFilter{
+		Granularity: domain.GranularityHour,
+		StartTime:   &last24Start,
+		EndTime:     &now,
+	})
+	if err != nil {
+		t.Fatalf("last24 query: %v", err)
+	}
+
+	monthTotal := sumUsageStatsRequests(monthStats)
+	last24Total := sumUsageStatsRequests(last24Stats)
+	if monthTotal != 3 || last24Total != 1 {
+		t.Fatalf("month=%d last24=%d, want 3/1 after recalc without raw overlap double counting", monthTotal, last24Total)
+	}
+}

--- a/tests/e2e/usage_stats_test.go
+++ b/tests/e2e/usage_stats_test.go
@@ -2,8 +2,11 @@ package e2e_test
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
+
+	"github.com/awsl-project/maxx/internal/repository/sqlite"
 )
 
 func TestGetUsageStats_Empty(t *testing.T) {
@@ -51,5 +54,53 @@ func TestRecalculateUsageStats(t *testing.T) {
 
 	if result["message"] == nil || result["message"] == "" {
 		t.Fatal("Expected success message in recalculate response")
+	}
+}
+
+func TestUsageStatsMonthAndLast24HoursDivergeAfterHistoricalBackfill(t *testing.T) {
+	env := NewTestEnv(t)
+	now := time.Now().UTC().Truncate(time.Minute)
+
+	request := &sqlite.ProxyRequest{TenantID: 1, ClientType: "openai", ProjectID: 20, Status: "COMPLETED"}
+	if err := env.DB.GormDB().Create(request).Error; err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+	attempts := []*sqlite.ProxyUpstreamAttempt{
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: now.Add(-48 * time.Hour).UnixMilli(), ResponseModel: "gpt-5", InputTokenCount: 100},
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: now.Add(-25 * time.Hour).UnixMilli(), ResponseModel: "gpt-5", InputTokenCount: 200},
+		{TenantID: 1, ProxyRequestID: request.ID, ProviderID: 10, Status: "COMPLETED", EndTime: now.Add(-10 * time.Minute).UnixMilli(), ResponseModel: "gpt-5", InputTokenCount: 300},
+	}
+	if err := env.DB.GormDB().Create(&attempts).Error; err != nil {
+		t.Fatalf("seed attempts: %v", err)
+	}
+
+	resp := env.AdminPost("/api/admin/usage-stats/recalculate", nil)
+	AssertStatus(t, resp, http.StatusOK)
+
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	last24Start := now.Add(-24 * time.Hour).Format(time.RFC3339)
+	end := now.Format(time.RFC3339)
+
+	monthResp := env.AdminGet("/api/admin/usage-stats?granularity=day&start=" + url.QueryEscape(monthStart) + "&end=" + url.QueryEscape(end))
+	AssertStatus(t, monthResp, http.StatusOK)
+	last24Resp := env.AdminGet("/api/admin/usage-stats?granularity=hour&start=" + url.QueryEscape(last24Start) + "&end=" + url.QueryEscape(end))
+	AssertStatus(t, last24Resp, http.StatusOK)
+
+	var monthStats, last24Stats []struct {
+		TotalRequests uint64 `json:"totalRequests"`
+	}
+	DecodeJSON(t, monthResp, &monthStats)
+	DecodeJSON(t, last24Resp, &last24Stats)
+
+	var monthTotal, last24Total uint64
+	for _, stat := range monthStats {
+		monthTotal += stat.TotalRequests
+	}
+	for _, stat := range last24Stats {
+		last24Total += stat.TotalRequests
+	}
+
+	if monthTotal != 3 || last24Total != 1 {
+		t.Fatalf("month=%d last24=%d, want 3/1 through admin API after recalculate", monthTotal, last24Total)
 	}
 }


### PR DESCRIPTION
## Summary
- Backfill usage stats from the earliest raw upstream attempt when minute stats do not exist yet, instead of only scanning the last 2 hours.
- Roll up from the earliest source stats bucket when the target granularity has no existing buckets, so initial hour/day/month aggregation does not drop historical data.
- Restrict non-minute realtime raw backfill to the current hour to avoid double-counting completed historical hour/day buckets into the current bucket.
- Add repository and admin API regressions for the stats tab “this month” vs. “last 24 hours” scenario.

## Validation
- `go test ./internal/repository/sqlite -run 'TestAggregateAndRollUpInitialRunBackfillsHistoricalAttempts|TestQueryRealtimeBackfillDoesNotDoubleCountCompletedHour' -count=1 -v`
- `go test ./internal/repository/sqlite -count=1`
- `go test ./tests/e2e -run 'TestUsageStatsMonthAndLast24HoursDivergeAfterHistoricalBackfill' -count=1 -v`
- `go test ./tests/e2e -run 'TestUsageStats|TestRecalculateUsageStats' -count=1`
- `pnpm --dir web typecheck`

## Evidence
- Local UI/mock screenshots were captured for the simulated stats tab flow:
  - `maxx-stats-month.png`: month query shows 3 requests from 48h/25h/10min mock attempts.
  - `maxx-stats-last24.png`: last-24h query shows only the 10min attempt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复使用统计历史回填可能导致重复计数的问题。
  * 优化首次统计聚合和重新计算时的数据起始范围，确保历史数据正确纳入。
  * 修正“本月”与“最近24小时”统计结果的时间范围差异。

* **测试**
  * 新增管理端统计接口及回填场景的回归验证。
  * 增加界面和模拟数据截图，辅助确认不同时间范围下的统计表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->