### PR TITLE
fix(requests): publish reasoning effort before dispatch

### DIFF
--- a/internal/executor/format_conversion_dispatch_test.go
+++ b/internal/executor/format_conversion_dispatch_test.go
@@ -23,6 +23,7 @@ type openAIOnlyConversionAdapter struct {
 	responseBody     string
 	responseStatus   int
 	responseStreamed bool
+	onExecute        func()
 }
 
 func (a *openAIOnlyConversionAdapter) SupportedClientTypes() []domain.ClientType {
@@ -31,6 +32,9 @@ func (a *openAIOnlyConversionAdapter) SupportedClientTypes() []domain.ClientType
 
 func (a *openAIOnlyConversionAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
 	a.calls++
+	if a.onExecute != nil {
+		a.onExecute()
+	}
 	a.seenClientType = flow.GetClientType(c)
 	a.seenRequestURI = flow.GetRequestURI(c)
 	a.seenRequestBody = append([]byte(nil), flow.GetRequestBody(c)...)

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -200,8 +200,14 @@ routeLoop:
 			// final converted body, before it reaches the adapter. Idempotent, so
 			// re-running on retry is safe.
 			requestBody = e.applyOutboundParamPolicy(requestBody, currentClientType, mappedModel, matchedRoute.Provider)
-			if effort := requestmeta.ReasoningEffort(requestBody); effort != "" {
+			if effort := requestmeta.ReasoningEffort(requestBody); effort != "" && effort != proxyReq.ReasoningEffort {
 				proxyReq.ReasoningEffort = effort
+				if err := e.proxyRequestRepo.Update(proxyReq); err != nil {
+					log.Printf("[Executor] Failed to update proxy request reasoning effort: %v", err)
+				}
+				if e.broadcaster != nil {
+					e.broadcaster.BroadcastProxyRequest(proxyReq)
+				}
 			}
 
 			eventChan := domain.NewAdapterEventChan()

--- a/internal/executor/param_policy_dispatch_test.go
+++ b/internal/executor/param_policy_dispatch_test.go
@@ -93,6 +93,34 @@ func TestDispatchClampsReasoningEffortCeiling(t *testing.T) {
 }
 
 // DefaultEffort fills an absent effort; a below-ceiling explicit value is kept.
+func TestDispatchBroadcastsPolicyReasoningBeforeAdapterExecute(t *testing.T) {
+	var updatesBeforeAdapter int
+	adapter := &openAIOnlyConversionAdapter{
+		responseBody: `{"id":"x","object":"chat.completion","choices":[]}`,
+		onExecute: func() {
+			updatesBeforeAdapter = 0
+		},
+	}
+	c, e, proxyRepo := paramPolicyDispatchCtx(t,
+		`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":false}`,
+		&domain.ReasoningPolicy{DefaultEffort: "low"}, adapter)
+	adapter.onExecute = func() {
+		updatesBeforeAdapter = len(proxyRepo.updated)
+	}
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if updatesBeforeAdapter == 0 {
+		t.Fatal("reasoning effort was not persisted before adapter execution")
+	}
+	if got := proxyRepo.updated[updatesBeforeAdapter-1].ReasoningEffort; got != "low" {
+		t.Fatalf("pre-adapter reasoning effort = %q, want low", got)
+	}
+}
+
 func TestDispatchFillsDefaultEffortWhenAbsent(t *testing.T) {
 	adapter := &openAIOnlyConversionAdapter{responseBody: `{"id":"x","object":"chat.completion","choices":[]}`}
 	c, e, proxyRepo := paramPolicyDispatchCtx(t,

--- a/internal/executor/param_policy_dispatch_test.go
+++ b/internal/executor/param_policy_dispatch_test.go
@@ -92,14 +92,10 @@ func TestDispatchClampsReasoningEffortCeiling(t *testing.T) {
 	}
 }
 
-// DefaultEffort fills an absent effort; a below-ceiling explicit value is kept.
 func TestDispatchBroadcastsPolicyReasoningBeforeAdapterExecute(t *testing.T) {
 	var updatesBeforeAdapter int
 	adapter := &openAIOnlyConversionAdapter{
 		responseBody: `{"id":"x","object":"chat.completion","choices":[]}`,
-		onExecute: func() {
-			updatesBeforeAdapter = 0
-		},
 	}
 	c, e, proxyRepo := paramPolicyDispatchCtx(t,
 		`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":false}`,
@@ -121,6 +117,7 @@ func TestDispatchBroadcastsPolicyReasoningBeforeAdapterExecute(t *testing.T) {
 	}
 }
 
+// DefaultEffort fills an absent effort; a below-ceiling explicit value is kept.
 func TestDispatchFillsDefaultEffortWhenAbsent(t *testing.T) {
 	adapter := &openAIOnlyConversionAdapter{responseBody: `{"id":"x","object":"chat.completion","choices":[]}`}
 	c, e, proxyRepo := paramPolicyDispatchCtx(t,


### PR DESCRIPTION
## Summary
- persist and broadcast the provider-policy reasoning effort immediately after outbound policy application
- make the requests tab show the final expected reasoning effort before the upstream adapter finishes
- add a regression test proving the reasoning effort is persisted before adapter execution

## Validation
- go test ./internal/executor
- go test ./...
- pnpm --dir web typecheck
- pnpm --dir web build
- pnpm --dir web lint
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化推理强度参数的更新逻辑，仅在值发生实际变化时保存并广播，减少不必要的更新。
  - 在请求缺少推理强度时正确应用默认策略，并确保执行前完成保存。
  - 增强执行回调处理，避免空回调导致异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->