### PR TITLE
fix: include codex models in user panel availability

### DIFF
--- a/internal/handler/models_availability_test.go
+++ b/internal/handler/models_availability_test.go
@@ -245,3 +245,47 @@ func TestModelsHandlerFiltersProjectScopedModelList(t *testing.T) {
 		t.Fatalf("ids = %v, want only project model", ids)
 	}
 }
+
+func TestUserPanelAvailableModelsIncludesCodexOnlyVisibleRoute(t *testing.T) {
+	providers := []*domain.Provider{{
+		ID:                   10,
+		TenantID:             1,
+		Name:                 "codex-only",
+		Type:                 "custom",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		SupportModels:        []string{"gpt-codex-panel"},
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: "https://example.invalid/v1",
+			APIKey:  "test-key",
+		}},
+	}}
+	routes := []*domain.Route{{
+		ID:         1,
+		TenantID:   1,
+		ProviderID: 10,
+		ClientType: domain.ClientTypeCodex,
+		ProjectID:  0,
+		IsEnabled:  true,
+		Position:   1,
+		Weight:     1,
+	}}
+	r, providerRepo := newModelAvailabilityRouter(t, providers, routes, nil)
+	modelsHandler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-codex-panel"}}, providerRepo, nil, r)
+	selfServiceHandler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+			domain.SettingKeyProxyRouteResponsesEnabled:      "true",
+			domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+			domain.SettingKeyProxyRouteGeminiEnabled:         "false",
+		}},
+	})
+	selfServiceHandler.modelsHandler = modelsHandler
+
+	names, err := selfServiceHandler.collectUserPanelAvailableModelNames(1, 0)
+	if err != nil {
+		t.Fatalf("collectUserPanelAvailableModelNames: %v", err)
+	}
+	if !containsModel(names, "gpt-codex-panel") {
+		t.Fatalf("names = %v, want Codex-only model", names)
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -316,19 +317,61 @@ func (h *SelfServiceHandler) handleUserPanelModels(w http.ResponseWriter, r *htt
 		return
 	}
 
-	names, err := h.modelsHandler.collectAvailableModelNames(
-		tenantID,
-		domain.ClientTypeOpenAI,
-		0,
-		0,
-		canonicalToken.ID,
-		"",
-	)
+	names, err := h.collectUserPanelAvailableModelNames(tenantID, canonicalToken.ID)
 	if err != nil {
 		writeSelfServiceInternalError(w, "CollectUserPanelModels failed", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, names)
+}
+
+func (h *SelfServiceHandler) collectUserPanelAvailableModelNames(tenantID, apiTokenID uint64) ([]string, error) {
+	if h.modelsHandler == nil {
+		return nil, fmt.Errorf("models handler not configured")
+	}
+
+	merged := make(map[string]struct{})
+	for _, clientType := range h.userPanelModelClientTypes() {
+		names, err := h.modelsHandler.collectAvailableModelNames(tenantID, clientType, 0, 0, apiTokenID, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			addModelName(merged, name)
+		}
+	}
+
+	names := make([]string, 0, len(merged))
+	for name := range merged {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (h *SelfServiceHandler) userPanelModelClientTypes() []domain.ClientType {
+	clientTypes := make([]domain.ClientType, 0, 4)
+	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteOpenAIChatEnabled, true) {
+		clientTypes = append(clientTypes, domain.ClientTypeOpenAI)
+	}
+	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteResponsesEnabled, true) {
+		clientTypes = append(clientTypes, domain.ClientTypeCodex)
+	}
+	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteClaudeMessagesEnabled, true) {
+		clientTypes = append(clientTypes, domain.ClientTypeClaude)
+	}
+	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteGeminiEnabled, false) {
+		clientTypes = append(clientTypes, domain.ClientTypeGemini)
+	}
+	return clientTypes
+}
+
+func (h *SelfServiceHandler) proxyRouteSettingEnabled(key string, defaultEnabled bool) bool {
+	value, err := h.svc.GetSetting(key)
+	if err != nil || strings.TrimSpace(value) == "" {
+		return defaultEnabled
+	}
+	return strings.EqualFold(strings.TrimSpace(value), "true")
 }
 
 func (h *SelfServiceHandler) handleProviders(w http.ResponseWriter, r *http.Request, id uint64) {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3014,3 +3014,32 @@ func TestAdminHandler_UserPanelMemberUsageStatsFollowRegeneratedKeyHistory(t *te
 		t.Fatalf("filters = %+v, want one query per historical user panel token", usageRepo.filters)
 	}
 }
+
+func TestUserPanelModelClientTypesDefaultsIncludeCodex(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{}},
+	})
+
+	got := handler.userPanelModelClientTypes()
+	want := []domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeClaude}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("client types = %v, want %v", got, want)
+	}
+}
+
+func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
+			domain.SettingKeyProxyRouteResponsesEnabled:      "true",
+			domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
+			domain.SettingKeyProxyRouteGeminiEnabled:         "true",
+		}},
+	})
+
+	got := handler.userPanelModelClientTypes()
+	want := []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeGemini}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("client types = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix user panel model availability so it is not hard-coded to OpenAI routing.
- Collect available models across the proxy routes visible in the user panel, including Codex/Responses by default.
- Preserve existing route visibility defaults: OpenAI/Codex/Claude visible by default, Gemini hidden unless enabled.

## Validation
- `go test ./internal/handler -run 'TestUserPanelModelClientTypes|TestSelfService|TestModels'`
- `pnpm typecheck`
- `pnpm lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 用户面板现在支持展示 OpenAI、Codex、Claude 和 Gemini 模型。
  * 模型列表会根据代理路由设置筛选，自动去重并按名称排序。
  * 新增客户端类型展示，可根据可见路由动态筛选。

* **改进**
  * 未配置路由设置或读取失败时，将使用默认启用状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->