### PR TITLE
fix(proxy): keep Gemini route enabled by default

### DIFF
--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -91,5 +91,5 @@ func proxyRouteEnabled(settings repository.SystemSettingRepository, key string) 
 }
 
 func proxyRouteEnabledByDefault(key string) bool {
-	return key != domain.SettingKeyProxyRouteGeminiEnabled
+	return true
 }

--- a/internal/core/proxy_routes_test.go
+++ b/internal/core/proxy_routes_test.go
@@ -88,12 +88,14 @@ func TestRegisterProxyRoutes_RoutesGeminiGenerationToProxy(t *testing.T) {
 	}
 }
 
-func TestRegisterProxyRoutes_GeminiGenerationDisabledByDefault(t *testing.T) {
+func TestRegisterProxyRoutes_GeminiGenerationEnabledByDefault(t *testing.T) {
 	mux := http.NewServeMux()
+	proxyCalled := false
 
 	RegisterProxyRoutes(mux, ProxyRouteHandlers{
 		ProxyHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			t.Fatalf("did not expect default-disabled Gemini path to hit ProxyHandler")
+			proxyCalled = true
+			w.WriteHeader(http.StatusNoContent)
 		}),
 		SettingRepo: proxyRouteSettingsRepo{values: map[string]string{}},
 	})
@@ -101,8 +103,11 @@ func TestRegisterProxyRoutes_GeminiGenerationDisabledByDefault(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:generateContent", nil))
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	if !proxyCalled {
+		t.Fatal("expected default-enabled Gemini path to hit ProxyHandler")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
 	}
 }
 

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -987,7 +987,7 @@ const (
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"       // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteOpenAIChatEnabled          = "proxy_route_openai_chat_enabled"           // 是否暴露 OpenAI Chat Completions 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteResponsesEnabled           = "proxy_route_responses_enabled"             // 是否暴露 Responses/Codex 代理路由，"true" 或 "false"，默认 "true"
-	SettingKeyProxyRouteGeminiEnabled              = "proxy_route_gemini_enabled"                // 是否暴露 Gemini 代理路由，"true" 或 "false"，默认 "false"
+	SettingKeyProxyRouteGeminiEnabled              = "proxy_route_gemini_enabled"                // 是否暴露 Gemini 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyEnablePprof                          = "enable_pprof"                              // 是否启用 pprof 性能分析，"true" 或 "false"，默认 "false"
 	SettingKeyPprofPort                            = "pprof_port"                                // pprof 服务端口，默认 6060
 	SettingKeyPprofPassword                        = "pprof_password"                            // pprof 访问密码，为空表示不需要密码

--- a/internal/handler/admin_settings_test.go
+++ b/internal/handler/admin_settings_test.go
@@ -37,7 +37,7 @@ func (r *settingsTestRepo) Delete(key string) error {
 	return nil
 }
 
-func TestHandleSettingsDeleteReturnsBadRequestWhenDeletingLastPublicProxyRoute(t *testing.T) {
+func TestHandleSettingsDeleteResetsPublicProxyRouteToDefaultEnabled(t *testing.T) {
 	repo := &settingsTestRepo{values: map[string]string{
 		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
 		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
@@ -78,10 +78,10 @@ func TestHandleSettingsDeleteReturnsBadRequestWhenDeletingLastPublicProxyRoute(t
 
 	handler.handleSettings(rec, req, []string{"admin", "settings", domain.SettingKeyProxyRouteGeminiEnabled})
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusNoContent, rec.Body.String())
 	}
-	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "true" {
-		t.Fatalf("gemini setting = %q, want unchanged true", got)
+	if _, ok := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; ok {
+		t.Fatal("gemini setting still exists after delete")
 	}
 }

--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -278,17 +278,38 @@ func TestProviderProxyRoutesGeminiModelListToModelsHandler(t *testing.T) {
 }
 
 func TestProjectProxyHonorsDisabledProxyRouteExposure(t *testing.T) {
-	handler := NewProjectProxyHandler(nil, nil, &fakeProjectRepo{
-		project: &domain.Project{ID: 42, Name: "Demo", Slug: "demo"},
-	}, fakeProxyRouteExposureSettings{values: map[string]string{
-		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
-	}})
+	tests := []struct {
+		name       string
+		settingKey string
+		path       string
+	}{
+		{
+			name:       "claude",
+			settingKey: domain.SettingKeyProxyRouteClaudeMessagesEnabled,
+			path:       "/project/demo/v1/messages",
+		},
+		{
+			name:       "gemini",
+			settingKey: domain.SettingKeyProxyRouteGeminiEnabled,
+			path:       "/project/demo/v1beta/models/gemini-2.5-pro:generateContent",
+		},
+	}
 
-	rec := httptest.NewRecorder()
-	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/project/demo/v1/messages", nil))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewProjectProxyHandler(nil, nil, &fakeProjectRepo{
+				project: &domain.Project{ID: 42, Name: "Demo", Slug: "demo"},
+			}, fakeProxyRouteExposureSettings{values: map[string]string{
+				tt.settingKey: "false",
+			}})
 
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, tt.path, nil))
+
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+			}
+		})
 	}
 }
 

--- a/internal/handler/proxy_api_paths.go
+++ b/internal/handler/proxy_api_paths.go
@@ -91,5 +91,5 @@ func proxyRouteExposureEnabled(settings repository.SystemSettingRepository, path
 }
 
 func proxyRouteExposureEnabledByDefault(key string) bool {
-	return key != domain.SettingKeyProxyRouteGeminiEnabled
+	return true
 }

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -361,7 +361,7 @@ func (h *SelfServiceHandler) userPanelModelClientTypes() []domain.ClientType {
 	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteClaudeMessagesEnabled, true) {
 		clientTypes = append(clientTypes, domain.ClientTypeClaude)
 	}
-	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteGeminiEnabled, false) {
+	if h.proxyRouteSettingEnabled(domain.SettingKeyProxyRouteGeminiEnabled, true) {
 		clientTypes = append(clientTypes, domain.ClientTypeGemini)
 	}
 	return clientTypes

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3017,13 +3017,13 @@ func TestAdminHandler_UserPanelMemberUsageStatsFollowRegeneratedKeyHistory(t *te
 	}
 }
 
-func TestUserPanelModelClientTypesDefaultsIncludeCodex(t *testing.T) {
+func TestUserPanelModelClientTypesDefaultsIncludeGemini(t *testing.T) {
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
 		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{}},
 	})
 
 	got := handler.userPanelModelClientTypes()
-	want := []domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeClaude}
+	want := []domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeClaude, domain.ClientTypeGemini}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("client types = %v, want %v", got, want)
 	}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3029,6 +3029,20 @@ func TestUserPanelModelClientTypesDefaultsIncludeGemini(t *testing.T) {
 	}
 }
 
+func TestUserPanelModelClientTypesHonorsExplicitGeminiDisabled(t *testing.T) {
+	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
+		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{
+			domain.SettingKeyProxyRouteGeminiEnabled: "false",
+		}},
+	})
+
+	got := handler.userPanelModelClientTypes()
+	want := []domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeClaude}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("client types = %v, want %v", got, want)
+	}
+}
+
 func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
 	handler := newSelfServiceHandlerForTests(selfServiceTestDeps{
 		settingsRepo: &selfServiceSettingsRepo{values: map[string]string{

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1397,7 +1397,7 @@ func (s *AdminService) validatePublicProxyRouteExposureUpdate(key, value string)
 
 func publicProxyRouteSettingEnabled(key, value string) bool {
 	if value == "" {
-		return key != domain.SettingKeyProxyRouteGeminiEnabled
+		return true
 	}
 	return value != "false"
 }

--- a/internal/service/public_proxy_route_settings_test.go
+++ b/internal/service/public_proxy_route_settings_test.go
@@ -79,24 +79,23 @@ func TestUpdateSettingRejectsDisablingLastPublicProxyRoute(t *testing.T) {
 	}
 }
 
-func TestUpdateSettingTreatsUnsetGeminiAsDisabledByDefault(t *testing.T) {
+func TestUpdateSettingTreatsUnsetGeminiAsEnabledByDefault(t *testing.T) {
 	repo := &publicProxyRouteSettingRepo{values: map[string]string{
 		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
 		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
-		domain.SettingKeyProxyRouteResponsesEnabled:      "true",
+		domain.SettingKeyProxyRouteResponsesEnabled:      "false",
 	}}
 	svc := newPublicProxyRouteSettingsService(repo)
 
-	err := svc.UpdateSetting(domain.SettingKeyProxyRouteResponsesEnabled, "false")
-	if !errors.Is(err, domain.ErrInvalidInput) {
-		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	if err := svc.UpdateSetting(domain.SettingKeyProxyRouteResponsesEnabled, "false"); err != nil {
+		t.Fatalf("UpdateSetting returned error: %v", err)
 	}
-	if got := repo.values[domain.SettingKeyProxyRouteResponsesEnabled]; got != "true" {
-		t.Fatalf("responses setting = %q, want unchanged true", got)
+	if got := repo.values[domain.SettingKeyProxyRouteResponsesEnabled]; got != "false" {
+		t.Fatalf("responses setting = %q, want false", got)
 	}
 }
 
-func TestDeleteSettingRejectsDeletingExplicitLastEnabledGemini(t *testing.T) {
+func TestDeleteSettingResetsExplicitGeminiToDefaultEnabled(t *testing.T) {
 	repo := &publicProxyRouteSettingRepo{values: map[string]string{
 		domain.SettingKeyProxyRouteClaudeMessagesEnabled: "false",
 		domain.SettingKeyProxyRouteOpenAIChatEnabled:     "false",
@@ -105,12 +104,11 @@ func TestDeleteSettingRejectsDeletingExplicitLastEnabledGemini(t *testing.T) {
 	}}
 	svc := newPublicProxyRouteSettingsService(repo)
 
-	err := svc.DeleteSetting(domain.SettingKeyProxyRouteGeminiEnabled)
-	if !errors.Is(err, domain.ErrInvalidInput) {
-		t.Fatalf("error = %v, want ErrInvalidInput", err)
+	if err := svc.DeleteSetting(domain.SettingKeyProxyRouteGeminiEnabled); err != nil {
+		t.Fatalf("DeleteSetting returned error: %v", err)
 	}
-	if got := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; got != "true" {
-		t.Fatalf("gemini setting = %q, want unchanged true", got)
+	if _, ok := repo.values[domain.SettingKeyProxyRouteGeminiEnabled]; ok {
+		t.Fatal("gemini setting still exists after delete")
 	}
 }
 

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -617,13 +617,12 @@ func TestProxyCodexPassthrough(t *testing.T) {
 	}
 }
 
-func TestProxyGeminiPassthrough(t *testing.T) {
+func TestProxyGeminiPassthroughEnabledByDefault(t *testing.T) {
 	captured := &capturedRequest{}
 	mock := newMockGeminiUpstream(t, captured)
 	defer mock.Close()
 
 	env := NewProxyTestEnv(t)
-	enableGeminiPublicProxyRoute(t, env)
 	providerID := createProvider(t, env, "mock-gemini", mock.URL, []string{"gemini"})
 	createRoute(t, env, "gemini", providerID)
 

--- a/web/src/lib/proxy-route-exposure.test.ts
+++ b/web/src/lib/proxy-route-exposure.test.ts
@@ -15,13 +15,13 @@ describe('proxy route exposure visibility', () => {
       proxy_route_claude_messages_enabled: 'false',
       proxy_route_openai_chat_enabled: 'true',
       proxy_route_responses_enabled: 'false',
-      proxy_route_gemini_enabled: 'true',
+      proxy_route_gemini_enabled: 'false',
     };
 
     expect(isProxyRouteVisible(settings, 'claude')).toBe(false);
     expect(isProxyRouteVisible(settings, 'openai')).toBe(true);
     expect(isProxyRouteVisible(settings, 'codex')).toBe(false);
-    expect(isProxyRouteVisible(settings, 'gemini')).toBe(true);
+    expect(isProxyRouteVisible(settings, 'gemini')).toBe(false);
   });
 
   it('filters client lists with the same visibility rules', () => {

--- a/web/src/lib/proxy-route-exposure.test.ts
+++ b/web/src/lib/proxy-route-exposure.test.ts
@@ -7,7 +7,7 @@ describe('proxy route exposure visibility', () => {
     expect(isProxyRouteVisible(undefined, 'claude')).toBe(true);
     expect(isProxyRouteVisible(undefined, 'openai')).toBe(true);
     expect(isProxyRouteVisible(undefined, 'codex')).toBe(true);
-    expect(isProxyRouteVisible(undefined, 'gemini')).toBe(false);
+    expect(isProxyRouteVisible(undefined, 'gemini')).toBe(true);
   });
 
   it('hides only routes explicitly set to false', () => {

--- a/web/src/lib/proxy-route-exposure.ts
+++ b/web/src/lib/proxy-route-exposure.ts
@@ -13,7 +13,7 @@ export function isProxyRouteVisible(
 ): boolean {
   const settingValue = settings?.[proxyRouteExposureSettingKeys[clientType]];
   if (settingValue === undefined) {
-    return clientType !== 'gemini';
+    return true;
   }
   return settingValue !== 'false';
 }

--- a/web/src/lib/user-panel-endpoints.test.ts
+++ b/web/src/lib/user-panel-endpoints.test.ts
@@ -13,6 +13,10 @@ describe('user panel endpoints', () => {
       { id: 'openai', url: 'https://maxx.example.com/v1' },
       { id: 'codex', url: 'https://maxx.example.com/v1' },
       { id: 'claude', url: 'https://maxx.example.com' },
+      {
+        id: 'gemini',
+        url: 'https://maxx.example.com/v1beta/models/{model}:generateContent',
+      },
     ]);
   });
 
@@ -45,12 +49,12 @@ describe('user panel endpoints', () => {
     ]);
   });
 
-  it('hides OpenAI and Codex endpoints independently', () => {
+  it('hides OpenAI and Codex endpoints independently while leaving Gemini default-visible', () => {
     expect(
       buildUserPanelEndpointHints('https://maxx.example.com', {
         proxy_route_openai_chat_enabled: 'false',
         proxy_route_responses_enabled: 'false',
       }).map((endpoint) => endpoint.id),
-    ).toEqual(['claude']);
+    ).toEqual(['claude', 'gemini']);
   });
 });

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1487,7 +1487,7 @@
     "proxyRouteResponses": "Responses / Codex",
     "proxyRouteResponsesDesc": "Controls the Responses and Codex compatible entrypoints.",
     "proxyRouteGemini": "Gemini",
-    "proxyRouteGeminiDesc": "Controls the Google AI Studio style Gemini generation entrypoint. Disabled by default.",
+    "proxyRouteGeminiDesc": "Controls the Google AI Studio style Gemini generation entrypoint.",
     "proxyRouteExposureHint": "These toggles only affect public proxy entrypoints, not model list routes, image routes, or provider-specific URLs.",
     "autoSortSettings": "Auto-Sort Settings",
     "autoSortAntigravity": "Auto-Sort Antigravity",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1484,7 +1484,7 @@
     "proxyRouteResponses": "Responses / Codex",
     "proxyRouteResponsesDesc": "控制 Responses 与 Codex 兼容入口。",
     "proxyRouteGemini": "Gemini",
-    "proxyRouteGeminiDesc": "控制 Google AI Studio 风格的 Gemini 生成入口。默认关闭。",
+    "proxyRouteGeminiDesc": "控制 Google AI Studio 风格的 Gemini 生成入口。",
     "proxyRouteExposureHint": "这些开关只影响公开代理入口，不影响模型列表、图片接口或提供商专属 URL。",
     "autoSortSettings": "自动排序设置",
     "autoSortAntigravity": "自动排序 Antigravity",

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -117,7 +117,7 @@ const PROXY_ROUTE_EXPOSURE_SETTINGS: ProxyRouteExposureSetting[] = [
     titleKey: 'settings.proxyRouteGemini',
     descKey: 'settings.proxyRouteGeminiDesc',
     paths: ['/v1beta/models/*'],
-    defaultEnabled: false,
+    defaultEnabled: true,
   },
 ];
 


### PR DESCRIPTION
## Summary
- keep Gemini public proxy route visible/enabled when the setting is absent
- align backend route gates, provider/project proxy path exposure, user panel model/client hints, and settings UI defaults
- update unit and e2e coverage so only explicit `proxy_route_gemini_enabled=false` disables Gemini

## Tests
- `/usr/local/go/bin/go test ./internal/core ./internal/service ./internal/handler`
- `/usr/local/go/bin/go test ./tests/e2e -run 'Gemini|ProxyGemini|Cooldown_GeminiProtocol' -count=1`\n- `pnpm test -- src/lib/proxy-route-exposure.test.ts src/lib/user-panel-endpoints.test.ts src/pages/documentation/route-exposure.test.ts`\n- `pnpm run typecheck`\n\nNote: frontend commands warn because current Node is v24.16.0 while package.json expects >=22.12.0 <23; tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Gemini 代理路由现默认启用，无需额外配置即可使用。
  * Gemini 路由在用户面板和设置页面中默认可见。
  * 删除 Gemini 的显式配置后，将恢复为默认启用状态。

* **文案**
  * 更新中英文设置说明，移除“默认关闭”的描述。

* **测试**
  * 更新相关测试，覆盖默认启用、请求转发及配置重置场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->