### PR TITLE
feat: add provider force 502 switch

### DIFF
--- a/internal/domain/backup.go
+++ b/internal/domain/backup.go
@@ -43,6 +43,7 @@ type BackupProvider struct {
 	ExposedModelsEnabled bool            `json:"exposedModelsEnabled,omitempty"`
 	ExposedModels        []string        `json:"exposedModels,omitempty"`
 	MaxConcurrency       int             `json:"maxConcurrency,omitempty"`
+	ForceHTTP502         bool            `json:"forceHTTP502,omitempty"`
 }
 
 // BackupProject represents a project for backup (using slug as identifier)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -463,6 +463,9 @@ type Provider struct {
 	// Maximum number of upstream sessions allowed at once. Zero means unlimited.
 	MaxConcurrency int `json:"maxConcurrency,omitempty"`
 
+	// ForceHTTP502 forces this provider to fail with a synthetic 502 before any upstream call.
+	ForceHTTP502 bool `json:"forceHTTP502,omitempty"`
+
 	// 为 true 时，该 provider 不参与导出/备份
 	ExcludeFromExport bool `json:"excludeFromExport,omitempty"`
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -356,6 +356,13 @@ func shouldSkipErrorCooldown(provider *domain.Provider) bool {
 	return provider != nil && provider.Config != nil && provider.Config.DisableErrorCooldown
 }
 
+func shouldSkipErrorCooldownUpdate(provider *domain.Provider, proxyErr *domain.ProxyError) bool {
+	if shouldSkipErrorCooldown(provider) {
+		return true
+	}
+	return proxyErr != nil && proxyErr.Code == "provider_forced_502"
+}
+
 func applyDisabledErrorCooldownRetryPolicy(provider *domain.Provider, proxyErr *domain.ProxyError) {
 	if !shouldSkipErrorCooldown(provider) || proxyErr == nil {
 		return

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -261,6 +261,9 @@ routeLoop:
 			}
 
 			err := executeWithProviderSlot(releaseProvider, func() error {
+				if matchedRoute.Provider.ForceHTTP502 {
+					return forcedProviderHTTP502Error(matchedRoute.Provider)
+				}
 				return matchedRoute.ProviderAdapter.Execute(c, matchedRoute.Provider)
 			})
 			c.Writer = originalWriter
@@ -471,7 +474,7 @@ routeLoop:
 			if ok && ctx.Err() != context.Canceled {
 				log.Printf("[Executor] ProxyError - Scope: %s, Reason: %s, Retryable: %v, Provider: %d",
 					proxyErr.Scope, proxyErr.Reason, proxyErr.Retryable, matchedRoute.Provider.ID)
-				if !shouldSkipErrorCooldown(matchedRoute.Provider) && !shouldDeferNetworkErrorCooldown(proxyErr, attempt, retryConfig) {
+				if !shouldSkipErrorCooldownUpdate(matchedRoute.Provider, proxyErr) && !shouldDeferNetworkErrorCooldown(proxyErr, attempt, retryConfig) {
 					e.handleCooldown(proxyErr, matchedRoute.Provider, currentClientType, mappedModel)
 					if e.broadcaster != nil {
 						e.broadcaster.BroadcastMessage("cooldown_update", map[string]interface{}{
@@ -594,6 +597,19 @@ func clearProxyRequestDetail(req *domain.ProxyRequest, clearDetail bool) {
 	}
 	req.RequestInfo = nil
 	req.ResponseInfo = nil
+}
+
+func forcedProviderHTTP502Error(provider *domain.Provider) *domain.ProxyError {
+	name := "provider"
+	if provider != nil && provider.Name != "" {
+		name = provider.Name
+	}
+	proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, true, "forced provider 502: "+name)
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonServerError
+	proxyErr.HTTPStatusCode = http.StatusBadGateway
+	proxyErr.Code = "provider_forced_502"
+	return proxyErr
 }
 
 func asProxyError(err error) (*domain.ProxyError, bool) {

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -360,6 +360,75 @@ func TestMapModelForProviderProxyHonorsModelMapping(t *testing.T) {
 	}
 }
 
+func TestExecuteProviderProxyForceHTTP502SkipsAdapter(t *testing.T) {
+	providerID := uint64(99004)
+	cooldown.Default().ClearCooldown(providerID, "", "")
+	defer cooldown.Default().ClearCooldown(providerID, "", "")
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	adapter := &sequenceAdapter{}
+	e := &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      0,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	c.Set(flow.KeyRequestBody, []byte(`{"model":"gpt-test"}`))
+	c.Set(flow.KeyOriginalRequestBody, []byte(`{"model":"gpt-test"}`))
+	c.Set(flow.KeyRequestHeaders, http.Header{"Content-Type": []string{"application/json"}})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:      1,
+		ID:            42,
+		ClientType:    domain.ClientTypeOpenAI,
+		RequestModel:  "gpt-test",
+		ResponseModel: "gpt-test",
+		IsStream:      false,
+		Status:        "IN_PROGRESS",
+		RouteID:       11,
+		ProviderID:    providerID,
+	}
+	route := &domain.Route{ID: 11, ProviderID: providerID, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: providerID, Name: "forced", Type: "custom", ForceHTTP502: true}
+
+	err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter)
+	if err == nil {
+		t.Fatal("ExecuteProviderProxy returned nil, want forced 502 error")
+	}
+	proxyErr, ok := asProxyError(err)
+	if !ok {
+		t.Fatalf("error type = %T, want ProxyError", err)
+	}
+	if proxyErr.HTTPStatusCode != http.StatusBadGateway || proxyErr.Code != "provider_forced_502" {
+		t.Fatalf("proxy error = %+v, want forced 502", proxyErr)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want 0", adapter.calls)
+	}
+	if len(attemptRepo.created) != 1 || len(attemptRepo.updated) != 1 {
+		t.Fatalf("attempt create/update counts = %d/%d, want 1/1", len(attemptRepo.created), len(attemptRepo.updated))
+	}
+	if attemptRepo.updated[0].Status != "FAILED" {
+		t.Fatalf("attempt status = %q, want FAILED", attemptRepo.updated[0].Status)
+	}
+	if proxyReq.Status != "FAILED" || proxyReq.StatusCode != http.StatusBadGateway {
+		t.Fatalf("proxy request status/code = %s/%d, want FAILED/502", proxyReq.Status, proxyReq.StatusCode)
+	}
+}
+
 func TestExecuteProviderProxyRetriesSameProvider(t *testing.T) {
 	providerID := uint64(99005)
 	cooldown.Default().ClearCooldown(providerID, "", "")

--- a/internal/repository/sqlite/models.go
+++ b/internal/repository/sqlite/models.go
@@ -98,6 +98,7 @@ type Provider struct {
 	ExposedModelsEnabled int `gorm:"default:0"`
 	ExposedModels        LongText
 	MaxConcurrency       int `gorm:"default:0"`
+	ForceHTTP502         int `gorm:"default:0"`
 	ExcludeFromExport    int `gorm:"default:0"`
 	BlackBox             int `gorm:"default:0"`
 }

--- a/internal/repository/sqlite/provider.go
+++ b/internal/repository/sqlite/provider.go
@@ -212,6 +212,7 @@ func (r *ProviderRepository) toModel(p *domain.Provider) *Provider {
 		ExposedModelsEnabled: boolToInt(p.ExposedModelsEnabled),
 		ExposedModels:        LongText(toJSON(p.ExposedModels)),
 		MaxConcurrency:       p.MaxConcurrency,
+		ForceHTTP502:         boolToInt(p.ForceHTTP502),
 		ExcludeFromExport:    boolToInt(p.ExcludeFromExport),
 		BlackBox:             boolToInt(p.BlackBox),
 	}
@@ -234,6 +235,7 @@ func (r *ProviderRepository) toDomain(m *Provider) *domain.Provider {
 		ExposedModelsEnabled: m.ExposedModelsEnabled != 0,
 		ExposedModels:        fromJSON[[]string](string(m.ExposedModels)),
 		MaxConcurrency:       m.MaxConcurrency,
+		ForceHTTP502:         m.ForceHTTP502 != 0,
 		ExcludeFromExport:    m.ExcludeFromExport != 0,
 		BlackBox:             m.BlackBox != 0,
 	}

--- a/internal/service/admin_provider_test.go
+++ b/internal/service/admin_provider_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
 )
 
+func TestAdminServiceProviderForceHTTP502IsPersisted(t *testing.T) {
+	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("NewDBWithDSN() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := sqlite.NewProviderRepository(db)
+	svc := NewAdminService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "", nil, nil, nil)
+	provider := &domain.Provider{Name: "faulty", Type: "custom", ForceHTTP502: true}
+	if err := svc.CreateProvider(domain.DefaultTenantID, provider); err != nil {
+		t.Fatalf("CreateProvider() error = %v", err)
+	}
+	created, err := repo.GetByID(domain.DefaultTenantID, provider.ID)
+	if err != nil {
+		t.Fatalf("GetByID() error = %v", err)
+	}
+	if !created.ForceHTTP502 {
+		t.Fatalf("created ForceHTTP502 = false, want true")
+	}
+
+	created.ForceHTTP502 = false
+	if err := svc.UpdateProvider(domain.DefaultTenantID, created); err != nil {
+		t.Fatalf("UpdateProvider() error = %v", err)
+	}
+	updated, err := repo.GetByID(domain.DefaultTenantID, created.ID)
+	if err != nil {
+		t.Fatalf("GetByID() after update error = %v", err)
+	}
+	if updated.ForceHTTP502 {
+		t.Fatalf("updated ForceHTTP502 = true, want false")
+	}
+}
+
 func TestAdminServiceProviderMaxConcurrencyIsPersistedAndNormalized(t *testing.T) {
 	db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -126,6 +126,7 @@ func (s *BackupService) Export(tenantID uint64) (*domain.BackupFile, error) {
 			ExposedModelsEnabled: p.ExposedModelsEnabled,
 			ExposedModels:        p.ExposedModels,
 			MaxConcurrency:       p.MaxConcurrency,
+			ForceHTTP502:         p.ForceHTTP502,
 		})
 	}
 
@@ -543,6 +544,7 @@ func (s *BackupService) importProviders(tenantID uint64, providers []domain.Back
 			ExposedModelsEnabled: bp.ExposedModelsEnabled,
 			ExposedModels:        bp.ExposedModels,
 			MaxConcurrency:       bp.MaxConcurrency,
+			ForceHTTP502:         bp.ForceHTTP502,
 		}
 		if p.MaxConcurrency < 0 {
 			p.MaxConcurrency = 0

--- a/tests/e2e/provider_force_502_test.go
+++ b/tests/e2e/provider_force_502_test.go
@@ -1,0 +1,63 @@
+package e2e_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestProviderForceHTTP502EndToEnd(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockOpenAIUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "force-502-provider", mock.URL, []string{"openai"})
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusOK)
+	_, path, _, _ := captured.Get()
+	if path != "/v1/chat/completions" {
+		t.Fatalf("upstream path before force 502 = %q, want /v1/chat/completions", path)
+	}
+
+	updateResp := env.AdminPut("/api/admin/providers/"+itoa(providerID), map[string]any{
+		"id":                   providerID,
+		"name":                 "force-502-provider",
+		"type":                 "custom",
+		"supportedClientTypes": []string{"openai"},
+		"forceHTTP502":         true,
+		"config": map[string]any{
+			"custom": map[string]any{
+				"baseURL": mock.URL,
+				"apiKey":  "sk-mock-test-key",
+			},
+		},
+	})
+	defer updateResp.Body.Close()
+	assertStatus(t, updateResp, http.StatusOK)
+
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusBadGateway)
+	body, _ := io.ReadAll(resp.Body)
+	if got := gjson.GetBytes(body, "error.code").String(); got != "provider_forced_502" {
+		t.Fatalf("error.code = %q, want provider_forced_502; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "error.message").String(); got == "" {
+		t.Fatalf("missing error.message; body=%s", body)
+	}
+
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), nil)
+	defer resp.Body.Close()
+	assertStatus(t, resp, http.StatusBadGateway)
+
+	_, pathAfterForce, _, _ := captured.Get()
+	if pathAfterForce != path {
+		t.Fatalf("upstream was called while force 502 enabled: path changed from %q to %q", path, pathAfterForce)
+	}
+}

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -264,6 +264,7 @@ export interface Provider {
   exposedModelsEnabled?: boolean; // 是否启用对外暴露模型白名单，默认关闭
   exposedModels?: string[]; // 允许对外暴露的模型列表（通配符模式），仅启用后生效
   maxConcurrency?: number; // 最大并发上游会话数，0 表示不限制
+  forceHTTP502?: boolean; // 为 true 时在调用上游前强制伪造 502 错误
   excludeFromExport?: boolean; // 为 true 时不参与导出/备份
   blackBox?: boolean; // 为 true 时不可编辑且不向 UI/API 暴露配置细节
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1788,6 +1788,8 @@
     "displayName": "Display Name",
     "maxConcurrency": "Max concurrency",
     "maxConcurrencyDesc": "Active upstream sessions cap. 0 = unlimited.",
+    "forceHTTP502": "Force 502",
+    "forceHTTP502Desc": "Fault-injection switch. When enabled, this provider fails with a synthetic 502 before any real upstream call. Disabled by default.",
     "customBackend": "Backend",
     "customBackendHttp": "HTTP relay (pass-through)",
     "customBackendHttpDesc": "Forward requests to an upstream that already speaks the selected client protocol.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1785,6 +1785,8 @@
     "displayName": "显示名称",
     "maxConcurrency": "最大并发",
     "maxConcurrencyDesc": "上游会话并发上限，0 表示不限制。",
+    "forceHTTP502": "强制 502",
+    "forceHTTP502Desc": "故障注入开关。开启后该 provider 在调用真实上游前会被强制伪造成 502 错误，默认关闭。",
     "customBackend": "后端类型",
     "customBackendHttp": "HTTP 中转（原样转发）",
     "customBackendHttpDesc": "转发到已经支持所选客户端协议的上游服务。",

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -1,10 +1,11 @@
 import { type KeyboardEvent } from 'react';
-import { Activity, Ban, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
+import { Activity, AlertTriangle, Ban, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import { useCooldowns } from '@/hooks/use-cooldowns';
 import { ClientIcon } from '@/components/icons/client-icons';
 import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { MarqueeBackground } from '@/components/ui/marquee-background';
+import { Switch } from '@/components/ui/switch';
 import type {
   Provider,
   ProviderStats,
@@ -57,6 +58,9 @@ interface ProviderRowProps {
   onClick?: () => void;
   title?: string;
   className?: string;
+  canManageFaultInjection?: boolean;
+  onForceHTTP502Change?: (checked: boolean) => void;
+  forceHTTP502Pending?: boolean;
 }
 
 // 获取 Claude 模型额度百分比和重置时间
@@ -217,6 +221,9 @@ export function ProviderRow({
   onClick,
   title,
   className,
+  canManageFaultInjection = false,
+  onForceHTTP502Change,
+  forceHTTP502Pending = false,
 }: ProviderRowProps) {
   const { t } = useTranslation();
   // 使用通用配置系统
@@ -539,6 +546,23 @@ export function ProviderRow({
           )}
         </div>
       )}
+
+      <div
+        className="relative z-10 flex shrink-0 items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-2.5 py-1.5"
+        title={t('provider.forceHTTP502Desc')}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <AlertTriangle className="h-3.5 w-3.5 text-destructive" />
+        <span className="hidden text-[11px] font-semibold text-destructive md:inline">
+          {t('provider.forceHTTP502')}
+        </span>
+        <Switch
+          aria-label={t('provider.forceHTTP502')}
+          checked={!!provider.forceHTTP502}
+          disabled={!canManageFaultInjection || forceHTTP502Pending || provider.blackBox}
+          onCheckedChange={(checked) => onForceHTTP502Change?.(checked)}
+        />
+      </div>
 
       {/* Kiro Quota Area */}
       {isKiro && (

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -20,6 +20,7 @@ import {
   useUpdateSetting,
   useProxyRequestUpdates,
   useCreateProvider,
+  useUpdateProvider,
   useCreateModelMapping,
   useBulkDeleteProviders,
   useRoutes,
@@ -164,6 +165,7 @@ export function ProvidersPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const createProvider = useCreateProvider();
+  const updateProvider = useUpdateProvider();
   const createModelMapping = useCreateModelMapping();
   const bulkDeleteProviders = useBulkDeleteProviders();
   const canManageProviderSettings = user?.role === 'admin';
@@ -907,6 +909,14 @@ export function ProvidersPage() {
                                     isSelected &&
                                       'border-primary/50 bg-primary/5 ring-1 ring-primary/20',
                                   )}
+                                  canManageFaultInjection={providerCanOpen}
+                                  forceHTTP502Pending={updateProvider.isPending}
+                                  onForceHTTP502Change={(forceHTTP502) =>
+                                    updateProvider.mutate({
+                                      id: provider.id,
+                                      data: { forceHTTP502 },
+                                    })
+                                  }
                                   onClick={
                                     providerCanOpen
                                       ? () => openProviderEditor(provider.id)


### PR DESCRIPTION
## Summary
- Add a provider-level Force 502 fault-injection switch, disabled by default.
- Persist `forceHTTP502` through domain/sqlite/API/backup and expose it in the providers UI.
- Intercept selected providers in executor before adapter execution and return a synthetic 502 with `provider_forced_502`, without calling the real upstream.
- Keep forced 502 out of cooldown updates so the switch consistently returns 502 while enabled instead of being hidden by route cooldown.

## Validation
- `go test ./...`
- `pnpm --dir web typecheck`
- `pnpm --dir web test -- src/pages/providers src/lib/transport`
- `go test ./tests/e2e -run TestProviderForceHTTP502EndToEnd -count=1`
- `git diff --check`
- Manual local E2E flow with UI screenshots: provider switch off -> real OpenAI-compatible route returns 200 and mock upstream hit count is 1 -> enable Force 502 in UI -> repeated `/v1/chat/completions` calls return 502 while mock hit count remains 1.

## Notes
- This is an explicit fault-injection/debug switch. It is visible in the provider row and disabled for read-only/black-box providers.
- No release was triggered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“强制返回 HTTP 502”故障注入开关，可在调用上游前模拟可重试的 502 错误。
  * 提供商配置页面支持查看和切换该开关，并根据权限及提供商类型限制操作。
* **改进**
  * 该配置支持保存、更新及备份导入导出。
  * 触发强制 502 时不会调用上游，且不会更新错误冷却状态。
* **测试**
  * 增加配置持久化、请求行为及端到端场景验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->