### PR TITLE
fix: surface provider concurrency pre-dispatch failures

### DIFF
--- a/internal/executor/force_retry_setting_test.go
+++ b/internal/executor/force_retry_setting_test.go
@@ -172,6 +172,52 @@ func TestDispatchForceRetryUpstreamErrorsDoesNotOverrideCanceledContext(t *testi
 	}
 }
 
+func TestDispatchProviderConcurrencyLimitFailsBeforeUpstreamWithExplicit429(t *testing.T) {
+	adapter, proxyReq, c, e := newForceRetryDispatchHarness(
+		t,
+		false,
+		&forceRetrySequenceAdapter{},
+		&domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	)
+	e.router = router.NewRouter(nil, nil, nil, nil, nil)
+	storedState, ok := c.Get(flow.KeyExecutorState)
+	if !ok {
+		t.Fatal("executor state missing")
+	}
+	provider := storedState.(*execState).routes[0].Provider
+	provider.MaxConcurrency = 1
+	release, acquired := e.router.TryAcquireProvider(provider)
+	if !acquired {
+		t.Fatal("failed to acquire provider slot for test setup")
+	}
+	defer release()
+
+	e.dispatch(c)
+
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want 0", adapter.calls)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 0 {
+		t.Fatalf("attempt count = %d, want 0", proxyReq.ProxyUpstreamAttemptCount)
+	}
+	if proxyReq.Status != "FAILED" {
+		t.Fatalf("proxy request status = %q, want FAILED", proxyReq.Status)
+	}
+	if proxyReq.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status code = %d, want %d", proxyReq.StatusCode, http.StatusTooManyRequests)
+	}
+	if c.Err == nil || !errors.Is(c.Err, domain.ErrNoAvailableProviders) {
+		t.Fatalf("dispatch error = %v, want ErrNoAvailableProviders", c.Err)
+	}
+	var proxyErr *domain.ProxyError
+	if !errors.As(c.Err, &proxyErr) {
+		t.Fatalf("dispatch error type = %T, want ProxyError", c.Err)
+	}
+	if proxyErr.Reason != domain.CooldownReasonConcurrentLimit {
+		t.Fatalf("proxy error reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonConcurrentLimit)
+	}
+}
+
 func newForceRetryDispatchHarness(
 	t *testing.T,
 	forceRetry bool,

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -174,9 +174,11 @@ routeLoop:
 				var acquired bool
 				releaseProvider, acquired = e.router.TryAcquireProvider(matchedRoute.Provider)
 				if !acquired {
-					log.Printf("[Executor] Provider %d is at its concurrency limit; trying the next route", matchedRoute.Provider.ID)
-					proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached")
+					log.Printf("[Executor] Provider %d is at its concurrency limit before upstream dispatch; trying the next route", matchedRoute.Provider.ID)
+					proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, true, "provider concurrency limit reached before upstream dispatch")
 					proxyErr.Scope = domain.ScopeProvider
+					proxyErr.Reason = domain.CooldownReasonConcurrentLimit
+					proxyErr.HTTPStatusCode = http.StatusTooManyRequests
 					state.lastErr = proxyErr
 					continue routeLoop
 				}


### PR DESCRIPTION
## Summary
- surface provider concurrency-limit failures before upstream dispatch as explicit 429 errors
- mark the failure reason as `concurrent_limit` so request records no longer look like silent upstream drops
- add regression coverage that the adapter is not called and no upstream attempt is created when the local provider slot is already exhausted

## Tests
- `go test ./internal/executor`
- `go test ./internal/handler -run 'ProviderProxy|Proxy'`

## Notes
This does not send requests when the provider concurrency limiter is already full. It makes that local pre-dispatch stop explicit and observable instead of looking like the request disappeared before upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 当提供商并发容量已满时，请求会在访问上游服务前快速失败。
  * 返回 HTTP 429，并明确提示因并发限制暂时无法处理请求。
  * 改进失败状态和错误原因记录，提升问题诊断清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->