### PR TITLE
feat(provider): add API token quota checks

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -399,7 +399,7 @@ func main() {
 	projectWaiter := waiter.NewProjectWaiter(cachedSessionRepo, settingRepo, wsHub)
 
 	// Create executor
-	requestExecutor := executor.NewExecutor(r, proxyRequestRepo, attemptRepo, cachedRetryConfigRepo, cachedSessionRepo, cachedModelMappingRepo, settingRepo, wsHub, projectWaiter, instanceID)
+	requestExecutor := executor.NewExecutor(r, proxyRequestRepo, attemptRepo, cachedAPITokenRepo, cachedRetryConfigRepo, cachedSessionRepo, cachedModelMappingRepo, settingRepo, wsHub, projectWaiter, instanceID)
 
 	// Create client adapter
 	clientAdapter := client.NewAdapter()

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -371,6 +371,7 @@ func InitializeServerComponents(
 		r,
 		repos.ProxyRequestRepo,
 		repos.AttemptRepo,
+		repos.CachedAPITokenRepo,
 		repos.CachedRetryConfigRepo,
 		repos.CachedSessionRepo,
 		repos.CachedModelMappingRepo,

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -33,6 +33,7 @@ var (
 	ErrInviteCodeExpired                    = errors.New("invite code expired")
 	ErrInviteCodeExhausted                  = errors.New("invite code exhausted")
 	ErrInviteCodeDisabled                   = errors.New("invite code disabled")
+	ErrAPITokenQuotaExhausted               = errors.New("API token quota exhausted")
 )
 
 // ErrorScope defines what resource is broken, determining cooldown granularity

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -374,6 +374,9 @@ type ProviderConfigGrok struct {
 }
 
 type ProviderConfig struct {
+	// 启用额度检查。开启后,通过 API 令牌访问该提供商时必须有可用额度。
+	QuotaEnabled bool `json:"quotaEnabled,omitempty"`
+
 	// 禁用错误自动冷冻（只影响错误触发的冷冻）
 	DisableErrorCooldown bool `json:"disableErrorCooldown,omitempty"`
 	// 智能映射轮询重试：禁用错误自动冻结时，按候选映射模型轮询失败重试。
@@ -1242,8 +1245,16 @@ type APIToken struct {
 	// 使用次数
 	UseCount uint64 `json:"useCount"`
 
+	// 额度余额。单位沿用请求 cost 的最小单位;默认 0。
+	QuotaBalance uint64 `json:"quotaBalance"`
+
 	// 软删除时间
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
+}
+
+// APITokenQuotaRechargeResult reports the result of a bulk quota recharge.
+type APITokenQuotaRechargeResult struct {
+	UpdatedCount int `json:"updatedCount"`
 }
 
 // APITokenInactiveExpiry is the inactivity window after a token was last used.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -24,6 +24,7 @@ type Executor struct {
 	router           *router.Router
 	proxyRequestRepo repository.ProxyRequestRepository
 	attemptRepo      repository.ProxyUpstreamAttemptRepository
+	apiTokenRepo     repository.APITokenRepository
 	retryConfigRepo  repository.RetryConfigRepository
 	sessionRepo      repository.SessionRepository
 	modelMappingRepo repository.ModelMappingRepository
@@ -42,6 +43,7 @@ func NewExecutor(
 	r *router.Router,
 	prr repository.ProxyRequestRepository,
 	ar repository.ProxyUpstreamAttemptRepository,
+	apiTokenRepo repository.APITokenRepository,
 	rcr repository.RetryConfigRepository,
 	sessionRepo repository.SessionRepository,
 	modelMappingRepo repository.ModelMappingRepository,
@@ -54,6 +56,7 @@ func NewExecutor(
 		router:           r,
 		proxyRequestRepo: prr,
 		attemptRepo:      ar,
+		apiTokenRepo:     apiTokenRepo,
 		retryConfigRepo:  rcr,
 		sessionRepo:      sessionRepo,
 		modelMappingRepo: modelMappingRepo,

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -87,6 +87,17 @@ routeLoop:
 			proxyReq.RouteID = matchedRoute.Route.ID
 			proxyReq.ProviderID = matchedRoute.Provider.ID
 			proxyReq.MappedModel = mappedModel
+			if quotaErr := e.ensureAPITokenQuota(state, proxyReq, matchedRoute.Provider); quotaErr != nil {
+				rejectProxyRequestForQuota(proxyReq, quotaErr)
+				clearProxyRequestDetail(proxyReq, clearDetail)
+				_ = e.proxyRequestRepo.Update(proxyReq)
+				if e.broadcaster != nil {
+					e.broadcaster.BroadcastProxyRequest(proxyReq)
+				}
+				state.lastErr = quotaErr
+				c.Err = quotaErr
+				return
+			}
 			_ = e.proxyRequestRepo.Update(proxyReq)
 			if e.broadcaster != nil {
 				e.broadcaster.BroadcastProxyRequest(proxyReq)
@@ -281,6 +292,7 @@ routeLoop:
 				attemptRecord.Error = ""
 
 				pricing.FinalizeAttemptCost(attemptRecord, multiplier)
+				e.deductAPITokenQuota(state, attemptRecord)
 
 				if clearDetail {
 					attemptRecord.RequestInfo = nil
@@ -355,6 +367,7 @@ routeLoop:
 			attemptRecord.Error = err.Error()
 
 			pricing.FinalizeAttemptCost(attemptRecord, multiplier)
+			e.deductAPITokenQuota(state, attemptRecord)
 
 			if clearDetail {
 				attemptRecord.RequestInfo = nil

--- a/internal/executor/quota.go
+++ b/internal/executor/quota.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func providerQuotaEnabled(provider *domain.Provider) bool {
+	return provider != nil && provider.Config != nil && provider.Config.QuotaEnabled
+}
+
+func (e *Executor) ensureAPITokenQuota(state *execState, proxyReq *domain.ProxyRequest, provider *domain.Provider) error {
+	if !providerQuotaEnabled(provider) {
+		return nil
+	}
+	if e.apiTokenRepo == nil || state.apiTokenID == 0 {
+		return newAPITokenQuotaError()
+	}
+	token, err := e.apiTokenRepo.GetByID(state.tenantID, state.apiTokenID)
+	if err != nil || token == nil || token.QuotaBalance == 0 {
+		return newAPITokenQuotaError()
+	}
+	return nil
+}
+
+func (e *Executor) deductAPITokenQuota(state *execState, attempt *domain.ProxyUpstreamAttempt) {
+	if e.apiTokenRepo == nil || state == nil || state.apiTokenID == 0 || attempt == nil || attempt.Cost == 0 {
+		return
+	}
+	if err := e.apiTokenRepo.DeductQuotaBalanceToZero(state.tenantID, state.apiTokenID, attempt.Cost); err != nil {
+		log.Printf("[Executor] API token quota deduct failed token=%d cost=%d: %v", state.apiTokenID, attempt.Cost, err)
+	}
+}
+
+func rejectProxyRequestForQuota(proxyReq *domain.ProxyRequest, err error) {
+	if proxyReq == nil {
+		return
+	}
+	proxyReq.Status = "REJECTED"
+	proxyReq.Error = err.Error()
+	proxyReq.StatusCode = http.StatusForbidden
+	proxyReq.EndTime = time.Now()
+	proxyReq.Duration = proxyReq.EndTime.Sub(proxyReq.StartTime)
+}
+
+func newAPITokenQuotaError() *domain.ProxyError {
+	proxyErr := domain.NewProxyErrorWithMessage(domain.ErrAPITokenQuotaExhausted, false, "当前令牌额度不足")
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.Code = "api_token_quota_exhausted"
+	proxyErr.HTTPStatusCode = http.StatusForbidden
+	return proxyErr
+}

--- a/internal/executor/quota_test.go
+++ b/internal/executor/quota_test.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type quotaTokenRepo struct {
+	token         *domain.APIToken
+	deductedToken uint64
+	deductedCost  uint64
+}
+
+func (r *quotaTokenRepo) Create(token *domain.APIToken) error     { return nil }
+func (r *quotaTokenRepo) Update(token *domain.APIToken) error     { return nil }
+func (r *quotaTokenRepo) Delete(tenantID uint64, id uint64) error { return nil }
+func (r *quotaTokenRepo) DeleteExpired(tenantID uint64, now time.Time, inactiveExpiry time.Duration) ([]*domain.APIToken, error) {
+	return nil, nil
+}
+func (r *quotaTokenRepo) GetByID(tenantID uint64, id uint64) (*domain.APIToken, error) {
+	if r.token == nil || r.token.ID != id || r.token.TenantID != tenantID {
+		return nil, domain.ErrNotFound
+	}
+	return r.token, nil
+}
+func (r *quotaTokenRepo) GetByToken(tenantID uint64, token string) (*domain.APIToken, error) {
+	return nil, errors.New("not implemented")
+}
+func (r *quotaTokenRepo) List(tenantID uint64) ([]*domain.APIToken, error) { return nil, nil }
+func (r *quotaTokenRepo) UpdateLastSeen(tenantID uint64, id uint64, lastIP string, lastSeenAt time.Time) error {
+	return nil
+}
+func (r *quotaTokenRepo) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	return int64(len(ids)), nil
+}
+func (r *quotaTokenRepo) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	r.deductedToken = id
+	r.deductedCost = amount
+	return nil
+}
+
+func TestEnsureAPITokenQuotaRejectsEnabledProviderWhenBalanceIsZero(t *testing.T) {
+	repo := &quotaTokenRepo{token: &domain.APIToken{ID: 7, TenantID: 1, QuotaBalance: 0}}
+	exec := &Executor{apiTokenRepo: repo}
+	provider := &domain.Provider{Config: &domain.ProviderConfig{QuotaEnabled: true}}
+	proxyReq := &domain.ProxyRequest{TenantID: 1, APITokenID: 7, StartTime: time.Now()}
+
+	err := exec.ensureAPITokenQuota(&execState{tenantID: 1, apiTokenID: 7}, proxyReq, provider)
+	if err == nil {
+		t.Fatal("expected quota error")
+	}
+	if !errors.Is(err, domain.ErrAPITokenQuotaExhausted) {
+		t.Fatalf("error = %v, want ErrAPITokenQuotaExhausted", err)
+	}
+}
+
+func TestEnsureAPITokenQuotaAllowsDisabledProviderWithZeroBalance(t *testing.T) {
+	exec := &Executor{apiTokenRepo: &quotaTokenRepo{}}
+	provider := &domain.Provider{Config: &domain.ProviderConfig{QuotaEnabled: false}}
+
+	if err := exec.ensureAPITokenQuota(&execState{tenantID: 1, apiTokenID: 0}, &domain.ProxyRequest{}, provider); err != nil {
+		t.Fatalf("ensureAPITokenQuota = %v, want nil", err)
+	}
+}
+
+func TestDeductAPITokenQuotaUsesAttemptCost(t *testing.T) {
+	repo := &quotaTokenRepo{}
+	exec := &Executor{apiTokenRepo: repo}
+
+	exec.deductAPITokenQuota(&execState{tenantID: 1, apiTokenID: 7}, &domain.ProxyUpstreamAttempt{Cost: 42})
+
+	if repo.deductedToken != 7 || repo.deductedCost != 42 {
+		t.Fatalf("deduct token/cost = %d/%d, want 7/42", repo.deductedToken, repo.deductedCost)
+	}
+}

--- a/internal/executor/single_attempt.go
+++ b/internal/executor/single_attempt.go
@@ -52,6 +52,15 @@ func (e *Executor) ExecuteOnce(
 	isStream bool,
 	clearDetail bool,
 ) (*domain.ProxyUpstreamAttempt, error) {
+	quotaState := &execState{tenantID: proxyReq.TenantID, apiTokenID: proxyReq.APITokenID}
+	if quotaState.tenantID == 0 {
+		quotaState.tenantID = maxxctx.GetTenantID(c.Request.Context())
+	}
+	if quotaErr := e.ensureAPITokenQuota(quotaState, proxyReq, provider); quotaErr != nil {
+		rejectProxyRequestForQuota(proxyReq, quotaErr)
+		return nil, quotaErr
+	}
+
 	attempt := &domain.ProxyUpstreamAttempt{
 		TenantID:       proxyReq.TenantID,
 		ProxyRequestID: proxyReq.ID,
@@ -113,6 +122,7 @@ func (e *Executor) ExecuteOnce(
 
 	multiplier := getProviderMultiplier(provider, clientType)
 	pricing.FinalizeAttemptCost(attempt, multiplier)
+	e.deductAPITokenQuota(quotaState, attempt)
 
 	if clearDetail {
 		attempt.RequestInfo = nil

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1788,6 +1788,10 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 		h.handleCleanupExpiredAPITokens(w, r, tenantID)
 		return
 	}
+	if strings.HasSuffix(path, "/api-tokens/quota/recharge") {
+		h.handleRechargeAPITokenQuota(w, r, tenantID)
+		return
+	}
 
 	switch r.Method {
 	case http.MethodGet:
@@ -1852,6 +1856,7 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 			ProjectID     *uint64 `json:"projectID"`
 			IsEnabled     *bool   `json:"isEnabled"`
 			DevMode       *bool   `json:"devMode"`
+			QuotaBalance  *uint64 `json:"quotaBalance"`
 			ExpiresAt     *string `json:"expiresAt"`
 			ResetValidity *bool   `json:"resetValidity"`
 		}
@@ -1877,6 +1882,9 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 		}
 		if body.DevMode != nil {
 			existing.DevMode = *body.DevMode
+		}
+		if body.QuotaBalance != nil {
+			existing.QuotaBalance = *body.QuotaBalance
 		}
 		if body.ExpiresAt != nil {
 			if *body.ExpiresAt == "" {
@@ -1915,6 +1923,31 @@ func (h *AdminHandler) handleAPITokens(w http.ResponseWriter, r *http.Request, i
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+func (h *AdminHandler) handleRechargeAPITokenQuota(w http.ResponseWriter, r *http.Request, tenantID uint64) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	var body struct {
+		IDs    []uint64 `json:"ids"`
+		Amount uint64   `json:"amount"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	result, err := h.svc.RechargeAPITokenQuota(tenantID, body.IDs, body.Amount)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, domain.ErrInvalidInput) {
+			status = http.StatusBadRequest
+		}
+		writeJSON(w, status, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (h *AdminHandler) handleCleanupExpiredAPITokens(w http.ResponseWriter, r *http.Request, tenantID uint64) {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -501,6 +501,37 @@ func (r *selfServiceAPITokenRepo) UpdateLastSeen(_ uint64, _ uint64, _ string, _
 	return nil
 }
 
+func (r *selfServiceAPITokenRepo) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	var updated int64
+	for _, token := range r.tokens {
+		if token.TenantID != tenantID {
+			continue
+		}
+		for _, id := range ids {
+			if token.ID == id {
+				token.QuotaBalance += amount
+				updated++
+				break
+			}
+		}
+	}
+	return updated, nil
+}
+
+func (r *selfServiceAPITokenRepo) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	for _, token := range r.tokens {
+		if token.ID == id && token.TenantID == tenantID {
+			if token.QuotaBalance > amount {
+				token.QuotaBalance -= amount
+			} else {
+				token.QuotaBalance = 0
+			}
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
+
 type selfServiceUsageStatsRepo struct {
 	providerStats  map[uint64]*domain.ProviderStats
 	stats          []*domain.UsageStats

--- a/internal/handler/token_auth_test.go
+++ b/internal/handler/token_auth_test.go
@@ -111,6 +111,14 @@ func (r *tokenAuthTestRepo) UpdateLastSeen(tenantID uint64, id uint64, lastIP st
 	return nil
 }
 
+func (r *tokenAuthTestRepo) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	return 0, nil
+}
+
+func (r *tokenAuthTestRepo) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	return nil
+}
+
 func TestTokenAuthValidateRequestUpdatesLastSeenWithClientIP(t *testing.T) {
 	repo := newTokenAuthTestRepo()
 	cachedRepo := cached.NewAPITokenRepository(repo)

--- a/internal/repository/cached/api_token.go
+++ b/internal/repository/cached/api_token.go
@@ -174,6 +174,43 @@ func (r *APITokenRepository) UpdateLastSeen(tenantID uint64, id uint64, lastIP s
 	return nil
 }
 
+func (r *APITokenRepository) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	updated, err := r.repo.AddQuotaBalance(tenantID, ids, amount)
+	if err != nil {
+		return 0, err
+	}
+	r.mu.Lock()
+	for _, id := range ids {
+		if t, ok := r.cache[id]; ok && t != nil && t.TenantID == tenantID {
+			t.QuotaBalance += amount
+		}
+	}
+	r.mu.Unlock()
+	if updated > 0 {
+		for _, id := range ids {
+			r.bc.publish(OpUpdate, id)
+		}
+	}
+	return updated, nil
+}
+
+func (r *APITokenRepository) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	if err := r.repo.DeductQuotaBalanceToZero(tenantID, id, amount); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	if t, ok := r.cache[id]; ok && t != nil && t.TenantID == tenantID {
+		if t.QuotaBalance > amount {
+			t.QuotaBalance -= amount
+		} else {
+			t.QuotaBalance = 0
+		}
+	}
+	r.mu.Unlock()
+	r.bc.publish(OpUpdate, id)
+	return nil
+}
+
 // InvalidateCache clears all cached tokens
 func (r *APITokenRepository) InvalidateCache() {
 	r.mu.Lock()

--- a/internal/repository/cached/api_token_test.go
+++ b/internal/repository/cached/api_token_test.go
@@ -74,6 +74,31 @@ func (r *apiTokenTestRepo) UpdateLastSeen(tenantID uint64, id uint64, lastIP str
 	return nil
 }
 
+func (r *apiTokenTestRepo) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	if r.token == nil || len(ids) == 0 {
+		return 0, nil
+	}
+	for _, id := range ids {
+		if r.token.ID == id && r.token.TenantID == tenantID {
+			r.token.QuotaBalance += amount
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+func (r *apiTokenTestRepo) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	if r.token == nil || r.token.ID != id || r.token.TenantID != tenantID {
+		return domain.ErrNotFound
+	}
+	if r.token.QuotaBalance > amount {
+		r.token.QuotaBalance -= amount
+	} else {
+		r.token.QuotaBalance = 0
+	}
+	return nil
+}
+
 func TestAPITokenRepositoryUpdateLastSeenKeepsLastIPWhenIPIsEmpty(t *testing.T) {
 	baseRepo := &apiTokenTestRepo{}
 	repo := NewAPITokenRepository(baseRepo)

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -347,6 +347,8 @@ type APITokenRepository interface {
 	GetByToken(tenantID uint64, token string) (*domain.APIToken, error)
 	List(tenantID uint64) ([]*domain.APIToken, error)
 	UpdateLastSeen(tenantID uint64, id uint64, lastIP string, lastSeenAt time.Time) error
+	AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error)
+	DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error
 }
 
 type ModelMappingRepository interface {

--- a/internal/repository/sqlite/api_token.go
+++ b/internal/repository/sqlite/api_token.go
@@ -33,16 +33,17 @@ func (r *APITokenRepository) Create(t *domain.APIToken) error {
 func (r *APITokenRepository) Update(t *domain.APIToken) error {
 	t.UpdatedAt = time.Now()
 	updates := map[string]any{
-		"updated_at":   toTimestamp(t.UpdatedAt),
-		"name":         t.Name,
-		"description":  LongText(t.Description),
-		"project_id":   t.ProjectID,
-		"is_enabled":   boolToInt(t.IsEnabled),
-		"dev_mode":     boolToInt(t.DevMode),
-		"expires_at":   toTimestampPtr(t.ExpiresAt),
-		"last_used_at": toTimestampPtr(t.LastUsedAt),
-		"last_ip":      t.LastIP,
-		"last_ip_at":   toTimestampPtr(t.LastIPAt),
+		"updated_at":    toTimestamp(t.UpdatedAt),
+		"name":          t.Name,
+		"description":   LongText(t.Description),
+		"project_id":    t.ProjectID,
+		"is_enabled":    boolToInt(t.IsEnabled),
+		"dev_mode":      boolToInt(t.DevMode),
+		"expires_at":    toTimestampPtr(t.ExpiresAt),
+		"last_used_at":  toTimestampPtr(t.LastUsedAt),
+		"last_ip":       t.LastIP,
+		"last_ip_at":    toTimestampPtr(t.LastIPAt),
+		"quota_balance": t.QuotaBalance,
 	}
 	if t.Token != "" {
 		updates["token"] = t.Token
@@ -168,42 +169,63 @@ func (r *APITokenRepository) toModel(t *domain.APIToken) *APIToken {
 			},
 			DeletedAt: toTimestampPtr(t.DeletedAt),
 		},
-		TenantID:    t.TenantID,
-		Token:       t.Token,
-		TokenPrefix: t.TokenPrefix,
-		Name:        t.Name,
-		Description: LongText(t.Description),
-		ProjectID:   t.ProjectID,
-		IsEnabled:   boolToInt(t.IsEnabled),
-		DevMode:     boolToInt(t.DevMode),
-		ExpiresAt:   toTimestampPtr(t.ExpiresAt),
-		LastUsedAt:  toTimestampPtr(t.LastUsedAt),
-		LastIP:      t.LastIP,
-		LastIPAt:    toTimestampPtr(t.LastIPAt),
-		UseCount:    t.UseCount,
+		TenantID:     t.TenantID,
+		Token:        t.Token,
+		TokenPrefix:  t.TokenPrefix,
+		Name:         t.Name,
+		Description:  LongText(t.Description),
+		ProjectID:    t.ProjectID,
+		IsEnabled:    boolToInt(t.IsEnabled),
+		DevMode:      boolToInt(t.DevMode),
+		ExpiresAt:    toTimestampPtr(t.ExpiresAt),
+		LastUsedAt:   toTimestampPtr(t.LastUsedAt),
+		LastIP:       t.LastIP,
+		LastIPAt:     toTimestampPtr(t.LastIPAt),
+		UseCount:     t.UseCount,
+		QuotaBalance: t.QuotaBalance,
 	}
 }
 
 func (r *APITokenRepository) toDomain(m *APIToken) *domain.APIToken {
 	return &domain.APIToken{
-		ID:          m.ID,
-		CreatedAt:   fromTimestamp(m.CreatedAt),
-		UpdatedAt:   fromTimestamp(m.UpdatedAt),
-		DeletedAt:   fromTimestampPtr(m.DeletedAt),
-		TenantID:    m.TenantID,
-		Token:       m.Token,
-		TokenPrefix: m.TokenPrefix,
-		Name:        m.Name,
-		Description: string(m.Description),
-		ProjectID:   m.ProjectID,
-		IsEnabled:   m.IsEnabled == 1,
-		DevMode:     m.DevMode == 1,
-		ExpiresAt:   fromTimestampPtr(m.ExpiresAt),
-		LastUsedAt:  fromTimestampPtr(m.LastUsedAt),
-		LastIP:      m.LastIP,
-		LastIPAt:    fromTimestampPtr(m.LastIPAt),
-		UseCount:    m.UseCount,
+		ID:           m.ID,
+		CreatedAt:    fromTimestamp(m.CreatedAt),
+		UpdatedAt:    fromTimestamp(m.UpdatedAt),
+		DeletedAt:    fromTimestampPtr(m.DeletedAt),
+		TenantID:     m.TenantID,
+		Token:        m.Token,
+		TokenPrefix:  m.TokenPrefix,
+		Name:         m.Name,
+		Description:  string(m.Description),
+		ProjectID:    m.ProjectID,
+		IsEnabled:    m.IsEnabled == 1,
+		DevMode:      m.DevMode == 1,
+		ExpiresAt:    fromTimestampPtr(m.ExpiresAt),
+		LastUsedAt:   fromTimestampPtr(m.LastUsedAt),
+		LastIP:       m.LastIP,
+		LastIPAt:     fromTimestampPtr(m.LastIPAt),
+		UseCount:     m.UseCount,
+		QuotaBalance: m.QuotaBalance,
 	}
+}
+
+func (r *APITokenRepository) AddQuotaBalance(tenantID uint64, ids []uint64, amount uint64) (int64, error) {
+	if len(ids) == 0 || amount == 0 {
+		return 0, nil
+	}
+	result := tenantScope(r.db.gorm.Model(&APIToken{}), tenantID).
+		Where("id IN ?", ids).
+		Update("quota_balance", gorm.Expr("quota_balance + ?", amount))
+	return result.RowsAffected, result.Error
+}
+
+func (r *APITokenRepository) DeductQuotaBalanceToZero(tenantID uint64, id uint64, amount uint64) error {
+	if id == 0 || amount == 0 {
+		return nil
+	}
+	return tenantScope(r.db.gorm.Model(&APIToken{}), tenantID).
+		Where("id = ?", id).
+		Update("quota_balance", gorm.Expr("CASE WHEN quota_balance > ? THEN quota_balance - ? ELSE 0 END", amount, amount)).Error
 }
 
 // boolToInt converts bool to int

--- a/internal/repository/sqlite/api_token_quota_test.go
+++ b/internal/repository/sqlite/api_token_quota_test.go
@@ -1,0 +1,68 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestAPITokenQuotaBalanceDefaultsAndDeductsToZero(t *testing.T) {
+	db, err := NewDB(filepath.Join(t.TempDir(), "quota.db"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewAPITokenRepository(db)
+	token := &domain.APIToken{
+		TenantID:    domain.DefaultTenantID,
+		Token:       "maxx_test_quota",
+		TokenPrefix: "maxx_test",
+		Name:        "quota token",
+		IsEnabled:   true,
+	}
+	if err := repo.Create(token); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.GetByID(domain.DefaultTenantID, token.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.QuotaBalance != 0 {
+		t.Fatalf("default quota balance = %d, want 0", got.QuotaBalance)
+	}
+
+	updated, err := repo.AddQuotaBalance(domain.DefaultTenantID, []uint64{token.ID}, 100)
+	if err != nil {
+		t.Fatalf("AddQuotaBalance: %v", err)
+	}
+	if updated != 1 {
+		t.Fatalf("updated = %d, want 1", updated)
+	}
+
+	got, err = repo.GetByID(domain.DefaultTenantID, token.ID)
+	if err != nil {
+		t.Fatalf("GetByID after add: %v", err)
+	}
+	if got.QuotaBalance != 100 {
+		t.Fatalf("quota after add = %d, want 100", got.QuotaBalance)
+	}
+
+	if err := repo.DeductQuotaBalanceToZero(domain.DefaultTenantID, token.ID, 40); err != nil {
+		t.Fatalf("DeductQuotaBalanceToZero partial: %v", err)
+	}
+	got, _ = repo.GetByID(domain.DefaultTenantID, token.ID)
+	if got.QuotaBalance != 60 {
+		t.Fatalf("quota after partial deduct = %d, want 60", got.QuotaBalance)
+	}
+
+	if err := repo.DeductQuotaBalanceToZero(domain.DefaultTenantID, token.ID, 1000); err != nil {
+		t.Fatalf("DeductQuotaBalanceToZero overdraw: %v", err)
+	}
+	got, _ = repo.GetByID(domain.DefaultTenantID, token.ID)
+	if got.QuotaBalance != 0 {
+		t.Fatalf("quota after overdraw = %d, want 0", got.QuotaBalance)
+	}
+}

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -174,19 +174,20 @@ func (RoutingStrategy) TableName() string { return "routing_strategies" }
 // APIToken model
 type APIToken struct {
 	SoftDeleteModel
-	TenantID    uint64 `gorm:"index"`
-	Token       string `gorm:"size:255;uniqueIndex"`
-	TokenPrefix string `gorm:"size:32"`
-	Name        string `gorm:"size:255"`
-	Description LongText
-	ProjectID   uint64
-	IsEnabled   int `gorm:"default:1"`
-	DevMode     int `gorm:"default:0"`
-	ExpiresAt   int64
-	LastUsedAt  int64
-	LastIP      string `gorm:"size:64"`
-	LastIPAt    int64
-	UseCount    uint64
+	TenantID     uint64 `gorm:"index"`
+	Token        string `gorm:"size:255;uniqueIndex"`
+	TokenPrefix  string `gorm:"size:32"`
+	Name         string `gorm:"size:255"`
+	Description  LongText
+	ProjectID    uint64
+	IsEnabled    int `gorm:"default:1"`
+	DevMode      int `gorm:"default:0"`
+	ExpiresAt    int64
+	LastUsedAt   int64
+	LastIP       string `gorm:"size:64"`
+	LastIPAt     int64
+	UseCount     uint64
+	QuotaBalance uint64 `gorm:"default:0"`
 }
 
 func (APIToken) TableName() string { return "api_tokens" }

--- a/internal/repository/sqlite/usage_stats_regression_test.go
+++ b/internal/repository/sqlite/usage_stats_regression_test.go
@@ -48,11 +48,11 @@ func TestAggregateAndRollUpInitialRunBackfillsHistoricalAttempts(t *testing.T) {
 	for range repo.AggregateAndRollUp(0) {
 	}
 
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	historicalStart := now.Add(-72 * time.Hour)
 	last24Start := now.Add(-24 * time.Hour)
 	monthStats, err := repo.Query(1, repository.UsageStatsFilter{
 		Granularity: domain.GranularityDay,
-		StartTime:   &monthStart,
+		StartTime:   &historicalStart,
 		EndTime:     &now,
 	})
 	if err != nil {
@@ -94,11 +94,11 @@ func TestQueryRealtimeBackfillDoesNotDoubleCountCompletedHour(t *testing.T) {
 	}
 	close(progress)
 
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	historicalStart := now.Add(-72 * time.Hour)
 	last24Start := now.Add(-24 * time.Hour)
 	monthStats, err := repo.Query(1, repository.UsageStatsFilter{
 		Granularity: domain.GranularityDay,
-		StartTime:   &monthStart,
+		StartTime:   &historicalStart,
 		EndTime:     &now,
 	})
 	if err != nil {

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1589,6 +1589,17 @@ func (s *AdminService) UpdateAPIToken(tenantID uint64, token *domain.APIToken) e
 	return s.apiTokenRepo.Update(token)
 }
 
+func (s *AdminService) RechargeAPITokenQuota(tenantID uint64, ids []uint64, amount uint64) (*domain.APITokenQuotaRechargeResult, error) {
+	if len(ids) == 0 || amount == 0 {
+		return nil, domain.ErrInvalidInput
+	}
+	updated, err := s.apiTokenRepo.AddQuotaBalance(tenantID, ids, amount)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.APITokenQuotaRechargeResult{UpdatedCount: int(updated)}, nil
+}
+
 func (s *AdminService) DeleteAPIToken(tenantID uint64, id uint64) error {
 	return s.apiTokenRepo.Delete(tenantID, id)
 }

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -175,7 +175,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	projectWaiter := waiter.NewProjectWaiter(cachedSessionRepo, settingRepo, wsHub)
 
 	// Create executor
-	requestExecutor := executor.NewExecutor(r, proxyRequestRepo, attemptRepo, cachedRetryConfigRepo, cachedSessionRepo, cachedModelMappingRepo, settingRepo, wsHub, projectWaiter, "test-instance")
+	requestExecutor := executor.NewExecutor(r, proxyRequestRepo, attemptRepo, cachedAPITokenRepo, cachedRetryConfigRepo, cachedSessionRepo, cachedModelMappingRepo, settingRepo, wsHub, projectWaiter, "test-instance")
 
 	// Create client adapter
 	clientAdapter := client.NewAdapter()

--- a/tests/e2e/usage_stats_test.go
+++ b/tests/e2e/usage_stats_test.go
@@ -77,11 +77,11 @@ func TestUsageStatsMonthAndLast24HoursDivergeAfterHistoricalBackfill(t *testing.
 	resp := env.AdminPost("/api/admin/usage-stats/recalculate", nil)
 	AssertStatus(t, resp, http.StatusOK)
 
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	historicalStart := now.Add(-72 * time.Hour).Format(time.RFC3339)
 	last24Start := now.Add(-24 * time.Hour).Format(time.RFC3339)
 	end := now.Format(time.RFC3339)
 
-	monthResp := env.AdminGet("/api/admin/usage-stats?granularity=day&start=" + url.QueryEscape(monthStart) + "&end=" + url.QueryEscape(end))
+	monthResp := env.AdminGet("/api/admin/usage-stats?granularity=day&start=" + url.QueryEscape(historicalStart) + "&end=" + url.QueryEscape(end))
 	AssertStatus(t, monthResp, http.StatusOK)
 	last24Resp := env.AdminGet("/api/admin/usage-stats?granularity=hour&start=" + url.QueryEscape(last24Start) + "&end=" + url.QueryEscape(end))
 	AssertStatus(t, last24Resp, http.StatusOK)

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -119,6 +119,7 @@ export {
   useAPIToken,
   useCreateAPIToken,
   useUpdateAPIToken,
+  useRechargeAPITokenQuota,
   useDeleteAPIToken,
   useCleanupExpiredAPITokens,
 } from './use-api-tokens';

--- a/web/src/hooks/queries/use-api-tokens.ts
+++ b/web/src/hooks/queries/use-api-tokens.ts
@@ -3,7 +3,12 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTransport, type APITokenUpdateData, type CreateAPITokenData } from '@/lib/transport';
+import {
+  getTransport,
+  type APITokenQuotaRechargeData,
+  type APITokenUpdateData,
+  type CreateAPITokenData,
+} from '@/lib/transport';
 
 // Query Keys
 export const apiTokenKeys = {
@@ -59,6 +64,17 @@ export function useUpdateAPIToken() {
       getTransport().updateAPIToken(id, data),
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: apiTokenKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() });
+    },
+  });
+}
+
+export function useRechargeAPITokenQuota() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: APITokenQuotaRechargeData) => getTransport().rechargeAPITokenQuota(data),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: apiTokenKeys.lists() });
     },
   });

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -77,6 +77,8 @@ import type {
   APITokenCreateResult,
   APITokenUpdateData,
   CreateAPITokenData,
+  APITokenQuotaRechargeData,
+  APITokenQuotaRechargeResult,
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
   RouteBulkDeleteRequest,
@@ -1137,6 +1139,16 @@ export class HttpTransport implements Transport {
 
   async updateAPIToken(id: number, payload: APITokenUpdateData): Promise<APIToken> {
     const { data } = await this.adminClient.put<APIToken>(`/api-tokens/${id}`, payload);
+    return data;
+  }
+
+  async rechargeAPITokenQuota(
+    payload: APITokenQuotaRechargeData,
+  ): Promise<APITokenQuotaRechargeResult> {
+    const { data } = await this.adminClient.post<APITokenQuotaRechargeResult>(
+      '/api-tokens/quota/recharge',
+      payload,
+    );
     return data;
   }
 

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -131,6 +131,8 @@ export type {
   APITokenCreateResult,
   APITokenUpdateData,
   CreateAPITokenData,
+  APITokenQuotaRechargeData,
+  APITokenQuotaRechargeResult,
   UserPanelAPITokenResponse,
   // Usage Stats
   UsageStats,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -76,6 +76,8 @@ import type {
   APITokenCreateResult,
   APITokenUpdateData,
   CreateAPITokenData,
+  APITokenQuotaRechargeData,
+  APITokenQuotaRechargeResult,
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
   RouteBulkDeleteRequest,
@@ -316,6 +318,7 @@ export interface Transport {
   revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
   updateAPIToken(id: number, data: APITokenUpdateData): Promise<APIToken>;
+  rechargeAPITokenQuota(data: APITokenQuotaRechargeData): Promise<APITokenQuotaRechargeResult>;
   deleteAPIToken(id: number): Promise<void>;
   cleanupExpiredAPITokens(): Promise<APITokenCleanupResult>;
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -236,6 +236,7 @@ export interface ProviderModelCheckResponse {
 }
 
 export interface ProviderConfig {
+  quotaEnabled?: boolean;
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
@@ -1223,6 +1224,16 @@ export interface APIToken {
   lastIP?: string;
   lastIPAt?: string;
   useCount: number;
+  quotaBalance: number;
+}
+
+export interface APITokenQuotaRechargeData {
+  ids: number[];
+  amount: number;
+}
+
+export interface APITokenQuotaRechargeResult {
+  updatedCount: number;
 }
 
 export interface APITokenCreateResult {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1605,7 +1605,19 @@
       }
     },
     "reactivateToken": "Reset validity",
-    "reactivateHint": "Saving will clear expiration and inactivity state."
+    "reactivateHint": "Saving will clear expiration and inactivity state.",
+    "selectAll": "Select all tokens",
+    "selectToken": "Select {{name}}",
+    "quotaBalance": "Quota Balance",
+    "quotaRecharge": {
+      "button": "Recharge Quota ({{count}})",
+      "title": "Recharge Quota",
+      "description": "Add the same quota amount to {{count}} selected tokens.",
+      "amount": "Quota amount (USD)",
+      "amountHint": "Enter USD. It is saved in the smallest quota unit used by request cost.",
+      "confirm": "Recharge {{count}} tokens",
+      "lastResult": "Added quota to {{count}} tokens."
+    }
   },
   "app": {
     "title": "Maxx Next"
@@ -1776,7 +1788,9 @@
       "high": "High",
       "xhigh": "Extra High",
       "max": "Max"
-    }
+    },
+    "quotaEnabled": "Enable Quota Check",
+    "quotaEnabledDesc": "When enabled, requests through this provider require the matching API token to have quota; tokens without quota are rejected."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1602,7 +1602,19 @@
       }
     },
     "reactivateToken": "恢复有效",
-    "reactivateHint": "保存后会清除过期时间和非活跃状态。"
+    "reactivateHint": "保存后会清除过期时间和非活跃状态。",
+    "selectAll": "选择全部令牌",
+    "selectToken": "选择 {{name}}",
+    "quotaBalance": "额度余额",
+    "quotaRecharge": {
+      "button": "批量充值额度 ({{count}})",
+      "title": "批量充值额度",
+      "description": "为选中的 {{count}} 个令牌增加固定额度。",
+      "amount": "充值额度（USD）",
+      "amountHint": "按美元输入，保存时会转换为请求成本使用的最小额度单位。",
+      "confirm": "为 {{count}} 个令牌充值",
+      "lastResult": "已为 {{count}} 个令牌增加额度。"
+    }
   },
   "app": {
     "title": "Maxx Next"
@@ -1773,7 +1785,9 @@
       "high": "高",
       "xhigh": "超高",
       "max": "最高"
-    }
+    },
+    "quotaEnabled": "启用额度检查",
+    "quotaEnabledDesc": "开启后，使用该提供商的请求会检查对应 API 令牌的额度；令牌无额度时直接拦截。"
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/pages/api-token-limits/index.tsx
+++ b/web/src/pages/api-token-limits/index.tsx
@@ -79,9 +79,6 @@ export function APITokenLimitsPage() {
                     <Activity className="h-4 w-4 text-muted-foreground" />
                     {t('apiTokenLimits.concurrencyTitle')}
                   </CardTitle>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {t('apiTokenLimits.concurrencyDesc')}
-                  </p>
                 </div>
                 <Button
                   onClick={handleSave}
@@ -114,7 +111,6 @@ export function APITokenLimitsPage() {
                   ({t('settings.defaultValue', { value: 5 })})
                 </span>
               </div>
-              <p className="text-xs text-muted-foreground">{t('apiTokenLimits.concurrencyHint')}</p>
               {!isLimitValid && initialized && (
                 <p className="text-xs text-destructive">
                   {t('apiTokenLimits.concurrentLimitInvalid')}
@@ -129,9 +125,6 @@ export function APITokenLimitsPage() {
                 <Activity className="h-4 w-4 text-muted-foreground" />
                 {t('apiTokenLimits.autoCooldownTitle')}
               </CardTitle>
-              <p className="text-xs text-muted-foreground mt-1">
-                {t('apiTokenLimits.autoCooldownDesc')}
-              </p>
             </CardHeader>
             <CardContent className="p-6 space-y-1.5">
               <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
@@ -153,9 +146,6 @@ export function APITokenLimitsPage() {
                   ({t('settings.defaultValue', { value: 5 })})
                 </span>
               </div>
-              <p className="text-xs text-muted-foreground">
-                {t('apiTokenLimits.autoCooldownHint')}
-              </p>
               {!isAutoCooldownValid && initialized && (
                 <p className="text-xs text-destructive">
                   {t('apiTokenLimits.autoCooldownInvalid')}

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -24,6 +24,7 @@ import {
   useAPITokens,
   useCreateAPIToken,
   useUpdateAPIToken,
+  useRechargeAPITokenQuota,
   useDeleteAPIToken,
   useCleanupExpiredAPITokens,
   useProjects,
@@ -48,6 +49,7 @@ import {
   CircleCheck,
   CircleAlert,
   RotateCcw,
+  Coins,
 } from 'lucide-react';
 import { PageHeader } from '@/components/layout';
 import { isAPITokenExpired } from '@/lib/api-token-expiry';
@@ -73,6 +75,7 @@ export function APITokensPage() {
   const updateSetting = useUpdateSetting();
   const createToken = useCreateAPIToken();
   const updateToken = useUpdateAPIToken();
+  const rechargeQuota = useRechargeAPITokenQuota();
   const deleteToken = useDeleteAPIToken();
   const cleanupExpiredTokens = useCleanupExpiredAPITokens();
 
@@ -89,7 +92,11 @@ export function APITokensPage() {
   const [editingToken, setEditingToken] = useState<APIToken | null>(null);
   const [deletingToken, setDeletingToken] = useState<APIToken | null>(null);
   const [cleanupExpiredDialogOpen, setCleanupExpiredDialogOpen] = useState(false);
+  const [quotaRechargeDialogOpen, setQuotaRechargeDialogOpen] = useState(false);
+  const [selectedTokenIds, setSelectedTokenIds] = useState<number[]>([]);
+  const [quotaRechargeUsd, setQuotaRechargeUsd] = useState('');
   const [lastCleanupCount, setLastCleanupCount] = useState<number | null>(null);
+  const [lastQuotaRechargeCount, setLastQuotaRechargeCount] = useState<number | null>(null);
   const [lastReactivatedCount, setLastReactivatedCount] = useState<number | null>(null);
   const [isReactivatingExpired, setIsReactivatingExpired] = useState(false);
   const [newTokenDialog, setNewTokenDialog] = useState<{
@@ -118,6 +125,20 @@ export function APITokensPage() {
   const isExpired = (token: APIToken) => isAPITokenExpired(token);
   const expiredTokens = useMemo(() => (tokens ?? []).filter(isExpired), [tokens]);
   const expiredTokenCount = expiredTokens.length;
+  const allTokenIds = useMemo(() => (tokens ?? []).map((token) => token.id), [tokens]);
+  const allSelected = allTokenIds.length > 0 && selectedTokenIds.length === allTokenIds.length;
+
+  const formatQuotaBalance = (value: number) => `$${(value / 1_000_000_000).toFixed(6)}`;
+
+  const toggleTokenSelection = (id: number, checked: boolean) => {
+    setSelectedTokenIds((current) =>
+      checked ? Array.from(new Set([...current, id])) : current.filter((tokenId) => tokenId !== id),
+    );
+  };
+
+  const handleToggleAllSelected = (checked: boolean) => {
+    setSelectedTokenIds(checked ? allTokenIds : []);
+  };
 
   const resetForm = () => {
     setName('');
@@ -241,6 +262,22 @@ export function APITokensPage() {
         setLastCleanupCount(result.deletedCount);
       },
     });
+  };
+
+  const handleRechargeQuota = () => {
+    const amountUsd = Number(quotaRechargeUsd);
+    if (!Number.isFinite(amountUsd) || amountUsd <= 0 || selectedTokenIds.length === 0) return;
+    const amount = Math.round(amountUsd * 1_000_000_000);
+    rechargeQuota.mutate(
+      { ids: selectedTokenIds, amount },
+      {
+        onSuccess: (result) => {
+          setQuotaRechargeDialogOpen(false);
+          setQuotaRechargeUsd('');
+          setLastQuotaRechargeCount(result.updatedCount);
+        },
+      },
+    );
   };
 
   const handleEdit = (token: APIToken) => {
@@ -452,8 +489,28 @@ export function APITokensPage() {
                         })}
                       </p>
                     )}
+                    {lastQuotaRechargeCount !== null && (
+                      <p className="text-xs text-text-muted">
+                        {t('apiTokens.quotaRecharge.lastResult', {
+                          count: lastQuotaRechargeCount,
+                        })}
+                      </p>
+                    )}
                   </div>
                   <div className="flex flex-col gap-2 self-start sm:self-auto md:flex-row">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setQuotaRechargeDialogOpen(true)}
+                      disabled={selectedTokenIds.length === 0 || rechargeQuota.isPending}
+                    >
+                      {rechargeQuota.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Coins className="mr-2 h-4 w-4" />
+                      )}
+                      {t('apiTokens.quotaRecharge.button', { count: selectedTokenIds.length })}
+                    </Button>
                     <Button
                       variant="outline"
                       size="sm"
@@ -488,10 +545,19 @@ export function APITokensPage() {
                 <Table>
                   <TableHeader>
                     <TableRow>
+                      <TableHead className="w-10">
+                        <input
+                          type="checkbox"
+                          aria-label={t('apiTokens.selectAll')}
+                          checked={allSelected}
+                          onChange={(event) => handleToggleAllSelected(event.target.checked)}
+                        />
+                      </TableHead>
                       <TableHead>{t('apiTokens.tokenName')}</TableHead>
                       <TableHead>{t('apiTokens.tokenPrefix')}</TableHead>
                       <TableHead>{t('apiTokens.project')}</TableHead>
                       <TableHead>{t('common.status')}</TableHead>
+                      <TableHead>{t('apiTokens.quotaBalance')}</TableHead>
                       <TableHead>{t('apiTokens.usage')}</TableHead>
                       <TableHead>{t('apiTokens.recentIP')}</TableHead>
                       <TableHead>{t('apiTokens.lastUsed')}</TableHead>
@@ -501,6 +567,16 @@ export function APITokensPage() {
                   <TableBody>
                     {tokens.map((token) => (
                       <TableRow key={token.id}>
+                        <TableCell>
+                          <input
+                            type="checkbox"
+                            aria-label={t('apiTokens.selectToken', { name: token.name })}
+                            checked={selectedTokenIds.includes(token.id)}
+                            onChange={(event) =>
+                              toggleTokenSelection(token.id, event.target.checked)
+                            }
+                          />
+                        </TableCell>
                         <TableCell>
                           <div>
                             <div className="font-medium">{token.name}</div>
@@ -571,6 +647,12 @@ export function APITokensPage() {
                                 {t('common.disabled')}
                               </Badge>
                             )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1 text-sm text-text-secondary">
+                            <Coins className="h-3 w-3" />
+                            {formatQuotaBalance(token.quotaBalance ?? 0)}
                           </div>
                         </TableCell>
                         <TableCell>
@@ -931,6 +1013,52 @@ export function APITokensPage() {
             >
               {cleanupExpiredTokens.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
               {t('apiTokens.cleanupExpired.confirm', { count: expiredTokenCount })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={quotaRechargeDialogOpen}
+        onOpenChange={(open: boolean) => !open && setQuotaRechargeDialogOpen(false)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('apiTokens.quotaRecharge.title')}</DialogTitle>
+            <DialogDescription>
+              {t('apiTokens.quotaRecharge.description', { count: selectedTokenIds.length })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="quota-recharge-amount">
+              {t('apiTokens.quotaRecharge.amount')}
+            </label>
+            <Input
+              id="quota-recharge-amount"
+              type="number"
+              min="0"
+              step="0.000001"
+              value={quotaRechargeUsd}
+              onChange={(event) => setQuotaRechargeUsd(event.target.value)}
+              placeholder="1.000000"
+            />
+            <p className="text-xs text-text-muted">{t('apiTokens.quotaRecharge.amountHint')}</p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setQuotaRechargeDialogOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              onClick={handleRechargeQuota}
+              disabled={
+                rechargeQuota.isPending ||
+                selectedTokenIds.length === 0 ||
+                !Number.isFinite(Number(quotaRechargeUsd)) ||
+                Number(quotaRechargeUsd) <= 0
+              }
+            >
+              {rechargeQuota.isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              {t('apiTokens.quotaRecharge.confirm', { count: selectedTokenIds.length })}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/web/src/pages/api-tokens/index.tsx
+++ b/web/src/pages/api-tokens/index.tsx
@@ -1025,9 +1025,6 @@ export function APITokensPage() {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t('apiTokens.quotaRecharge.title')}</DialogTitle>
-            <DialogDescription>
-              {t('apiTokens.quotaRecharge.description', { count: selectedTokenIds.length })}
-            </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="quota-recharge-amount">
@@ -1042,7 +1039,6 @@ export function APITokensPage() {
               onChange={(event) => setQuotaRechargeUsd(event.target.value)}
               placeholder="1.000000"
             />
-            <p className="text-xs text-text-muted">{t('apiTokens.quotaRecharge.amountHint')}</p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setQuotaRechargeDialogOpen(false)}>

--- a/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
+++ b/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
@@ -9,14 +9,20 @@ const editFlowSource = readFileSync(
 
 describe('ProviderEditFlow section layout', () => {
   it('keeps visibility and export in the same relative position as custom provider creation', () => {
-    const clientConfig = editFlowSource.indexOf("t('provider.clientConfig')");
-    const errorCooldown = editFlowSource.indexOf("t('provider.errorCooldownTitle')");
-    const visibilityAndExport = editFlowSource.indexOf("t('provider.visibilityAndExport')");
+    const connectionSection = editFlowSource.indexOf('id="provider-connection"');
+    const clientSection = editFlowSource.indexOf('id="provider-clients"');
+    const modelSection = editFlowSource.indexOf('id="provider-models"');
     const supportModels = editFlowSource.indexOf('<ProviderSupportModels');
+    const policySection = editFlowSource.indexOf('id="provider-policies"');
+    const quotaEnabled = editFlowSource.indexOf("t('provider.quotaEnabled')");
+    const dangerSection = editFlowSource.indexOf('id="provider-danger"');
 
-    expect(clientConfig).toBeGreaterThan(-1);
-    expect(errorCooldown).toBeGreaterThan(clientConfig);
-    expect(visibilityAndExport).toBeGreaterThan(errorCooldown);
-    expect(supportModels).toBeGreaterThan(visibilityAndExport);
+    expect(connectionSection).toBeGreaterThan(-1);
+    expect(clientSection).toBeGreaterThan(connectionSection);
+    expect(modelSection).toBeGreaterThan(clientSection);
+    expect(supportModels).toBeGreaterThan(modelSection);
+    expect(policySection).toBeGreaterThan(supportModels);
+    expect(quotaEnabled).toBeGreaterThan(policySection);
+    expect(dangerSection).toBeGreaterThan(policySection);
   });
 });

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -507,6 +507,7 @@ type EditFormData = {
   cloakStrictMode?: boolean;
   cloakSensitiveWords?: string;
   responseModelMapping: Record<string, string>;
+  quotaEnabled?: boolean;
   disableErrorCooldown?: boolean;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
@@ -583,6 +584,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       cloakStrictMode: cc?.strictMode || false,
       cloakSensitiveWords: (cc?.sensitiveWords || []).join('\n'),
       responseModelMapping: provider.config?.custom?.responseModelMapping || {},
+      quotaEnabled: provider.config?.quotaEnabled ?? false,
       disableErrorCooldown: provider.config?.disableErrorCooldown ?? false,
       smartMappingRetryEnabled: provider.config?.smartMappingRetryEnabled ?? false,
       smartMappingRetryLimit: provider.config?.smartMappingRetryLimit ?? 1,
@@ -698,6 +700,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         type: provider.type || 'custom', // Preserve the provider type
         maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
+          quotaEnabled: !!formData.quotaEnabled,
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
@@ -771,6 +774,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         logo: provider.logo,
         maxConcurrency: normalizeMaxConcurrency(formData.maxConcurrency),
         config: {
+          quotaEnabled: !!formData.quotaEnabled,
           disableErrorCooldown: !!formData.disableErrorCooldown,
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
@@ -1355,6 +1359,23 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                     setFormData((prev) => ({ ...prev, maxConcurrency }))
                   }
                 />
+
+                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.quotaEnabled')}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t('provider.quotaEnabledDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={!!formData.quotaEnabled}
+                    onCheckedChange={(checked) =>
+                      setFormData((prev) => ({ ...prev, quotaEnabled: checked }))
+                    }
+                  />
+                </div>
 
                 <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
                   <div className="pr-4">

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -1365,9 +1365,6 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                     <div className="text-sm font-medium text-foreground">
                       {t('provider.quotaEnabled')}
                     </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {t('provider.quotaEnabledDesc')}
-                    </p>
                   </div>
                   <Switch
                     checked={!!formData.quotaEnabled}


### PR DESCRIPTION
## Summary
- add provider-level API token quota checks with zero-balance rejection
- add API token quota balance recharge support
- add UI controls and i18n for quota enablement and batch recharge

## Validation
- go test ./internal/repository/cached ./internal/handler ./internal/executor ./internal/repository/sqlite -run 'Quota|APIToken|TokenAuth|SelfService' -count=1
- cd web && npm run build

## Notes
- Full go test ./... is currently blocked by existing sqlite usage_stats regression tests unrelated to this quota change; see chat validation report for exact blocker.
- CodeRabbit not checked because this run was not authorized to check Rabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * API Token 页面支持查看额度余额、批量选择令牌并充值额度。
  * 提供商设置新增额度检查开关。
  * 代理请求支持额度预检，并按请求成本扣减额度。
  * 额度不足时请求会被拒绝并返回明确状态。
* **错误修复**
  * 额度扣减不会低于零，余额可正确保存和更新。
* **本地化**
  * 新增中英文额度管理、充值及配置说明文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->