### PR TITLE
fix: ensure grok streams and image requests use compatible paths

### DIFF
--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -145,12 +145,41 @@ func (a *CLIProxyAPIGrokAdapter) Execute(c *flow.Ctx, p *domain.Provider) error 
 	}
 
 	sourceFormat := translator.FormatOpenAI
-	execReq := executor.Request{Model: model, Payload: requestBody, Format: sourceFormat}
-	execOpts := executor.Options{Stream: stream, OriginalRequest: requestBody, SourceFormat: sourceFormat}
+	metadata := requestMetadata(flow.GetRequestURI(c))
+	if isOpenAIImagesRequest(flow.GetRequestURI(c)) {
+		sourceFormat = translator.FromString("openai-image")
+	}
+	execReq := executor.Request{Model: model, Payload: requestBody, Format: sourceFormat, Metadata: metadata}
+	execOpts := executor.Options{Stream: stream, OriginalRequest: requestBody, SourceFormat: sourceFormat, Metadata: metadata}
 	if stream {
 		return a.executeStream(c, w, execReq, execOpts)
 	}
 	return a.executeNonStream(c, w, execReq, execOpts)
+}
+
+func requestMetadata(requestURI string) map[string]any {
+	path := requestPath(requestURI)
+	if path == "" {
+		return nil
+	}
+	return map[string]any{executor.RequestPathMetadataKey: path}
+}
+
+func requestPath(requestURI string) string {
+	path := strings.TrimSpace(requestURI)
+	if path == "" {
+		return ""
+	}
+	if i := strings.Index(path, "?"); i >= 0 {
+		path = path[:i]
+	}
+	return strings.TrimSpace(path)
+}
+
+func isOpenAIImagesRequest(requestURI string) bool {
+	path := requestPath(requestURI)
+	return path == "/v1/images" || path == "/images" ||
+		strings.HasPrefix(path, "/v1/images/") || strings.HasPrefix(path, "/images/")
 }
 
 func updateModelInBody(body []byte, model string) ([]byte, error) {

--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -214,6 +214,8 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 	eventChan := flow.GetEventChan(c)
 	var sseBuffer bytes.Buffer
 	firstChunkSent := false
+	sawFinishReason := false
+	sawDone := false
 	var streamErr error
 	for chunk := range stream.Chunks {
 		if chunk.Err != nil {
@@ -222,13 +224,27 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 		}
 		if len(chunk.Payload) > 0 {
 			sseBuffer.Write(chunk.Payload)
-			_, _ = w.Write(chunk.Payload)
+			out, chunkSawFinishReason, chunkSawDone := ensureOpenAIStreamFinishBeforeDone(chunk.Payload, execReq.Model, sawFinishReason)
+			if chunkSawFinishReason {
+				sawFinishReason = true
+			}
+			if chunkSawDone {
+				sawDone = true
+			}
+			_, _ = w.Write(out)
 			flusher.Flush()
 			if !firstChunkSent && eventChan != nil {
 				eventChan.SendFirstToken(time.Now().UnixMilli())
 				firstChunkSent = true
 			}
 		}
+	}
+	if streamErr == nil && !sawDone {
+		if !sawFinishReason {
+			_, _ = w.Write(openAIStreamFinishChunk(execReq.Model))
+		}
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		flusher.Flush()
 	}
 	if eventChan != nil && sseBuffer.Len() > 0 {
 		eventChan.SendResponseInfo(&domain.ResponseInfo{Status: http.StatusOK, Body: sseBuffer.String()})
@@ -246,6 +262,72 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 		return proxyErr
 	}
 	return nil
+}
+
+func ensureOpenAIStreamFinishBeforeDone(payload []byte, model string, alreadySawFinishReason bool) ([]byte, bool, bool) {
+	if len(payload) == 0 {
+		return payload, false, false
+	}
+	var out bytes.Buffer
+	sawFinishReason := false
+	sawDone := false
+	finishInserted := false
+	for _, line := range strings.SplitAfter(string(payload), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "data:") {
+			data := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+			if data == "[DONE]" {
+				sawDone = true
+				if !alreadySawFinishReason && !sawFinishReason && !finishInserted {
+					out.Write(openAIStreamFinishChunk(model))
+					finishInserted = true
+				}
+			} else if openAIChunkHasFinishReason([]byte(data)) {
+				sawFinishReason = true
+			}
+		}
+		out.WriteString(line)
+	}
+	if out.Len() == 0 {
+		return payload, sawFinishReason, sawDone
+	}
+	return out.Bytes(), sawFinishReason || finishInserted, sawDone
+}
+
+func openAIChunkHasFinishReason(data []byte) bool {
+	var root struct {
+		Choices []struct {
+			FinishReason *string `json:"finish_reason"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	for _, choice := range root.Choices {
+		if choice.FinishReason != nil && strings.TrimSpace(*choice.FinishReason) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIStreamFinishChunk(model string) []byte {
+	if strings.TrimSpace(model) == "" {
+		model = "grok"
+	}
+	payload := map[string]any{
+		"id":      "chatcmpl-grok-final",
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{},
+			"finish_reason": "stop",
+		}},
+	}
+	encoded, _ := json.Marshal(payload)
+	return []byte("data: " + string(encoded) + "\n\n")
 }
 
 func extractModelFromResponse(payload []byte) string {

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestNewAdapterAcceptsCPAExportedXAIOAuthJSONShape(t *testing.T) {
@@ -87,5 +88,24 @@ func TestEnsureOpenAIStreamFinishBeforeDoneDoesNotDuplicateFinishReason(t *testi
 	}
 	if count := strings.Count(body, `"finish_reason":"stop"`); count != 1 {
 		t.Fatalf("finish_reason stop count = %d, want 1; body=%s", count, body)
+	}
+}
+
+func TestGrokImagesRequestUsesOpenAIImageSourceFormat(t *testing.T) {
+	if !isOpenAIImagesRequest("/v1/images/generations") {
+		t.Fatalf("/v1/images/generations should be treated as an OpenAI Images request")
+	}
+	if !isOpenAIImagesRequest("/images/generations?source=test") {
+		t.Fatalf("/images/generations?source=test should be treated as an OpenAI Images request")
+	}
+	if isOpenAIImagesRequest("/v1/chat/completions") {
+		t.Fatalf("/v1/chat/completions must not be treated as an OpenAI Images request")
+	}
+}
+
+func TestGrokRequestMetadataCarriesRequestPath(t *testing.T) {
+	metadata := requestMetadata("/v1/images/generations?source=test")
+	if got := metadata[executor.RequestPathMetadataKey]; got != "/v1/images/generations" {
+		t.Fatalf("request_path metadata = %v, want /v1/images/generations", got)
 	}
 }

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -1,6 +1,7 @@
 package cliproxyapi_grok
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
@@ -52,5 +53,39 @@ func TestNewAdapterAcceptsCPAExportedXAIOAuthJSONShape(t *testing.T) {
 	}
 	if got := grok.authObj.Metadata["base_url"]; got != "https://cli-chat-proxy.grok.com/v1" {
 		t.Fatalf("base_url metadata = %v", got)
+	}
+}
+
+func TestEnsureOpenAIStreamFinishBeforeDoneInsertsFinishReason(t *testing.T) {
+	input := []byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"model\":\"grok-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n")
+
+	out, sawFinishReason, sawDone := ensureOpenAIStreamFinishBeforeDone(input, "grok-test", false)
+	body := string(out)
+	if !sawFinishReason {
+		t.Fatalf("sawFinishReason = false, want true; body=%s", body)
+	}
+	if !sawDone {
+		t.Fatalf("sawDone = false, want true; body=%s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Fatalf("stream body missing terminal finish_reason stop: %s", body)
+	}
+	finishIdx := strings.Index(body, `"finish_reason":"stop"`)
+	doneIdx := strings.Index(body, "data: [DONE]")
+	if finishIdx < 0 || doneIdx < 0 || finishIdx > doneIdx {
+		t.Fatalf("finish_reason must be emitted before [DONE]; body=%s", body)
+	}
+}
+
+func TestEnsureOpenAIStreamFinishBeforeDoneDoesNotDuplicateFinishReason(t *testing.T) {
+	input := []byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"model\":\"grok-test\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+
+	out, sawFinishReason, sawDone := ensureOpenAIStreamFinishBeforeDone(input, "grok-test", false)
+	body := string(out)
+	if !sawFinishReason || !sawDone {
+		t.Fatalf("sawFinishReason=%v sawDone=%v body=%s", sawFinishReason, sawDone, body)
+	}
+	if count := strings.Count(body, `"finish_reason":"stop"`); count != 1 {
+		t.Fatalf("finish_reason stop count = %d, want 1; body=%s", count, body)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure Grok streaming responses emit an OpenAI-compatible terminal chunk with `finish_reason` before `[DONE]`
- route Grok OpenAI Images requests through CLIProxyAPI's `openai-image` xAI handler by preserving the inbound image request path metadata
- add regression coverage for missing finish reasons, duplicate finish avoidance, and Grok image request path detection

## Verification
- `go test ./internal/adapter/provider/cliproxyapi_grok`
- `go test ./internal/adapter/client ./internal/handler ./internal/adapter/provider/cliproxyapi_grok ./tests/e2e -run 'Grok|Image|Images|Proxy|Client|OpenAI'`
- Earlier on this PR before the image-routing follow-up: `cd web && npm run build`
- Earlier on this PR before the image-routing follow-up: `go test . ./internal/adapter/provider/cliproxyapi_grok ./internal/executor ./internal/handler ./tests/e2e -run 'Grok|OpenAI|Provider|Proxy|Stream|Image|Chat'`

## Notes
- An initial `go test ./...` before building `web/dist` failed with `main.go:26:12: pattern all:web/dist: no matching files found`; after building the frontend, the root-package targeted verification passed.
- This PR does not include generated `web/dist` artifacts.