### PR TITLE
Fix user panel models and invite status

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -478,7 +478,6 @@ func main() {
 	proxyHandler := handler.NewProxyHandler(clientAdapter, requestExecutor, cachedSessionRepo, settingRepo, tokenAuthMiddleware)
 	proxyHandler.SetRequestTracker(requestTracker)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
-	selfServiceHandler := handler.NewSelfServiceHandler(adminService)
 	adminHandler.SetUserRepo(userRepo)
 	adminHandler.SetAuthEnabled(authEnabled)
 	authHandler := handler.NewAuthHandler(
@@ -498,6 +497,7 @@ func main() {
 
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
+	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -461,7 +461,7 @@ func InitializeServerComponents(
 	)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
-	selfServiceHandler := handler.NewSelfServiceHandler(adminService)
+	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)
 	adminHandler.SetUserRepo(repos.UserRepo)
 	adminHandler.SetAuthEnabled(authEnabled)
 	antigravityHandler := handler.NewAntigravityHandler(adminService, repos.AntigravityQuotaRepo, wailsBroadcaster)

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -39,12 +39,17 @@ const defaultUserPanelDailyCheckInAmountUSD = "10"
 
 // SelfServiceHandler exposes tenant-scoped provider/project APIs for authenticated users.
 type SelfServiceHandler struct {
-	svc *service.AdminService
+	svc           *service.AdminService
+	modelsHandler *ModelsHandler
 }
 
 // NewSelfServiceHandler creates a new self-service handler.
-func NewSelfServiceHandler(svc *service.AdminService) *SelfServiceHandler {
-	return &SelfServiceHandler{svc: svc}
+func NewSelfServiceHandler(svc *service.AdminService, modelsHandler ...*ModelsHandler) *SelfServiceHandler {
+	var mh *ModelsHandler
+	if len(modelsHandler) > 0 {
+		mh = modelsHandler[0]
+	}
+	return &SelfServiceHandler{svc: svc, modelsHandler: mh}
 }
 
 func writeSelfServiceInternalError(w http.ResponseWriter, context string, err error) {
@@ -244,6 +249,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	case "user-panel":
 		switch {
+		case len(parts) == 3 && parts[2] == "models":
+			h.handleUserPanelModels(w, r)
 		case len(parts) == 3 && parts[2] == "check-in":
 			h.handleUserPanelDailyCheckIn(w, r)
 		default:
@@ -271,6 +278,57 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 	}
+}
+
+func (h *SelfServiceHandler) handleUserPanelModels(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !h.userPanelLayoutEnabled() {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "user panel models are not enabled"})
+		return
+	}
+	if h.modelsHandler == nil {
+		writeSelfServiceInternalError(w, "UserPanelModels failed", fmt.Errorf("models handler not configured"))
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	userID := maxxctx.GetUserID(r.Context())
+	if tenantID == 0 || userID == 0 {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user required"})
+		return
+	}
+
+	existing, err := findUserPanelAPITokensForUser(h.svc, tenantID, userID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetUserPanelAPITokens failed", err)
+		return
+	}
+	canonicalToken, err := normalizeUserPanelAPITokensForUser(h.svc, tenantID, userID, existing)
+	if err != nil {
+		writeSelfServiceInternalError(w, "NormalizeUserPanelAPITokens failed", err)
+		return
+	}
+	if canonicalToken == nil || !canonicalToken.IsEnabled {
+		writeJSON(w, http.StatusOK, []string{})
+		return
+	}
+
+	names, err := h.modelsHandler.collectAvailableModelNames(
+		tenantID,
+		domain.ClientTypeOpenAI,
+		0,
+		0,
+		canonicalToken.ID,
+		"",
+	)
+	if err != nil {
+		writeSelfServiceInternalError(w, "CollectUserPanelModels failed", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, names)
 }
 
 func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Request, id uint64) {

--- a/internal/handler/self_service_routes.go
+++ b/internal/handler/self_service_routes.go
@@ -19,6 +19,8 @@ var protectedSelfServiceRoutePatterns = []string{
 	"/api/api-tokens/",
 	"/api/user-panel-token",
 	"/api/user-panel-token/",
+	"/api/user-panel/models",
+	"/api/user-panel/models/",
 	"/api/user-panel/check-in",
 	"/api/user-panel/check-in/",
 	"/api/model-mappings",

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -129,6 +129,7 @@ export {
   useCreateUserPanelAPIToken,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
+  useUserPanelAvailableModels,
   useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
 } from './use-user-panel-token';

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -5,6 +5,7 @@ import { getTransport } from '@/lib/transport';
 export const userPanelTokenKeys = {
   all: ['user-panel-token'] as const,
   detail: () => [...userPanelTokenKeys.all, 'detail'] as const,
+  availableModels: () => [...userPanelTokenKeys.all, 'available-models'] as const,
   dailyCheckInStatus: () => [...userPanelTokenKeys.all, 'daily-check-in-status'] as const,
 };
 
@@ -47,6 +48,14 @@ export function useRegenerateUserPanelAPIToken() {
 export function useRevealUserPanelAPIToken() {
   return useMutation({
     mutationFn: () => getTransport().revealUserPanelAPIToken(),
+  });
+}
+
+export function useUserPanelAvailableModels(enabled = true) {
+  return useQuery({
+    queryKey: userPanelTokenKeys.availableModels(),
+    queryFn: () => getTransport().getUserPanelAvailableModels(),
+    enabled,
   });
 }
 

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -1133,6 +1133,11 @@ export class HttpTransport implements Transport {
     return data;
   }
 
+  async getUserPanelAvailableModels(): Promise<string[]> {
+    const { data } = await this.client.get<string[]>('/user-panel/models');
+    return this.expectArray<string>(data, '/user-panel/models');
+  }
+
   async getUserPanelDailyCheckInStatus(): Promise<UserPanelDailyCheckInResult> {
     const { data } = await this.client.get<UserPanelDailyCheckInResult>(
       '/user-panel/check-in',

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -317,6 +317,7 @@ export interface Transport {
   createUserPanelAPIToken(): Promise<APITokenCreateResult>;
   regenerateUserPanelAPIToken(): Promise<APITokenCreateResult>;
   revealUserPanelAPIToken(): Promise<UserPanelAPITokenRevealResult>;
+  getUserPanelAvailableModels(): Promise<string[]>;
   getUserPanelDailyCheckInStatus(): Promise<UserPanelDailyCheckInResult>;
   checkInUserPanelDailyQuota(): Promise<UserPanelDailyCheckInResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;

--- a/web/src/lib/user-panel-endpoints.test.ts
+++ b/web/src/lib/user-panel-endpoints.test.ts
@@ -10,7 +10,8 @@ describe('user panel endpoints', () => {
     const endpoints = buildUserPanelEndpointHints('https://maxx.example.com/');
 
     expect(endpoints).toEqual([
-      { id: 'openai-codex', url: 'https://maxx.example.com/v1' },
+      { id: 'openai', url: 'https://maxx.example.com/v1' },
+      { id: 'codex', url: 'https://maxx.example.com/v1' },
       { id: 'claude', url: 'https://maxx.example.com' },
     ]);
   });
@@ -36,7 +37,7 @@ describe('user panel endpoints', () => {
         proxy_route_gemini_enabled: 'true',
       }),
     ).toEqual([
-      { id: 'openai-codex', url: 'https://maxx.example.com/v1' },
+      { id: 'codex', url: 'https://maxx.example.com/v1' },
       {
         id: 'gemini',
         url: 'https://maxx.example.com/v1beta/models/{model}:generateContent',
@@ -44,7 +45,7 @@ describe('user panel endpoints', () => {
     ]);
   });
 
-  it('hides the combined OpenAI / Codex endpoint only when both routes are disabled', () => {
+  it('hides OpenAI and Codex endpoints independently', () => {
     expect(
       buildUserPanelEndpointHints('https://maxx.example.com', {
         proxy_route_openai_chat_enabled: 'false',

--- a/web/src/lib/user-panel-endpoints.ts
+++ b/web/src/lib/user-panel-endpoints.ts
@@ -1,7 +1,7 @@
 import { isProxyRouteVisible } from '@/lib/proxy-route-exposure';
 
 export interface UserPanelEndpointHint {
-  id: 'openai-codex' | 'claude' | 'gemini';
+  id: 'openai' | 'codex' | 'claude' | 'gemini';
   url: string;
 }
 
@@ -16,8 +16,11 @@ export function buildUserPanelEndpointHints(
   const baseUrl = trimTrailingSlash(origin);
   const endpoints: UserPanelEndpointHint[] = [];
 
-  if (isProxyRouteVisible(settings, 'openai') || isProxyRouteVisible(settings, 'codex')) {
-    endpoints.push({ id: 'openai-codex', url: `${baseUrl}/v1` });
+  if (isProxyRouteVisible(settings, 'openai')) {
+    endpoints.push({ id: 'openai', url: `${baseUrl}/v1` });
+  }
+  if (isProxyRouteVisible(settings, 'codex')) {
+    endpoints.push({ id: 'codex', url: `${baseUrl}/v1` });
   }
   if (isProxyRouteVisible(settings, 'claude')) {
     endpoints.push({ id: 'claude', url: baseUrl });

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -167,14 +167,14 @@
     "dailyCheckInReward": "Claim {{amount}} quota each day",
     "dailyCheckInAction": "Check in",
     "dailyCheckInDone": "Claimed today",
-    "dailyCheckInSuccess": "Checked in. $10 quota added.",
+    "dailyCheckInSuccess": "Checked in. {{amount}} quota added.",
     "dailyCheckInAlreadyDone": "Already checked in today.",
     "dailyCheckInError": "Check-in failed. Try again later.",
     "noDedicatedKeyDescription": "Generate one to use it.",
     "createKey": "Generate",
     "quickStart": "Quick start",
     "noUsageHint": "No usage yet. Copy the key to start tracking.",
-    "routeOpenAI": "OpenAI compatible",
+    "routeOpenAI": "OpenAI",
     "routeClaude": "Claude",
     "routeGemini": "Gemini",
     "routeResponses": "Responses",
@@ -195,7 +195,12 @@
     "showKey": "Show key",
     "hideKey": "Hide key",
     "fullKeyVisible": "Full key is visible. Hide it when you are done.",
-    "revealKeyError": "Failed to reveal key. Please try again."
+    "revealKeyError": "Failed to reveal key. Please try again.",
+    "availableModelsCount": "{{count}} models",
+    "availableModelsLoadFailed": "Failed to load available models",
+    "noAvailableModels": "No available models. Contact an administrator to configure routes or models.",
+    "moreAvailableModels": "+{{count}} more",
+    "routeCodex": "Codex"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -1155,7 +1160,8 @@
     "usagesTitleWithCode": "Invite code {{codePrefix}} usages",
     "usageUser": "User",
     "usageTime": "Used At",
-    "usageIP": "IP Address"
+    "usageIP": "IP Address",
+    "statusUsed": "Used"
   },
   "users": {
     "title": "Users",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -167,14 +167,14 @@
     "dailyCheckInReward": "每日领取 {{amount}} 额度",
     "dailyCheckInAction": "签到领取",
     "dailyCheckInDone": "今日已领取",
-    "dailyCheckInSuccess": "签到成功，已增加 $10 额度。",
+    "dailyCheckInSuccess": "签到成功，已增加 {{amount}} 额度。",
     "dailyCheckInAlreadyDone": "今日已签到。",
     "dailyCheckInError": "签到失败，请稍后再试。",
     "noDedicatedKeyDescription": "生成后可直接使用。",
     "createKey": "生成",
     "quickStart": "快速示例",
     "noUsageHint": "暂无调用，复制 Key 后开始统计。",
-    "routeOpenAI": "OpenAI 兼容",
+    "routeOpenAI": "OpenAI",
     "routeClaude": "Claude",
     "routeGemini": "Gemini",
     "routeResponses": "Responses",
@@ -195,7 +195,12 @@
     "showKey": "显示密钥",
     "hideKey": "隐藏密钥",
     "fullKeyVisible": "完整密钥已显示，使用后请及时隐藏。",
-    "revealKeyError": "密钥显示失败，请重试。"
+    "revealKeyError": "密钥显示失败，请重试。",
+    "availableModelsCount": "{{count}} 个模型",
+    "availableModelsLoadFailed": "可用模型加载失败",
+    "noAvailableModels": "暂无可用模型，请联系管理员配置路由或模型。",
+    "moreAvailableModels": "+{{count}} 个更多",
+    "routeCodex": "Codex"
   },
   "dashboard": {
     "title": "仪表板",
@@ -1152,7 +1157,8 @@
     "usagesTitleWithCode": "邀请码 {{codePrefix}} 的使用记录",
     "usageUser": "用户",
     "usageTime": "使用时间",
-    "usageIP": "IP 地址"
+    "usageIP": "IP 地址",
+    "statusUsed": "已使用"
   },
   "users": {
     "title": "用户管理",

--- a/web/src/pages/invite-codes/index.tsx
+++ b/web/src/pages/invite-codes/index.tsx
@@ -135,6 +135,19 @@ export function InviteCodesPage() {
     return `${code.usedCount}/${code.maxUses}`;
   };
 
+  const getInviteCodeDisplayStatus = (code: InviteCode) => {
+    if (code.status === 'disabled') return 'disabled';
+    if (code.maxUses > 0 && code.usedCount >= code.maxUses) return 'used';
+    return 'active';
+  };
+
+  const inviteCodeStatusLabel = (code: InviteCode) => {
+    const status = getInviteCodeDisplayStatus(code);
+    if (status === 'used') return t('inviteCodes.statusUsed');
+    if (status === 'disabled') return t('inviteCodes.statusDisabled');
+    return t('inviteCodes.statusActive');
+  };
+
   const isBusy = useMemo(
     () => createInviteCodes.isPending || updateInviteCode.isPending || deleteInviteCode.isPending,
     [createInviteCodes.isPending, updateInviteCode.isPending, deleteInviteCode.isPending],
@@ -183,10 +196,12 @@ export function InviteCodesPage() {
                     <TableRow key={code.id}>
                       <TableCell className="font-medium">{code.codePrefix}</TableCell>
                       <TableCell>
-                        <Badge variant={code.status === 'active' ? 'default' : 'outline'}>
-                          {code.status === 'active'
-                            ? t('inviteCodes.statusActive')
-                            : t('inviteCodes.statusDisabled')}
+                        <Badge
+                          variant={
+                            getInviteCodeDisplayStatus(code) === 'active' ? 'default' : 'outline'
+                          }
+                        >
+                          {inviteCodeStatusLabel(code)}
                         </Badge>
                       </TableCell>
                       <TableCell>{maxUsesLabel(code)}</TableCell>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -23,6 +23,7 @@ import {
   useProxyRequests,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
+  useUserPanelAvailableModels,
   useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
   useUserPanelAPIToken,
@@ -30,11 +31,7 @@ import {
   usePublicSettings,
 } from '@/hooks/queries';
 import type { APIToken, ProxyRequest } from '@/lib/transport';
-import { isProxyRouteVisible } from '@/lib/proxy-route-exposure';
-import {
-  buildUserPanelChatCompletionsExample,
-  buildUserPanelEndpointHints,
-} from '@/lib/user-panel-endpoints';
+import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
 import {
   getUserPanelTabStorageKey,
   resolveUserPanelTab,
@@ -53,6 +50,12 @@ function formatQuotaBalance(value: number) {
 function formatQuotaAmount(value: number) {
   const amount = (value || 0) / 1_000_000_000;
   return `$${Number.isInteger(amount) ? amount.toFixed(0) : amount.toFixed(2)}`;
+}
+
+function parseDailyCheckInAmountSetting(value?: string) {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount <= 0) return undefined;
+  return Math.round(amount * 1_000_000_000);
 }
 
 function formatDateTime(value?: string) {
@@ -183,6 +186,11 @@ export function UserPanelPage() {
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
   const { data: userPanelRequests } = useProxyRequests({ limit: 25 });
   const { data: publicSettings } = usePublicSettings();
+  const {
+    data: availableModels,
+    isLoading: availableModelsLoading,
+    isError: availableModelsError,
+  } = useUserPanelAvailableModels(Boolean(user));
   const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
   const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(dailyCheckInEnabled);
   useProxyRequestUpdates();
@@ -191,7 +199,6 @@ export function UserPanelPage() {
   const revealUserPanelToken = useRevealUserPanelAPIToken();
   const dailyCheckIn = useUserPanelDailyCheckIn();
   const [copiedEndpointId, setCopiedEndpointId] = useState('');
-  const [exampleCopied, setExampleCopied] = useState(false);
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
   const [revealedUserPanelToken, setRevealedUserPanelToken] = useState('');
@@ -217,7 +224,9 @@ export function UserPanelPage() {
     userPanelRequests?.items.filter((request) => isActiveUserPanelRequest(request)).length ?? 0;
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const hasCheckedInToday = dailyCheckInStatus?.alreadyCheckedIn || dailyCheckInDone;
-  const dailyCheckInRewardAmount = dailyCheckInStatus?.rewardAmount ?? 10_000_000_000;
+  const dailyCheckInRewardAmount =
+    dailyCheckInStatus?.rewardAmount ??
+    parseDailyCheckInAmountSetting(publicSettings?.user_panel_daily_checkin_amount);
   const maskedUserPanelToken = userPanelToken?.tokenPrefix || 'maxx_••••';
   const userPanelTokenValue = revealedUserPanelToken || maskedUserPanelToken;
   const userPanelTokenRevealed = Boolean(revealedUserPanelToken);
@@ -225,16 +234,16 @@ export function UserPanelPage() {
   const endpointHints = buildUserPanelEndpointHints(origin, publicSettings).map((endpoint) => ({
     ...endpoint,
     label:
-      endpoint.id === 'openai-codex'
-        ? t('userPanel.routeOpenAICodex')
-        : endpoint.id === 'claude'
-          ? t('userPanel.routeClaude')
-          : t('userPanel.routeGemini'),
+      endpoint.id === 'openai'
+        ? t('userPanel.routeOpenAI')
+        : endpoint.id === 'codex'
+          ? t('userPanel.routeCodex')
+          : endpoint.id === 'claude'
+            ? t('userPanel.routeClaude')
+            : t('userPanel.routeGemini'),
   }));
-  const showChatCompletionsExample = isProxyRouteVisible(publicSettings, 'openai');
-  const curlExample = showChatCompletionsExample
-    ? buildUserPanelChatCompletionsExample({ origin })
-    : '';
+  const visibleAvailableModels = (availableModels ?? []).slice(0, 12);
+  const hiddenAvailableModelCount = Math.max((availableModels?.length ?? 0) - visibleAvailableModels.length, 0);
 
   useEffect(() => {
     setRevealedUserPanelToken('');
@@ -302,13 +311,6 @@ export function UserPanelPage() {
     }
   };
 
-  const handleCopyExample = async () => {
-    if (!curlExample || typeof navigator === 'undefined' || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(curlExample);
-    setExampleCopied(true);
-    window.setTimeout(() => setExampleCopied(false), 1600);
-  };
-
   const handleCreateUserPanelToken = async () => {
     const result = await createUserPanelToken.mutateAsync();
     setOneTimeToken(result.token);
@@ -333,7 +335,7 @@ export function UserPanelPage() {
       setDailyCheckInMessage(
         result.alreadyCheckedIn
           ? t('userPanel.dailyCheckInAlreadyDone')
-          : t('userPanel.dailyCheckInSuccess'),
+          : t('userPanel.dailyCheckInSuccess', { amount: formatQuotaAmount(result.rewardAmount) }),
       );
     } catch {
       setDailyCheckInMessage(t('userPanel.dailyCheckInError'));
@@ -398,9 +400,11 @@ export function UserPanelPage() {
                         {t('userPanel.dailyCheckInTitle')}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        {t('userPanel.dailyCheckInReward', {
-                          amount: formatQuotaAmount(dailyCheckInRewardAmount),
-                        })}
+                        {dailyCheckInRewardAmount
+                          ? t('userPanel.dailyCheckInReward', {
+                              amount: formatQuotaAmount(dailyCheckInRewardAmount),
+                            })
+                          : t('common.loading')}
                       </p>
                       {dailyCheckInMessage ? (
                         <p className="mt-1 text-xs text-muted-foreground">{dailyCheckInMessage}</p>
@@ -572,6 +576,38 @@ export function UserPanelPage() {
               </CardHeader>
               <CardContent className="space-y-4 p-5">
                 <div className="rounded-xl border border-border bg-muted/25 p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {t('userPanel.availableModels')}
+                    </p>
+                    {availableModels && availableModels.length > 0 ? (
+                      <Badge variant="secondary">
+                        {t('userPanel.availableModelsCount', { count: availableModels.length })}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {availableModelsLoading ? (
+                    <p className="mt-3 text-sm text-muted-foreground">{t('common.loading')}</p>
+                  ) : availableModelsError ? (
+                    <p className="mt-3 text-sm text-destructive">{t('userPanel.availableModelsLoadFailed')}</p>
+                  ) : visibleAvailableModels.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {visibleAvailableModels.map((model) => (
+                        <Badge key={model} variant="outline" className="max-w-full truncate font-mono">
+                          {model}
+                        </Badge>
+                      ))}
+                      {hiddenAvailableModelCount > 0 ? (
+                        <Badge variant="secondary">
+                          {t('userPanel.moreAvailableModels', { count: hiddenAvailableModelCount })}
+                        </Badge>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="mt-3 text-sm text-muted-foreground">{t('userPanel.noAvailableModels')}</p>
+                  )}
+                </div>
+                <div className="rounded-xl border border-border bg-muted/25 p-4">
                   <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     {t('userPanel.baseURL')}
                   </p>
@@ -601,27 +637,6 @@ export function UserPanelPage() {
                     ))}
                   </div>
                 </div>
-                {showChatCompletionsExample && (
-                  <div className="rounded-xl border border-border bg-muted/25 p-4">
-                    <div className="flex items-center justify-between gap-3">
-                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        {t('userPanel.quickStart')}
-                      </p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-8 gap-2"
-                        onClick={handleCopyExample}
-                      >
-                        <Copy className="size-3.5" />
-                        {exampleCopied ? t('common.copied') : t('common.copy')}
-                      </Button>
-                    </div>
-                    <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg bg-background px-3 py-2 text-xs text-muted-foreground">
-                      <code>{curlExample}</code>
-                    </pre>
-                  </div>
-                )}
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- show exhausted invite codes as used when usage reaches max uses
- add user-panel available-models endpoint and card
- split OpenAI/Codex endpoint hints by route exposure, remove Quick Start, and make check-in success amount dynamic

## Validation
- git diff --check
- npm --prefix web run typecheck
- npm --prefix web test -- user-panel-endpoints
- npm --prefix web run build
- go test ./...
- Playwright mock UI regression for invite 5/5, no Codex when disabled, no Quick Start, dynamic check-in amount, and available models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 用户面板新增可用模型列表，支持加载、失败及无结果状态，最多展示 12 个模型。
  * OpenAI 与 Codex 端点现可独立显示和配置。
  * 每日签到成功提示展示实际领取额度，并支持加载状态。

* **问题修复**
  * 邀请码状态准确区分为启用、已使用和已禁用。
  * 更新中英文用户面板相关文案及状态提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->