### PR TITLE
fix: handle split grok stream terminators

### DIFF
--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -245,6 +245,7 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 	firstChunkSent := false
 	sawFinishReason := false
 	sawDone := false
+	var pendingSSE string
 	var streamErr error
 	for chunk := range stream.Chunks {
 		if chunk.Err != nil {
@@ -253,7 +254,8 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 		}
 		if len(chunk.Payload) > 0 {
 			sseBuffer.Write(chunk.Payload)
-			out, chunkSawFinishReason, chunkSawDone := ensureOpenAIStreamFinishBeforeDone(chunk.Payload, execReq.Model, sawFinishReason)
+			out, rest, chunkSawFinishReason, chunkSawDone := ensureOpenAIStreamFinishBeforeDoneWithPending(pendingSSE, chunk.Payload, execReq.Model, sawFinishReason)
+			pendingSSE = rest
 			if chunkSawFinishReason {
 				sawFinishReason = true
 			}
@@ -268,11 +270,23 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 			}
 		}
 	}
-	if streamErr == nil && !sawDone {
-		if !sawFinishReason {
-			_, _ = w.Write(openAIStreamFinishChunk(execReq.Model))
+	if streamErr == nil {
+		if pendingSSE != "" {
+			out, _, pendingSawFinishReason, pendingSawDone := ensureOpenAIStreamFinishBeforeDoneWithPending("", []byte(pendingSSE), execReq.Model, sawFinishReason)
+			if pendingSawFinishReason {
+				sawFinishReason = true
+			}
+			if pendingSawDone {
+				sawDone = true
+			}
+			_, _ = w.Write(out)
 		}
-		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		if !sawDone {
+			if !sawFinishReason {
+				_, _ = w.Write(openAIStreamFinishChunk(execReq.Model))
+			}
+			_, _ = w.Write([]byte("data: [DONE]\n\n"))
+		}
 		flusher.Flush()
 	}
 	if eventChan != nil && sseBuffer.Len() > 0 {
@@ -294,14 +308,26 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 }
 
 func ensureOpenAIStreamFinishBeforeDone(payload []byte, model string, alreadySawFinishReason bool) ([]byte, bool, bool) {
-	if len(payload) == 0 {
-		return payload, false, false
+	out, _, sawFinishReason, sawDone := ensureOpenAIStreamFinishBeforeDoneWithPending("", payload, model, alreadySawFinishReason)
+	return out, sawFinishReason, sawDone
+}
+
+func ensureOpenAIStreamFinishBeforeDoneWithPending(pending string, payload []byte, model string, alreadySawFinishReason bool) ([]byte, string, bool, bool) {
+	if pending == "" && len(payload) == 0 {
+		return payload, "", false, false
 	}
+	combined := pending + string(payload)
 	var out bytes.Buffer
 	sawFinishReason := false
 	sawDone := false
 	finishInserted := false
-	for _, line := range strings.SplitAfter(string(payload), "\n") {
+	for len(combined) > 0 {
+		idx := strings.IndexByte(combined, '\n')
+		if idx < 0 {
+			return out.Bytes(), combined, sawFinishReason || finishInserted, sawDone
+		}
+		line := combined[:idx+1]
+		combined = combined[idx+1:]
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "data:") {
 			data := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
@@ -317,10 +343,7 @@ func ensureOpenAIStreamFinishBeforeDone(payload []byte, model string, alreadySaw
 		}
 		out.WriteString(line)
 	}
-	if out.Len() == 0 {
-		return payload, sawFinishReason, sawDone
-	}
-	return out.Bytes(), sawFinishReason || finishInserted, sawDone
+	return out.Bytes(), "", sawFinishReason || finishInserted, sawDone
 }
 
 func openAIChunkHasFinishReason(data []byte) bool {

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -78,6 +78,33 @@ func TestEnsureOpenAIStreamFinishBeforeDoneInsertsFinishReason(t *testing.T) {
 	}
 }
 
+func TestEnsureOpenAIStreamFinishBeforeDoneHandlesDoneSplitAcrossChunks(t *testing.T) {
+	first := []byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"model\":\"grok-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\ndata: [")
+	second := []byte("DONE]\n\n")
+
+	out1, pending, sawFinishReason, sawDone := ensureOpenAIStreamFinishBeforeDoneWithPending("", first, "grok-test", false)
+	out2, pending, chunkSawFinishReason, chunkSawDone := ensureOpenAIStreamFinishBeforeDoneWithPending(pending, second, "grok-test", sawFinishReason)
+	if chunkSawFinishReason {
+		sawFinishReason = true
+	}
+	if chunkSawDone {
+		sawDone = true
+	}
+	body := string(append(out1, out2...))
+	if pending != "" {
+		t.Fatalf("pending = %q, want empty; body=%s", pending, body)
+	}
+	if !sawDone {
+		t.Fatalf("sawDone = false, want true; body=%s", body)
+	}
+	if !sawFinishReason {
+		t.Fatalf("sawFinishReason = false, want true; body=%s", body)
+	}
+	if !strings.Contains(body, `"finish_reason":"stop"`) {
+		t.Fatalf("split [DONE] stream missing terminal finish_reason stop: %s", body)
+	}
+}
+
 func TestEnsureOpenAIStreamFinishBeforeDoneDoesNotDuplicateFinishReason(t *testing.T) {
 	input := []byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"model\":\"grok-test\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
 


### PR DESCRIPTION
## Summary
- buffer Grok SSE stream lines across SDK/network chunks before inspecting `data:` frames
- ensure a terminal OpenAI `finish_reason` chunk is inserted before `[DONE]` even when `[DONE]` is split across payload chunks
- add regression coverage for split `[DONE]` chunk boundaries

## Verification
- `go test ./internal/adapter/provider/cliproxyapi_grok ./internal/adapter/client ./internal/handler ./tests/e2e -run 'Grok|Images|Image|OpenAI|Proxy|Stream|Chat' -count=1`
- `go test ./...`

## Live check note
A live Grok OAuth stream attempt with the provided config did not reach streaming because upstream returned `personal-team-blocked:spending-limit`; no token values are included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化流式响应处理，正确解析跨数据块拆分的内容。
  - 改善流结束标记、完成状态及结束原因的处理，避免响应丢失或重复。
- **测试**
  - 增加对分段流结束标记的覆盖，验证响应能够完整结束并正确记录停止原因。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->