### PR TITLE
fix(user-panel): show balance and check-in status

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1380,7 +1380,7 @@ func (h *SelfServiceHandler) userPanelCheckInDate(now time.Time) string {
 }
 
 func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
@@ -1393,6 +1393,22 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 	userID := maxxctx.GetUserID(r.Context())
 	if tenantID == 0 || userID == 0 {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user required"})
+		return
+	}
+
+	checkInDate := h.userPanelCheckInDate(time.Now())
+	if r.Method == http.MethodGet {
+		alreadyCheckedIn, err := h.svc.HasUserPanelDailyCheckIn(tenantID, userID, checkInDate)
+		if err != nil {
+			writeSelfServiceInternalError(w, "HasUserPanelDailyCheckIn failed", err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"alreadyCheckedIn": alreadyCheckedIn,
+			"checkedIn":        false,
+			"checkInDate":      checkInDate,
+			"rewardAmount":     userPanelDailyCheckInRewardAmount,
+		})
 		return
 	}
 
@@ -1421,7 +1437,6 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 		canonicalToken = result.APIToken
 	}
 
-	checkInDate := h.userPanelCheckInDate(time.Now())
 	claimed, err := h.svc.CheckInUserPanelDailyQuota(tenantID, userID, canonicalToken.ID, checkInDate, userPanelDailyCheckInRewardAmount)
 	if err != nil {
 		writeSelfServiceInternalError(w, "CheckInUserPanelDailyQuota failed", err)

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -536,6 +536,13 @@ type selfServiceDailyCheckInRepo struct {
 	claims map[string]bool
 }
 
+func (r *selfServiceDailyCheckInRepo) HasClaim(tenantID uint64, userID uint64, date string) (bool, error) {
+	if r.claims == nil {
+		return false, nil
+	}
+	return r.claims[fmt.Sprintf("%d:%d:%s", tenantID, userID, date)], nil
+}
+
 func (r *selfServiceDailyCheckInRepo) Claim(tenantID uint64, userID uint64, date string) (bool, error) {
 	if r.claims == nil {
 		r.claims = map[string]bool{}
@@ -2387,6 +2394,52 @@ func TestSelfServiceHandler_UserPanelDailyCheckInAddsTenDollarsOncePerDay(t *tes
 	}
 	if secondResult["checkedIn"] != false || secondResult["alreadyCheckedIn"] != true {
 		t.Fatalf("second response = %#v, want alreadyCheckedIn true", secondResult)
+	}
+}
+
+func TestSelfServiceHandler_UserPanelDailyCheckInStatusReportsAlreadyCheckedIn(t *testing.T) {
+	dailyRepo := &selfServiceDailyCheckInRepo{}
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			"ui_multitenant_enabled":                      "true",
+			"ui_multitenant_layout":                       "user_panel",
+			domain.SettingKeyUserPanelDailyCheckInEnabled: "true",
+			domain.SettingKeyTimezone:                     "UTC",
+		}},
+		apiTokenRepo:     &selfServiceAPITokenRepo{},
+		dailyCheckInRepo: dailyRepo,
+	})
+
+	before := httptest.NewRecorder()
+	handler.ServeHTTP(before, newSelfServiceRequest(http.MethodGet, "/user-panel/check-in"))
+	if before.Code != http.StatusOK {
+		t.Fatalf("before status = %d, want %d, body = %s", before.Code, http.StatusOK, before.Body.String())
+	}
+	var beforeResult map[string]any
+	if err := json.Unmarshal(before.Body.Bytes(), &beforeResult); err != nil {
+		t.Fatalf("decode before response: %v", err)
+	}
+	if beforeResult["alreadyCheckedIn"] != false {
+		t.Fatalf("before response = %#v, want not checked in", beforeResult)
+	}
+
+	claim := httptest.NewRecorder()
+	handler.ServeHTTP(claim, newSelfServiceRequest(http.MethodPost, "/user-panel/check-in"))
+	if claim.Code != http.StatusOK {
+		t.Fatalf("claim status = %d, want %d, body = %s", claim.Code, http.StatusOK, claim.Body.String())
+	}
+
+	after := httptest.NewRecorder()
+	handler.ServeHTTP(after, newSelfServiceRequest(http.MethodGet, "/user-panel/check-in"))
+	if after.Code != http.StatusOK {
+		t.Fatalf("after status = %d, want %d, body = %s", after.Code, http.StatusOK, after.Body.String())
+	}
+	var afterResult map[string]any
+	if err := json.Unmarshal(after.Body.Bytes(), &afterResult); err != nil {
+		t.Fatalf("decode after response: %v", err)
+	}
+	if afterResult["alreadyCheckedIn"] != true {
+		t.Fatalf("after response = %#v, want checked in", afterResult)
 	}
 }
 

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -276,6 +276,7 @@ type SystemSettingRepository interface {
 }
 
 type UserPanelDailyCheckInRepository interface {
+	HasClaim(tenantID uint64, userID uint64, date string) (bool, error)
 	Claim(tenantID uint64, userID uint64, date string) (bool, error)
 	DeleteClaim(tenantID uint64, userID uint64, date string) error
 }

--- a/internal/repository/sqlite/user_panel_daily_checkin.go
+++ b/internal/repository/sqlite/user_panel_daily_checkin.go
@@ -15,6 +15,17 @@ func NewUserPanelDailyCheckInRepository(db *DB) *UserPanelDailyCheckInRepository
 	return &UserPanelDailyCheckInRepository{db: db}
 }
 
+func (r *UserPanelDailyCheckInRepository) HasClaim(tenantID uint64, userID uint64, date string) (bool, error) {
+	if tenantID == 0 || userID == 0 || date == "" {
+		return false, nil
+	}
+	var count int64
+	err := r.db.gorm.Model(&UserPanelDailyCheckIn{}).
+		Where("tenant_id = ? AND user_id = ? AND date = ?", tenantID, userID, date).
+		Count(&count).Error
+	return count > 0, err
+}
+
 func (r *UserPanelDailyCheckInRepository) Claim(tenantID uint64, userID uint64, date string) (bool, error) {
 	if tenantID == 0 || userID == 0 || date == "" {
 		return false, nil

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1623,6 +1623,13 @@ func (s *AdminService) CheckInUserPanelDailyQuota(tenantID uint64, userID uint64
 	return true, nil
 }
 
+func (s *AdminService) HasUserPanelDailyCheckIn(tenantID uint64, userID uint64, checkInDate string) (bool, error) {
+	if s.userPanelDailyCheckInRepo == nil || tenantID == 0 || userID == 0 || checkInDate == "" {
+		return false, domain.ErrInvalidInput
+	}
+	return s.userPanelDailyCheckInRepo.HasClaim(tenantID, userID, checkInDate)
+}
+
 func (s *AdminService) DeleteAPIToken(tenantID uint64, id uint64) error {
 	return s.apiTokenRepo.Delete(tenantID, id)
 }

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -129,6 +129,7 @@ export {
   useCreateUserPanelAPIToken,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
+  useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
 } from './use-user-panel-token';
 

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -5,6 +5,7 @@ import { getTransport } from '@/lib/transport';
 export const userPanelTokenKeys = {
   all: ['user-panel-token'] as const,
   detail: () => [...userPanelTokenKeys.all, 'detail'] as const,
+  dailyCheckInStatus: () => [...userPanelTokenKeys.all, 'daily-check-in-status'] as const,
 };
 
 async function refreshUserPanelTokenDependents(queryClient: QueryClient) {
@@ -46,6 +47,14 @@ export function useRegenerateUserPanelAPIToken() {
 export function useRevealUserPanelAPIToken() {
   return useMutation({
     mutationFn: () => getTransport().revealUserPanelAPIToken(),
+  });
+}
+
+export function useUserPanelDailyCheckInStatus(enabled = true) {
+  return useQuery({
+    queryKey: userPanelTokenKeys.dailyCheckInStatus(),
+    queryFn: () => getTransport().getUserPanelDailyCheckInStatus(),
+    enabled,
   });
 }
 

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -1133,6 +1133,13 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async getUserPanelDailyCheckInStatus(): Promise<UserPanelDailyCheckInResult> {
+    const { data } = await this.client.get<UserPanelDailyCheckInResult>(
+      '/user-panel/check-in',
+    );
+    return data;
+  }
+
   async checkInUserPanelDailyQuota(): Promise<UserPanelDailyCheckInResult> {
     const { data } = await this.client.post<UserPanelDailyCheckInResult>(
       '/user-panel/check-in',

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -317,6 +317,7 @@ export interface Transport {
   createUserPanelAPIToken(): Promise<APITokenCreateResult>;
   regenerateUserPanelAPIToken(): Promise<APITokenCreateResult>;
   revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult>;
+  getUserPanelDailyCheckInStatus(): Promise<UserPanelDailyCheckInResult>;
   checkInUserPanelDailyQuota(): Promise<UserPanelDailyCheckInResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
   updateAPIToken(id: number, data: APITokenUpdateData): Promise<APIToken>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1250,7 +1250,7 @@ export interface UserPanelAPITokenRevealResult {
 }
 
 export interface UserPanelDailyCheckInResult {
-  apiToken: APIToken;
+  apiToken?: APIToken;
   alreadyCheckedIn: boolean;
   checkedIn: boolean;
   checkInDate: string;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -138,6 +138,7 @@
     "noKeys": "No keys are available for this account.",
     "unnamedKey": "Unnamed key",
     "useCount": "Uses",
+    "quotaBalance": "Balance",
     "lastUsed": "Recent",
     "apiAccess": "API Access",
     "baseURL": "Base URL",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -138,6 +138,7 @@
     "noKeys": "当前账号暂无可用 Key。",
     "unnamedKey": "未命名 Key",
     "useCount": "调用",
+    "quotaBalance": "余额",
     "lastUsed": "最近",
     "apiAccess": "接口接入",
     "baseURL": "基础地址",

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -23,6 +23,7 @@ import {
   useProxyRequests,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
+  useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
   useUserPanelAPIToken,
   useProxyRequestUpdates,
@@ -177,6 +178,8 @@ export function UserPanelPage() {
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
   const { data: userPanelRequests } = useProxyRequests({ limit: 25 });
   const { data: publicSettings } = usePublicSettings();
+  const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
+  const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(dailyCheckInEnabled);
   useProxyRequestUpdates();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
@@ -208,6 +211,7 @@ export function UserPanelPage() {
   const activeRequestCount =
     userPanelRequests?.items.filter((request) => isActiveUserPanelRequest(request)).length ?? 0;
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
+  const hasCheckedInToday = dailyCheckInStatus?.alreadyCheckedIn || dailyCheckInDone;
   const maskedUserPanelToken = userPanelToken?.tokenPrefix || 'maxx_••••';
   const userPanelTokenValue = revealedUserPanelToken || maskedUserPanelToken;
   const userPanelTokenRevealed = Boolean(revealedUserPanelToken);
@@ -230,6 +234,15 @@ export function UserPanelPage() {
     setRevealedUserPanelToken('');
     setRevealKeyError('');
   }, [userPanelToken?.id]);
+
+  useEffect(() => {
+    if (dailyCheckInStatus?.alreadyCheckedIn) {
+      setDailyCheckInDone(true);
+    } else if (!dailyCheckInEnabled) {
+      setDailyCheckInDone(false);
+      setDailyCheckInMessage('');
+    }
+  }, [dailyCheckInEnabled, dailyCheckInStatus?.alreadyCheckedIn]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -323,7 +336,6 @@ export function UserPanelPage() {
 
   const tokenActionPending = createUserPanelToken.isPending || regenerateUserPanelToken.isPending;
   const revealActionPending = revealUserPanelToken.isPending;
-  const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
 
   return (
     <main className="min-h-svh bg-muted/30 px-4 py-6 text-foreground sm:px-6 lg:px-8">
@@ -388,19 +400,19 @@ export function UserPanelPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
-                    {userPanelToken ? (
+                    {hasCheckedInToday ? (
                       <Badge variant="secondary">
-                        {formatQuotaBalance(userPanelToken.quotaBalance)}
+                        {t('userPanel.dailyCheckInDone')}
                       </Badge>
                     ) : null}
                     <Button
                       size="sm"
                       className="h-8 gap-2"
-                      disabled={dailyCheckIn.isPending || dailyCheckInDone}
+                      disabled={dailyCheckIn.isPending || hasCheckedInToday}
                       onClick={handleDailyCheckIn}
                     >
                       <Gift className="size-3.5" />
-                      {dailyCheckInDone
+                      {hasCheckedInToday
                         ? t('userPanel.dailyCheckInDone')
                         : dailyCheckIn.isPending
                           ? t('common.loading')
@@ -462,7 +474,7 @@ export function UserPanelPage() {
                       </Button>
                     </div>
 
-                    <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-center">
+                    <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_460px] lg:items-center">
                       <div className="space-y-1">
                         <div className="relative">
                           <Input
@@ -495,7 +507,15 @@ export function UserPanelPage() {
                           <p className="text-xs text-muted-foreground">{t('userPanel.fullKeyVisible')}</p>
                         ) : null}
                       </div>
-                      <div className="grid grid-cols-3 gap-2">
+                      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                        <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
+                          <p className="text-[11px] text-muted-foreground">
+                            {t('userPanel.quotaBalance')}
+                          </p>
+                          <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
+                            {formatQuotaBalance(userPanelToken.quotaBalance)}
+                          </p>
+                        </div>
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
                           <p className="text-[11px] text-muted-foreground">
                             {t('userPanel.useCount')}


### PR DESCRIPTION
## Summary
- keep user-panel token quota balance visible in the key stats area even when daily check-in is disabled
- add a check-in status read path so already-claimed users see the claimed state after refresh
- update the daily check-in UI to show the claimed badge/button state from persisted status

## Validation
- `go test ./internal/service ./internal/handler ./internal/repository/sqlite`
- `cd web && pnpm typecheck && pnpm test`
- `cd web && pnpm build && cd .. && go test ./...`
- screenshot mock verification:
  - `/home/moltbot/clawd-wechat/tmp/maxx-balance-visible-checkin-off.png`
  - `/home/moltbot/clawd-wechat/tmp/maxx-checkin-already-status.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 用户面板新增每日签到状态查询，可显示当天是否已签到及奖励信息。
  - 已签到时显示状态标记并禁用重复签到。
  - 新增配额余额展示，并支持中英文界面文本。

- **界面优化**
  - 调整 API 密钥信息区域布局，将配额余额移至该区域展示。
  - 每日签到卡片可根据公开配置显示或隐藏。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->