### PR TITLE
fix(provider): add highest reasoning effort options

### DIFF
--- a/internal/reqpolicy/reqpolicy.go
+++ b/internal/reqpolicy/reqpolicy.go
@@ -9,7 +9,7 @@
 //
 // Phase 1 handles reasoning effort. Effort is ordered:
 //
-//	none < minimal < low < medium < high
+//	none < minimal < low < medium < high < xhigh < max
 //
 // plus the special "auto" (defer to provider). Two composable primitives:
 //
@@ -35,6 +35,8 @@ const (
 	rankLow
 	rankMedium
 	rankHigh
+	rankXHigh
+	rankMax
 )
 
 var effortToRank = map[string]int{
@@ -43,6 +45,8 @@ var effortToRank = map[string]int{
 	"low":     rankLow,
 	"medium":  rankMedium,
 	"high":    rankHigh,
+	"xhigh":   rankXHigh,
+	"max":     rankMax,
 }
 
 var rankToEffort = map[int]string{
@@ -51,6 +55,8 @@ var rankToEffort = map[int]string{
 	rankLow:     "low",
 	rankMedium:  "medium",
 	rankHigh:    "high",
+	rankXHigh:   "xhigh",
+	rankMax:     "max",
 }
 
 // parseRank normalizes an effort string to its rank. ok is false for empty or
@@ -74,8 +80,9 @@ type effortValue struct {
 
 // codec hides each protocol's JSON path and value vocabulary for effort.
 type codec struct {
-	path   string              // gjson/sjson dotted path in the outbound body
-	toWire func(string) string // rank name -> protocol wire form
+	path        string              // gjson/sjson dotted path in the outbound body
+	toWire      func(string) string // rank name -> protocol wire form
+	maxWireRank int                 // highest rank this protocol can express; 0 means no protocol-specific cap
 }
 
 func identity(s string) string { return s }
@@ -90,8 +97,8 @@ func codecFor(protocol domain.ClientType) *codec {
 	case domain.ClientTypeCodex:
 		return &codec{path: "reasoning.effort", toWire: identity}
 	case domain.ClientTypeGemini:
-		// Gemini's thinkingLevel vocabulary is upper-case (LOW/MEDIUM/HIGH).
-		return &codec{path: "generationConfig.thinkingConfig.thinkingLevel", toWire: strings.ToUpper}
+		// Gemini's thinkingLevel vocabulary is upper-case and currently tops out at HIGH.
+		return &codec{path: "generationConfig.thinkingConfig.thinkingLevel", toWire: strings.ToUpper, maxWireRank: rankHigh}
 	default:
 		return nil
 	}
@@ -116,6 +123,9 @@ func (c *codec) read(body []byte) effortValue {
 }
 
 func (c *codec) write(body []byte, rank int) []byte {
+	if c.maxWireRank > 0 && rank > c.maxWireRank {
+		rank = c.maxWireRank
+	}
 	name, ok := rankToEffort[rank]
 	if !ok {
 		return body
@@ -150,6 +160,10 @@ func claudeThinkingBudgetForRank(rank int) int64 {
 		return 8192
 	case rankHigh:
 		return 16000
+	case rankXHigh:
+		return 32000
+	case rankMax:
+		return 64000
 	default:
 		return 0
 	}

--- a/internal/reqpolicy/reqpolicy_test.go
+++ b/internal/reqpolicy/reqpolicy_test.go
@@ -57,11 +57,31 @@ func TestApply_AutoPassesThroughWithoutCeiling(t *testing.T) {
 }
 
 func TestApply_UnknownVocabularyClampedWhenCapped(t *testing.T) {
-	// A ceiling must hold even against a value we can't rank (e.g. "xhigh").
+	// A ceiling must hold even against a value we can't rank.
 	eff := Resolve(nil, mustPolicy("medium", ""), "")
-	out := Apply([]byte(`{"reasoning_effort":"xhigh"}`), domain.ClientTypeOpenAI, eff)
+	out := Apply([]byte(`{"reasoning_effort":"ultra"}`), domain.ClientTypeOpenAI, eff)
 	if got := effortAt(t, out, domain.ClientTypeOpenAI); got != "medium" {
 		t.Fatalf("unknown reasoning_effort = %q, want clamped to medium", got)
+	}
+}
+
+func TestApply_ExtendedEffortsAreOrderedAndWritable(t *testing.T) {
+	clamped := Apply(
+		[]byte(`{"reasoning_effort":"max"}`),
+		domain.ClientTypeOpenAI,
+		Resolve(nil, mustPolicy("xhigh", ""), ""),
+	)
+	if got := effortAt(t, clamped, domain.ClientTypeOpenAI); got != "xhigh" {
+		t.Fatalf("max above xhigh ceiling = %q, want xhigh", got)
+	}
+
+	filled := Apply(
+		[]byte(`{"model":"m"}`),
+		domain.ClientTypeOpenAI,
+		Resolve(nil, mustPolicy("", "max"), ""),
+	)
+	if got := effortAt(t, filled, domain.ClientTypeOpenAI); got != "max" {
+		t.Fatalf("default effort = %q, want max", got)
 	}
 }
 
@@ -105,6 +125,25 @@ func TestApply_GeminiUpperCaseWire(t *testing.T) {
 	}
 }
 
+func TestApply_GeminiCapsExtendedWireToHigh(t *testing.T) {
+	eff := Resolve(nil, mustPolicy("", "max"), "")
+	out := Apply([]byte(`{}`), domain.ClientTypeGemini, eff)
+	if got := gjson.GetBytes(out, "generationConfig.thinkingConfig.thinkingLevel").String(); got != "HIGH" {
+		t.Fatalf("thinkingLevel = %q, want HIGH (Gemini wire maximum)", got)
+	}
+}
+
+func TestValidEffort_AcceptsExtendedEfforts(t *testing.T) {
+	for _, effort := range []string{"none", "minimal", "low", "medium", "high", "xhigh", "max", ""} {
+		if !ValidEffort(effort) {
+			t.Fatalf("ValidEffort(%q) = false, want true", effort)
+		}
+	}
+	if ValidEffort("ultra") {
+		t.Fatal("ValidEffort(ultra) = true, want false")
+	}
+}
+
 func TestApply_ClaudeDefaultWritesThinkingBudget(t *testing.T) {
 	eff := Resolve(nil, mustPolicy("", "medium"), "")
 	out := Apply([]byte(`{"model":"claude-sonnet","max_tokens":4096}`), domain.ClientTypeClaude, eff)
@@ -116,6 +155,17 @@ func TestApply_ClaudeDefaultWritesThinkingBudget(t *testing.T) {
 	}
 	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 8193 {
 		t.Fatalf("max_tokens = %d, want bumped above thinking budget; body=%s", got, out)
+	}
+}
+
+func TestApply_ClaudeMaxWritesHighestThinkingBudget(t *testing.T) {
+	eff := Resolve(nil, mustPolicy("", "max"), "")
+	out := Apply([]byte(`{"model":"claude-sonnet","max_tokens":4096}`), domain.ClientTypeClaude, eff)
+	if got := gjson.GetBytes(out, "thinking.budget_tokens").Int(); got != 64000 {
+		t.Fatalf("thinking.budget_tokens = %d, want 64000; body=%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "max_tokens").Int(); got != 64001 {
+		t.Fatalf("max_tokens = %d, want bumped above max thinking budget; body=%s", got, out)
 	}
 }
 

--- a/internal/reqpolicy/validate.go
+++ b/internal/reqpolicy/validate.go
@@ -25,10 +25,10 @@ func ValidatePolicy(p *domain.ReasoningPolicy) error {
 		return nil
 	}
 	if !ValidEffort(p.MaxEffort) {
-		return fmt.Errorf("%w: invalid maxEffort %q (want one of none|minimal|low|medium|high)", domain.ErrInvalidInput, p.MaxEffort)
+		return fmt.Errorf("%w: invalid maxEffort %q (want one of none|minimal|low|medium|high|xhigh|max)", domain.ErrInvalidInput, p.MaxEffort)
 	}
 	if !ValidEffort(p.DefaultEffort) {
-		return fmt.Errorf("%w: invalid defaultEffort %q (want one of none|minimal|low|medium|high)", domain.ErrInvalidInput, p.DefaultEffort)
+		return fmt.Errorf("%w: invalid defaultEffort %q (want one of none|minimal|low|medium|high|xhigh|max)", domain.ErrInvalidInput, p.DefaultEffort)
 	}
 	return nil
 }

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -35,8 +35,8 @@ export interface ProviderConfigCustomDisguise {
 }
 
 export interface ReasoningPolicy {
-  maxEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
-  defaultEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+  maxEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+  defaultEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 }
 
 export interface ProviderConfigCustom {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1758,7 +1758,9 @@
       "minimal": "Minimal",
       "low": "Low",
       "medium": "Medium",
-      "high": "High"
+      "high": "High",
+      "xhigh": "Extra High",
+      "max": "Max"
     }
   },
   "cooldown": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1755,7 +1755,9 @@
       "minimal": "极低",
       "low": "低",
       "medium": "中",
-      "high": "高"
+      "high": "高",
+      "xhigh": "超高",
+      "max": "最高"
     }
   },
   "cooldown": {

--- a/web/src/pages/providers/components/reasoning-policy-settings.tsx
+++ b/web/src/pages/providers/components/reasoning-policy-settings.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-const EFFORTS = ['none', 'minimal', 'low', 'medium', 'high'] as const;
+const EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 const UNSET_VALUE = '__unset__';
 
 type ReasoningEffort = (typeof EFFORTS)[number];


### PR DESCRIPTION
## Summary
- add `xhigh` and `max` to the provider reasoning policy effort tiers
- show the new tiers in the provider reasoning policy UI (`超高` / `最高` in Chinese)
- keep protocol-specific behavior safe: Gemini policy writes still cap to `HIGH`, while OpenAI/Codex can emit `xhigh`/`max` and Claude maps them to larger thinking budgets

## Validation
- `go test ./internal/reqpolicy ./internal/executor ./internal/requestmeta`
- `go test ./internal/...`
- `cd web && pnpm typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 推理强度新增“超高”和“最高”选项，可分别设置默认及最大推理强度。
  * Claude 支持更高的思考预算配置。
  * Gemini 会自动将超出其支持范围的推理强度调整为“高”。

* **改进**
  * 推理强度配置增加上限校验，避免使用协议不支持的等级。
  * 中英文界面新增相关选项及本地化文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->