### PR TITLE
Fix request cleanup state and searchable test providers

### DIFF
--- a/web/src/hooks/queries/use-requests.test.ts
+++ b/web/src/hooks/queries/use-requests.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { ProxyRequest } from '@/lib/transport';
-import { isProxyRequestError, mergeProxyRequestAttemptUpdate } from './use-requests';
+import {
+  isProxyRequestError,
+  mergeProxyRequestAttemptUpdate,
+  shouldRefetchCleanupFailedCount,
+} from './use-requests';
 
 const baseRequest = {
   id: 1,
@@ -57,6 +61,24 @@ describe('isProxyRequestError', () => {
     expect(isProxyRequestError(request('FAILED'))).toBe(true);
     expect(isProxyRequestError(request('REJECTED'))).toBe(true);
     expect(isProxyRequestError(request('COMPLETED', 503))).toBe(true);
+  });
+});
+
+describe('shouldRefetchCleanupFailedCount', () => {
+  it('refreshes cleanup counts when an error record appears', () => {
+    expect(shouldRefetchCleanupFailedCount(request('FAILED'))).toBe(true);
+    expect(shouldRefetchCleanupFailedCount(request('REJECTED'))).toBe(true);
+    expect(shouldRefetchCleanupFailedCount(request('COMPLETED', 503))).toBe(true);
+  });
+
+  it('refreshes cleanup counts when a request settles without an error', () => {
+    expect(shouldRefetchCleanupFailedCount(request('COMPLETED'))).toBe(true);
+    expect(shouldRefetchCleanupFailedCount(request('CANCELLED'))).toBe(true);
+  });
+
+  it('does not refetch cleanup counts for still-active non-error updates', () => {
+    expect(shouldRefetchCleanupFailedCount(request('PENDING'))).toBe(false);
+    expect(shouldRefetchCleanupFailedCount(request('IN_PROGRESS'))).toBe(false);
   });
 });
 

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -53,6 +53,12 @@ export function isProxyRequestError(request: ProxyRequest): boolean {
   return request.status === 'FAILED' || request.status === 'REJECTED' || request.statusCode >= 400;
 }
 
+export function shouldRefetchCleanupFailedCount(request: ProxyRequest): boolean {
+  return (
+    isProxyRequestError(request) || request.status === 'COMPLETED' || request.status === 'CANCELLED'
+  );
+}
+
 function matchesRequestTimeRange(
   request: ProxyRequest,
   startTime?: string,
@@ -250,6 +256,11 @@ export function useCleanupFailedProxyRequests() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: requestKeys.all });
       queryClient.invalidateQueries({ queryKey: ['requestsCount'] });
+      queryClient.invalidateQueries({ queryKey: requestKeys.cleanupFailedCounts() });
+      void queryClient.refetchQueries({
+        queryKey: requestKeys.cleanupFailedCounts(),
+        type: 'active',
+      });
     },
   });
 }
@@ -712,7 +723,7 @@ export function useProxyRequestUpdates() {
           invalidateProviderStats = true;
           invalidateCooldowns = true;
         }
-        if (isProxyRequestError(updatedRequest)) {
+        if (shouldRefetchCleanupFailedCount(updatedRequest)) {
           refetchCleanupFailedCount = true;
         }
       }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -213,6 +213,7 @@
       "description": "Manually add existing providers, then concurrently test model availability and latency with the same prompt. Tests only run after you click start.",
       "providerSelect": "Provider",
       "providerPlaceholder": "Select an existing provider",
+      "providerSearchEmpty": "No matching providers",
       "addProvider": "Add",
       "noSelectedProviders": "No providers added yet.",
       "unsupportedBadge": "Unsupported in v1",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -213,6 +213,7 @@
       "description": "手动添加已有提供商，按同一个问题并发测试模型可用性与响应时间。测试只会在点击开始后触发。",
       "providerSelect": "提供商",
       "providerPlaceholder": "选择已有提供商",
+      "providerSearchEmpty": "没有匹配的提供商",
       "addProvider": "新增",
       "noSelectedProviders": "尚未添加提供商。",
       "unsupportedBadge": "首版暂不支持",

--- a/web/src/pages/test-field/index.tsx
+++ b/web/src/pages/test-field/index.tsx
@@ -13,11 +13,6 @@ import {
   CardTitle,
   Input,
   Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Table,
   TableBody,
   TableCell,
@@ -25,6 +20,14 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui';
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '@/components/ui/combobox';
 import { Textarea } from '@/components/ui/textarea';
 import { useProviders } from '@/hooks/queries';
 import { getTransport, type Provider, type TestFieldModelBenchmarkResponse } from '@/lib/transport';
@@ -64,6 +67,7 @@ export function TestFieldPage() {
   const [providerToAdd, setProviderToAdd] = useState<string>(
     cachedBenchmarkState?.providerToAdd ?? '',
   );
+  const [providerSearch, setProviderSearch] = useState('');
   const [selectedProviderIDs, setSelectedProviderIDs] = useState<number[]>(
     cachedBenchmarkState?.selectedProviderIDs ?? [],
   );
@@ -93,6 +97,13 @@ export function TestFieldPage() {
   const availableProviders = providers.filter(
     (provider) => !selectedProviderIDs.includes(provider.id),
   );
+  const filteredAvailableProviders = useMemo(() => {
+    const query = providerSearch.trim().toLowerCase();
+    if (!query) return availableProviders;
+    return availableProviders.filter((provider) =>
+      providerLabel(provider).toLowerCase().includes(query),
+    );
+  }, [availableProviders, providerSearch]);
   const providerToAddLabel = providerToAdd
     ? providerLabel(
         providers.find((provider) => provider.id === Number(providerToAdd)) ??
@@ -134,6 +145,7 @@ export function TestFieldPage() {
     if (!id || selectedProviderIDs.includes(id)) return;
     setSelectedProviderIDs((ids) => [...ids, id]);
     setProviderToAdd('');
+    setProviderSearch('');
   };
 
   const removeProvider = (id: number) => {
@@ -200,22 +212,34 @@ export function TestFieldPage() {
               <div className="grid gap-3 md:grid-cols-[1fr_auto]">
                 <div className="space-y-2">
                   <Label>{t('testField.benchmark.providerSelect')}</Label>
-                  <Select
-                    value={providerToAdd}
+                  <Combobox
+                    value={providerToAdd || null}
                     onValueChange={(value) => setProviderToAdd(value ?? '')}
-                    disabled={isRunning}
+                    onInputValueChange={(value) => setProviderSearch(value)}
+                    itemToStringLabel={(value) =>
+                      providerLabel(
+                        providers.find((provider) => provider.id === Number(value)) ??
+                          ({ id: Number(value), name: `#${value}`, type: '-' } as Provider),
+                      )
+                    }
                   >
-                    <SelectTrigger>
-                      <SelectValue>{providerToAddLabel}</SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableProviders.map((provider) => (
-                        <SelectItem key={provider.id} value={String(provider.id)}>
-                          {providerLabel(provider)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                    <ComboboxInput
+                      className="w-full"
+                      disabled={isRunning}
+                      placeholder={providerToAddLabel}
+                      showClear
+                    />
+                    <ComboboxContent>
+                      <ComboboxEmpty>{t('testField.benchmark.providerSearchEmpty')}</ComboboxEmpty>
+                      <ComboboxList>
+                        {filteredAvailableProviders.map((provider) => (
+                          <ComboboxItem key={provider.id} value={String(provider.id)}>
+                            {providerLabel(provider)}
+                          </ComboboxItem>
+                        ))}
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
                 </div>
                 <Button
                   className="self-end"


### PR DESCRIPTION
## Summary
- refresh failed-request cleanup count after cleanup mutations and settled request updates so the cleanup button state catches up immediately
- replace the Test Field provider select with the existing searchable Combobox and filter by provider name/type/id
- add regression coverage for cleanup count refresh decisions and i18n copy for the provider search empty state

## Validation
- `pnpm exec prettier --write src/hooks/queries/use-requests.ts src/hooks/queries/use-requests.test.ts src/pages/test-field/index.tsx src/locales/zh.json src/locales/en.json`
- `pnpm vitest run src/hooks/queries/use-requests.test.ts`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- local Playwright user-flow script against Vite dev server: provider search filters/selects correctly; cleanup button is enabled before cleanup and disabled immediately after successful cleanup
- `git diff --check`
- `pnpm lint`

## Notes
- Browser-based local check used mocked API responses for the two affected UI flows; no production backend state was modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 测试字段中的供应商选择器支持搜索，可按名称快速筛选。
  - 无匹配结果时显示本地化提示；添加供应商后自动清空搜索内容。

- **问题修复**
  - 清理失败请求计数在请求失败、拒绝、完成或取消等状态变化后及时刷新。
  - 清理操作成功后主动更新相关计数，确保页面数据保持最新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->