### PR TITLE
Fix test field results scroll and cache state

### DIFF
--- a/web/src/pages/test-field/index.tsx
+++ b/web/src/pages/test-field/index.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { FlaskConical, Plus, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
 import { PageHeader } from '@/components/layout/page-header';
 import {
   Badge,
@@ -40,20 +41,47 @@ function providerLabel(provider: Provider) {
   return `${provider.name} · ${provider.type} · #${provider.id}`;
 }
 
+type TestFieldBenchmarkCache = {
+  providerToAdd: string;
+  selectedProviderIDs: number[];
+  prompt: string;
+  concurrency: number;
+  timeoutMs: number;
+  maxModelsPerProvider: number;
+  result: TestFieldModelBenchmarkResponse | null;
+};
+
+const testFieldBenchmarkCacheKey = ['test-field', 'benchmark-state'] as const;
+
 export function TestFieldPage() {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const cachedBenchmarkState = queryClient.getQueryData<TestFieldBenchmarkCache>(
+    testFieldBenchmarkCacheKey,
+  );
   const providersQuery = useProviders();
   const providers = useMemo(() => providersQuery.data ?? [], [providersQuery.data]);
-  const [providerToAdd, setProviderToAdd] = useState<string>('');
-  const [selectedProviderIDs, setSelectedProviderIDs] = useState<number[]>([]);
-  const [prompt, setPrompt] = useState('请用一句话回答：你现在可用吗？');
-  const [concurrency, setConcurrency] = useState(4);
-  const [timeoutMs, setTimeoutMs] = useState(30000);
-  const [maxModelsPerProvider, setMaxModelsPerProvider] = useState(20);
-  const [result, setResult] = useState<TestFieldModelBenchmarkResponse | null>(null);
+  const [providerToAdd, setProviderToAdd] = useState<string>(
+    cachedBenchmarkState?.providerToAdd ?? '',
+  );
+  const [selectedProviderIDs, setSelectedProviderIDs] = useState<number[]>(
+    cachedBenchmarkState?.selectedProviderIDs ?? [],
+  );
+  const [prompt, setPrompt] = useState(
+    cachedBenchmarkState?.prompt ?? '请用一句话回答：你现在可用吗？',
+  );
+  const [concurrency, setConcurrency] = useState(cachedBenchmarkState?.concurrency ?? 4);
+  const [timeoutMs, setTimeoutMs] = useState(cachedBenchmarkState?.timeoutMs ?? 30000);
+  const [maxModelsPerProvider, setMaxModelsPerProvider] = useState(
+    cachedBenchmarkState?.maxModelsPerProvider ?? 20,
+  );
+  const [result, setResult] = useState<TestFieldModelBenchmarkResponse | null>(
+    cachedBenchmarkState?.result ?? null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  const resultsCardRef = useRef<HTMLDivElement | null>(null);
 
   const selectedProviders = useMemo(
     () =>
@@ -72,6 +100,34 @@ export function TestFieldPage() {
       )
     : t('testField.benchmark.providerPlaceholder');
   const canRun = selectedProviderIDs.length > 0 && prompt.trim().length > 0 && !isRunning;
+
+  useEffect(() => {
+    queryClient.setQueryData<TestFieldBenchmarkCache>(testFieldBenchmarkCacheKey, {
+      providerToAdd,
+      selectedProviderIDs,
+      prompt,
+      concurrency,
+      timeoutMs,
+      maxModelsPerProvider,
+      result,
+    });
+  }, [
+    concurrency,
+    maxModelsPerProvider,
+    prompt,
+    providerToAdd,
+    queryClient,
+    result,
+    selectedProviderIDs,
+    timeoutMs,
+  ]);
+
+  useEffect(() => {
+    if (!result) return;
+    requestAnimationFrame(() => {
+      resultsCardRef.current?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    });
+  }, [result]);
 
   const addProvider = () => {
     const id = Number(providerToAdd);
@@ -127,232 +183,242 @@ export function TestFieldPage() {
   };
 
   return (
-    <div className="h-full min-h-0 flex-1 space-y-4 overflow-y-auto p-4 pt-0">
+    <div className="flex h-full flex-col bg-background">
       <PageHeader title={t('testField.title')} description={t('testField.description')} />
 
-      <Card className="border-border bg-card">
-        <CardHeader className="border-b border-border py-4">
-          <CardTitle className="text-base font-medium flex items-center gap-2">
-            <FlaskConical className="h-4 w-4 text-muted-foreground" />
-            {t('testField.benchmark.title')}
-          </CardTitle>
-          <CardDescription>{t('testField.benchmark.description')}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-5 p-6">
-          <div className="grid gap-3 md:grid-cols-[1fr_auto]">
-            <div className="space-y-2">
-              <Label>{t('testField.benchmark.providerSelect')}</Label>
-              <Select
-                value={providerToAdd}
-                onValueChange={(value) => setProviderToAdd(value ?? '')}
-                disabled={isRunning}
-              >
-                <SelectTrigger>
-                  <SelectValue>{providerToAddLabel}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {availableProviders.map((provider) => (
-                    <SelectItem key={provider.id} value={String(provider.id)}>
-                      {providerLabel(provider)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <Button
-              className="self-end"
-              type="button"
-              onClick={addProvider}
-              disabled={!providerToAdd || isRunning}
-            >
-              <Plus className="mr-2 h-4 w-4" />
-              {t('testField.benchmark.addProvider')}
-            </Button>
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            {selectedProviders.length === 0 ? (
-              <span className="text-sm text-muted-foreground">
-                {t('testField.benchmark.noSelectedProviders')}
-              </span>
-            ) : (
-              selectedProviders.map((provider) => {
-                const supported = SUPPORTED_PROVIDER_TYPES.has(provider.type);
-                return (
-                  <Badge
-                    key={provider.id}
-                    variant={supported ? 'secondary' : 'outline'}
-                    className="gap-2 py-1"
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="mx-auto max-w-7xl space-y-4">
+          <Card className="border-border bg-card">
+            <CardHeader className="border-b border-border py-4">
+              <CardTitle className="text-base font-medium flex items-center gap-2">
+                <FlaskConical className="h-4 w-4 text-muted-foreground" />
+                {t('testField.benchmark.title')}
+              </CardTitle>
+              <CardDescription>{t('testField.benchmark.description')}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-5 p-6">
+              <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+                <div className="space-y-2">
+                  <Label>{t('testField.benchmark.providerSelect')}</Label>
+                  <Select
+                    value={providerToAdd}
+                    onValueChange={(value) => setProviderToAdd(value ?? '')}
+                    disabled={isRunning}
                   >
-                    <span>{providerLabel(provider)}</span>
-                    {!supported && (
-                      <span className="text-muted-foreground">
-                        {t('testField.benchmark.unsupportedBadge')}
-                      </span>
-                    )}
-                    <button
-                      type="button"
-                      className="rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
-                      aria-label={t('testField.benchmark.removeProvider')}
-                      onClick={() => removeProvider(provider.id)}
-                      disabled={isRunning}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </Badge>
-                );
-              })
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="test-field-prompt">{t('testField.benchmark.prompt')}</Label>
-            <Textarea
-              id="test-field-prompt"
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              disabled={isRunning}
-              rows={3}
-            />
-          </div>
-
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className="space-y-2">
-              <Label htmlFor="test-field-concurrency">{t('testField.benchmark.concurrency')}</Label>
-              <Input
-                id="test-field-concurrency"
-                type="number"
-                min={1}
-                max={10}
-                value={concurrency}
-                onChange={(event) => setConcurrency(Number(event.target.value) || 1)}
-                disabled={isRunning}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="test-field-timeout">{t('testField.benchmark.timeoutMs')}</Label>
-              <Input
-                id="test-field-timeout"
-                type="number"
-                min={1000}
-                max={30000}
-                value={timeoutMs}
-                onChange={(event) => setTimeoutMs(Number(event.target.value) || 30000)}
-                disabled={isRunning}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="test-field-max-models">
-                {t('testField.benchmark.maxModelsPerProvider')}
-              </Label>
-              <Input
-                id="test-field-max-models"
-                type="number"
-                min={1}
-                max={50}
-                value={maxModelsPerProvider}
-                onChange={(event) => setMaxModelsPerProvider(Number(event.target.value) || 20)}
-                disabled={isRunning}
-              />
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button type="button" onClick={runBenchmark} disabled={!canRun}>
-              {isRunning ? t('testField.benchmark.running') : t('testField.benchmark.run')}
-            </Button>
-            {isRunning && (
-              <Button type="button" variant="outline" onClick={cancelBenchmark}>
-                {t('testField.benchmark.cancel')}
-              </Button>
-            )}
-            <span className="text-xs text-muted-foreground">
-              {t('testField.benchmark.manualOnlyHint')}
-            </span>
-          </div>
-
-          {error && (
-            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {result && (
-        <Card className="border-border bg-card">
-          <CardHeader className="border-b border-border py-4">
-            <CardTitle className="text-base font-medium">
-              {t('testField.benchmark.resultsTitle')}
-            </CardTitle>
-            <CardDescription>
-              {t('testField.benchmark.resultsDescription', {
-                count: result.results.length,
-                concurrency: result.concurrency,
-              })}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4 p-6">
-            <div className="grid gap-2 md:grid-cols-2">
-              {result.providers.map((provider) => (
-                <div
-                  key={provider.providerID}
-                  className="rounded-md border border-border p-3 text-sm"
-                >
-                  <div className="font-medium">
-                    {provider.providerName || `#${provider.providerID}`}
-                  </div>
-                  <div className="text-muted-foreground">
-                    {provider.providerType || '-'} ·{' '}
-                    {t('testField.benchmark.modelsSummary', {
-                      tested: provider.testedCount,
-                      total: provider.modelCount,
-                    })}
-                  </div>
-                  {provider.error && <div className="mt-1 text-destructive">{provider.error}</div>}
+                    <SelectTrigger>
+                      <SelectValue>{providerToAddLabel}</SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableProviders.map((provider) => (
+                        <SelectItem key={provider.id} value={String(provider.id)}>
+                          {providerLabel(provider)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
-              ))}
-            </div>
+                <Button
+                  className="self-end"
+                  type="button"
+                  onClick={addProvider}
+                  disabled={!providerToAdd || isRunning}
+                >
+                  <Plus className="mr-2 h-4 w-4" />
+                  {t('testField.benchmark.addProvider')}
+                </Button>
+              </div>
 
-            <div className="overflow-x-auto rounded-md border border-border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t('testField.benchmark.rank')}</TableHead>
-                    <TableHead>{t('testField.benchmark.provider')}</TableHead>
-                    <TableHead>{t('testField.benchmark.model')}</TableHead>
-                    <TableHead>{t('testField.benchmark.duration')}</TableHead>
-                    <TableHead>{t('testField.benchmark.status')}</TableHead>
-                    <TableHead>{t('testField.benchmark.response')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {result.results.map((item, index) => (
-                    <TableRow key={`${item.providerID}:${item.model}`}>
-                      <TableCell>{index + 1}</TableCell>
-                      <TableCell>{item.providerName}</TableCell>
-                      <TableCell className="font-mono text-xs">{item.model}</TableCell>
-                      <TableCell>{formatDuration(item.durationMs)}</TableCell>
-                      <TableCell>
-                        {item.available ? (
-                          <Badge variant="secondary">{t('testField.benchmark.available')}</Badge>
-                        ) : (
-                          <Badge variant="destructive">
-                            {t('testField.benchmark.unavailable')}
-                          </Badge>
+              <div className="flex flex-wrap gap-2">
+                {selectedProviders.length === 0 ? (
+                  <span className="text-sm text-muted-foreground">
+                    {t('testField.benchmark.noSelectedProviders')}
+                  </span>
+                ) : (
+                  selectedProviders.map((provider) => {
+                    const supported = SUPPORTED_PROVIDER_TYPES.has(provider.type);
+                    return (
+                      <Badge
+                        key={provider.id}
+                        variant={supported ? 'secondary' : 'outline'}
+                        className="gap-2 py-1"
+                      >
+                        <span>{providerLabel(provider)}</span>
+                        {!supported && (
+                          <span className="text-muted-foreground">
+                            {t('testField.benchmark.unsupportedBadge')}
+                          </span>
                         )}
-                      </TableCell>
-                      <TableCell className="max-w-xl truncate text-sm text-muted-foreground">
-                        {item.available ? item.response : item.error}
-                      </TableCell>
-                    </TableRow>
+                        <button
+                          type="button"
+                          className="rounded-sm text-muted-foreground hover:text-foreground disabled:opacity-50"
+                          aria-label={t('testField.benchmark.removeProvider')}
+                          onClick={() => removeProvider(provider.id)}
+                          disabled={isRunning}
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </Badge>
+                    );
+                  })
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="test-field-prompt">{t('testField.benchmark.prompt')}</Label>
+                <Textarea
+                  id="test-field-prompt"
+                  value={prompt}
+                  onChange={(event) => setPrompt(event.target.value)}
+                  disabled={isRunning}
+                  rows={3}
+                />
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="test-field-concurrency">
+                    {t('testField.benchmark.concurrency')}
+                  </Label>
+                  <Input
+                    id="test-field-concurrency"
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={concurrency}
+                    onChange={(event) => setConcurrency(Number(event.target.value) || 1)}
+                    disabled={isRunning}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="test-field-timeout">{t('testField.benchmark.timeoutMs')}</Label>
+                  <Input
+                    id="test-field-timeout"
+                    type="number"
+                    min={1000}
+                    max={30000}
+                    value={timeoutMs}
+                    onChange={(event) => setTimeoutMs(Number(event.target.value) || 30000)}
+                    disabled={isRunning}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="test-field-max-models">
+                    {t('testField.benchmark.maxModelsPerProvider')}
+                  </Label>
+                  <Input
+                    id="test-field-max-models"
+                    type="number"
+                    min={1}
+                    max={50}
+                    value={maxModelsPerProvider}
+                    onChange={(event) => setMaxModelsPerProvider(Number(event.target.value) || 20)}
+                    disabled={isRunning}
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Button type="button" onClick={runBenchmark} disabled={!canRun}>
+                  {isRunning ? t('testField.benchmark.running') : t('testField.benchmark.run')}
+                </Button>
+                {isRunning && (
+                  <Button type="button" variant="outline" onClick={cancelBenchmark}>
+                    {t('testField.benchmark.cancel')}
+                  </Button>
+                )}
+                <span className="text-xs text-muted-foreground">
+                  {t('testField.benchmark.manualOnlyHint')}
+                </span>
+              </div>
+
+              {error && (
+                <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                  {error}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {result && (
+            <Card ref={resultsCardRef} className="border-border bg-card">
+              <CardHeader className="border-b border-border py-4">
+                <CardTitle className="text-base font-medium">
+                  {t('testField.benchmark.resultsTitle')}
+                </CardTitle>
+                <CardDescription>
+                  {t('testField.benchmark.resultsDescription', {
+                    count: result.results.length,
+                    concurrency: result.concurrency,
+                  })}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4 p-6">
+                <div className="grid gap-2 md:grid-cols-2">
+                  {result.providers.map((provider) => (
+                    <div
+                      key={provider.providerID}
+                      className="rounded-md border border-border p-3 text-sm"
+                    >
+                      <div className="font-medium">
+                        {provider.providerName || `#${provider.providerID}`}
+                      </div>
+                      <div className="text-muted-foreground">
+                        {provider.providerType || '-'} ·{' '}
+                        {t('testField.benchmark.modelsSummary', {
+                          tested: provider.testedCount,
+                          total: provider.modelCount,
+                        })}
+                      </div>
+                      {provider.error && (
+                        <div className="mt-1 text-destructive">{provider.error}</div>
+                      )}
+                    </div>
                   ))}
-                </TableBody>
-              </Table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+                </div>
+
+                <div className="overflow-x-auto rounded-md border border-border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t('testField.benchmark.rank')}</TableHead>
+                        <TableHead>{t('testField.benchmark.provider')}</TableHead>
+                        <TableHead>{t('testField.benchmark.model')}</TableHead>
+                        <TableHead>{t('testField.benchmark.duration')}</TableHead>
+                        <TableHead>{t('testField.benchmark.status')}</TableHead>
+                        <TableHead>{t('testField.benchmark.response')}</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {result.results.map((item, index) => (
+                        <TableRow key={`${item.providerID}:${item.model}`}>
+                          <TableCell>{index + 1}</TableCell>
+                          <TableCell>{item.providerName}</TableCell>
+                          <TableCell className="font-mono text-xs">{item.model}</TableCell>
+                          <TableCell>{formatDuration(item.durationMs)}</TableCell>
+                          <TableCell>
+                            {item.available ? (
+                              <Badge variant="secondary">
+                                {t('testField.benchmark.available')}
+                              </Badge>
+                            ) : (
+                              <Badge variant="destructive">
+                                {t('testField.benchmark.unavailable')}
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell className="max-w-xl truncate text-sm text-muted-foreground">
+                            {item.available ? item.response : item.error}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- align the test field page layout with other tabs: fixed page header plus a dedicated scrollable content region
- automatically scroll to benchmark results after a run so results are visible without hunting through a clipped page
- cache test field form state and benchmark results in React Query so switching tabs keeps the data like other cached views

## Validation
- 
- ok  	github.com/awsl-project/maxx/internal/handler	(cached)
- 
> web@0.1.1 lint /tmp/maxx-test-field-fix/web
> eslint .
- 
> web@0.1.1 typecheck /tmp/maxx-test-field-fix/web
> tsc -b --pretty false
- 
> web@0.1.1 build /tmp/maxx-test-field-fix/web
> tsc -b && vite build

vite v7.3.5 building client environment for production...
transforming...
✓ 3995 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                                1.34 kB │ gzip:   0.78 kB
dist/assets/openai-l2c0gsVT.png                                4.11 kB
dist/assets/aicodemirror-BcYX_CIO.png                          6.15 kB
dist/assets/codex-BFa__UH4.png                                 6.22 kB
dist/assets/deepseek-Cy3zNngq.png                              6.78 kB
dist/assets/claude-DFFwCAjh.png                                6.90 kB
dist/assets/inter-vietnamese-wght-normal-CBcvBZtf.woff2       10.25 kB
dist/assets/inter-greek-ext-wght-normal-DlzME5K_.woff2        11.23 kB
dist/assets/inter-cyrillic-wght-normal-DqGufNeO.woff2         18.75 kB
dist/assets/inter-greek-wght-normal-CkhJZR-_.woff2            19.00 kB
dist/assets/inter-cyrillic-ext-wght-normal-BOeWTOD4.woff2     25.96 kB
dist/assets/inter-latin-wght-normal-Dx4kXJAl.woff2            48.26 kB
dist/assets/inter-latin-ext-wght-normal-DO1Apj_S.woff2        85.07 kB
dist/assets/free-duck-BZiD-aaS.gif                           637.27 kB
dist/assets/index-CEP3if9n.css                               226.88 kB │ gzip:  33.66 kB
dist/assets/index-BjdCeiFo.js                                  4.72 kB │ gzip:   1.92 kB
dist/assets/index-CXbssO5Q.js                              2,234.94 kB │ gzip: 620.95 kB
✓ built in 5.68s
- user-view Playwright regression: 520px viewport, 160 result rows, results card auto-visible, page scroll reaches final row, cached result remains visible after SPA navigation away and back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 自动缓存并恢复基准测试配置与结果，减少页面刷新后的重复操作。
  * 测试结果生成后自动平滑滚动至结果区域。

* **改进**
  * 优化页面滚动布局及结果卡片展示。
  * 重组测试表单、错误提示、提供商摘要和结果表的界面结构，提升可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->