### PR TITLE
Add x-api-key Claude disguise mode

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -158,6 +158,7 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		// 2. Set headers — pick variant based on the effective disguise type
 		// (ResolveDisguise migrates the legacy `cloak` JSON field on the way in).
 		//   bedrock      — strip Claude Code identity entirely (applyBedrockCompatHeaders)
+		//   x-api-key    — minimal Claude headers with forced x-api-key auth
 		//   none         — raw forwarding: copy client headers, override auth only
 		//   claude-code  — inject Claude Code identity headers (legacy default)
 		//   "" / nil     — same as claude-code (backward compatibility)
@@ -169,6 +170,9 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		switch disguiseType {
 		case domain.DisguiseTypeBedrock:
 			applyBedrockCompatHeaders(upstreamReq, request, apiKey, stream)
+		case domain.DisguiseTypeXAPIKey:
+			applyXAPIKeyCompatHeaders(upstreamReq, apiKey, stream)
+			targetUserAgent = defaultClaudeUserAgent
 		case domain.DisguiseTypeNone:
 			// Raw forwarding: copy client headers, then override auth with the
 			// provider's key. This preserves whatever the inbound client sent

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -78,8 +78,10 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 		// "claude-opus-4-7", not on inference-profile IDs.
 		body = bedrock.AdaptThinkingForModel(body, bedrock.ShortNameForModel(modelName))
 		bedrockMode = true
-	case domain.DisguiseTypeNone, domain.DisguiseTypeXAPIKey:
-		// Explicit opt-out: no body transformation. x-api-key mode only changes outbound headers.
+	case domain.DisguiseTypeNone:
+		// Explicit opt-out: no body transformation.
+	case domain.DisguiseTypeXAPIKey:
+		// x-api-key mode only changes outbound headers; keep the body unmodified.
 	default:
 		// "" / "claude-code" / unknown / nil — keep legacy claude-code cloak default.
 		var ccOpts *domain.DisguiseClaudeCodeOptions

--- a/internal/adapter/provider/custom/claude_body.go
+++ b/internal/adapter/provider/custom/claude_body.go
@@ -78,8 +78,8 @@ func processClaudeRequestBody(body []byte, clientUserAgent string, customCfg *do
 		// "claude-opus-4-7", not on inference-profile IDs.
 		body = bedrock.AdaptThinkingForModel(body, bedrock.ShortNameForModel(modelName))
 		bedrockMode = true
-	case domain.DisguiseTypeNone:
-		// Explicit opt-out: no body transformation.
+	case domain.DisguiseTypeNone, domain.DisguiseTypeXAPIKey:
+		// Explicit opt-out: no body transformation. x-api-key mode only changes outbound headers.
 	default:
 		// "" / "claude-code" / unknown / nil — keep legacy claude-code cloak default.
 		var ccOpts *domain.DisguiseClaudeCodeOptions

--- a/internal/adapter/provider/custom/claude_headers.go
+++ b/internal/adapter/provider/custom/claude_headers.go
@@ -242,3 +242,32 @@ func ensureHeader(target http.Header, source http.Header, key, defaultValue stri
 		target.Set(key, val)
 	}
 }
+
+// applyXAPIKeyCompatHeaders sets a minimal Claude-compatible header set for
+// relay stations that reject Bearer auth and only accept x-api-key credentials.
+// It intentionally does not passthrough client Claude Code / beta / SDK identity
+// headers, so unsupported client-side header variants cannot leak upstream.
+func applyXAPIKeyCompatHeaders(req *http.Request, apiKey string, stream bool) {
+	// We own auth in this mode: force x-api-key and remove every common source
+	// credential header that could conflict with it.
+	req.Header.Del("Authorization")
+	req.Header.Del("x-api-key")
+	req.Header.Del("x-goog-api-key")
+	if apiKey != "" {
+		req.Header.Set("x-api-key", apiKey)
+	}
+
+	// Keep only the minimal protocol headers Maxx must control. Do not forward
+	// Claude Code fingerprint/beta headers; this mode is for narrow relay
+	// compatibility, not client identity emulation.
+	for _, h := range claudeIdentityHeaders {
+		req.Header.Del(h)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Connection", "keep-alive")
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
+}

--- a/internal/adapter/provider/custom/claude_headers_test.go
+++ b/internal/adapter/provider/custom/claude_headers_test.go
@@ -408,3 +408,36 @@ func TestApplyBedrockCompatHeadersFromClaudeBaseline(t *testing.T) {
 		t.Errorf("User-Agent should be replaced with AWS SDK string, got %q", req.Header.Get("User-Agent"))
 	}
 }
+
+func TestApplyXAPIKeyCompatHeadersUsesOnlyXAPIKeyAuthAndStripsClaudeIdentity(t *testing.T) {
+	req, _ := http.NewRequest("POST", "https://relay.example.com/v1/messages", nil)
+	clientReq, _ := http.NewRequest("POST", "https://example.com", nil)
+	clientReq.Header.Set("Anthropic-Beta", "client-beta")
+	clientReq.Header.Set("Anthropic-Version", "client-version")
+	clientReq.Header.Set("X-Stainless-Runtime", "node")
+
+	// Start from the normal Claude Code baseline to prove the compatibility mode
+	// is the final authority and does not leak unsupported passthrough headers.
+	applyClaudeHeaders(req, clientReq, "sk-old", true, []string{"extra-beta"}, false)
+	applyXAPIKeyCompatHeaders(req, "sk-new", true)
+
+	if got := req.Header.Get("x-api-key"); got != "sk-new" {
+		t.Fatalf("x-api-key = %q, want sk-new", got)
+	}
+	for _, name := range []string{"Authorization", "x-goog-api-key"} {
+		if got := req.Header.Get(name); got != "" {
+			t.Errorf("%s should be stripped, got %q", name, got)
+		}
+	}
+	for _, h := range claudeIdentityHeaders {
+		if got := req.Header.Get(h); got != "" {
+			t.Errorf("%s should be stripped, got %q", h, got)
+		}
+	}
+	if got := req.Header.Get("Accept"); got != "text/event-stream" {
+		t.Errorf("Accept = %q, want text/event-stream", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -75,6 +75,8 @@ const (
 	DisguiseTypeClaudeCode = "claude-code"
 	// DisguiseTypeBedrock — 洗掉 Claude Code 标识，让后端为 AWS Bedrock 的中转站不报 invalid beta flag
 	DisguiseTypeBedrock = "bedrock"
+	// DisguiseTypeXAPIKey — 使用最小 Claude header 集，强制通过 x-api-key 鉴权，适配只接受 x-api-key 的中转站
+	DisguiseTypeXAPIKey = "x-api-key"
 )
 
 // ProviderConfigCustomDisguise 描述对外伪装的目标客户端类型与对应子选项。

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -21,7 +21,7 @@ export type ClientType = 'claude' | 'codex' | 'gemini' | 'openai';
 
 // ===== Provider 相关 =====
 
-export type DisguiseType = 'none' | 'claude-code' | 'bedrock';
+export type DisguiseType = 'none' | 'claude-code' | 'bedrock' | 'x-api-key';
 
 export interface DisguiseClaudeCodeOptions {
   mode?: 'auto' | 'always' | 'never';

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1775,6 +1775,8 @@
     "disguiseTypeClaudeCodeDesc": "Inject Claude Code system prompt + claude-cli identity headers. Use this for relays that price/route by Claude Code traffic.",
     "disguiseTypeBedrock": "AWS Bedrock compatible",
     "disguiseTypeBedrockDesc": "Strip Claude Code identifying headers and Bedrock-incompatible body fields (betas, cache_control.scope, tools[].custom, etc). Use this for relays whose backend is AWS Bedrock.",
+    "disguiseTypeXAPIKey": "X-API-Key compatible",
+    "disguiseTypeXAPIKeyDesc": "Use a minimal Claude header set and force x-api-key authentication. Use this for Claude relays that only accept x-api-key.",
     "cloakMode": "Cloak Mode",
     "cloakModeDesc": "Controls whether the Claude Code system prompt and fake user_id are injected.",
     "cloakModeAuto": "Auto (only non-claude-cli clients)",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1772,6 +1772,8 @@
     "disguiseTypeClaudeCodeDesc": "注入 Claude Code 的 system 提示词与 claude-cli 身份头。适合按 Claude Code 流量定价/路由的中转站。",
     "disguiseTypeBedrock": "AWS Bedrock 兼容",
     "disguiseTypeBedrockDesc": "清除 Claude Code 标识 header，并删除 Bedrock 不接受的 body 字段（betas、cache_control.scope、tools[].custom 等）。适合后端为 AWS Bedrock 的中转站。",
+    "disguiseTypeXAPIKey": "X-API-Key 兼容",
+    "disguiseTypeXAPIKeyDesc": "使用最小 Claude header 集，并强制通过 x-api-key 鉴权。适合只接受 x-api-key 的 Claude 中转站。",
     "cloakMode": "伪装模式",
     "cloakModeDesc": "控制是否注入 Claude Code system 提示词与伪造 user_id。",
     "cloakModeAuto": "自动（仅非 claude-cli 客户端）",

--- a/web/src/pages/providers/components/clients-config-section.tsx
+++ b/web/src/pages/providers/components/clients-config-section.tsx
@@ -14,7 +14,7 @@ import type { ClientType } from '@/lib/transport';
 import type { ClientConfig } from '../types';
 import { useTranslation } from 'react-i18next';
 
-export type DisguiseTypeValue = 'none' | 'claude-code' | 'bedrock';
+export type DisguiseTypeValue = 'none' | 'claude-code' | 'bedrock' | 'x-api-key';
 
 interface DisguiseProp {
   type: DisguiseTypeValue;
@@ -178,14 +178,19 @@ export function ClientsConfigSection({
                         <SelectItem value="bedrock">
                           {t('provider.disguiseTypeBedrock')}
                         </SelectItem>
+                        <SelectItem value="x-api-key">
+                          {t('provider.disguiseTypeXAPIKey')}
+                        </SelectItem>
                       </SelectContent>
                     </Select>
                     <p className="text-xs text-muted-foreground mt-1">
                       {disguise.type === 'bedrock'
                         ? t('provider.disguiseTypeBedrockDesc')
-                        : disguise.type === 'claude-code'
-                          ? t('provider.disguiseTypeClaudeCodeDesc')
-                          : t('provider.disguiseTypeNoneDesc')}
+                        : disguise.type === 'x-api-key'
+                          ? t('provider.disguiseTypeXAPIKeyDesc')
+                          : disguise.type === 'claude-code'
+                            ? t('provider.disguiseTypeClaudeCodeDesc')
+                            : t('provider.disguiseTypeNoneDesc')}
                     </p>
                   </div>
 

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -502,7 +502,7 @@ type EditFormData = {
   supportModels: string[];
   exposedModelsEnabled: boolean;
   exposedModels: string[];
-  disguiseType?: 'none' | 'claude-code' | 'bedrock';
+  disguiseType?: 'none' | 'claude-code' | 'bedrock' | 'x-api-key';
   cloakMode?: 'auto' | 'always' | 'never';
   cloakStrictMode?: boolean;
   cloakSensitiveWords?: string;
@@ -568,7 +568,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     const disguise = customCfg?.disguise;
     const legacyCloak = customCfg?.cloak;
     // Default disguiseType: 'claude-code' (preserves legacy auto-cloak behavior).
-    const disguiseType = (disguise?.type ?? 'claude-code') as 'none' | 'claude-code' | 'bedrock';
+    const disguiseType = (disguise?.type ?? 'claude-code') as 'none' | 'claude-code' | 'bedrock' | 'x-api-key';
     const cc = disguise?.claudeCode ?? legacyCloak;
     return {
       name: provider.name,


### PR DESCRIPTION
## Summary
- add an `x-api-key` Claude disguise mode for custom providers
- force x-api-key auth and strip conflicting auth / Claude Code identity headers in that mode
- expose the new mode in provider UI locales and transport types

## Validation
- `git diff --check`
- `go test ./internal/domain ./internal/adapter/provider/custom`
- GitHub checks are passing: Backend Checks, Frontend Checks, e2e, playwright, gitleaks

Note: local `cd web && pnpm exec tsc --noEmit` was attempted but this checkout does not have a local `tsc` binary available; frontend validation is covered by the passing GitHub Frontend Checks.