### PR TITLE
fix(requests): record effective reasoning effort

### DIFF
--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/awsl-project/maxx/internal/executor/responsemodifier"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/pricing"
+	"github.com/awsl-project/maxx/internal/requestmeta"
 	"github.com/awsl-project/maxx/internal/sticky"
 )
 
@@ -199,6 +200,9 @@ routeLoop:
 			// final converted body, before it reaches the adapter. Idempotent, so
 			// re-running on retry is safe.
 			requestBody = e.applyOutboundParamPolicy(requestBody, currentClientType, mappedModel, matchedRoute.Provider)
+			if effort := requestmeta.ReasoningEffort(requestBody); effort != "" {
+				proxyReq.ReasoningEffort = effort
+			}
 
 			eventChan := domain.NewAdapterEventChan()
 			c.Set(flow.KeyClientType, currentClientType)

--- a/internal/executor/param_policy_dispatch_test.go
+++ b/internal/executor/param_policy_dispatch_test.go
@@ -19,7 +19,7 @@ import (
 // OpenRouter/custom shape) whose sole provider carries the given reasoning
 // policy, so the outbound body the adapter observes reflects the executor's
 // authoritative param stage.
-func paramPolicyDispatchCtx(t *testing.T, requestBody string, policy *domain.ReasoningPolicy, adapter *openAIOnlyConversionAdapter) (*flow.Ctx, *Executor) {
+func paramPolicyDispatchCtx(t *testing.T, requestBody string, policy *domain.ReasoningPolicy, adapter *openAIOnlyConversionAdapter) (*flow.Ctx, *Executor, *recordingProxyRequestRepo) {
 	t.Helper()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(requestBody)).WithContext(context.Background())
@@ -53,14 +53,15 @@ func paramPolicyDispatchCtx(t *testing.T, requestBody string, policy *domain.Rea
 		},
 	}
 	c.Set(flow.KeyExecutorState, state)
+	proxyRepo := &recordingProxyRequestRepo{}
 	e := &Executor{
-		proxyRequestRepo: &recordingProxyRequestRepo{},
+		proxyRequestRepo: proxyRepo,
 		attemptRepo:      &recordingAttemptRepo{},
 		modelMappingRepo: &staticModelMappingRepo{},
 		settingsRepo:     &stubExecutorSettingsRepo{},
 		converter:        converter.GetGlobalRegistry(),
 	}
-	return c, e
+	return c, e, proxyRepo
 }
 
 // A provider MaxEffort ceiling clamps the outbound reasoning_effort even though
@@ -68,7 +69,7 @@ func paramPolicyDispatchCtx(t *testing.T, requestBody string, policy *domain.Rea
 // stage, not the adapter, is authoritative and covers the passthrough path.
 func TestDispatchClampsReasoningEffortCeiling(t *testing.T) {
 	adapter := &openAIOnlyConversionAdapter{responseBody: `{"id":"x","object":"chat.completion","choices":[]}`}
-	c, e := paramPolicyDispatchCtx(t,
+	c, e, proxyRepo := paramPolicyDispatchCtx(t,
 		`{"model":"gpt-4o","reasoning_effort":"high","messages":[{"role":"user","content":"hi"}],"stream":false}`,
 		&domain.ReasoningPolicy{MaxEffort: "medium"}, adapter)
 
@@ -83,12 +84,18 @@ func TestDispatchClampsReasoningEffortCeiling(t *testing.T) {
 	if got := gjson.GetBytes(adapter.seenRequestBody, "reasoning_effort").String(); got != "medium" {
 		t.Fatalf("outbound reasoning_effort = %q, want clamped to medium; body=%s", got, adapter.seenRequestBody)
 	}
+	if len(proxyRepo.updated) == 0 {
+		t.Fatal("proxy request was not updated")
+	}
+	if got := proxyRepo.updated[len(proxyRepo.updated)-1].ReasoningEffort; got != "medium" {
+		t.Fatalf("recorded reasoning effort = %q, want medium", got)
+	}
 }
 
 // DefaultEffort fills an absent effort; a below-ceiling explicit value is kept.
 func TestDispatchFillsDefaultEffortWhenAbsent(t *testing.T) {
 	adapter := &openAIOnlyConversionAdapter{responseBody: `{"id":"x","object":"chat.completion","choices":[]}`}
-	c, e := paramPolicyDispatchCtx(t,
+	c, e, proxyRepo := paramPolicyDispatchCtx(t,
 		`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":false}`,
 		&domain.ReasoningPolicy{MaxEffort: "high", DefaultEffort: "low"}, adapter)
 
@@ -99,5 +106,11 @@ func TestDispatchFillsDefaultEffortWhenAbsent(t *testing.T) {
 	}
 	if got := gjson.GetBytes(adapter.seenRequestBody, "reasoning_effort").String(); got != "low" {
 		t.Fatalf("outbound reasoning_effort = %q, want default low; body=%s", got, adapter.seenRequestBody)
+	}
+	if len(proxyRepo.updated) == 0 {
+		t.Fatal("proxy request was not updated")
+	}
+	if got := proxyRepo.updated[len(proxyRepo.updated)-1].ReasoningEffort; got != "low" {
+		t.Fatalf("recorded reasoning effort = %q, want low", got)
 	}
 }


### PR DESCRIPTION
## Summary
- record the effective outbound reasoning effort after provider/global policy application
- make the requests tab reflect provider defaults and max-effort clamps instead of only the original client payload
- add regression coverage for default fill and ceiling clamp recording

## Root cause
The outbound request policy was applied inside the executor after the proxy request row was initially created. The requests page reads `proxy_requests.reasoning_effort`, which was populated from the original client payload, so provider-side defaults/clamps could work upstream while the UI still showed empty or the pre-clamp value.

## Validation
- `git diff --check`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- `go test ./...`

## Notes
- CodeRabbit was not checked or triggered in this flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 在发送上游请求前，系统会自动识别请求中的推理强度设置，并同步记录有效值。
  - 支持更准确地保留 `medium`、`low` 等推理强度配置，确保请求参数处理结果一致。

- **测试**
  - 增加了对不同推理强度场景的验证，提升相关请求处理的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->