### PR TITLE
fix(codex): honor project scope in websocket precheck

### DIFF
--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -65,6 +65,24 @@ func apiTokenProjectBinding(apiToken *domain.APIToken, currentProjectID uint64) 
 	return apiToken.ProjectID, true
 }
 
+func resolveProxyProjectID(r *http.Request, apiToken *domain.APIToken) (uint64, error) {
+	var projectID uint64
+	if r != nil {
+		if pidStr := r.Header.Get("X-Maxx-Project-ID"); pidStr != "" {
+			if isUserPanelAPIToken(apiToken) {
+				return 0, errors.New("user panel token cannot select project")
+			}
+			if pid, err := strconv.ParseUint(pidStr, 10, 64); err == nil {
+				projectID = pid
+			}
+		}
+	}
+	if tokenProjectID, ok := apiTokenProjectBinding(apiToken, projectID); ok {
+		projectID = tokenProjectID
+	}
+	return projectID, nil
+}
+
 // NewProxyHandler creates a new proxy handler
 func NewProxyHandler(
 	clientAdapter *client.Adapter,
@@ -101,9 +119,10 @@ func (h *ProxyHandler) SetRequestTracker(tracker RequestTracker) {
 func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if isResponsesWebSocketUpgrade(r) {
 		tenantID := domain.DefaultTenantID
-		var projectID uint64
+		var apiToken *domain.APIToken
 		if h.tokenAuth != nil {
-			apiToken, err := h.tokenAuth.ValidateRequest(r, domain.ClientTypeCodex)
+			var err error
+			apiToken, err = h.tokenAuth.ValidateRequest(r, domain.ClientTypeCodex)
 			if err != nil {
 				writeError(w, http.StatusUnauthorized, err.Error())
 				return
@@ -112,9 +131,16 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if apiToken.TenantID > 0 {
 					tenantID = apiToken.TenantID
 				}
-				// Token-bound project is known before upgrade; session binding is not.
-				projectID = apiToken.ProjectID
 			}
+		}
+		// ProjectProxyHandler resolves /project/{slug}/... before this point and
+		// passes the project ID in X-Maxx-Project-ID. Session binding is not
+		// available until after the WebSocket upgrade, so use the same initial
+		// header/token binding rules as HTTP/SSE requests.
+		projectID, err := resolveProxyProjectID(r, apiToken)
+		if err != nil {
+			writeError(w, http.StatusForbidden, err.Error())
+			return
 		}
 
 		// Codex only immediately falls back to HTTP/SSE when the WebSocket
@@ -295,24 +321,18 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 	c.Set(flow.KeyIsStream, stream)
 	c.Set(flow.KeyAPITokenID, apiTokenID)
 
-	var projectID uint64
-	if pidStr := r.Header.Get("X-Maxx-Project-ID"); pidStr != "" {
-		if isUserPanelAPIToken(apiToken) {
-			writeError(w, http.StatusForbidden, "user panel token cannot select project")
-			c.Abort()
-			return
-		}
-		if pid, err := strconv.ParseUint(pidStr, 10, 64); err == nil {
-			projectID = pid
-			log.Printf("[Proxy] Using project ID from header: %d", projectID)
-		}
+	projectID, err := resolveProxyProjectID(r, apiToken)
+	if err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		c.Abort()
+		return
+	}
+	if projectID != 0 {
+		log.Printf("[Proxy] Using initial project ID: %d", projectID)
 	}
 	c.Set(flow.KeyProjectID, projectID)
 
 	if apiToken != nil {
-		if tokenProjectID, ok := apiTokenProjectBinding(apiToken, projectID); ok {
-			c.Set(flow.KeyProjectID, tokenProjectID)
-		}
 		if err := h.tokenAuth.AcquireConcurrency(apiToken); err != nil {
 			log.Printf("[Proxy] Token concurrency limit hit: tokenID=%d err=%v", apiToken.ID, err)
 			h.executor.RecordRejectedProxyRequest(c, apiToken, http.StatusTooManyRequests, err.Error())

--- a/internal/handler/proxy_test.go
+++ b/internal/handler/proxy_test.go
@@ -256,3 +256,44 @@ func TestUserPanelAPITokenProjectBindingGuard(t *testing.T) {
 		t.Fatal("nil token should keep unauthenticated/default project behavior")
 	}
 }
+
+func TestResolveProxyProjectID(t *testing.T) {
+	regularGlobalToken := &domain.APIToken{Description: "global token"}
+	regularProjectToken := &domain.APIToken{Description: "project token", ProjectID: 42}
+	userPanelToken := &domain.APIToken{
+		Description: userPanelAPITokenDescription(123),
+		ProjectID:   42,
+	}
+
+	tests := []struct {
+		name        string
+		header      string
+		token       *domain.APIToken
+		wantProject uint64
+		wantErr     bool
+	}{
+		{name: "project proxy header with global token", header: "9", token: regularGlobalToken, wantProject: 9},
+		{name: "token-bound project without header", token: regularProjectToken, wantProject: 42},
+		{name: "project proxy header takes precedence", header: "9", token: regularProjectToken, wantProject: 9},
+		{name: "invalid header falls back to token binding", header: "invalid", token: regularProjectToken, wantProject: 42},
+		{name: "global token without project", token: regularGlobalToken},
+		{name: "user panel token cannot select header project", header: "9", token: userPanelToken, wantErr: true},
+		{name: "user panel token does not use token binding", token: userPanelToken},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/responses", nil)
+			if tt.header != "" {
+				req.Header.Set("X-Maxx-Project-ID", tt.header)
+			}
+			got, err := resolveProxyProjectID(req, tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.wantProject {
+				t.Fatalf("project ID = %d, want %d", got, tt.wantProject)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- honor `X-Maxx-Project-ID` during the Responses WebSocket eligibility precheck
- share the initial project-resolution rules between WebSocket and HTTP/SSE ingress
- preserve user-panel token project-selection restrictions
- add regression coverage for project headers, token bindings, precedence, and invalid headers

## Root cause

`ProjectProxyHandler` resolves `/project/{slug}/...` and passes the project ID in `X-Maxx-Project-ID`. The WebSocket pre-upgrade branch ignored that header and only used `apiToken.ProjectID`. A global API token therefore queried WebSocket provider eligibility for project `0` and returned `426 Upgrade Required`, even when the selected project route contained an eligible Responses WebSocket provider. HTTP/SSE ingress already consumed the project header, which made the failure transport-specific.

## Validation

- `go vet ./cmd/... ./internal/...`
- `go test -count=1 ./internal/...`
- `go build ./cmd/maxx`
- `git diff --check`
- staged Go sources are clean under `gofmt`

The combined Windows run of `go test -count=1 -timeout 600s ./cmd/... ./internal/...` reached two unrelated platform-specific failures in `cmd/maxx-cli/internal/cfg` (`0600` permission semantics and legacy XDG path migration); all `internal/...` packages, including the changed handler package, passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * HTTP 和 WebSocket 代理支持通过项目请求头选择项目。
  * 项目选择将根据令牌权限进行校验，无效选择会被拒绝。
  * WebSocket 握手阶段支持项目绑定，并在权限不足时返回 403。
  * HTTP 会话可继续根据后续绑定信息确定最终项目。
* **修复**
  * 优化不同类型令牌的项目解析与默认行为，提升代理连接的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->