### PR TITLE
fix(invite-codes): align status badge background with active style

### DIFF
--- a/web/src/pages/invite-codes/index.tsx
+++ b/web/src/pages/invite-codes/index.tsx
@@ -197,8 +197,12 @@ export function InviteCodesPage() {
                       <TableCell className="font-medium">{code.codePrefix}</TableCell>
                       <TableCell>
                         <Badge
-                          variant={
-                            getInviteCodeDisplayStatus(code) === 'active' ? 'default' : 'outline'
+                          variant="default"
+                          className={getInviteCodeDisplayStatus(code) === 'active'
+                            ? 'bg-green-500/10 text-green-500 border-green-500/20'
+                            : getInviteCodeDisplayStatus(code) === 'used'
+                              ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20'
+                              : 'bg-muted/40 text-muted-foreground border-border'
                           }
                         >
                           {inviteCodeStatusLabel(code)}


### PR DESCRIPTION
## 背景

邀请码页（邀请码 tab）状态 Badge 原为二态：`active` 用 `variant="default"`（主题实色块），其余用 `variant="outline"`（透明边框）。「可用」与项目其他页面（users / api-tokens / client-routes）的绿色语义标准不一致。

## 改动

将状态 Badge 改为三态语义化着色，使「可用」对齐项目统一标准：

- active（可用）→ `bg-green-500/10 text-green-500 border-green-500/20`
- used（已使用）→ `bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20`
- disabled（已禁用）→ `bg-muted/40 text-muted-foreground border-border`

## 验证

- `pnpm typecheck` 通过
- `eslint` 通过
- `pnpm test` 33 文件 140 用例全过
- `pnpm build` 成功，产物 CSS 含全部新增 class 规则
- 状态切换按钮逻辑未受影响（仍基于原始 `code.status==='active'`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 统一邀请码状态徽章的基础样式。
  * 根据活动、已使用和禁用状态分别显示绿色、琥珀色和灰色，提升状态辨识度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->