### PR TITLE
feat: align custom providers and fix request cleanup state

### DIFF
--- a/web/e2e/custom-provider-form-simplify.spec.ts
+++ b/web/e2e/custom-provider-form-simplify.spec.ts
@@ -135,12 +135,19 @@ test.describe('custom provider form simplification', () => {
     await page.getByRole('button', { name: /Gemini Web2API/i }).click();
 
     await expect(page).toHaveURL(/\/providers\/create\/custom/);
-    await expect(page.getByDisplayValue('Gemini Web2API')).toBeVisible();
-    await expect(page.getByDisplayValue('sk-gemini')).toBeVisible();
+    await expect(page.locator('input').first()).toHaveValue('Gemini Web2API');
+    await expect(page.locator('input[type="password"]').first()).toHaveValue('sk-gemini');
     await expect(page.getByText(/Do not append \/v1/i)).toBeVisible();
-    await expect(page.getByText(/^OpenAI$/)).toBeVisible();
-    await expect(page.getByText(/^Codex$/)).toBeVisible();
-    await expect(page.getByText(/^Gemini$/)).toBeVisible();
+    await expect(page.getByRole('main').getByText('OpenAI', { exact: true })).toBeVisible();
+    const switches = await page.locator('[role="switch"]').evaluateAll((elements) =>
+      elements.map((element) => ({
+        checked: element.getAttribute('aria-checked'),
+        text: element.closest('div')?.parentElement?.textContent?.replace(/\s+/g, ' ').trim(),
+      })),
+    );
+    expect(switches).toContainEqual(expect.objectContaining({ checked: 'true', text: 'OpenAI' }));
+    expect(switches).toContainEqual(expect.objectContaining({ checked: 'false', text: 'Codex' }));
+    expect(switches).toContainEqual(expect.objectContaining({ checked: 'false', text: 'Gemini' }));
     await expect(
       page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i }),
     ).not.toBeVisible();

--- a/web/e2e/custom-provider-form-simplify.spec.ts
+++ b/web/e2e/custom-provider-form-simplify.spec.ts
@@ -54,7 +54,8 @@ async function installProviderMocks(page: Page) {
       if (method === 'POST') return json(route, { ...provider, id: 2 });
       return json(route, [provider]);
     }
-    if (path === '/api/providers/1' || path === '/api/admin/providers/1') return json(route, provider);
+    if (path === '/api/providers/1' || path === '/api/admin/providers/1')
+      return json(route, provider);
     if (path.includes('/runtime-models')) return json(route, { models: ['claude-sonnet-4-5'] });
     if (
       path === '/api/admin/routes' ||
@@ -77,19 +78,34 @@ test.describe('custom provider form simplification', () => {
     await installProviderMocks(page);
   });
 
-  test('create flow keeps advanced provider settings collapsed until requested', async ({ page }) => {
+  test('create flow keeps advanced provider settings collapsed until requested', async ({
+    page,
+  }) => {
     await page.goto('/providers/create/custom');
 
     await expect(page.getByRole('heading', { name: /Basic Information|基本信息/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Client Configuration|客户端配置/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i })).not.toBeVisible();
-    await expect(page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i })).not.toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Client Configuration|客户端配置/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i }),
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i }),
+    ).not.toBeVisible();
     await expect(page.getByRole('heading', { name: /Model Mappings|模型映射/i })).not.toBeVisible();
 
-    await page.locator('summary').filter({ hasText: /^Advanced settings$/ }).click();
+    await page
+      .locator('summary')
+      .filter({ hasText: /^Advanced settings$/ })
+      .click();
 
-    await expect(page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i }),
+    ).toBeVisible();
     await expect(page.getByRole('heading', { name: /Model Mappings|模型映射/i })).toBeVisible();
   });
 
@@ -103,10 +119,30 @@ test.describe('custom provider form simplification', () => {
     await expect(page.locator('#provider-policies')).not.toBeVisible();
     await expect(page.locator('#provider-danger')).not.toBeVisible();
 
-    await page.locator('summary').filter({ hasText: /^Advanced settings$/ }).click();
+    await page
+      .locator('summary')
+      .filter({ hasText: /^Advanced settings$/ })
+      .click();
 
     await expect(page.locator('#provider-models')).toBeVisible();
     await expect(page.locator('#provider-policies')).toBeVisible();
     await expect(page.locator('#provider-danger')).toBeVisible();
+  });
+
+  test('Gemini Web2API preset opens the custom form with relay-safe defaults', async ({ page }) => {
+    await page.goto('/providers/create');
+
+    await page.getByRole('button', { name: /Gemini Web2API/i }).click();
+
+    await expect(page).toHaveURL(/\/providers\/create\/custom/);
+    await expect(page.getByDisplayValue('Gemini Web2API')).toBeVisible();
+    await expect(page.getByDisplayValue('sk-gemini')).toBeVisible();
+    await expect(page.getByText(/Do not append \/v1/i)).toBeVisible();
+    await expect(page.getByText(/^OpenAI$/)).toBeVisible();
+    await expect(page.getByText(/^Codex$/)).toBeVisible();
+    await expect(page.getByText(/^Gemini$/)).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i }),
+    ).not.toBeVisible();
   });
 });

--- a/web/e2e/custom-provider-form-simplify.spec.ts
+++ b/web/e2e/custom-provider-form-simplify.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const provider = {
+  id: 1,
+  tenantID: 1,
+  name: 'Mock Custom Relay',
+  type: 'custom',
+  logo: '',
+  config: {
+    custom: {
+      baseURL: 'https://relay.example.test/v1',
+      apiKey: 'sk-mock',
+      responsesPassthrough: true,
+      responsesWebSocket: true,
+    },
+  },
+  supportedClientTypes: ['claude', 'codex'],
+  supportModels: ['claude-*'],
+  exposedModelsEnabled: true,
+  exposedModels: ['claude-sonnet-4-5'],
+  maxConcurrency: 3,
+  excludeFromExport: false,
+  blackBox: false,
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({ contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+async function installProviderMocks(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'en');
+  });
+
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+    const method = route.request().method();
+
+    if (path === '/api/admin/auth/status') {
+      return json(route, {
+        authEnabled: true,
+        user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
+      });
+    }
+    if (path === '/api/admin/settings' || path === '/api/settings') return json(route, {});
+    if (path === '/api/admin/proxy-status' || path === '/api/proxy-status') {
+      return json(route, { running: true });
+    }
+    if (path.startsWith('/api/admin/provider-stats')) return json(route, {});
+    if (path.includes('/streaming-requests/counts')) return json(route, {});
+    if (path === '/api/admin/providers' || path === '/api/providers') {
+      if (method === 'POST') return json(route, { ...provider, id: 2 });
+      return json(route, [provider]);
+    }
+    if (path === '/api/providers/1' || path === '/api/admin/providers/1') return json(route, provider);
+    if (path.includes('/runtime-models')) return json(route, { models: ['claude-sonnet-4-5'] });
+    if (
+      path === '/api/admin/routes' ||
+      path === '/api/routes' ||
+      path === '/api/admin/model-mappings' ||
+      path === '/api/model-mappings' ||
+      path === '/api/admin/projects' ||
+      path === '/api/projects' ||
+      path === '/api/admin/api-tokens' ||
+      path === '/api/api-tokens'
+    ) {
+      return json(route, []);
+    }
+    return json(route, method === 'GET' ? {} : { ok: true });
+  });
+}
+
+test.describe('custom provider form simplification', () => {
+  test.beforeEach(async ({ page }) => {
+    await installProviderMocks(page);
+  });
+
+  test('create flow keeps advanced provider settings collapsed until requested', async ({ page }) => {
+    await page.goto('/providers/create/custom');
+
+    await expect(page.getByRole('heading', { name: /Basic Information|基本信息/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Client Configuration|客户端配置/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i })).not.toBeVisible();
+    await expect(page.getByRole('heading', { name: /Model Mappings|模型映射/i })).not.toBeVisible();
+
+    await page.locator('summary').filter({ hasText: /^Advanced settings$/ }).click();
+
+    await expect(page.getByRole('heading', { name: /Automatic Error Freeze|错误自动冻结/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Visibility and Export|可见性与导出/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Model Mappings|模型映射/i })).toBeVisible();
+  });
+
+  test('edit flow keeps model and policy sections collapsed until requested', async ({ page }) => {
+    await page.goto('/providers/1/edit');
+
+    await expect(page.getByText('Mock Custom Relay').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Connection|连接/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Client protocols|客户端/i })).toBeVisible();
+    await expect(page.locator('#provider-models')).not.toBeVisible();
+    await expect(page.locator('#provider-policies')).not.toBeVisible();
+    await expect(page.locator('#provider-danger')).not.toBeVisible();
+
+    await page.locator('summary').filter({ hasText: /^Advanced settings$/ }).click();
+
+    await expect(page.locator('#provider-models')).toBeVisible();
+    await expect(page.locator('#provider-policies')).toBeVisible();
+    await expect(page.locator('#provider-danger')).toBeVisible();
+  });
+});

--- a/web/e2e/provider-visibility-order-regression.spec.ts
+++ b/web/e2e/provider-visibility-order-regression.spec.ts
@@ -1,4 +1,67 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page, type Route } from '@playwright/test';
+
+const provider = {
+  id: 1,
+  tenantID: 1,
+  name: 'Mock Custom Relay',
+  type: 'custom',
+  logo: '',
+  config: {
+    custom: {
+      baseURL: 'https://relay.example.test/v1',
+      apiKey: 'sk-mock',
+      responsesPassthrough: true,
+      responsesWebSocket: true,
+    },
+  },
+  supportedClientTypes: ['claude', 'codex'],
+  supportModels: ['claude-*'],
+  exposedModelsEnabled: true,
+  exposedModels: ['claude-sonnet-4-5'],
+  maxConcurrency: 3,
+  excludeFromExport: false,
+  blackBox: false,
+};
+
+function json(route: Route, body: unknown) {
+  return route.fulfill({ contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+async function installProviderMocks(page: Page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path === '/api/admin/auth/status') {
+      return json(route, {
+        authEnabled: true,
+        user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
+      });
+    }
+    if (path === '/api/admin/settings' || path === '/api/settings') return json(route, {});
+    if (path === '/api/admin/proxy-status' || path === '/api/proxy-status') {
+      return json(route, { running: true });
+    }
+    if (path.startsWith('/api/admin/provider-stats')) return json(route, {});
+    if (path.includes('/streaming-requests/counts')) return json(route, {});
+    if (path === '/api/admin/providers' || path === '/api/providers') return json(route, [provider]);
+    if (path === '/api/providers/1' || path === '/api/admin/providers/1') return json(route, provider);
+    if (path.includes('/runtime-models')) return json(route, { models: ['claude-sonnet-4-5'] });
+    if (
+      path === '/api/admin/routes' ||
+      path === '/api/routes' ||
+      path === '/api/admin/model-mappings' ||
+      path === '/api/model-mappings' ||
+      path === '/api/admin/projects' ||
+      path === '/api/projects' ||
+      path === '/api/admin/api-tokens' ||
+      path === '/api/api-tokens'
+    ) {
+      return json(route, []);
+    }
+    return json(route, {});
+  });
+}
 
 async function sectionTop(section: Locator) {
   const box = await section.boundingBox();
@@ -10,22 +73,48 @@ function heading(page: Page, name: RegExp) {
   return page.getByRole('heading', { name }).first();
 }
 
-async function expectCustomProviderAdvancedSectionsCollapsed(page: Page) {
-  const clientConfig = heading(page, /Client Configuration|Client protocols|客户端配置|客户端协议/);
+async function expectCreateProviderAdvancedSectionsCollapsed(page: Page) {
+  const clientConfig = heading(page, /Client Configuration|客户端配置/);
   const advanced = page.locator('summary').filter({ hasText: /^Advanced settings$/ });
+  const modelMappings = heading(page, /Model Mappings|模型映射/);
   const errorCooldown = heading(page, /Automatic Error Freeze|错误自动冻结/);
-  const visibilityAndExport = heading(page, /Visibility and Export|Export & danger zone|可见性与导出|导出/);
+  const visibilityAndExport = heading(page, /Visibility and Export|可见性与导出/);
 
   await expect(clientConfig).toBeVisible();
   await expect(advanced).toBeVisible();
+  await expect(modelMappings).not.toBeVisible();
   await expect(errorCooldown).not.toBeVisible();
   await expect(visibilityAndExport).not.toBeVisible();
 
   await advanced.click();
 
+  await expect(modelMappings).toBeVisible();
   await expect(errorCooldown).toBeVisible();
   await expect(visibilityAndExport).toBeVisible();
+  expect(await sectionTop(errorCooldown)).toBeGreaterThan(await sectionTop(modelMappings));
   expect(await sectionTop(visibilityAndExport)).toBeGreaterThan(await sectionTop(errorCooldown));
+}
+
+async function expectEditProviderAdvancedSectionsCollapsed(page: Page) {
+  const clients = heading(page, /Client protocols|客户端协议/);
+  const advanced = page.locator('summary').filter({ hasText: /^Advanced settings$/ });
+  const models = page.locator('#provider-models');
+  const policies = page.locator('#provider-policies');
+  const danger = page.locator('#provider-danger');
+
+  await expect(clients).toBeVisible();
+  await expect(advanced).toBeVisible();
+  await expect(models).not.toBeVisible();
+  await expect(policies).not.toBeVisible();
+  await expect(danger).not.toBeVisible();
+
+  await advanced.click();
+
+  await expect(models).toBeVisible();
+  await expect(policies).toBeVisible();
+  await expect(danger).toBeVisible();
+  expect(await sectionTop(policies)).toBeGreaterThan(await sectionTop(models));
+  expect(await sectionTop(danger)).toBeGreaterThan(await sectionTop(policies));
 }
 
 test.use({ viewport: { width: 1440, height: 1800 }, locale: 'zh-CN' });
@@ -36,13 +125,14 @@ test.describe('Custom provider advanced section layout', () => {
       localStorage.setItem('maxx-admin-token', 'mock-token');
       localStorage.setItem('maxx-ui-language', 'zh');
     });
+    await installProviderMocks(page);
   });
 
   test('create and edit flows keep advanced settings collapsed by default', async ({ page }) => {
     await page.goto('/providers/create/custom');
-    await expectCustomProviderAdvancedSectionsCollapsed(page);
+    await expectCreateProviderAdvancedSectionsCollapsed(page);
 
     await page.goto('/providers/1/edit');
-    await expectCustomProviderAdvancedSectionsCollapsed(page);
+    await expectEditProviderAdvancedSectionsCollapsed(page);
   });
 });

--- a/web/e2e/provider-visibility-order-regression.spec.ts
+++ b/web/e2e/provider-visibility-order-regression.spec.ts
@@ -10,22 +10,27 @@ function heading(page: Page, name: RegExp) {
   return page.getByRole('heading', { name }).first();
 }
 
-async function expectCustomProviderSectionOrder(page: Page) {
-  const clientConfig = heading(page, /Client Configuration|客户端配置/);
+async function expectCustomProviderAdvancedSectionsCollapsed(page: Page) {
+  const clientConfig = heading(page, /Client Configuration|Client protocols|客户端配置|客户端协议/);
+  const advanced = page.locator('summary').filter({ hasText: /^Advanced settings$/ });
   const errorCooldown = heading(page, /Automatic Error Freeze|错误自动冻结/);
-  const visibilityAndExport = heading(page, /Visibility and Export|可见性与导出/);
+  const visibilityAndExport = heading(page, /Visibility and Export|Export & danger zone|可见性与导出|导出/);
 
   await expect(clientConfig).toBeVisible();
+  await expect(advanced).toBeVisible();
+  await expect(errorCooldown).not.toBeVisible();
+  await expect(visibilityAndExport).not.toBeVisible();
+
+  await advanced.click();
+
   await expect(errorCooldown).toBeVisible();
   await expect(visibilityAndExport).toBeVisible();
-
-  expect(await sectionTop(errorCooldown)).toBeGreaterThan(await sectionTop(clientConfig));
   expect(await sectionTop(visibilityAndExport)).toBeGreaterThan(await sectionTop(errorCooldown));
 }
 
 test.use({ viewport: { width: 1440, height: 1800 }, locale: 'zh-CN' });
 
-test.describe('Custom provider visibility/export section order', () => {
+test.describe('Custom provider advanced section layout', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem('maxx-admin-token', 'mock-token');
@@ -33,11 +38,11 @@ test.describe('Custom provider visibility/export section order', () => {
     });
   });
 
-  test('edit flow keeps visibility/export in the same position as create flow', async ({ page }) => {
+  test('create and edit flows keep advanced settings collapsed by default', async ({ page }) => {
     await page.goto('/providers/create/custom');
-    await expectCustomProviderSectionOrder(page);
+    await expectCustomProviderAdvancedSectionsCollapsed(page);
 
     await page.goto('/providers/1/edit');
-    await expectCustomProviderSectionOrder(page);
+    await expectCustomProviderAdvancedSectionsCollapsed(page);
   });
 });

--- a/web/src/hooks/queries/use-requests.test.ts
+++ b/web/src/hooks/queries/use-requests.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { ProxyRequest } from '@/lib/transport';
-import { isProxyRequestError, mergeProxyRequestAttemptUpdate } from './use-requests';
+import {
+  isProxyRequestError,
+  mergeProxyRequestAttemptUpdate,
+  shouldRefetchCleanupFailedCount,
+} from './use-requests';
 
 const baseRequest = {
   id: 1,
@@ -57,6 +61,35 @@ describe('isProxyRequestError', () => {
     expect(isProxyRequestError(request('FAILED'))).toBe(true);
     expect(isProxyRequestError(request('REJECTED'))).toBe(true);
     expect(isProxyRequestError(request('COMPLETED', 503))).toBe(true);
+  });
+});
+
+describe('shouldRefetchCleanupFailedCount', () => {
+  it('refetches when a new request is an error record', () => {
+    expect(shouldRefetchCleanupFailedCount(undefined, request('FAILED'))).toBe(true);
+  });
+
+  it('does not refetch when a new request is not an error record', () => {
+    expect(shouldRefetchCleanupFailedCount(undefined, request('COMPLETED'))).toBe(false);
+  });
+
+  it('refetches when an existing request leaves the cleanup-failed set', () => {
+    expect(shouldRefetchCleanupFailedCount(request('FAILED'), request('COMPLETED'))).toBe(true);
+  });
+
+  it('refetches when an existing request enters the cleanup-failed set', () => {
+    expect(shouldRefetchCleanupFailedCount(request('IN_PROGRESS'), request('COMPLETED', 500))).toBe(
+      true,
+    );
+  });
+
+  it('does not refetch when the cleanup-failed membership stays unchanged', () => {
+    expect(shouldRefetchCleanupFailedCount(request('FAILED'), request('COMPLETED', 503))).toBe(
+      false,
+    );
+    expect(shouldRefetchCleanupFailedCount(request('IN_PROGRESS'), request('COMPLETED'))).toBe(
+      false,
+    );
   });
 });
 

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -76,6 +76,16 @@ function matchesRequestTimeRange(
   return true;
 }
 
+export function shouldRefetchCleanupFailedCount(
+  previous: ProxyRequest | undefined,
+  next: ProxyRequest,
+): boolean {
+  if (!previous) {
+    return isProxyRequestError(next);
+  }
+  return isProxyRequestError(previous) !== isProxyRequestError(next);
+}
+
 export function mergeProxyRequestAttemptUpdate(
   request: ProxyRequest,
   attempt: ProxyUpstreamAttempt,
@@ -463,6 +473,7 @@ export function useProxyRequestUpdates() {
       for (const updatedRequest of updates) {
         const requestId = updatedRequest.id;
         let isKnown = knownRequestIds.has(requestId);
+        let shouldRefetchFailedCount = isProxyRequestError(updatedRequest);
 
         // 仅当详情查询正在被观察时才更新详情缓存，避免列表页“写缓存造内存”
         const detailKey = requestKeys.detail(requestId);
@@ -471,6 +482,7 @@ export function useProxyRequestUpdates() {
           // 后端可能会对 WS 广播做“瘦身”（不带 requestInfo/responseInfo 大字段），
           // 这里合并旧值，避免把详情页已加载的内容覆盖成空。
           queryClient.setQueryData<ProxyRequest>(detailKey, (old) => {
+            shouldRefetchFailedCount ||= shouldRefetchCleanupFailedCount(old, updatedRequest);
             if (!old) {
               return updatedRequest;
             }
@@ -551,6 +563,10 @@ export function useProxyRequestUpdates() {
             const index = old.items.findIndex((r) => r.id === requestId);
             if (index >= 0) {
               isKnown = true;
+              shouldRefetchFailedCount ||= shouldRefetchCleanupFailedCount(
+                old.items[index],
+                updatedRequest,
+              );
               if (!matchesFilter(updatedRequest)) {
                 const newItems = old.items.filter((r) => r.id !== requestId);
                 return normalizePage(newItems);
@@ -623,6 +639,10 @@ export function useProxyRequestUpdates() {
               }
 
               hasExisting = true;
+              shouldRefetchFailedCount ||= shouldRefetchCleanupFailedCount(
+                page.items[index],
+                updatedRequest,
+              );
 
               if (!matchesFilter(updatedRequest)) {
                 const newItems = page.items.filter((r) => r.id !== requestId);
@@ -717,7 +737,7 @@ export function useProxyRequestUpdates() {
           invalidateProviderStats = true;
           invalidateCooldowns = true;
         }
-        if (isProxyRequestError(updatedRequest)) {
+        if (shouldRefetchFailedCount) {
           refetchCleanupFailedCount = true;
         }
       }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2008,6 +2008,11 @@
       "deepseek": {
         "name": "DeepSeek",
         "description": "Claude + OpenAI"
+      },
+      "geminiWeb2Api": {
+        "name": "Gemini Web2API",
+        "description": "OpenAI + Codex + Gemini relay backed by Gemini Web",
+        "baseUrlHint": "Enter the Gemini Web2API service root, for example http://localhost:8081. Do not append /v1; maxx adds /v1 and /v1beta paths per protocol."
       }
     },
     "grok": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2011,8 +2011,8 @@
       },
       "geminiWeb2Api": {
         "name": "Gemini Web2API",
-        "description": "OpenAI + Codex + Gemini relay backed by Gemini Web",
-        "baseUrlHint": "Enter the Gemini Web2API service root, for example http://localhost:8081. Do not append /v1; maxx adds /v1 and /v1beta paths per protocol."
+        "description": "OpenAI-compatible relay backed by Gemini Web",
+        "baseUrlHint": "Enter the Gemini Web2API service root, for example http://localhost:8081. Do not append /v1; maxx adds the OpenAI-compatible /v1 path."
       }
     },
     "grok": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2007,8 +2007,8 @@
       },
       "geminiWeb2Api": {
         "name": "Gemini Web2API",
-        "description": "基于 Gemini Web 的 OpenAI + Codex + Gemini 转接服务",
-        "baseUrlHint": "填写 Gemini Web2API 服务根地址，例如 http://localhost:8081。不要追加 /v1；maxx 会按协议自动拼接 /v1 与 /v1beta 路径。"
+        "description": "基于 Gemini Web 的 OpenAI 兼容转接服务",
+        "baseUrlHint": "填写 Gemini Web2API 服务根地址，例如 http://localhost:8081。不要追加 /v1；maxx 会自动拼接 OpenAI 兼容的 /v1 路径。"
       }
     },
     "grok": {

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2004,6 +2004,11 @@
       "deepseek": {
         "name": "DeepSeek",
         "description": "Claude + OpenAI"
+      },
+      "geminiWeb2Api": {
+        "name": "Gemini Web2API",
+        "description": "基于 Gemini Web 的 OpenAI + Codex + Gemini 转接服务",
+        "baseUrlHint": "填写 Gemini Web2API 服务根地址，例如 http://localhost:8081。不要追加 /v1；maxx 会按协议自动拼接 /v1 与 /v1beta 路径。"
       }
     },
     "grok": {

--- a/web/src/pages/providers/components/clients-config-section.tsx
+++ b/web/src/pages/providers/components/clients-config-section.tsx
@@ -12,6 +12,7 @@ import {
 import { ClientIcon } from '@/components/icons/client-icons';
 import type { ClientType } from '@/lib/transport';
 import type { ClientConfig } from '../types';
+import { ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 export type DisguiseTypeValue = 'none' | 'claude-code' | 'bedrock';
@@ -32,6 +33,7 @@ interface ClientsConfigSectionProps {
   /** Codex client-level: allow Responses WebSocket upstream (custom providers). */
   responsesWebSocket?: boolean;
   onUpdateResponsesWebSocket?: (checked: boolean) => void;
+  advancedCollapsed?: boolean;
 }
 
 // Separate component for multiplier input to manage local state
@@ -87,6 +89,7 @@ export function ClientsConfigSection({
   onUpdateDisguise,
   responsesWebSocket,
   onUpdateResponsesWebSocket,
+  advancedCollapsed = false,
 }: ClientsConfigSectionProps) {
   const { t } = useTranslation();
   return (
@@ -116,13 +119,18 @@ export function ClientsConfigSection({
               </div>
             </div>
 
-            {/* Expandable/Visible Content */}
-            <div
-              className={`pt-4 transition-all duration-200 ${
+            {/* Advanced per-client fields are collapsed by default for custom providers. */}
+            <details
+              className={`group mt-4 transition-all duration-200 ${
                 client.enabled ? 'opacity-100' : 'opacity-50 grayscale pointer-events-none'
               }`}
+              open={!advancedCollapsed}
             >
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <summary className="flex cursor-pointer list-none items-center justify-between rounded-lg border border-border/70 bg-muted/30 px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50 [&::-webkit-details-marker]:hidden">
+                <span>{t('provider.advancedClientSettings', 'Advanced client settings')}</span>
+                <ChevronDown className="h-4 w-4 text-muted-foreground transition-transform group-open:rotate-180" />
+              </summary>
+              <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <label className="text-xs font-medium text-muted-foreground block mb-1.5 uppercase tracking-wide">
                     {t('provider.endpointOverride')}
@@ -175,9 +183,7 @@ export function ClientsConfigSection({
                         <SelectItem value="claude-code">
                           {t('provider.disguiseTypeClaudeCode')}
                         </SelectItem>
-                        <SelectItem value="bedrock">
-                          {t('provider.disguiseTypeBedrock')}
-                        </SelectItem>
+                        <SelectItem value="bedrock">{t('provider.disguiseTypeBedrock')}</SelectItem>
                       </SelectContent>
                     </Select>
                     <p className="text-xs text-muted-foreground mt-1">
@@ -255,7 +261,6 @@ export function ClientsConfigSection({
                 </div>
               )}
 
-
               {client.id === 'codex' && onUpdateResponsesWebSocket && (
                 <div className="mt-5 space-y-4">
                   <div className="border-t border-border/60" />
@@ -276,7 +281,7 @@ export function ClientsConfigSection({
                   </div>
                 </div>
               )}
-            </div>
+            </details>
           </div>
         ))}
       </div>

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -9,6 +9,7 @@ import {
   ArrowRight,
   Eye,
   EyeOff,
+  ChevronDown,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -344,181 +345,202 @@ export function CustomConfigStep() {
               onUpdateResponsesWebSocket={(checked) =>
                 updateFormData({ responsesWebSocket: checked })
               }
+              advancedCollapsed
             />
           </div>
 
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
-              {t('provider.errorCooldownTitle')}
-            </h3>
-            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-              <div className="pr-4">
-                <div className="text-sm font-medium text-foreground">
-                  {t('provider.disableErrorCooldown')}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t('provider.disableErrorCooldownDesc')}
-                </p>
-              </div>
-              <Switch
-                checked={!!formData.disableErrorCooldown}
-                onCheckedChange={(checked) =>
-                  updateFormData({
-                    disableErrorCooldown: checked,
-                    smartMappingRetryEnabled: checked ? formData.smartMappingRetryEnabled : false,
-                  })
-                }
-              />
-            </div>
-            <SmartMappingRetrySettings
-              disableErrorCooldown={!!formData.disableErrorCooldown}
-              enabled={formData.smartMappingRetryEnabled}
-              retryLimit={formData.smartMappingRetryLimit}
-              mappingTargetCount={mappingTargetCount}
-              onEnabledChange={(checked) => updateFormData({ smartMappingRetryEnabled: checked })}
-              onRetryLimitChange={(limit) => updateFormData({ smartMappingRetryLimit: limit })}
-            />
-            <ReasoningPolicySettings
-              value={formData.reasoning}
-              onChange={(reasoning) => updateFormData({ reasoning })}
-            />
-            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-              <div className="pr-4">
-                <div className="text-sm font-medium text-foreground">
-                  {t('provider.responsesPassthrough')}
-                </div>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t('provider.responsesPassthroughDesc')}
-                </p>
-              </div>
-              <Switch
-                checked={formData.responsesPassthrough !== false}
-                onCheckedChange={(checked) => updateFormData({ responsesPassthrough: checked })}
-              />
-            </div>
-          </div>
-
-          <div className="space-y-6">
-            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
-              {t('provider.visibilityAndExport')}
-            </h3>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                <div className="pr-4">
-                  <div className="text-sm font-medium text-foreground">
-                    {t('provider.blackBox')}
+          <details className="group rounded-xl border border-border bg-card/50 p-4">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-base font-semibold text-foreground [&::-webkit-details-marker]:hidden">
+              <span>{t('provider.advancedSettings', 'Advanced settings')}</span>
+              <ChevronDown className="h-5 w-5 text-muted-foreground transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="mt-6 space-y-6">
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+                  {t('provider.errorCooldownTitle')}
+                </h3>
+                <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.disableErrorCooldown')}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {t('provider.disableErrorCooldownDesc')}
+                    </p>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">{t('provider.blackBoxDesc')}</p>
+                  <Switch
+                    checked={!!formData.disableErrorCooldown}
+                    onCheckedChange={(checked) =>
+                      updateFormData({
+                        disableErrorCooldown: checked,
+                        smartMappingRetryEnabled: checked
+                          ? formData.smartMappingRetryEnabled
+                          : false,
+                      })
+                    }
+                  />
                 </div>
-                <Switch
-                  checked={!!formData.blackBox}
-                  onCheckedChange={(checked) =>
-                    updateFormData({
-                      blackBox: checked,
-                      excludeFromExport: checked ? true : formData.excludeFromExport,
-                    })
+                <SmartMappingRetrySettings
+                  disableErrorCooldown={!!formData.disableErrorCooldown}
+                  enabled={formData.smartMappingRetryEnabled}
+                  retryLimit={formData.smartMappingRetryLimit}
+                  mappingTargetCount={mappingTargetCount}
+                  onEnabledChange={(checked) =>
+                    updateFormData({ smartMappingRetryEnabled: checked })
                   }
+                  onRetryLimitChange={(limit) => updateFormData({ smartMappingRetryLimit: limit })}
                 />
-              </div>
-              <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                <div className="pr-4">
-                  <div className="text-sm font-medium text-foreground">
-                    {t('provider.excludeFromExport')}
+                <ReasoningPolicySettings
+                  value={formData.reasoning}
+                  onChange={(reasoning) => updateFormData({ reasoning })}
+                />
+                <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.responsesPassthrough')}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {t('provider.responsesPassthroughDesc')}
+                    </p>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {t('provider.excludeFromExportDesc')}
-                  </p>
+                  <Switch
+                    checked={formData.responsesPassthrough !== false}
+                    onCheckedChange={(checked) => updateFormData({ responsesPassthrough: checked })}
+                  />
                 </div>
-                <Switch
-                  checked={!!formData.excludeFromExport || !!formData.blackBox}
-                  disabled={!!formData.blackBox}
-                  onCheckedChange={(checked) => updateFormData({ excludeFromExport: checked })}
-                />
               </div>
-            </div>
-          </div>
 
-          {/* Model Mapping Section */}
-          <div className="space-y-6">
-            <div className="flex items-center justify-between border-b border-border pb-2">
-              <h3 className="text-lg font-semibold text-text-primary">
-                {t('modelMappings.title')}
-              </h3>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(formData.modelMappings || []),
-                    { pattern: '', target: '' },
-                  ];
-                  updateFormData({ modelMappings: newMappings });
-                }}
-              >
-                <Plus size={14} />
-                {t('routes.modelMapping.addMapping')}
-              </Button>
-            </div>
-
-            {formData.modelMappings && formData.modelMappings.length > 0 ? (
-              <div className="space-y-3">
-                {formData.modelMappings.map((mapping, index) => (
-                  <div key={index} className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg">
-                    <div className="flex-1">
-                      <label className="text-xs text-muted-foreground mb-1 block">
-                        {t('settings.matchPattern')}
-                      </label>
-                      <Input
-                        type="text"
-                        value={mapping.pattern}
-                        onChange={(e) => {
-                          const newMappings = [...(formData.modelMappings || [])];
-                          newMappings[index] = { ...newMappings[index], pattern: e.target.value };
-                          updateFormData({ modelMappings: newMappings });
-                        }}
-                        placeholder="*claude*, *sonnet*, *"
-                        className="font-mono text-sm"
-                      />
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+                  {t('provider.visibilityAndExport')}
+                </h3>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                    <div className="pr-4">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('provider.blackBox')}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {t('provider.blackBoxDesc')}
+                      </p>
                     </div>
-                    <ArrowRight size={16} className="text-muted-foreground shrink-0 mt-5" />
-                    <div className="flex-1">
-                      <label className="text-xs text-muted-foreground mb-1 block">
-                        {t('settings.targetModel')}
-                      </label>
-                      <ModelInput
-                        value={mapping.target}
-                        onChange={(value) => {
-                          const newMappings = [...(formData.modelMappings || [])];
-                          newMappings[index] = { ...newMappings[index], target: value };
-                          updateFormData({ modelMappings: newMappings });
-                        }}
-                        placeholder={t('modelInput.selectOrEnter')}
-                        extraModels={runtimeModelOptions}
-                        openSearchValue=""
-                      />
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="shrink-0 mt-5 text-muted-foreground hover:text-destructive"
-                      onClick={() => {
-                        const newMappings = (formData.modelMappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateFormData({ modelMappings: newMappings });
-                      }}
-                    >
-                      <Trash2 size={14} />
-                    </Button>
+                    <Switch
+                      checked={!!formData.blackBox}
+                      onCheckedChange={(checked) =>
+                        updateFormData({
+                          blackBox: checked,
+                          excludeFromExport: checked ? true : formData.excludeFromExport,
+                        })
+                      }
+                    />
                   </div>
-                ))}
+                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                    <div className="pr-4">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('provider.excludeFromExport')}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {t('provider.excludeFromExportDesc')}
+                      </p>
+                    </div>
+                    <Switch
+                      checked={!!formData.excludeFromExport || !!formData.blackBox}
+                      disabled={!!formData.blackBox}
+                      onCheckedChange={(checked) => updateFormData({ excludeFromExport: checked })}
+                    />
+                  </div>
+                </div>
               </div>
-            ) : (
-              <div className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg text-center">
-                {t('modelMappings.noMappings')}
+
+              {/* Model Mapping Section */}
+              <div className="space-y-6">
+                <div className="flex items-center justify-between border-b border-border pb-2">
+                  <h3 className="text-lg font-semibold text-text-primary">
+                    {t('modelMappings.title')}
+                  </h3>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      const newMappings = [
+                        ...(formData.modelMappings || []),
+                        { pattern: '', target: '' },
+                      ];
+                      updateFormData({ modelMappings: newMappings });
+                    }}
+                  >
+                    <Plus size={14} />
+                    {t('routes.modelMapping.addMapping')}
+                  </Button>
+                </div>
+
+                {formData.modelMappings && formData.modelMappings.length > 0 ? (
+                  <div className="space-y-3">
+                    {formData.modelMappings.map((mapping, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 p-3 bg-muted/50 rounded-lg"
+                      >
+                        <div className="flex-1">
+                          <label className="text-xs text-muted-foreground mb-1 block">
+                            {t('settings.matchPattern')}
+                          </label>
+                          <Input
+                            type="text"
+                            value={mapping.pattern}
+                            onChange={(e) => {
+                              const newMappings = [...(formData.modelMappings || [])];
+                              newMappings[index] = {
+                                ...newMappings[index],
+                                pattern: e.target.value,
+                              };
+                              updateFormData({ modelMappings: newMappings });
+                            }}
+                            placeholder="*claude*, *sonnet*, *"
+                            className="font-mono text-sm"
+                          />
+                        </div>
+                        <ArrowRight size={16} className="text-muted-foreground shrink-0 mt-5" />
+                        <div className="flex-1">
+                          <label className="text-xs text-muted-foreground mb-1 block">
+                            {t('settings.targetModel')}
+                          </label>
+                          <ModelInput
+                            value={mapping.target}
+                            onChange={(value) => {
+                              const newMappings = [...(formData.modelMappings || [])];
+                              newMappings[index] = { ...newMappings[index], target: value };
+                              updateFormData({ modelMappings: newMappings });
+                            }}
+                            placeholder={t('modelInput.selectOrEnter')}
+                            extraModels={runtimeModelOptions}
+                            openSearchValue=""
+                          />
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="shrink-0 mt-5 text-muted-foreground hover:text-destructive"
+                          onClick={() => {
+                            const newMappings = (formData.modelMappings || []).filter(
+                              (_, i) => i !== index,
+                            );
+                            updateFormData({ modelMappings: newMappings });
+                          }}
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg text-center">
+                    {t('modelMappings.noMappings')}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
+            </div>
+          </details>
 
           {saveStatus === 'error' && (
             <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -278,7 +278,9 @@ export function CustomConfigStep() {
                     className="w-full"
                   />
                   <p className="text-xs text-text-secondary mt-1">
-                    {t('provider.optionalUrlNote')}
+                    {formData.selectedTemplate === 'gemini-web2api'
+                      ? t('addProvider.templates.geminiWeb2Api.baseUrlHint')
+                      : t('provider.optionalUrlNote')}
                   </p>
                 </div>
 
@@ -301,7 +303,9 @@ export function CustomConfigStep() {
                       placeholder={
                         formData.backend === 'ollama'
                           ? t('provider.keyPlaceholderOptional')
-                          : t('provider.keyPlaceholder')
+                          : formData.selectedTemplate === 'gemini-web2api'
+                            ? 'sk-gemini'
+                            : t('provider.keyPlaceholder')
                       }
                       className="w-full pr-10"
                     />

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -351,6 +351,21 @@ export function CustomConfigStep() {
               }
               advancedCollapsed
             />
+
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.responsesPassthrough')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.responsesPassthroughDesc')}
+                </p>
+              </div>
+              <Switch
+                checked={formData.responsesPassthrough !== false}
+                onCheckedChange={(checked) => updateFormData({ responsesPassthrough: checked })}
+              />
+            </div>
           </div>
 
           <details className="group rounded-xl border border-border bg-card/50 p-4">
@@ -359,103 +374,6 @@ export function CustomConfigStep() {
               <ChevronDown className="h-5 w-5 text-muted-foreground transition-transform group-open:rotate-180" />
             </summary>
             <div className="mt-6 space-y-6">
-              <div className="space-y-6">
-                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
-                  {t('provider.errorCooldownTitle')}
-                </h3>
-                <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.disableErrorCooldown')}
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {t('provider.disableErrorCooldownDesc')}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={!!formData.disableErrorCooldown}
-                    onCheckedChange={(checked) =>
-                      updateFormData({
-                        disableErrorCooldown: checked,
-                        smartMappingRetryEnabled: checked
-                          ? formData.smartMappingRetryEnabled
-                          : false,
-                      })
-                    }
-                  />
-                </div>
-                <SmartMappingRetrySettings
-                  disableErrorCooldown={!!formData.disableErrorCooldown}
-                  enabled={formData.smartMappingRetryEnabled}
-                  retryLimit={formData.smartMappingRetryLimit}
-                  mappingTargetCount={mappingTargetCount}
-                  onEnabledChange={(checked) =>
-                    updateFormData({ smartMappingRetryEnabled: checked })
-                  }
-                  onRetryLimitChange={(limit) => updateFormData({ smartMappingRetryLimit: limit })}
-                />
-                <ReasoningPolicySettings
-                  value={formData.reasoning}
-                  onChange={(reasoning) => updateFormData({ reasoning })}
-                />
-                <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.responsesPassthrough')}
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {t('provider.responsesPassthroughDesc')}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={formData.responsesPassthrough !== false}
-                    onCheckedChange={(checked) => updateFormData({ responsesPassthrough: checked })}
-                  />
-                </div>
-              </div>
-
-              <div className="space-y-6">
-                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
-                  {t('provider.visibilityAndExport')}
-                </h3>
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                    <div className="pr-4">
-                      <div className="text-sm font-medium text-foreground">
-                        {t('provider.blackBox')}
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {t('provider.blackBoxDesc')}
-                      </p>
-                    </div>
-                    <Switch
-                      checked={!!formData.blackBox}
-                      onCheckedChange={(checked) =>
-                        updateFormData({
-                          blackBox: checked,
-                          excludeFromExport: checked ? true : formData.excludeFromExport,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
-                    <div className="pr-4">
-                      <div className="text-sm font-medium text-foreground">
-                        {t('provider.excludeFromExport')}
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {t('provider.excludeFromExportDesc')}
-                      </p>
-                    </div>
-                    <Switch
-                      checked={!!formData.excludeFromExport || !!formData.blackBox}
-                      disabled={!!formData.blackBox}
-                      onCheckedChange={(checked) => updateFormData({ excludeFromExport: checked })}
-                    />
-                  </div>
-                </div>
-              </div>
-
               {/* Model Mapping Section */}
               <div className="space-y-6">
                 <div className="flex items-center justify-between border-b border-border pb-2">
@@ -543,6 +461,91 @@ export function CustomConfigStep() {
                   </div>
                 )}
               </div>
+
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+                  {t('provider.errorCooldownTitle')}
+                </h3>
+                <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                  <div className="pr-4">
+                    <div className="text-sm font-medium text-foreground">
+                      {t('provider.disableErrorCooldown')}
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {t('provider.disableErrorCooldownDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={!!formData.disableErrorCooldown}
+                    onCheckedChange={(checked) =>
+                      updateFormData({
+                        disableErrorCooldown: checked,
+                        smartMappingRetryEnabled: checked
+                          ? formData.smartMappingRetryEnabled
+                          : false,
+                      })
+                    }
+                  />
+                </div>
+                <SmartMappingRetrySettings
+                  disableErrorCooldown={!!formData.disableErrorCooldown}
+                  enabled={formData.smartMappingRetryEnabled}
+                  retryLimit={formData.smartMappingRetryLimit}
+                  mappingTargetCount={mappingTargetCount}
+                  onEnabledChange={(checked) =>
+                    updateFormData({ smartMappingRetryEnabled: checked })
+                  }
+                  onRetryLimitChange={(limit) => updateFormData({ smartMappingRetryLimit: limit })}
+                />
+                <ReasoningPolicySettings
+                  value={formData.reasoning}
+                  onChange={(reasoning) => updateFormData({ reasoning })}
+                />
+              </div>
+
+              <div className="space-y-6">
+                <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+                  {t('provider.visibilityAndExport')}
+                </h3>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                    <div className="pr-4">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('provider.blackBox')}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {t('provider.blackBoxDesc')}
+                      </p>
+                    </div>
+                    <Switch
+                      checked={!!formData.blackBox}
+                      onCheckedChange={(checked) =>
+                        updateFormData({
+                          blackBox: checked,
+                          excludeFromExport: checked ? true : formData.excludeFromExport,
+                        })
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+                    <div className="pr-4">
+                      <div className="text-sm font-medium text-foreground">
+                        {t('provider.excludeFromExport')}
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {t('provider.excludeFromExportDesc')}
+                      </p>
+                    </div>
+                    <Switch
+                      checked={!!formData.excludeFromExport || !!formData.blackBox}
+                      disabled={!!formData.blackBox}
+                      onCheckedChange={(checked) => updateFormData({ excludeFromExport: checked })}
+                    />
+                  </div>
+                </div>
+              </div>
+
+
             </div>
           </details>
 

--- a/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
+++ b/web/src/pages/providers/components/provider-edit-flow-layout.test.ts
@@ -6,23 +6,44 @@ const editFlowSource = readFileSync(
   join(process.cwd(), 'src/pages/providers/components/provider-edit-flow.tsx'),
   'utf8',
 );
+const createFlowSource = readFileSync(
+  join(process.cwd(), 'src/pages/providers/components/custom-config-step.tsx'),
+  'utf8',
+);
 
-describe('ProviderEditFlow section layout', () => {
-  it('keeps visibility and export in the same relative position as custom provider creation', () => {
-    const connectionSection = editFlowSource.indexOf('id="provider-connection"');
-    const clientSection = editFlowSource.indexOf('id="provider-clients"');
-    const modelSection = editFlowSource.indexOf('id="provider-models"');
-    const supportModels = editFlowSource.indexOf('<ProviderSupportModels');
-    const policySection = editFlowSource.indexOf('id="provider-policies"');
-    const quotaEnabled = editFlowSource.indexOf("t('provider.quotaEnabled')");
-    const dangerSection = editFlowSource.indexOf('id="provider-danger"');
+function expectOrder(source: string, tokens: string[]) {
+  let previous = -1;
+  for (const token of tokens) {
+    const index = source.indexOf(token);
+    expect(index, token).toBeGreaterThan(-1);
+    expect(index, token).toBeGreaterThan(previous);
+    previous = index;
+  }
+}
 
-    expect(connectionSection).toBeGreaterThan(-1);
-    expect(clientSection).toBeGreaterThan(connectionSection);
-    expect(modelSection).toBeGreaterThan(clientSection);
-    expect(supportModels).toBeGreaterThan(modelSection);
-    expect(policySection).toBeGreaterThan(supportModels);
-    expect(quotaEnabled).toBeGreaterThan(policySection);
-    expect(dangerSection).toBeGreaterThan(policySection);
+describe('Provider create/edit section layout', () => {
+  it('keeps edit provider sections in the expected order', () => {
+    expectOrder(editFlowSource, [
+      'id="provider-connection"',
+      'id="provider-clients"',
+      "t('provider.responsesPassthrough')",
+      'id="provider-models"',
+      '<ProviderSupportModels',
+      'id="provider-policies"',
+      "t('provider.quotaEnabled')",
+      'id="provider-danger"',
+      "t('provider.excludeFromExport')",
+    ]);
+  });
+
+  it('keeps custom provider creation aligned with edit provider section order', () => {
+    expectOrder(createFlowSource, [
+      "t('provider.clientConfig')",
+      "t('provider.responsesPassthrough')",
+      '{/* Model Mapping Section */}',
+      "t('provider.errorCooldownTitle')",
+      "t('provider.visibilityAndExport')",
+      "t('provider.excludeFromExport')",
+    ]);
   });
 });

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   Globe,
   ChevronLeft,
+  ChevronDown,
   Key,
   Check,
   Trash2,
@@ -1293,6 +1294,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                   onUpdateResponsesWebSocket={(checked) =>
                     setFormData((prev) => ({ ...prev, responsesWebSocket: checked }))
                   }
+                  advancedCollapsed
                 />
 
                 <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
@@ -1313,155 +1315,169 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                 </div>
               </ProviderEditSection>
 
-              <ProviderEditSection
-                id="provider-models"
-                title={t('provider.infoSections.models')}
-                description={t('provider.infoSections.modelsDesc')}
-                icon={<Filter size={18} />}
-              >
-                <ProviderSupportModels
-                  supportModels={formData.supportModels}
-                  onChange={(models) => setFormData((prev) => ({ ...prev, supportModels: models }))}
-                />
-
-                <ProviderExposedModels
-                  enabled={formData.exposedModelsEnabled}
-                  exposedModels={formData.exposedModels}
-                  onEnabledChange={(enabled) =>
-                    setFormData((prev) => ({ ...prev, exposedModelsEnabled: enabled }))
-                  }
-                  onChange={(models) => setFormData((prev) => ({ ...prev, exposedModels: models }))}
-                />
-
-                <ProviderModelMappings
-                  provider={provider}
-                  runtimeModelsPreview={runtimeModelsPreview}
-                />
-
-                <ResponseModelMappings
-                  mappings={formData.responseModelMapping}
-                  onChange={(mappings) =>
-                    setFormData((prev) => ({ ...prev, responseModelMapping: mappings }))
-                  }
-                  disabled={saving}
-                />
-              </ProviderEditSection>
-
-              <ProviderEditSection
-                id="provider-policies"
-                title={t('provider.infoSections.policies')}
-                description={t('provider.infoSections.policiesDesc')}
-                icon={<Zap size={18} />}
-              >
-                <ProviderMaxConcurrencyField
-                  value={formData.maxConcurrency}
-                  onChange={(maxConcurrency) =>
-                    setFormData((prev) => ({ ...prev, maxConcurrency }))
-                  }
-                />
-
-                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.quotaEnabled')}
-                    </div>
-                  </div>
-                  <Switch
-                    checked={!!formData.quotaEnabled}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({ ...prev, quotaEnabled: checked }))
-                    }
-                  />
-                </div>
-
-                <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                  <div className="pr-4">
-                    <div className="text-sm font-medium text-foreground">
-                      {t('provider.disableErrorCooldown')}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {t('provider.disableErrorCooldownDesc')}
-                    </p>
-                  </div>
-                  <Switch
-                    checked={!!formData.disableErrorCooldown}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        disableErrorCooldown: checked,
-                        smartMappingRetryEnabled: checked ? prev.smartMappingRetryEnabled : false,
-                      }))
-                    }
-                  />
-                </div>
-
-                <SmartMappingRetrySettings
-                  disableErrorCooldown={!!formData.disableErrorCooldown}
-                  enabled={formData.smartMappingRetryEnabled}
-                  retryLimit={formData.smartMappingRetryLimit}
-                  mappingTargetCount={providerMappingTargetCount}
-                  onEnabledChange={(checked) =>
-                    setFormData((prev) => ({ ...prev, smartMappingRetryEnabled: checked }))
-                  }
-                  onRetryLimitChange={(limit) =>
-                    setFormData((prev) => ({ ...prev, smartMappingRetryLimit: limit }))
-                  }
-                />
-                <ReasoningPolicySettings
-                  value={formData.reasoning}
-                  onChange={(reasoning) => setFormData((prev) => ({ ...prev, reasoning }))}
-                />
-              </ProviderEditSection>
-
-              <ProviderEditSection
-                id="provider-danger"
-                title={t('provider.infoSections.danger')}
-                description={t('provider.infoSections.dangerDesc')}
-                icon={<Trash2 size={18} />}
-              >
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                    <div className="pr-4">
-                      <div className="text-sm font-medium text-foreground">
-                        {t('provider.blackBox')}
-                      </div>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {t('provider.blackBoxDesc')}
-                      </p>
-                    </div>
-                    <Switch
-                      checked={!!formData.blackBox}
-                      onCheckedChange={(checked) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          blackBox: checked,
-                          excludeFromExport: checked ? true : prev.excludeFromExport,
-                        }))
+              <details className="group rounded-xl border border-border bg-card/50 p-4">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-base font-semibold text-foreground [&::-webkit-details-marker]:hidden">
+                  <span>{t('provider.advancedSettings', 'Advanced settings')}</span>
+                  <ChevronDown className="h-5 w-5 text-muted-foreground transition-transform group-open:rotate-180" />
+                </summary>
+                <div className="mt-6 space-y-6">
+                  <ProviderEditSection
+                    id="provider-models"
+                    title={t('provider.infoSections.models')}
+                    description={t('provider.infoSections.modelsDesc')}
+                    icon={<Filter size={18} />}
+                  >
+                    <ProviderSupportModels
+                      supportModels={formData.supportModels}
+                      onChange={(models) =>
+                        setFormData((prev) => ({ ...prev, supportModels: models }))
                       }
                     />
-                  </div>
 
-                  <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
-                    <div className="pr-4">
-                      <div className="text-sm font-medium text-foreground">
-                        {t('provider.excludeFromExport')}
-                      </div>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {excludeFromExportLocked
-                          ? t('provider.excludeFromExportLockedDesc')
-                          : t('provider.excludeFromExportDesc')}
-                      </p>
-                    </div>
-                    <Switch
-                      checked={effectiveExcludeFromExport}
-                      disabled={excludeFromExportLocked || !!formData.blackBox}
-                      onCheckedChange={(checked) =>
-                        setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
+                    <ProviderExposedModels
+                      enabled={formData.exposedModelsEnabled}
+                      exposedModels={formData.exposedModels}
+                      onEnabledChange={(enabled) =>
+                        setFormData((prev) => ({ ...prev, exposedModelsEnabled: enabled }))
+                      }
+                      onChange={(models) =>
+                        setFormData((prev) => ({ ...prev, exposedModels: models }))
                       }
                     />
-                  </div>
+
+                    <ProviderModelMappings
+                      provider={provider}
+                      runtimeModelsPreview={runtimeModelsPreview}
+                    />
+
+                    <ResponseModelMappings
+                      mappings={formData.responseModelMapping}
+                      onChange={(mappings) =>
+                        setFormData((prev) => ({ ...prev, responseModelMapping: mappings }))
+                      }
+                      disabled={saving}
+                    />
+                  </ProviderEditSection>
+
+                  <ProviderEditSection
+                    id="provider-policies"
+                    title={t('provider.infoSections.policies')}
+                    description={t('provider.infoSections.policiesDesc')}
+                    icon={<Zap size={18} />}
+                  >
+                    <ProviderMaxConcurrencyField
+                      value={formData.maxConcurrency}
+                      onChange={(maxConcurrency) =>
+                        setFormData((prev) => ({ ...prev, maxConcurrency }))
+                      }
+                    />
+
+                    <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                      <div className="pr-4">
+                        <div className="text-sm font-medium text-foreground">
+                          {t('provider.quotaEnabled')}
+                        </div>
+                      </div>
+                      <Switch
+                        checked={!!formData.quotaEnabled}
+                        onCheckedChange={(checked) =>
+                          setFormData((prev) => ({ ...prev, quotaEnabled: checked }))
+                        }
+                      />
+                    </div>
+
+                    <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                      <div className="pr-4">
+                        <div className="text-sm font-medium text-foreground">
+                          {t('provider.disableErrorCooldown')}
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {t('provider.disableErrorCooldownDesc')}
+                        </p>
+                      </div>
+                      <Switch
+                        checked={!!formData.disableErrorCooldown}
+                        onCheckedChange={(checked) =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            disableErrorCooldown: checked,
+                            smartMappingRetryEnabled: checked
+                              ? prev.smartMappingRetryEnabled
+                              : false,
+                          }))
+                        }
+                      />
+                    </div>
+
+                    <SmartMappingRetrySettings
+                      disableErrorCooldown={!!formData.disableErrorCooldown}
+                      enabled={formData.smartMappingRetryEnabled}
+                      retryLimit={formData.smartMappingRetryLimit}
+                      mappingTargetCount={providerMappingTargetCount}
+                      onEnabledChange={(checked) =>
+                        setFormData((prev) => ({ ...prev, smartMappingRetryEnabled: checked }))
+                      }
+                      onRetryLimitChange={(limit) =>
+                        setFormData((prev) => ({ ...prev, smartMappingRetryLimit: limit }))
+                      }
+                    />
+                    <ReasoningPolicySettings
+                      value={formData.reasoning}
+                      onChange={(reasoning) => setFormData((prev) => ({ ...prev, reasoning }))}
+                    />
+                  </ProviderEditSection>
+
+                  <ProviderEditSection
+                    id="provider-danger"
+                    title={t('provider.infoSections.danger')}
+                    description={t('provider.infoSections.dangerDesc')}
+                    icon={<Trash2 size={18} />}
+                  >
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                        <div className="pr-4">
+                          <div className="text-sm font-medium text-foreground">
+                            {t('provider.blackBox')}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t('provider.blackBoxDesc')}
+                          </p>
+                        </div>
+                        <Switch
+                          checked={!!formData.blackBox}
+                          onCheckedChange={(checked) =>
+                            setFormData((prev) => ({
+                              ...prev,
+                              blackBox: checked,
+                              excludeFromExport: checked ? true : prev.excludeFromExport,
+                            }))
+                          }
+                        />
+                      </div>
+
+                      <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+                        <div className="pr-4">
+                          <div className="text-sm font-medium text-foreground">
+                            {t('provider.excludeFromExport')}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {excludeFromExportLocked
+                              ? t('provider.excludeFromExportLockedDesc')
+                              : t('provider.excludeFromExportDesc')}
+                          </p>
+                        </div>
+                        <Switch
+                          checked={effectiveExcludeFromExport}
+                          disabled={excludeFromExportLocked || !!formData.blackBox}
+                          onCheckedChange={(checked) =>
+                            setFormData((prev) => ({ ...prev, excludeFromExport: checked }))
+                          }
+                        />
+                      </div>
+                    </div>
+                  </ProviderEditSection>
                 </div>
-              </ProviderEditSection>
+              </details>
 
               {saveStatus === 'error' && (
                 <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -41,8 +41,11 @@ export function SelectTypeStep() {
       });
 
       updateFormData({
+        type: 'custom',
         selectedTemplate: templateId,
         name: template.name,
+        baseURL: template.baseURL ?? '',
+        apiKey: template.apiKey ?? '',
         backend: 'http',
         clients: updatedClients,
         modelMappings: template.modelMappings,
@@ -282,7 +285,9 @@ export function SelectTypeStep() {
                     </div>
 
                     <div className="flex-1 min-w-0 space-y-1">
-                      <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">Grok</h3>
+                      <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                        Grok
+                      </h3>
                       <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
                         Import xAI OAuth JSON from CLIProxyAPI
                       </p>
@@ -295,6 +300,48 @@ export function SelectTypeStep() {
                 </Button>
               )}
 
+              <Button
+                onClick={() => handleApplyTemplate('gemini-web2api')}
+                variant="ghost"
+                aria-label="Gemini Web2API OpenAI Codex Gemini"
+                className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                  formData.selectedTemplate === 'gemini-web2api'
+                    ? 'border-provider-custom bg-provider-custom/10 shadow-sm'
+                    : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                }`}
+              >
+                <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                  <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-custom/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                    <Sparkles className="size-5 md:size-6 text-provider-custom" />
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-1">
+                    <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                      {t('addProvider.templates.geminiWeb2Api.name', 'Gemini Web2API')}
+                    </h3>
+                    <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                      {t(
+                        'addProvider.templates.geminiWeb2Api.description',
+                        'OpenAI, Codex, and Gemini protocol relay backed by Gemini Web',
+                      )}
+                    </p>
+                    <div className="flex flex-wrap gap-1.5 pt-1" aria-label="Enabled protocols">
+                      {['OpenAI', 'Codex', 'Gemini'].map((client) => (
+                        <span
+                          key={client}
+                          className="rounded-full border border-provider-custom/30 bg-provider-custom/10 px-2 py-0.5 text-[11px] font-medium text-provider-custom"
+                        >
+                          {client}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                  {formData.selectedTemplate === 'gemini-web2api' && (
+                    <CheckCircle2 className="size-5 text-provider-custom shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                  )}
+                </div>
+              </Button>
 
               <Button
                 onClick={() => handleSelectType('custom')}
@@ -422,69 +469,71 @@ export function SelectTypeStep() {
                   </div>
                 </Button>
 
-                {quickTemplates.map((template) => {
-                  const Icon = template.icon === 'grid' ? Grid3X3 : Layers;
-                  const isSelected = formData.selectedTemplate === template.id;
-                  const templateName = template.nameKey ? t(template.nameKey) : template.name;
-                  const templateDescription = template.descriptionKey
-                    ? t(template.descriptionKey)
-                    : template.description;
+                {quickTemplates
+                  .filter((template) => template.id !== 'gemini-web2api')
+                  .map((template) => {
+                    const Icon = template.icon === 'grid' ? Grid3X3 : Layers;
+                    const isSelected = formData.selectedTemplate === template.id;
+                    const templateName = template.nameKey ? t(template.nameKey) : template.name;
+                    const templateDescription = template.descriptionKey
+                      ? t(template.descriptionKey)
+                      : template.description;
 
-                  return (
-                    <Button
-                      key={template.id}
-                      onClick={() => handleApplyTemplate(template.id)}
-                      variant="ghost"
-                      className={`group p-0 rounded-xl border text-left h-full w-full min-h-36 sm:min-h-40 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
-                        isSelected
-                          ? 'border-primary bg-primary/10 shadow-sm'
-                          : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
-                      }`}
-                    >
-                      <div className="p-4 sm:p-5 flex flex-col gap-3 sm:gap-4 h-full w-full">
-                        <div className="flex items-center justify-between w-full">
-                          <div
-                            className={`size-9 sm:size-10 rounded-lg flex items-center justify-center overflow-hidden transition-all duration-200 group-hover:scale-105 ${
-                              isSelected ? 'bg-primary/15' : 'bg-muted group-hover:bg-primary/10'
-                            }`}
-                          >
-                            {template.logoUrl ? (
-                              <img
-                                src={template.logoUrl}
-                                alt={templateName}
-                                className="w-full h-full object-contain"
-                              />
-                            ) : (
-                              <Icon
-                                className={`size-4 sm:size-5 ${
-                                  isSelected
-                                    ? 'text-primary'
-                                    : 'text-muted-foreground group-hover:text-primary transition-colors'
-                                }`}
-                              />
+                    return (
+                      <Button
+                        key={template.id}
+                        onClick={() => handleApplyTemplate(template.id)}
+                        variant="ghost"
+                        className={`group p-0 rounded-xl border text-left h-full w-full min-h-36 sm:min-h-40 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                          isSelected
+                            ? 'border-primary bg-primary/10 shadow-sm'
+                            : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                        }`}
+                      >
+                        <div className="p-4 sm:p-5 flex flex-col gap-3 sm:gap-4 h-full w-full">
+                          <div className="flex items-center justify-between w-full">
+                            <div
+                              className={`size-9 sm:size-10 rounded-lg flex items-center justify-center overflow-hidden transition-all duration-200 group-hover:scale-105 ${
+                                isSelected ? 'bg-primary/15' : 'bg-muted group-hover:bg-primary/10'
+                              }`}
+                            >
+                              {template.logoUrl ? (
+                                <img
+                                  src={template.logoUrl}
+                                  alt={templateName}
+                                  className="w-full h-full object-contain"
+                                />
+                              ) : (
+                                <Icon
+                                  className={`size-4 sm:size-5 ${
+                                    isSelected
+                                      ? 'text-primary'
+                                      : 'text-muted-foreground group-hover:text-primary transition-colors'
+                                  }`}
+                                />
+                              )}
+                            </div>
+                            {isSelected && (
+                              <CheckCircle2 className="size-4 sm:size-[18px] text-primary animate-in zoom-in-50 duration-200" />
                             )}
                           </div>
-                          {isSelected && (
-                            <CheckCircle2 className="size-4 sm:size-[18px] text-primary animate-in zoom-in-50 duration-200" />
-                          )}
-                        </div>
 
-                        <div className="flex-1 space-y-1">
-                          <h4
-                            className={`text-sm font-semibold leading-tight truncate transition-colors ${
-                              isSelected ? 'text-primary' : 'text-foreground'
-                            }`}
-                          >
-                            {templateName}
-                          </h4>
-                          <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-                            {templateDescription}
-                          </p>
+                          <div className="flex-1 space-y-1">
+                            <h4
+                              className={`text-sm font-semibold leading-tight truncate transition-colors ${
+                                isSelected ? 'text-primary' : 'text-foreground'
+                              }`}
+                            >
+                              {templateName}
+                            </h4>
+                            <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+                              {templateDescription}
+                            </p>
+                          </div>
                         </div>
-                      </div>
-                    </Button>
-                  );
-                })}
+                      </Button>
+                    );
+                  })}
               </div>
             </div>
           )}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -303,7 +303,7 @@ export function SelectTypeStep() {
               <Button
                 onClick={() => handleApplyTemplate('gemini-web2api')}
                 variant="ghost"
-                aria-label="Gemini Web2API OpenAI Codex Gemini"
+                aria-label="Gemini Web2API OpenAI"
                 className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
                   formData.selectedTemplate === 'gemini-web2api'
                     ? 'border-provider-custom bg-provider-custom/10 shadow-sm'
@@ -322,11 +322,11 @@ export function SelectTypeStep() {
                     <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
                       {t(
                         'addProvider.templates.geminiWeb2Api.description',
-                        'OpenAI, Codex, and Gemini protocol relay backed by Gemini Web',
+                        'OpenAI-compatible relay backed by Gemini Web',
                       )}
                     </p>
                     <div className="flex flex-wrap gap-1.5 pt-1" aria-label="Enabled protocols">
-                      {['OpenAI', 'Codex', 'Gemini'].map((client) => (
+                      {['OpenAI'].map((client) => (
                         <span
                           key={client}
                           className="rounded-full border border-provider-custom/30 bg-provider-custom/10 px-2 py-0.5 text-[11px] font-medium text-provider-custom"

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -65,6 +65,20 @@ describe('provider type helpers', () => {
     expect(zhipuTemplate?.clientBaseURLs.openai).toBe('https://open.bigmodel.cn/api/paas/v4');
   });
 
+  it('configures Gemini Web2API as a custom relay preset across OpenAI, Codex, and Gemini', () => {
+    const geminiWeb2Api = quickTemplates.find((template) => template.id === 'gemini-web2api');
+
+    expect(geminiWeb2Api?.name).toBe('Gemini Web2API');
+    expect(geminiWeb2Api?.supportedClients).toEqual(['openai', 'codex', 'gemini']);
+    expect(geminiWeb2Api?.baseURL).toBe('');
+    expect(geminiWeb2Api?.apiKey).toBe('sk-gemini');
+    expect(geminiWeb2Api?.clientBaseURLs).toEqual({});
+    expect(geminiWeb2Api?.modelMappings).toContainEqual({
+      pattern: '*',
+      target: 'gemini-3.6-flash',
+    });
+  });
+
   it('enables both Claude and OpenAI for the DeepSeek quick template', () => {
     const deepseek = quickTemplates.find((template) => template.id === 'deepseek');
 

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -65,11 +65,11 @@ describe('provider type helpers', () => {
     expect(zhipuTemplate?.clientBaseURLs.openai).toBe('https://open.bigmodel.cn/api/paas/v4');
   });
 
-  it('configures Gemini Web2API as a custom relay preset across OpenAI, Codex, and Gemini', () => {
+  it('configures Gemini Web2API as an OpenAI-only custom relay preset for now', () => {
     const geminiWeb2Api = quickTemplates.find((template) => template.id === 'gemini-web2api');
 
     expect(geminiWeb2Api?.name).toBe('Gemini Web2API');
-    expect(geminiWeb2Api?.supportedClients).toEqual(['openai', 'codex', 'gemini']);
+    expect(geminiWeb2Api?.supportedClients).toEqual(['openai']);
     expect(geminiWeb2Api?.baseURL).toBe('');
     expect(geminiWeb2Api?.apiKey).toBe('sk-gemini');
     expect(geminiWeb2Api?.clientBaseURLs).toEqual({});

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -219,11 +219,11 @@ export const quickTemplates: QuickTemplate[] = [
   {
     id: 'gemini-web2api',
     name: 'Gemini Web2API',
-    description: 'OpenAI + Codex + Gemini via Gemini Web relay',
+    description: 'OpenAI-compatible relay backed by Gemini Web',
     nameKey: 'addProvider.templates.geminiWeb2Api.name',
     descriptionKey: 'addProvider.templates.geminiWeb2Api.description',
     icon: 'layers',
-    supportedClients: ['openai', 'codex', 'gemini'],
+    supportedClients: ['openai'],
     clientBaseURLs: {},
     baseURL: '',
     apiKey: 'sk-gemini',

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -211,9 +211,28 @@ export type QuickTemplate = {
   supportedClients: ClientType[];
   clientBaseURLs: Partial<Record<ClientType, string>>;
   modelMappings?: TemplateModelMapping[]; // 可选的模型映射
+  baseURL?: string;
+  apiKey?: string;
 };
 
 export const quickTemplates: QuickTemplate[] = [
+  {
+    id: 'gemini-web2api',
+    name: 'Gemini Web2API',
+    description: 'OpenAI + Codex + Gemini via Gemini Web relay',
+    nameKey: 'addProvider.templates.geminiWeb2Api.name',
+    descriptionKey: 'addProvider.templates.geminiWeb2Api.description',
+    icon: 'layers',
+    supportedClients: ['openai', 'codex', 'gemini'],
+    clientBaseURLs: {},
+    baseURL: '',
+    apiKey: 'sk-gemini',
+    modelMappings: [
+      { pattern: 'gpt-4*', target: 'gemini-3.6-flash' },
+      { pattern: 'gpt-5*', target: 'gemini-3.5-flash-thinking' },
+      { pattern: '*', target: 'gemini-3.6-flash' },
+    ],
+  },
   {
     id: '88code',
     name: '88 Code',


### PR DESCRIPTION
## Summary
- Simplify custom provider create/edit flows by collapsing advanced controls behind native advanced settings sections.
- Align the custom provider create flow with the edit flow ordering and behavior: client passthrough beside client protocols, models first in advanced settings, then policies, then visibility/export safeguards.
- Add a Gemini Web2API provider preset that still persists as a custom provider, avoiding a risky new adapter/request-chain implementation.
- Keep Gemini Web2API OpenAI-only for now: default supported client type is only `openai`; Codex and Gemini clients stay disabled by default.
- Prefill `sk-gemini` and warn admins to enter the service root without `/v1`.
- Fix the Requests tab cleanup-failed-records button state so its count refreshes when live request updates enter or leave the cleanup-failed set.
- Add regression coverage for the custom provider simplification, Gemini Web2API preset, cleanup-failed count refresh logic, and create/edit layout alignment.

## Validation
- `pnpm exec vitest run src/pages/providers/components/provider-edit-flow-layout.test.ts src/pages/providers/types.test.ts src/hooks/queries/use-requests.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec playwright test e2e/custom-provider-form-simplify.spec.ts e2e/provider-visibility-order-regression.spec.ts --project=chromium`
- Manual Chrome/Playwright regression with mocked admin/provider APIs:
  - Select the single Gemini Web2API preset entry
  - Verify the card only advertises OpenAI
  - Verify the custom form defaults and `/v1` base URL warning
  - Assert protocol switches are `Claude=false`, `OpenAI=true`, `Codex=false`, `Gemini=false`
- Screenshot evidence sent in chat:
  - `/home/moltbot/clawd-wechat/tmp/maxx-gemini-web2api-openai-only/01-select-openai-only.png`
  - `/home/moltbot/clawd-wechat/tmp/maxx-gemini-web2api-openai-only/02-form-openai-only.png`
