### PR TITLE
fix(bedrock): handle adaptive thinking schema errors

### DIFF
--- a/internal/adapter/provider/bedrock/adapter.go
+++ b/internal/adapter/provider/bedrock/adapter.go
@@ -227,12 +227,8 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// Sanitize request body for Bedrock
 	requestBody = sanitizeRequestBody(requestBody)
 
-	// Model-specific thinking config: Opus 4.7 rejects the classic
-	// thinking.type="enabled" shape and requires adaptive. Earlier
-	// sanitize steps run without knowing the target model; this step
-	// rewrites the thinking block (and sets output_config.effort) based
-	// on the resolved Bedrock ID's short name, so classic-shape clients
-	// (e.g. Claude Code CLI) can still hit adaptive-only models.
+	// Model-specific thinking config: some adaptive-first models reject
+	// sampling params even when no explicit thinking block is present.
 	if short, _, ok := extractNameAndDate(bedrockModelID); ok {
 		requestBody = AdaptThinkingForModel(requestBody, short)
 	}
@@ -246,10 +242,9 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	// `redacted_thinking`) is recoverable by stripping those blocks
 	// and replaying once. (2) a 400 rejecting temperature/top_p/top_k
 	// (extended-thinking mode) is recoverable by stripping those
-	// fields and replaying once. (3) a 400 rejecting
-	// thinking.type="enabled" for an adaptive-only model is recoverable
-	// by rewriting to thinking.type="adaptive" and moving the budget
-	// signal into output_config.effort. Cross-deployment replays produced by
+	// fields and replaying once. (3) a 400 rejecting one thinking shape
+	// is recoverable by switching to the other shape. Cross-deployment
+	// replays produced by
 	// clients that captured a transcript against Anthropic and now
 	// hit Bedrock are the common cause; retry preserves the rest of
 	// the conversation rather than failing the whole request.
@@ -263,6 +258,7 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	thinkingRetried := false
 	samplingRetried := false
 	adaptiveRetried := false
+	classicRetried := false
 	for {
 		var attemptErr error
 		resp, attemptErr = a.sendBedrockRequest(ctx, c, upstreamURL, requestBody, region, clientWantsStream)
@@ -315,6 +311,15 @@ func (a *BedrockAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 			if !bytes.Equal(rewritten, requestBody) {
 				requestBody = rewritten
 				adaptiveRetried = true
+				continue
+			}
+		}
+
+		if !classicRetried && resp.StatusCode == 400 && IsAdaptiveThinkingRejectedError(body) {
+			rewritten := RewriteAdaptiveThinkingToClassic(requestBody)
+			if !bytes.Equal(rewritten, requestBody) {
+				requestBody = rewritten
+				classicRetried = true
 				continue
 			}
 		}

--- a/internal/adapter/provider/bedrock/sanitizer.go
+++ b/internal/adapter/provider/bedrock/sanitizer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -16,11 +17,13 @@ import (
 // - Sets `anthropic_version`
 // - Then runs the relay-safe transformations via SanitizeForBedrockCompat.
 //
-// Bedrock feature support (verified via real API tests):
+// Bedrock feature support changes by model generation:
 //
-//	ACCEPTED: cache_control (system/tools/messages), thinking(enabled), tools, tool_use
-//	REJECTED: stream, output_config, context_management, reasoning, betas,
-//	          thinking(adaptive), tools[].custom, cache_control.scope
+//	adaptive-first: thinking(adaptive) + output_config.effort
+//	classic fallback: thinking(enabled) + thinking.budget_tokens
+//
+// The sanitizer emits the adaptive shape by default; runtime retry paths can
+// rewrite back to classic when an older Bedrock schema rejects adaptive.
 func sanitizeRequestBody(body []byte) []byte {
 	// Remove `model` field (Bedrock uses URL path)
 	body, _ = sjson.DeleteBytes(body, "model")
@@ -47,36 +50,23 @@ func sanitizeRequestBody(body []byte) []byte {
 // "bedrock" disguise mode.
 func SanitizeForBedrockCompat(body []byte) []byte {
 	// Remove unsupported top-level fields
-	for _, field := range []string{"output_config", "context_management", "reasoning", "betas"} {
+	for _, field := range []string{"context_management", "reasoning", "betas"} {
 		if gjson.GetBytes(body, field).Exists() {
 			body, _ = sjson.DeleteBytes(body, field)
 		}
 	}
+	body = sanitizeOutputConfig(body)
 
-	// Fix thinking config: Bedrock only supports "enabled"/"disabled", not "adaptive"
-	thinkingType := gjson.GetBytes(body, "thinking.type").String()
-	if thinkingType == "adaptive" {
-		body, _ = sjson.SetBytes(body, "thinking.type", "enabled")
-		// Ensure budget_tokens is set
-		if !gjson.GetBytes(body, "thinking.budget_tokens").Exists() {
-			maxTokens := gjson.GetBytes(body, "max_tokens").Int()
-			if maxTokens > 1024 {
-				body, _ = sjson.SetBytes(body, "thinking.budget_tokens", maxTokens-1)
-			} else {
-				body, _ = sjson.SetBytes(body, "thinking.budget_tokens", 1024)
-			}
-		}
-	}
-
-	body = EnsureMaxTokensAboveThinkingBudget(body)
+	// Prefer Bedrock's newer adaptive-thinking schema. Older models that
+	// reject adaptive are handled by the runtime fallback path.
+	body = RewriteClassicThinkingToAdaptive(body)
 
 	// Anthropic rule (enforced by Bedrock): when extended thinking is on,
 	// `temperature` must be 1 and `top_p` / `top_k` are not allowed. Rather
 	// than try to clamp temperature, strip all three — the model picks
 	// sensible defaults and the caller's intent of "no sampling override"
-	// is preserved. The model-specific always-on adaptive case (Opus 4.7
-	// without an explicit thinking block) is handled later by
-	// AdaptThinkingForModel, which calls StripSamplingParams again.
+	// is preserved. The model-specific always-on adaptive case without an
+	// explicit thinking block is handled later by AdaptThinkingForModel.
 	switch gjson.GetBytes(body, "thinking.type").String() {
 	case "enabled", "adaptive":
 		body = StripSamplingParams(body)
@@ -110,6 +100,20 @@ func SanitizeForBedrockCompat(body []byte) []byte {
 		}
 	}
 
+	return body
+}
+
+func sanitizeOutputConfig(body []byte) []byte {
+	outputConfig := gjson.GetBytes(body, "output_config")
+	if !outputConfig.Exists() {
+		return body
+	}
+	effort := outputConfig.Get("effort").String()
+	if effort == "" {
+		body, _ = sjson.DeleteBytes(body, "output_config")
+		return body
+	}
+	body, _ = sjson.SetRawBytes(body, "output_config", []byte(`{"effort":`+strconv.Quote(effort)+`}`))
 	return body
 }
 

--- a/internal/adapter/provider/bedrock/sanitizer_test.go
+++ b/internal/adapter/provider/bedrock/sanitizer_test.go
@@ -14,7 +14,7 @@ func TestSanitizeForBedrockCompatStripsRejectedTopLevelFields(t *testing.T) {
 		"model":"claude-sonnet-4-5",
 		"stream":true,
 		"betas":["claude-code-20250219"],
-		"output_config":{"foo":"bar"},
+		"output_config":{"effort":"high","foo":"bar"},
 		"context_management":{"x":1},
 		"reasoning":{"effort":"high"},
 		"max_tokens":1024,
@@ -23,10 +23,16 @@ func TestSanitizeForBedrockCompatStripsRejectedTopLevelFields(t *testing.T) {
 
 	result := SanitizeForBedrockCompat(body)
 
-	for _, f := range []string{"betas", "output_config", "context_management", "reasoning"} {
+	for _, f := range []string{"betas", "context_management", "reasoning"} {
 		if gjson.GetBytes(result, f).Exists() {
 			t.Errorf("expected %s to be stripped, still present", f)
 		}
+	}
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "high" {
+		t.Errorf("output_config.effort = %q, want high", got)
+	}
+	if gjson.GetBytes(result, "output_config.foo").Exists() {
+		t.Error("output_config.foo should be stripped")
 	}
 
 	// model and stream are NOT stripped — relay still needs them. Only the
@@ -39,24 +45,48 @@ func TestSanitizeForBedrockCompatStripsRejectedTopLevelFields(t *testing.T) {
 	}
 }
 
-func TestSanitizeForBedrockCompatConvertsAdaptiveThinking(t *testing.T) {
+func TestSanitizeForBedrockCompatPreservesAdaptiveThinking(t *testing.T) {
 	body := []byte(`{
 		"thinking":{"type":"adaptive"},
+		"output_config":{"effort":"medium"},
 		"max_tokens":4096,
 		"messages":[{"role":"user","content":"hi"}]
 	}`)
 
 	result := SanitizeForBedrockCompat(body)
 
-	if got := gjson.GetBytes(result, "thinking.type").String(); got != "enabled" {
-		t.Errorf("thinking.type = %q, want enabled", got)
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Errorf("thinking.type = %q, want adaptive", got)
 	}
-	if got := gjson.GetBytes(result, "thinking.budget_tokens").Int(); got != 4095 {
-		t.Errorf("thinking.budget_tokens = %d, want 4095 (max_tokens-1)", got)
+	if gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Error("thinking.budget_tokens should not be added for adaptive thinking")
+	}
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "medium" {
+		t.Errorf("output_config.effort = %q, want medium", got)
 	}
 }
 
-func TestSanitizeForBedrockCompatRaisesMaxTokensWhenBudgetExceeds(t *testing.T) {
+func TestSanitizeForBedrockCompatConvertsClassicThinkingToAdaptive(t *testing.T) {
+	body := []byte(`{
+		"thinking":{"type":"enabled","budget_tokens":4096},
+		"max_tokens":8192,
+		"messages":[{"role":"user","content":"hi"}]
+	}`)
+
+	result := SanitizeForBedrockCompat(body)
+
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Errorf("thinking.type = %q, want adaptive", got)
+	}
+	if gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Error("thinking.budget_tokens should be removed")
+	}
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "low" {
+		t.Errorf("output_config.effort = %q, want low", got)
+	}
+}
+
+func TestSanitizeForBedrockCompatDoesNotRaiseMaxTokensAfterAdaptiveRewrite(t *testing.T) {
 	body := []byte(`{
 		"thinking":{"type":"enabled","budget_tokens":5000},
 		"max_tokens":2048,
@@ -65,8 +95,11 @@ func TestSanitizeForBedrockCompatRaisesMaxTokensWhenBudgetExceeds(t *testing.T) 
 
 	result := SanitizeForBedrockCompat(body)
 
-	if got := gjson.GetBytes(result, "max_tokens").Int(); got != 5001 {
-		t.Errorf("max_tokens = %d, want 5001 (budget+1)", got)
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Errorf("thinking.type = %q, want adaptive", got)
+	}
+	if got := gjson.GetBytes(result, "max_tokens").Int(); got != 2048 {
+		t.Errorf("max_tokens = %d, want unchanged 2048", got)
 	}
 }
 

--- a/internal/adapter/provider/bedrock/thinking_policy.go
+++ b/internal/adapter/provider/bedrock/thinking_policy.go
@@ -15,16 +15,13 @@ import (
 //
 // Models split into three camps:
 //
-//   adaptive-only   — Opus 4.7: rejects thinking.type="enabled" with
-//                     "\"thinking.type.enabled\" is not supported"
-//   classic-only    — Sonnet/Opus 4.x pre-4.6, 3.7 and older: reject adaptive
-//   either         — Opus 4.6, Sonnet 4.6: accept both (adaptive recommended)
+//   adaptive-first  — newer SKUs reject thinking.type="enabled" and ask for
+//                     adaptive + output_config.effort
+//   classic-only    — older SKUs reject adaptive / output_config.effort
+//   either          — accept both (adaptive recommended)
 //
-// The sanitizer already handles classic-only (it rewrites adaptive →
-// enabled). What's new is the adaptive-only tier. AdaptThinkingForModel
-// performs the inverse rewrite when the resolved short name requires it,
-// so clients that only speak the classic shape (Claude Code CLI on
-// Bedrock) can still hit Opus 4.7.
+// Default normalization is adaptive-first. Runtime validation errors can
+// still rewrite back to classic for older Bedrock schemas.
 
 // adaptiveOnlyModels is the set of short names that reject classic
 // extended-thinking. Kept as a small hand-maintained list because
@@ -41,10 +38,9 @@ func requiresAdaptiveThinking(shortName string) bool {
 	return adaptiveOnlyModels[shortName]
 }
 
-// AdaptThinkingForModel rewrites a classic extended-thinking config into
-// adaptive form when the target model demands it. Idempotent: if the
-// payload already uses adaptive, or the model doesn't require it, or
-// there's no thinking config at all, the body is returned unchanged.
+// AdaptThinkingForModel applies model-specific adjustments after the generic
+// adaptive-first sanitizer. Kept for adaptive-only models that reject sampling
+// params even when no explicit thinking block is present.
 //
 // Budget → effort translation is conservative:
 //   - budget_tokens >= 32k → "high"
@@ -97,6 +93,22 @@ func RewriteClassicThinkingToAdaptive(body []byte) []byte {
 	return body
 }
 
+// RewriteAdaptiveThinkingToClassic converts adaptive thinking into the classic
+// Bedrock shape for older models that reject output_config.effort/adaptive.
+func RewriteAdaptiveThinkingToClassic(body []byte) []byte {
+	if gjson.GetBytes(body, "thinking.type").String() != "adaptive" {
+		return body
+	}
+
+	effort := gjson.GetBytes(body, "output_config.effort").String()
+	budget := budgetForEffort(effort)
+	body, _ = sjson.SetBytes(body, "thinking.type", "enabled")
+	body, _ = sjson.SetBytes(body, "thinking.budget_tokens", budget)
+	body, _ = sjson.DeleteBytes(body, "output_config")
+	body = EnsureMaxTokensAboveThinkingBudget(body)
+	return body
+}
+
 func effortForThinkingBudget(budget int64) string {
 	switch {
 	case budget >= 32000:
@@ -108,15 +120,41 @@ func effortForThinkingBudget(budget int64) string {
 	}
 }
 
+func budgetForEffort(effort string) int64 {
+	switch effort {
+	case "max":
+		return 64000
+	case "high":
+		return 32000
+	case "medium":
+		return 8192
+	default:
+		return 1024
+	}
+}
+
 var classicThinkingRejectedPattern = regexp.MustCompile(
-	`(?i)(?:"?thinking\.type\.enabled"?|thinking\.type\s*=\s*"?enabled"?)` +
+	`(?i)(?:"?thinking\.type\.enabled"?|"?\.\.enabled"?|thinking\.type\s*=\s*"?enabled"?)` +
 		`[^\n]{0,200}\b(?:not\s+supported|unsupported|is\s+not\s+allowed|requires?\s+adaptive)\b` +
 		`|` +
-		`\buse\b[^\n]{0,120}"?thinking\.type\.adaptive"?[^\n]{0,120}\boutput_config\.effort\b`,
+		`\buse\b[^\n]{0,120}(?:"?thinking\.type\.adaptive"?|"?\.\.adaptive"?)[^\n]{0,120}\boutput_config\.effort\b`,
 )
 
 // IsClassicThinkingRejectedError reports whether Bedrock rejected the classic
 // thinking.type="enabled" shape and asked for adaptive thinking instead.
 func IsClassicThinkingRejectedError(body []byte) bool {
 	return classicThinkingRejectedPattern.Match(body)
+}
+
+var adaptiveThinkingRejectedPattern = regexp.MustCompile(
+	`(?i)(?:output_config\.effort|thinking\.type\.adaptive|"?\.\.adaptive"?)` +
+		`[^\n]{0,200}\b(?:extra\s+inputs?\s+are\s+not\s+permitted|not\s+supported|unsupported|is\s+not\s+allowed)\b` +
+		`|` +
+		`\buse\b[^\n]{0,120}(?:"?thinking\.type\.enabled"?|"?\.\.enabled"?)[^\n]{0,120}\b(?:budget_tokens|thinking\.budget_tokens)\b`,
+)
+
+// IsAdaptiveThinkingRejectedError reports whether Bedrock rejected the
+// adaptive thinking shape and needs a retry with classic enabled/budget_tokens.
+func IsAdaptiveThinkingRejectedError(body []byte) bool {
+	return adaptiveThinkingRejectedPattern.Match(body)
 }

--- a/internal/adapter/provider/bedrock/thinking_policy_test.go
+++ b/internal/adapter/provider/bedrock/thinking_policy_test.go
@@ -198,6 +198,52 @@ func TestRewriteClassicThinkingToAdaptive(t *testing.T) {
 	}
 }
 
+func TestRewriteAdaptiveThinkingToClassic(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantBudget int64
+		wantMax    int64
+	}{
+		{
+			name:       "high effort maps to classic budget",
+			input:      `{"thinking":{"type":"adaptive"},"output_config":{"effort":"high"},"max_tokens":64000}`,
+			wantBudget: 32000,
+			wantMax:    64000,
+		},
+		{
+			name:       "missing effort maps to low budget",
+			input:      `{"thinking":{"type":"adaptive"},"max_tokens":4096}`,
+			wantBudget: 1024,
+			wantMax:    4096,
+		},
+		{
+			name:       "max_tokens raised above fallback budget",
+			input:      `{"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"},"max_tokens":200}`,
+			wantBudget: 8192,
+			wantMax:    8193,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := RewriteAdaptiveThinkingToClassic([]byte(c.input))
+			if gt := gjson.GetBytes(got, "thinking.type").String(); gt != "enabled" {
+				t.Fatalf("thinking.type = %q; want enabled (body=%s)", gt, string(got))
+			}
+			if budget := gjson.GetBytes(got, "thinking.budget_tokens").Int(); budget != c.wantBudget {
+				t.Fatalf("thinking.budget_tokens = %d; want %d (body=%s)", budget, c.wantBudget, string(got))
+			}
+			if gjson.GetBytes(got, "output_config").Exists() {
+				t.Fatalf("output_config should be removed (body=%s)", string(got))
+			}
+			if maxTokens := gjson.GetBytes(got, "max_tokens").Int(); maxTokens != c.wantMax {
+				t.Fatalf("max_tokens = %d; want %d (body=%s)", maxTokens, c.wantMax, string(got))
+			}
+		})
+	}
+}
+
 func TestIsClassicThinkingRejectedError(t *testing.T) {
 	cases := []struct {
 		name string
@@ -207,6 +253,11 @@ func TestIsClassicThinkingRejectedError(t *testing.T) {
 		{
 			name: "reported bedrock validation",
 			body: `{"message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}`,
+			want: true,
+		},
+		{
+			name: "redacted bedrock validation path",
+			body: `{"message":"\"..enabled\" is not supported for this model. Use \"..adaptive\" and \"output_config.effort\" to control thinking behavior."}`,
 			want: true,
 		},
 		{
@@ -230,6 +281,43 @@ func TestIsClassicThinkingRejectedError(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := IsClassicThinkingRejectedError([]byte(c.body)); got != c.want {
 				t.Fatalf("IsClassicThinkingRejectedError = %v; want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsAdaptiveThinkingRejectedError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "output config effort rejected",
+			body: `{"message":"output_config.effort: Extra inputs are not permitted"}`,
+			want: true,
+		},
+		{
+			name: "adaptive not supported",
+			body: `{"message":"\"thinking.type.adaptive\" is not supported for this model"}`,
+			want: true,
+		},
+		{
+			name: "redacted adaptive not supported",
+			body: `{"message":"\"..adaptive\" is not supported for this model. Use \"..enabled\" with \"thinking.budget_tokens\"."}`,
+			want: true,
+		},
+		{
+			name: "classic rejection is not adaptive rejection",
+			body: `{"message":"\"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\"."}`,
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsAdaptiveThinkingRejectedError([]byte(c.body)); got != c.want {
+				t.Fatalf("IsAdaptiveThinkingRejectedError = %v; want %v", got, c.want)
 			}
 		})
 	}

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -95,9 +95,9 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 	// 4. Ensure minimum thinking budget if present
 	body = ensureMinThinkingBudget(body)
 
-	// 4b. For bedrock disguise: re-check the `max_tokens > thinking.budget_tokens`
-	// invariant. ensureMinThinkingBudget may have just raised budget_tokens to 1024,
-	// which can violate Bedrock's constraint even though the body looked valid at step 2.
+	// 4b. For bedrock disguise classic fallback: re-check the
+	// `max_tokens > thinking.budget_tokens` invariant. The adaptive-first
+	// path is a no-op here.
 	if bedrockMode {
 		body = bedrock.EnsureMaxTokensAboveThinkingBudget(body)
 	}

--- a/internal/adapter/provider/custom/claude_body_test.go
+++ b/internal/adapter/provider/custom/claude_body_test.go
@@ -728,12 +728,13 @@ func bedrockDisguiseCustomCfg() *domain.ProviderConfigCustom {
 
 func TestProcessClaudeRequestBodyBedrockDisguiseStripsUnsupportedFields(t *testing.T) {
 	// A representative Claude Code request body that includes every field Bedrock
-	// rejects: betas, output_config, context_management, reasoning, tools[].custom,
-	// cache_control.scope, and thinking.type=adaptive.
+	// rejects: betas, context_management, reasoning, tools[].custom, and
+	// cache_control.scope. Adaptive thinking/output_config.effort are now the
+	// default Bedrock shape.
 	body := []byte(`{
 		"model":"claude-sonnet-4-5",
 		"betas":["claude-code-20250219"],
-		"output_config":{"foo":"bar"},
+		"output_config":{"effort":"medium"},
 		"context_management":{"x":1},
 		"reasoning":{"effort":"high"},
 		"thinking":{"type":"adaptive"},
@@ -762,19 +763,21 @@ func TestProcessClaudeRequestBodyBedrockDisguiseStripsUnsupportedFields(t *testi
 	}
 
 	// Bedrock-rejected top-level fields gone
-	for _, f := range []string{"output_config", "context_management", "reasoning"} {
+	for _, f := range []string{"context_management", "reasoning"} {
 		if gjson.GetBytes(result, f).Exists() {
 			t.Errorf("expected %s to be stripped", f)
 		}
 	}
-
-	// thinking.type=adaptive → enabled
-	if got := gjson.GetBytes(result, "thinking.type").String(); got != "enabled" {
-		t.Errorf("thinking.type = %q, want enabled", got)
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "medium" {
+		t.Errorf("output_config.effort = %q, want medium", got)
 	}
-	// budget_tokens auto-populated
-	if got := gjson.GetBytes(result, "thinking.budget_tokens").Int(); got <= 0 {
-		t.Errorf("thinking.budget_tokens should be > 0, got %d", got)
+
+	// thinking.type=adaptive is preserved by default.
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Errorf("thinking.type = %q, want adaptive", got)
+	}
+	if gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Error("thinking.budget_tokens should not be auto-populated for adaptive thinking")
 	}
 
 	// cache_control.scope stripped from system / tools / messages, type preserved
@@ -897,13 +900,7 @@ func TestProcessClaudeRequestBodyBedrockDisguisePreservesSamplingForClassic(t *t
 	}
 }
 
-// TestProcessClaudeRequestBodyBedrockDisguiseRecheckMaxTokensAfterMinBudget
-// guards against a subtle ordering bug: SanitizeForBedrockCompat enforces
-// `max_tokens > thinking.budget_tokens` early, then ensureMinThinkingBudget
-// raises the budget to 1024 — which can put max_tokens BELOW the new budget.
-// processClaudeRequestBody must re-run the constraint after the min-budget
-// raise so Bedrock doesn't reject the request.
-func TestProcessClaudeRequestBodyBedrockDisguiseRecheckMaxTokensAfterMinBudget(t *testing.T) {
+func TestProcessClaudeRequestBodyBedrockDisguiseDefaultsClassicThinkingToAdaptive(t *testing.T) {
 	body := []byte(`{
 		"model":"claude-sonnet-4-6",
 		"max_tokens":200,
@@ -913,14 +910,14 @@ func TestProcessClaudeRequestBodyBedrockDisguiseRecheckMaxTokensAfterMinBudget(t
 
 	result, _ := processClaudeRequestBody(body, "claude-cli/2.1.23 (external, cli)", bedrockDisguiseCustomCfg())
 
-	// ensureMinThinkingBudget should have raised budget to 1024
-	if got := gjson.GetBytes(result, "thinking.budget_tokens").Int(); got != 1024 {
-		t.Errorf("thinking.budget_tokens = %d, want 1024 (min)", got)
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Errorf("thinking.type = %q, want adaptive", got)
 	}
-	// max_tokens MUST then be raised above the new budget
-	maxT := gjson.GetBytes(result, "max_tokens").Int()
-	if maxT <= 1024 {
-		t.Errorf("max_tokens = %d, want > 1024 (above raised budget)", maxT)
+	if gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Error("thinking.budget_tokens should be removed by adaptive default")
+	}
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "low" {
+		t.Errorf("output_config.effort = %q, want low", got)
 	}
 }
 

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock.go
@@ -32,7 +32,7 @@ func init() {
 
 type bedrockFixer struct{}
 
-func (f *bedrockFixer) Name() string    { return "bedrock" }
+func (f *bedrockFixer) Name() string  { return "bedrock" }
 func (f *bedrockFixer) Priority() int { return 0 } // highest — covers everything
 
 func (f *bedrockFixer) MatchResponse(resp *http.Response, body []byte, clientType domain.ClientType) bool {
@@ -53,6 +53,12 @@ func (f *bedrockFixer) MatchResponse(resp *http.Response, body []byte, clientTyp
 	// leaves the thinking blocks in place; the retry then fails the
 	// same way and the thinking_envelope fixer never gets a chance.
 	if bedrock.IsThinkingBlockEnvelopeError(body) {
+		return false
+	}
+	if bedrock.IsClassicThinkingRejectedError(body) {
+		return false
+	}
+	if bedrock.IsAdaptiveThinkingRejectedError(body) {
 		return false
 	}
 	return true

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock_adaptive_thinking.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock_adaptive_thinking.go
@@ -1,0 +1,39 @@
+package error_fixer
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+var _ ErrorFixer = (*bedrockAdaptiveThinkingFixer)(nil)
+
+func init() {
+	Register(&bedrockAdaptiveThinkingFixer{})
+}
+
+type bedrockAdaptiveThinkingFixer struct{}
+
+func (f *bedrockAdaptiveThinkingFixer) Name() string { return "bedrock_adaptive_thinking" }
+func (f *bedrockAdaptiveThinkingFixer) Priority() int {
+	return 0
+}
+
+func (f *bedrockAdaptiveThinkingFixer) MatchResponse(resp *http.Response, body []byte, clientType domain.ClientType) bool {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest || clientType != domain.ClientTypeClaude {
+		return false
+	}
+	if !bytes.Contains(body, []byte("Bedrock Runtime")) &&
+		!bytes.Contains(body, []byte("InvokeModel")) {
+		return false
+	}
+	return bedrock.IsClassicThinkingRejectedError(body)
+}
+
+func (f *bedrockAdaptiveThinkingFixer) FixRequest(req *http.Request, body []byte) (*http.Request, []byte) {
+	body = bedrock.StripSamplingParams(body)
+	body = bedrock.RewriteClassicThinkingToAdaptive(body)
+	return req, body
+}

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock_adaptive_thinking_test.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock_adaptive_thinking_test.go
@@ -1,0 +1,50 @@
+package error_fixer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+func TestBedrockAdaptiveThinkingFixer_MatchResponse(t *testing.T) {
+	f := &bedrockAdaptiveThinkingFixer{}
+
+	body := []byte(`{"error":{"message":"InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, https response error StatusCode: 400, ValidationException: \"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`)
+
+	if !f.MatchResponse(&http.Response{StatusCode: http.StatusBadRequest}, body, domain.ClientTypeClaude) {
+		t.Fatal("expected adaptive-thinking Bedrock schema error to match")
+	}
+	if f.MatchResponse(&http.Response{StatusCode: http.StatusBadRequest}, body, domain.ClientTypeOpenAI) {
+		t.Fatal("OpenAI client type should not match")
+	}
+}
+
+func TestBedrockAdaptiveThinkingFixer_FixRequest(t *testing.T) {
+	f := &bedrockAdaptiveThinkingFixer{}
+	req, _ := http.NewRequest(http.MethodPost, "https://example.com", nil)
+
+	_, result := f.FixRequest(req, []byte(`{
+		"thinking": {"type":"enabled","budget_tokens":32000},
+		"temperature": 0.2,
+		"top_p": 0.9,
+		"top_k": 10,
+		"max_tokens": 64000
+	}`))
+
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive", got)
+	}
+	if gjson.GetBytes(result, "thinking.budget_tokens").Exists() {
+		t.Fatal("thinking.budget_tokens should be removed")
+	}
+	if got := gjson.GetBytes(result, "output_config.effort").String(); got != "high" {
+		t.Fatalf("output_config.effort = %q, want high", got)
+	}
+	for _, field := range []string{"temperature", "top_p", "top_k"} {
+		if gjson.GetBytes(result, field).Exists() {
+			t.Fatalf("%s should be stripped for adaptive-thinking retry", field)
+		}
+	}
+}

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock_classic_thinking.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock_classic_thinking.go
@@ -1,0 +1,38 @@
+package error_fixer
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+var _ ErrorFixer = (*bedrockClassicThinkingFixer)(nil)
+
+func init() {
+	Register(&bedrockClassicThinkingFixer{})
+}
+
+type bedrockClassicThinkingFixer struct{}
+
+func (f *bedrockClassicThinkingFixer) Name() string { return "bedrock_classic_thinking" }
+func (f *bedrockClassicThinkingFixer) Priority() int {
+	return 0
+}
+
+func (f *bedrockClassicThinkingFixer) MatchResponse(resp *http.Response, body []byte, clientType domain.ClientType) bool {
+	if resp == nil || resp.StatusCode != http.StatusBadRequest || clientType != domain.ClientTypeClaude {
+		return false
+	}
+	if !bytes.Contains(body, []byte("Bedrock Runtime")) &&
+		!bytes.Contains(body, []byte("InvokeModel")) {
+		return false
+	}
+	return bedrock.IsAdaptiveThinkingRejectedError(body)
+}
+
+func (f *bedrockClassicThinkingFixer) FixRequest(req *http.Request, body []byte) (*http.Request, []byte) {
+	rewritten := bedrock.RewriteAdaptiveThinkingToClassic(body)
+	return (&bedrockFixer{}).FixRequest(req, rewritten)
+}

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock_classic_thinking_test.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock_classic_thinking_test.go
@@ -1,0 +1,67 @@
+package error_fixer
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+func TestBedrockClassicThinkingFixer_MatchResponse(t *testing.T) {
+	f := &bedrockClassicThinkingFixer{}
+
+	body := []byte(`{"error":{"message":"InvokeModel: operation error Bedrock Runtime: InvokeModel, https response error StatusCode: 400, ValidationException: output_config.effort: Extra inputs are not permitted"}}`)
+
+	if !f.MatchResponse(&http.Response{StatusCode: http.StatusBadRequest}, body, domain.ClientTypeClaude) {
+		t.Fatal("expected adaptive rejection to match classic-thinking fallback")
+	}
+	if f.MatchResponse(&http.Response{StatusCode: http.StatusBadRequest}, body, domain.ClientTypeOpenAI) {
+		t.Fatal("OpenAI client type should not match")
+	}
+}
+
+func TestBedrockClassicThinkingFixer_FixRequest(t *testing.T) {
+	f := &bedrockClassicThinkingFixer{}
+	req, _ := http.NewRequest(http.MethodPost, "https://example.com", nil)
+
+	_, result := f.FixRequest(req, []byte(`{
+		"thinking": {"type":"adaptive"},
+		"output_config": {"effort":"medium"},
+		"max_tokens": 200
+	}`))
+
+	if got := gjson.GetBytes(result, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want enabled", got)
+	}
+	if got := gjson.GetBytes(result, "thinking.budget_tokens").Int(); got != 8192 {
+		t.Fatalf("thinking.budget_tokens = %d, want 8192", got)
+	}
+	if gjson.GetBytes(result, "output_config").Exists() {
+		t.Fatal("output_config should be removed")
+	}
+	if got := gjson.GetBytes(result, "max_tokens").Int(); got != 8193 {
+		t.Fatalf("max_tokens = %d, want 8193", got)
+	}
+}
+
+func TestBedrockClassicThinkingFixer_FixRequestWithoutAdaptiveFallsBackToStrip(t *testing.T) {
+	f := &bedrockClassicThinkingFixer{}
+	req, _ := http.NewRequest(http.MethodPost, "https://example.com", nil)
+
+	_, result := f.FixRequest(req, []byte(`{
+		"output_config": {"effort":"high"},
+		"context_management": {"truncation":"auto"},
+		"reasoning": {"budget_tokens":4096},
+		"messages": [{"role":"user","content":"hi"}]
+	}`))
+
+	for _, field := range []string{"output_config", "context_management", "reasoning"} {
+		if gjson.GetBytes(result, field).Exists() {
+			t.Fatalf("%s should be stripped", field)
+		}
+	}
+	if !gjson.GetBytes(result, "messages").Exists() {
+		t.Fatal("messages should be preserved")
+	}
+}

--- a/internal/adapter/provider/custom/error_fixer/000_bedrock_test.go
+++ b/internal/adapter/provider/custom/error_fixer/000_bedrock_test.go
@@ -19,11 +19,11 @@ func TestBedrockFixer_MatchResponse(t *testing.T) {
 		want       bool
 	}{
 		{
-			name:       "Bedrock InvokeModel error",
+			name:       "Bedrock adaptive rejection is not fixed by legacy bedrock fixer",
 			resp:       &http.Response{StatusCode: 400},
 			body:       `{"error":{"message":"InvokeModel: operation error Bedrock Runtime: InvokeModel, https response error StatusCode: 400, ValidationException: output_config.effort: Extra inputs are not permitted"}}`,
 			clientType: domain.ClientTypeClaude,
-			want:       true,
+			want:       false,
 		},
 		{
 			name:       "Bedrock InvokeModelWithResponseStream",
@@ -84,6 +84,13 @@ func TestBedrockFixer_MatchResponse(t *testing.T) {
 			name:       "Bedrock SDK error wrapping thinking signature — should defer to thinking_envelope",
 			resp:       &http.Response{StatusCode: 400},
 			body:       "{\"error\":{\"message\":\"operation error Bedrock Runtime: InvokeModelWithResponseStream, ValidationException: Invalid `signature` in `thinking` block\"}}",
+			clientType: domain.ClientTypeClaude,
+			want:       false,
+		},
+		{
+			name:       "Bedrock adaptive-thinking schema error is not fixed by legacy bedrock fixer",
+			resp:       &http.Response{StatusCode: 400},
+			body:       `{"error":{"message":"InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, https response error StatusCode: 400, ValidationException: \"..enabled\" is not supported for this model. Use \"..adaptive\" and \"output_config.effort\" to control thinking behavior."}}`,
 			clientType: domain.ClientTypeClaude,
 			want:       false,
 		},

--- a/internal/adapter/provider/custom/error_fixer/fixer_test.go
+++ b/internal/adapter/provider/custom/error_fixer/fixer_test.go
@@ -97,6 +97,34 @@ func TestFindFixers_BedrockDefersToThinkingEnvelope(t *testing.T) {
 	}
 }
 
+func TestFindFixers_BedrockAdaptiveThinkingPreemptsLegacyBedrock(t *testing.T) {
+	fixers := FindFixers(
+		&http.Response{StatusCode: 400},
+		[]byte(`{"error":{"message":"InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, ValidationException: \"thinking.type.enabled\" is not supported for this model. Use \"thinking.type.adaptive\" and \"output_config.effort\" to control thinking behavior."}}`),
+		domain.ClientTypeClaude,
+	)
+	if len(fixers) != 1 {
+		t.Fatalf("fixers = %v, want exactly bedrock_adaptive_thinking", fixerNames(fixers))
+	}
+	if fixers[0].Name() != "bedrock_adaptive_thinking" {
+		t.Fatalf("fixer = %s, want bedrock_adaptive_thinking", fixers[0].Name())
+	}
+}
+
+func TestFindFixers_BedrockClassicThinkingPreemptsLegacyBedrock(t *testing.T) {
+	fixers := FindFixers(
+		&http.Response{StatusCode: 400},
+		[]byte(`{"error":{"message":"InvokeModel: operation error Bedrock Runtime: InvokeModel, ValidationException: output_config.effort: Extra inputs are not permitted"}}`),
+		domain.ClientTypeClaude,
+	)
+	if len(fixers) != 1 {
+		t.Fatalf("fixers = %v, want exactly bedrock_classic_thinking", fixerNames(fixers))
+	}
+	if fixers[0].Name() != "bedrock_classic_thinking" {
+		t.Fatalf("fixer = %s, want bedrock_classic_thinking", fixers[0].Name())
+	}
+}
+
 func fixerNames(fixers []ErrorFixer) []string {
 	names := make([]string, 0, len(fixers))
 	for _, f := range fixers {

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -452,6 +452,42 @@ func TestRequestFailureStatusOnlyCancelsForClientDisconnectEvidence(t *testing.T
 	}
 }
 
+func TestDisabledErrorCooldownDoesNotRetryBedrockAdaptiveThinkingSchemaError(t *testing.T) {
+	proxyErr := domain.NewProxyErrorWithMessage(
+		errors.New(`InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, https response error StatusCode: 400, ValidationException: "..enabled" is not supported for this model. Use "..adaptive" and "output_config.effort" to control thinking behavior.`),
+		false,
+		"upstream returned status 400",
+	)
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.HTTPStatusCode = http.StatusBadRequest
+
+	if isDisabledErrorCooldownRetryableError(proxyErr) {
+		t.Fatal("Bedrock adaptive-thinking schema error should not be retryable")
+	}
+
+	applyDisabledErrorCooldownRetryPolicy(
+		&domain.Provider{Config: &domain.ProviderConfig{DisableErrorCooldown: true}},
+		proxyErr,
+	)
+	if proxyErr.Retryable {
+		t.Fatal("disableErrorCooldown should not force-retry Bedrock adaptive-thinking schema errors")
+	}
+}
+
+func TestDisabledErrorCooldownStillRetriesOrdinaryHTTP400(t *testing.T) {
+	proxyErr := domain.NewProxyErrorWithMessage(
+		errors.New(`{"error":{"message":"temporary upstream 400"}}`),
+		false,
+		"upstream returned status 400",
+	)
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.HTTPStatusCode = http.StatusBadRequest
+
+	if !isDisabledErrorCooldownRetryableError(proxyErr) {
+		t.Fatal("ordinary HTTP 400 should still follow disableErrorCooldown retry policy")
+	}
+}
+
 func newDisabledCooldownStreamTestExecutor(proxyRepo *recordingProxyRequestRepo, attemptRepo *recordingAttemptRepo) *Executor {
 	return &Executor{
 		proxyRequestRepo: proxyRepo,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -382,6 +382,9 @@ func isDisabledErrorCooldownRetryableError(proxyErr *domain.ProxyError) bool {
 	if proxyErr == nil {
 		return false
 	}
+	if isBedrockAdaptiveThinkingSchemaError(proxyErr) {
+		return false
+	}
 	if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
 		return true
 	}
@@ -414,6 +417,21 @@ func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
 
 func shouldRetryCommittedResponseError(proxyErr *domain.ProxyError) bool {
 	return proxyErr != nil && proxyErr.Retryable && isCommittedStreamReadRetryableError(proxyErr)
+}
+
+func isBedrockAdaptiveThinkingSchemaError(proxyErr *domain.ProxyError) bool {
+	if proxyErr == nil || proxyErr.Scope != domain.ScopeRequest || proxyErr.HTTPStatusCode != http.StatusBadRequest {
+		return false
+	}
+	text := strings.ToLower(proxyErr.Message)
+	if proxyErr.Err != nil {
+		text += " " + strings.ToLower(proxyErr.Err.Error())
+	}
+	return strings.Contains(text, "bedrock runtime") &&
+		strings.Contains(text, "validationexception") &&
+		strings.Contains(text, "enabled") &&
+		strings.Contains(text, "adaptive") &&
+		strings.Contains(text, "output_config.effort")
 }
 
 // handleAsyncCooldownUpdate listens for async cooldown updates from providers

--- a/tests/e2e/error_fixer_test.go
+++ b/tests/e2e/error_fixer_test.go
@@ -176,6 +176,103 @@ func TestErrorFixer_ExtraBodyFields(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 }
 
+func TestErrorFixer_BedrockAdaptiveThinking(t *testing.T) {
+	mock := newErrorThenSuccessUpstream(t, 400,
+		map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"type":    "invalid_request_error",
+				"message": `InvokeModelWithResponseStream: operation error Bedrock Runtime: InvokeModelWithResponseStream, https response error StatusCode: 400, ValidationException: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`,
+			},
+		},
+		func(t *testing.T, body []byte) {
+			t.Helper()
+			if got := gjson.GetBytes(body, "thinking.type").String(); got != "adaptive" {
+				t.Fatalf("thinking.type = %q, want adaptive", got)
+			}
+			if gjson.GetBytes(body, "thinking.budget_tokens").Exists() {
+				t.Fatal("thinking.budget_tokens should be removed on retry")
+			}
+			if got := gjson.GetBytes(body, "output_config.effort").String(); got != "high" {
+				t.Fatalf("output_config.effort = %q, want high", got)
+			}
+			for _, field := range []string{"temperature", "top_p", "top_k"} {
+				if gjson.GetBytes(body, field).Exists() {
+					t.Fatalf("%s should be stripped on adaptive-thinking retry", field)
+				}
+			}
+		},
+	)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "bedrock-mock-adaptive-thinking", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages", map[string]any{
+		"model":       "claude-opus-4-7",
+		"max_tokens":  64000,
+		"temperature": 0.2,
+		"top_p":       0.9,
+		"top_k":       10,
+		"thinking": map[string]any{
+			"type":          "enabled",
+			"budget_tokens": 32000,
+		},
+		"messages": []map[string]any{
+			{"role": "user", "content": "Hello"},
+		},
+	}, nil)
+	defer resp.Body.Close()
+
+	assertStatus(t, resp, http.StatusOK)
+}
+
+func TestErrorFixer_BedrockClassicThinkingFallback(t *testing.T) {
+	mock := newErrorThenSuccessUpstream(t, 400,
+		map[string]any{
+			"type": "error",
+			"error": map[string]any{
+				"type":    "invalid_request_error",
+				"message": `InvokeModel: operation error Bedrock Runtime: InvokeModel, https response error StatusCode: 400, ValidationException: output_config.effort: Extra inputs are not permitted`,
+			},
+		},
+		func(t *testing.T, body []byte) {
+			t.Helper()
+			if got := gjson.GetBytes(body, "thinking.type").String(); got != "enabled" {
+				t.Fatalf("thinking.type = %q, want enabled", got)
+			}
+			if got := gjson.GetBytes(body, "thinking.budget_tokens").Int(); got != 8192 {
+				t.Fatalf("thinking.budget_tokens = %d, want 8192", got)
+			}
+			if gjson.GetBytes(body, "output_config").Exists() {
+				t.Fatal("output_config should be removed on classic fallback")
+			}
+			if got := gjson.GetBytes(body, "max_tokens").Int(); got != 8193 {
+				t.Fatalf("max_tokens = %d, want 8193", got)
+			}
+		},
+	)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "bedrock-mock-classic-thinking", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages", map[string]any{
+		"model":         "claude-sonnet-4-5",
+		"max_tokens":    200,
+		"thinking":      map[string]any{"type": "adaptive"},
+		"output_config": map[string]any{"effort": "medium"},
+		"messages": []map[string]any{
+			{"role": "user", "content": "Hello"},
+		},
+	}, nil)
+	defer resp.Body.Close()
+
+	assertStatus(t, resp, http.StatusOK)
+}
+
 func TestErrorFixer_ToolCustomFields(t *testing.T) {
 	mock := newErrorThenSuccessUpstream(t, 400,
 		map[string]any{
@@ -499,4 +596,3 @@ func TestErrorFixer_BedrockStripAll(t *testing.T) {
 		t.Errorf("expected 2 upstream calls (bedrock fixer in 1 retry), got %d", count)
 	}
 }
-


### PR DESCRIPTION
## Summary
- make Bedrock sanitization adaptive-first: classic thinking requests are normalized to thinking.type=adaptive + output_config.effort by default
- add direct/custom runtime fallbacks in both directions: classic -> adaptive when Bedrock rejects enabled, and adaptive -> classic when older schemas reject output_config.effort/adaptive
- keep legacy Bedrock strict-schema cleanup for unrelated fields, and prevent disableErrorCooldown from route-retrying unrecoverable adaptive-thinking schema errors

## Tests
- /usr/local/go/bin/go test ./internal/adapter/provider/bedrock
- /usr/local/go/bin/go test ./internal/adapter/provider/custom ./internal/adapter/provider/custom/error_fixer
- /usr/local/go/bin/go test -count=1 -timeout 300s ./tests/e2e -run 'TestErrorFixer_BedrockAdaptiveThinking|TestErrorFixer_BedrockClassicThinkingFallback|TestErrorFixer_ExtraBodyFields|TestErrorFixer_BedrockStripAll|TestDisableErrorCooldownRetriesAllHTTPErrorStatuses'
- /usr/local/go/bin/go test ./internal/executor
- /usr/local/go/bin/go test -count=1 -timeout 600s ./cmd/... ./internal/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化 Bedrock 思考模式兼容性，优先支持自适应思考配置。
  * 遇到配置不兼容时，自动在自适应与经典思考模式之间切换并重试。
  * 自动保留有效的输出配置，移除不兼容参数并调整思考预算。
  * 相关配置校验错误不会触发无效重试，普通 HTTP 400 错误仍遵循原有策略。

* **测试**
  * 增加单元测试与集成测试，覆盖错误识别、模式切换、请求修复及成功重试场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->