### PR TITLE
feat: add invite registration auto approval setting

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -486,6 +486,7 @@ func main() {
 		tenantRepo,
 		inviteCodeRepo,
 		inviteCodeUsageRepo,
+		settingRepo,
 		authEnabled,
 	)
 	antigravityHandler := handler.NewAntigravityHandler(adminService, antigravityQuotaRepo, wsHub)

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -447,6 +447,7 @@ func InitializeServerComponents(
 		repos.TenantRepo,
 		repos.InviteCodeRepo,
 		repos.InviteCodeUsageRepo,
+		repos.SettingRepo,
 		authEnabled,
 	)
 

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -978,6 +978,7 @@ const (
 	SettingKeyProxyRequestsDisabled                = "proxy_requests_disabled"                   // 是否全局禁用代理请求，"true" 或 "false"，默认 "false"
 	SettingKeyUserPanelDailyCheckInEnabled         = "user_panel_daily_checkin_enabled"          // 用户控制台每日签到，"true" 或 "false"，默认 "false"
 	SettingKeyUserPanelDailyCheckInAmount          = "user_panel_daily_checkin_amount"           // 用户控制台每日签到额度（美元），默认 "10"
+	SettingKeyInviteRegistrationAutoApproveEnabled = "invite_registration_auto_approve_enabled"  // 邀请码注册自动通过审批，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"       // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteOpenAIChatEnabled          = "proxy_route_openai_chat_enabled"           // 是否暴露 OpenAI Chat Completions 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteResponsesEnabled           = "proxy_route_responses_enabled"             // 是否暴露 Responses/Codex 代理路由，"true" 或 "false"，默认 "true"

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -24,6 +24,7 @@ type AuthHandler struct {
 	tenantRepo      repository.TenantRepository
 	inviteCodeRepo  repository.InviteCodeRepository
 	inviteUsageRepo repository.InviteCodeUsageRepository
+	settingRepo     repository.SystemSettingRepository
 	authEnabled     bool
 	passkeyStore    *passkeySessionStore
 }
@@ -74,6 +75,7 @@ func NewAuthHandler(
 	tenantRepo repository.TenantRepository,
 	inviteCodeRepo repository.InviteCodeRepository,
 	inviteUsageRepo repository.InviteCodeUsageRepository,
+	settingRepo repository.SystemSettingRepository,
 	authEnabled bool,
 ) *AuthHandler {
 	return &AuthHandler{
@@ -82,6 +84,7 @@ func NewAuthHandler(
 		tenantRepo:      tenantRepo,
 		inviteCodeRepo:  inviteCodeRepo,
 		inviteUsageRepo: inviteUsageRepo,
+		settingRepo:     settingRepo,
 		authEnabled:     authEnabled,
 		passkeyStore:    newPasskeySessionStore(),
 	}
@@ -336,11 +339,21 @@ func (h *AuthHandler) handleApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	userStatus := domain.UserStatusPending
+	autoApprove, err := h.inviteRegistrationAutoApproveEnabled()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	if autoApprove {
+		userStatus = domain.UserStatusActive
+	}
+
 	user := &domain.User{
 		TenantID: tenantID,
 		Username: body.Username,
 		Role:     domain.UserRoleMember,
-		Status:   domain.UserStatusPending,
+		Status:   userStatus,
 	}
 
 	now := time.Now()
@@ -565,10 +578,29 @@ func (h *AuthHandler) handleApply(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	message := "registration submitted, waiting for admin approval"
+	if autoApprove {
+		message = "registration approved, you can now sign in"
+	}
+
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"success": true,
-		"message": "registration submitted, waiting for admin approval",
+		"message": message,
 	})
+}
+
+func (h *AuthHandler) inviteRegistrationAutoApproveEnabled() (bool, error) {
+	if h.settingRepo == nil {
+		return false, nil
+	}
+
+	value, err := h.settingRepo.Get(domain.SettingKeyInviteRegistrationAutoApproveEnabled)
+	if err != nil {
+		log.Printf("[Auth] Failed to load %s: %v", domain.SettingKeyInviteRegistrationAutoApproveEnabled, err)
+		return false, err
+	}
+
+	return strings.TrimSpace(strings.ToLower(value)) == "true", nil
 }
 
 // handleChangePassword handles self-service password change

--- a/internal/handler/auth_handler_invite_test.go
+++ b/internal/handler/auth_handler_invite_test.go
@@ -95,6 +95,23 @@ type stubInviteUsageRepo struct {
 	createErr error
 }
 
+type stubInviteSettingRepo struct {
+	values map[string]string
+	err    error
+}
+
+func (r *stubInviteSettingRepo) Get(key string) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.values[key], nil
+}
+func (r *stubInviteSettingRepo) Set(key, value string) error { return nil }
+func (r *stubInviteSettingRepo) GetAll() ([]*domain.SystemSetting, error) {
+	return nil, nil
+}
+func (r *stubInviteSettingRepo) Delete(key string) error { return nil }
+
 func (r *stubInviteUsageRepo) Create(usage *domain.InviteCodeUsage) error {
 	if r.createErr != nil {
 		return r.createErr
@@ -117,7 +134,7 @@ func TestHandleApply_RollbackOnCreateFailure(t *testing.T) {
 	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 7, TenantID: 1, CodeHash: codeHash}}
 	usageRepo := &stubInviteUsageRepo{}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, usageRepo, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, usageRepo, nil, true)
 
 	payload := map[string]string{
 		"username":   "user1",
@@ -155,7 +172,7 @@ func TestHandleApply_InviteCodeExpired(t *testing.T) {
 		consumeErr: domain.ErrInviteCodeExpired,
 	}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, nil, true)
 
 	payload := map[string]string{
 		"username":   "user2",
@@ -181,7 +198,7 @@ func TestHandleApply_InviteCodeSystemError(t *testing.T) {
 		consumeErr: errors.New("db down"),
 	}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, nil, true)
 
 	payload := map[string]string{
 		"username":   "user3",
@@ -204,7 +221,7 @@ func TestHandleApply_RollbackWithoutUsageRepo(t *testing.T) {
 	codeHash := domain.HashInviteCode("CODE123")
 	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 9, TenantID: 1, CodeHash: codeHash}}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, nil, true)
 
 	payload := map[string]string{
 		"username":   "user4",
@@ -231,7 +248,7 @@ func TestHandleApply_RollbackWhenUsageCreateFails(t *testing.T) {
 	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 10, TenantID: 1, CodeHash: codeHash}}
 	usageRepo := &stubInviteUsageRepo{createErr: errors.New("usage down")}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, usageRepo, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, usageRepo, nil, true)
 
 	payload := map[string]string{
 		"username":   "user6",
@@ -257,7 +274,7 @@ func TestHandleApply_ResolveTenantFromInvite(t *testing.T) {
 	codeHash := domain.HashInviteCode("CODE123")
 	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 11, TenantID: 42, CodeHash: codeHash}}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, nil, true)
 
 	payload := map[string]string{
 		"username":   "user5",
@@ -290,7 +307,7 @@ func TestHandleApply_InvalidPasswordRejectedBeforeInviteConsume(t *testing.T) {
 	codeHash := domain.HashInviteCode("CODE123")
 	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 12, TenantID: 42, CodeHash: codeHash}}
 
-	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, true)
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, nil, true)
 
 	payload := map[string]string{
 		"username":   "user7",
@@ -311,5 +328,76 @@ func TestHandleApply_InvalidPasswordRejectedBeforeInviteConsume(t *testing.T) {
 	}
 	if len(userRepo.users) != 0 {
 		t.Fatalf("unexpected users created: %d", len(userRepo.users))
+	}
+}
+
+func TestHandleApply_DefaultKeepsInviteRegistrationPending(t *testing.T) {
+	userRepo := &stubInviteUserRepo{users: map[string]*domain.User{}}
+	codeHash := domain.HashInviteCode("CODE123")
+	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 13, TenantID: 42, CodeHash: codeHash}}
+	settingsRepo := &stubInviteSettingRepo{values: map[string]string{}}
+
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, settingsRepo, true)
+
+	payload := map[string]string{
+		"username":   "pending-user",
+		"password":   "Pass8!aa",
+		"inviteCode": "CODE123",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/admin/auth/apply", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	created := userRepo.users["pending-user"]
+	if created == nil {
+		t.Fatalf("user not created")
+	}
+	if created.Status != domain.UserStatusPending {
+		t.Fatalf("status = %s, want %s", created.Status, domain.UserStatusPending)
+	}
+}
+
+func TestHandleApply_AutoApproveSettingCreatesActiveInviteRegistration(t *testing.T) {
+	userRepo := &stubInviteUserRepo{users: map[string]*domain.User{}}
+	codeHash := domain.HashInviteCode("CODE123")
+	inviteRepo := &stubInviteRepo{invite: &domain.InviteCode{ID: 14, TenantID: 42, CodeHash: codeHash}}
+	settingsRepo := &stubInviteSettingRepo{values: map[string]string{
+		domain.SettingKeyInviteRegistrationAutoApproveEnabled: "true",
+	}}
+
+	h := NewAuthHandler(nil, userRepo, nil, inviteRepo, nil, settingsRepo, true)
+
+	payload := map[string]string{
+		"username":   "active-user",
+		"password":   "Pass9!aa",
+		"inviteCode": "CODE123",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/admin/auth/apply", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	created := userRepo.users["active-user"]
+	if created == nil {
+		t.Fatalf("user not created")
+	}
+	if created.Status != domain.UserStatusActive {
+		t.Fatalf("status = %s, want %s", created.Status, domain.UserStatusActive)
+	}
+	var response map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["message"] != "registration approved, you can now sign in" {
+		t.Fatalf("message = %v", response["message"])
 	}
 }

--- a/internal/handler/auth_handler_password_policy_test.go
+++ b/internal/handler/auth_handler_password_policy_test.go
@@ -137,7 +137,7 @@ func TestHandleRegister_InvalidPasswordRejected(t *testing.T) {
 	}
 	userRepo := newRegisterTestUserRepo(admin)
 	authMiddleware := NewAuthMiddleware(nil)
-	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, true)
+	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, nil, true)
 
 	token, err := authMiddleware.GenerateToken(admin)
 	if err != nil {
@@ -189,7 +189,7 @@ func TestHandleChangePassword_InvalidNewPasswordRejected(t *testing.T) {
 	}
 	userRepo := newRegisterTestUserRepo(admin)
 	authMiddleware := NewAuthMiddleware(nil)
-	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, true)
+	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, nil, true)
 
 	token, err := authMiddleware.GenerateToken(admin)
 	if err != nil {

--- a/internal/handler/auth_passkey_test.go
+++ b/internal/handler/auth_passkey_test.go
@@ -181,7 +181,7 @@ func newPasskeyHandlerAndToken(t *testing.T, user *domain.User) (*AuthHandler, s
 
 	userRepo := newPasskeyTestUserRepo(user)
 	authMiddleware := NewAuthMiddleware(nil)
-	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, true)
+	handler := NewAuthHandler(authMiddleware, userRepo, &passkeyTestTenantRepo{}, nil, nil, nil, true)
 
 	token, err := authMiddleware.GenerateToken(user)
 	if err != nil {

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -13,7 +13,7 @@ func validateSystemSettingValue(key, value string) error {
 	switch key {
 	case domain.SettingKeyReasoningPolicy:
 		return reqpolicy.ValidatePolicyJSON(value)
-	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled:
+	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled, domain.SettingKeyInviteRegistrationAutoApproveEnabled:
 		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -190,7 +190,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 	// Create admin and auth handlers
 	adminHandler := handler.NewAdminHandler(adminService, backupService, "")
 	adminHandler.SetUserRepo(userRepo)
-	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, inviteCodeRepo, inviteCodeUsageRepo, true)
+	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, inviteCodeRepo, inviteCodeUsageRepo, settingRepo, true)
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -177,7 +177,7 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 	// Create handlers
 	adminHandler := handler.NewAdminHandler(adminService, backupService, "")
 	adminHandler.SetUserRepo(userRepo)
-	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, inviteCodeRepo, inviteCodeUsageRepo, true)
+	authHandler := handler.NewAuthHandler(authMiddleware, userRepo, tenantRepo, inviteCodeRepo, inviteCodeUsageRepo, settingRepo, true)
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1342,6 +1342,8 @@
     "userPanelDailyCheckIn": "Daily check-in",
     "userPanelDailyCheckInDesc": "Allow users to claim the configured check-in quota once per day from the user console.",
     "userPanelDailyCheckInAmount": "Daily check-in amount (USD)",
+    "inviteRegistrationAutoApprove": "Auto-approve invite registrations",
+    "inviteRegistrationAutoApproveDesc": "When enabled, new users who register with a valid invite code become active immediately without manual admin approval. Disabled by default.",
     "forceProjectBinding": "Force Project Binding",
     "enableForceProjectBinding": "Enable Force Project Binding",
     "forceProjectBindingDesc": "When enabled, new sessions must select a project before executing requests",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1339,6 +1339,8 @@
     "userPanelDailyCheckIn": "每日签到",
     "userPanelDailyCheckInDesc": "开启后用户每天可在用户控制台领取配置的签到额度。",
     "userPanelDailyCheckInAmount": "每日签到额度（美元）",
+    "inviteRegistrationAutoApprove": "邀请码注册自动通过",
+    "inviteRegistrationAutoApproveDesc": "开启后，通过有效邀请码注册的新用户会直接激活，不再需要后台手动同意。默认关闭。",
     "forceProjectBinding": "强制项目绑定",
     "enableForceProjectBinding": "启用强制项目绑定",
     "forceProjectBindingDesc": "开启后，新会话必须选择项目才能继续执行请求",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -75,6 +75,7 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = '45000';
 const MULTITENANT_UI_LAYOUT_SETTING_KEY = 'ui_multitenant_layout';
 const USER_PANEL_DAILY_CHECKIN_SETTING_KEY = 'user_panel_daily_checkin_enabled';
 const USER_PANEL_DAILY_CHECKIN_AMOUNT_SETTING_KEY = 'user_panel_daily_checkin_amount';
+const INVITE_REGISTRATION_AUTO_APPROVE_SETTING_KEY = 'invite_registration_auto_approve_enabled';
 const DEFAULT_USER_PANEL_DAILY_CHECKIN_AMOUNT = '10';
 type MultiTenantUILayout = 'current' | 'user_panel';
 
@@ -1704,19 +1705,30 @@ function MultiTenantUISection() {
   const settingsDailyCheckInAmount =
     settings?.[USER_PANEL_DAILY_CHECKIN_AMOUNT_SETTING_KEY] ||
     DEFAULT_USER_PANEL_DAILY_CHECKIN_AMOUNT;
+  const settingsInviteRegistrationAutoApproveEnabled =
+    settings?.[INVITE_REGISTRATION_AUTO_APPROVE_SETTING_KEY] === 'true';
   const [localEnabled, setLocalEnabled] = useState(settingsEnabled);
   const [localLayout, setLocalLayout] = useState<MultiTenantUILayout>(settingsLayout);
   const [localDailyCheckInEnabled, setLocalDailyCheckInEnabled] = useState(
     settingsDailyCheckInEnabled,
   );
   const [localDailyCheckInAmount, setLocalDailyCheckInAmount] = useState(settingsDailyCheckInAmount);
+  const [localInviteRegistrationAutoApproveEnabled, setLocalInviteRegistrationAutoApproveEnabled] =
+    useState(settingsInviteRegistrationAutoApproveEnabled);
 
   useEffect(() => {
     setLocalEnabled(settingsEnabled);
     setLocalLayout(settingsLayout);
     setLocalDailyCheckInEnabled(settingsDailyCheckInEnabled);
     setLocalDailyCheckInAmount(settingsDailyCheckInAmount);
-  }, [settingsEnabled, settingsLayout, settingsDailyCheckInEnabled, settingsDailyCheckInAmount]);
+    setLocalInviteRegistrationAutoApproveEnabled(settingsInviteRegistrationAutoApproveEnabled);
+  }, [
+    settingsEnabled,
+    settingsLayout,
+    settingsDailyCheckInEnabled,
+    settingsDailyCheckInAmount,
+    settingsInviteRegistrationAutoApproveEnabled,
+  ]);
 
   const handleToggle = async (checked: boolean) => {
     const previous = localEnabled;
@@ -1757,6 +1769,20 @@ function MultiTenantUISection() {
       });
     } catch (error) {
       setLocalDailyCheckInEnabled(previous);
+      throw error;
+    }
+  };
+
+  const handleInviteRegistrationAutoApproveToggle = async (checked: boolean) => {
+    const previous = localInviteRegistrationAutoApproveEnabled;
+    setLocalInviteRegistrationAutoApproveEnabled(checked);
+    try {
+      await updateSetting.mutateAsync({
+        key: INVITE_REGISTRATION_AUTO_APPROVE_SETTING_KEY,
+        value: checked ? 'true' : 'false',
+      });
+    } catch (error) {
+      setLocalInviteRegistrationAutoApproveEnabled(previous);
       throw error;
     }
   };
@@ -1831,6 +1857,25 @@ function MultiTenantUISection() {
                 </SelectItem>
               </SelectContent>
             </Select>
+          </div>
+        )}
+
+        {localEnabled && (
+          <div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/20 p-4">
+            <div>
+              <div className="text-sm font-medium text-foreground">
+                {t('settings.inviteRegistrationAutoApprove')}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {t('settings.inviteRegistrationAutoApproveDesc')}
+              </p>
+            </div>
+            <Switch
+              aria-label={t('settings.inviteRegistrationAutoApprove')}
+              checked={localInviteRegistrationAutoApproveEnabled}
+              onCheckedChange={handleInviteRegistrationAutoApproveToggle}
+              disabled={updateSetting.isPending}
+            />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- add a default-off `invite_registration_auto_approve_enabled` system setting
- expose the toggle in the multi-tenant settings section
- when enabled, invite-code registration creates active users instead of pending users
- keep invite validation, password policy, tenant resolution, usage recording, and rollback behavior intact

## Validation
- `go test ./internal/handler`
- `go test ./internal/service`
- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm build`
- `go test ./...`

Note: `pnpm build` reports the existing Vite large chunk warning; build exits successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“邀请码注册自动审批”设置，默认关闭。
  * 开启后，邀请码注册的账户可直接激活并登录；关闭时需等待审批。
  * 在设置页面提供该功能的开关，并支持更新失败时自动恢复原状态。
  * 新增中英文界面文案及相关配置校验。

* **测试**
  * 补充自动审批开启与关闭场景的注册流程测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->