### PR TITLE
fix: pass through grok stream chunks promptly

### DIFF
--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -324,7 +324,24 @@ func ensureOpenAIStreamFinishBeforeDoneWithPending(pending string, payload []byt
 	for len(combined) > 0 {
 		idx := strings.IndexByte(combined, '\n')
 		if idx < 0 {
-			return out.Bytes(), combined, sawFinishReason || finishInserted, sawDone
+			trimmed := strings.TrimSpace(combined)
+			if isPotentialOpenAIDoneLinePrefix(trimmed) {
+				return out.Bytes(), combined, sawFinishReason || finishInserted, sawDone
+			}
+			if strings.HasPrefix(trimmed, "data:") {
+				data := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+				if data == "[DONE]" {
+					sawDone = true
+					if !alreadySawFinishReason && !sawFinishReason && !finishInserted {
+						out.Write(openAIStreamFinishChunk(model))
+						finishInserted = true
+					}
+				} else if openAIChunkHasFinishReason([]byte(data)) {
+					sawFinishReason = true
+				}
+			}
+			out.WriteString(combined)
+			return out.Bytes(), "", sawFinishReason || finishInserted, sawDone
 		}
 		line := combined[:idx+1]
 		combined = combined[idx+1:]
@@ -344,6 +361,17 @@ func ensureOpenAIStreamFinishBeforeDoneWithPending(pending string, payload []byt
 		out.WriteString(line)
 	}
 	return out.Bytes(), "", sawFinishReason || finishInserted, sawDone
+}
+
+func isPotentialOpenAIDoneLinePrefix(line string) bool {
+	if !strings.HasPrefix(line, "data:") {
+		return false
+	}
+	data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+	if data == "" {
+		return true
+	}
+	return strings.HasPrefix("[DONE]", data)
 }
 
 func openAIChunkHasFinishReason(data []byte) bool {

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -78,6 +78,20 @@ func TestEnsureOpenAIStreamFinishBeforeDoneInsertsFinishReason(t *testing.T) {
 	}
 }
 
+func TestEnsureOpenAIStreamFinishBeforeDonePassesThroughChunkWithoutNewline(t *testing.T) {
+	input := []byte(`data: {"id":"chunk-1","object":"chat.completion.chunk","model":"grok-test","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}`)
+	out, pending, sawFinishReason, sawDone := ensureOpenAIStreamFinishBeforeDoneWithPending("", input, "grok-test", false)
+	if pending != "" {
+		t.Fatalf("pending = %q, want empty", pending)
+	}
+	if sawFinishReason || sawDone {
+		t.Fatalf("sawFinishReason=%v sawDone=%v, want false/false", sawFinishReason, sawDone)
+	}
+	if string(out) != string(input) {
+		t.Fatalf("output changed: got %q want %q", string(out), string(input))
+	}
+}
+
 func TestEnsureOpenAIStreamFinishBeforeDoneHandlesDoneSplitAcrossChunks(t *testing.T) {
 	first := []byte("data: {\"id\":\"chunk-1\",\"object\":\"chat.completion.chunk\",\"model\":\"grok-test\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":null}]}\n\ndata: [")
 	second := []byte("DONE]\n\n")


### PR DESCRIPTION
## Summary
- avoid buffering normal Grok SSE chunks that do not end with a newline
- only hold incomplete lines that are plausible split `[DONE]` terminators
- preserve prompt token delivery while still inserting a terminal OpenAI `finish_reason` chunk before split `[DONE]`

## Verification
- `go test ./internal/adapter/provider/cliproxyapi_grok ./internal/adapter/client ./internal/handler ./tests/e2e -run 'Grok|Images|Image|OpenAI|Proxy|Stream|Chat' -count=1`
- `go test ./...`
