### PR TITLE
test: cover grok openai client stream visibility

### DIFF
--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -23,7 +23,12 @@ import (
 type CLIProxyAPIGrokAdapter struct {
 	provider *domain.Provider
 	authObj  *auth.Auth
-	executor *exec.XAIExecutor
+	executor grokExecutor
+}
+
+type grokExecutor interface {
+	Execute(context.Context, *auth.Auth, executor.Request, executor.Options) (executor.Response, error)
+	ExecuteStream(context.Context, *auth.Auth, executor.Request, executor.Options) (*executor.StreamResult, error)
 }
 
 func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {

--- a/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter_test.go
@@ -1,12 +1,39 @@
 package cliproxyapi_grok
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
+
+type fakeGrokExecutor struct {
+	chunks        []executor.StreamChunk
+	requests      []executor.Request
+	streamOptions []executor.Options
+}
+
+func (f *fakeGrokExecutor) Execute(context.Context, *auth.Auth, executor.Request, executor.Options) (executor.Response, error) {
+	return executor.Response{}, errors.New("unexpected non-stream execution")
+}
+
+func (f *fakeGrokExecutor) ExecuteStream(_ context.Context, _ *auth.Auth, req executor.Request, opts executor.Options) (*executor.StreamResult, error) {
+	f.requests = append(f.requests, req)
+	f.streamOptions = append(f.streamOptions, opts)
+	ch := make(chan executor.StreamChunk, len(f.chunks))
+	for _, chunk := range f.chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return &executor.StreamResult{Chunks: ch}, nil
+}
 
 func TestNewAdapterAcceptsCPAExportedXAIOAuthJSONShape(t *testing.T) {
 	provider := &domain.Provider{
@@ -129,6 +156,127 @@ func TestEnsureOpenAIStreamFinishBeforeDoneDoesNotDuplicateFinishReason(t *testi
 	}
 	if count := strings.Count(body, `"finish_reason":"stop"`); count != 1 {
 		t.Fatalf("finish_reason stop count = %d, want 1; body=%s", count, body)
+	}
+}
+
+func TestExecuteStreamReturnsClientVisibleGrokContentAndFinishReason(t *testing.T) {
+	provider := &domain.Provider{
+		ID:   42,
+		Type: "grok",
+		Name: "Grok Test",
+		Config: &domain.ProviderConfig{Grok: &domain.ProviderConfigGrok{
+			Type:         "xai",
+			AuthKind:     "oauth",
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+		}},
+	}
+	adapter, err := NewAdapter(provider)
+	if err != nil {
+		t.Fatalf("NewAdapter() error = %v", err)
+	}
+	grok := adapter.(*CLIProxyAPIGrokAdapter)
+	fakeExec := &fakeGrokExecutor{chunks: []executor.StreamChunk{
+		{Payload: []byte(`data: {"id":"chunk-1","object":"chat.completion.chunk","model":"grok-test","choices":[{"index":0,"delta":{"content":"hel"},"finish_reason":null}]}`)},
+		{Payload: []byte(`data: {"id":"chunk-2","object":"chat.completion.chunk","model":"grok-test","choices":[{"index":0,"delta":{"content":"lo"},"finish_reason":null}]}` + "\n\n")},
+		{Payload: []byte("data: [")},
+		{Payload: []byte("DONE]\n\n")},
+	}}
+	grok.executor = fakeExec
+
+	body := []byte(`{"model":"grok-test","stream":true,"messages":[{"role":"user","content":"say hello"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	c.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+	c.Set(flow.KeyRequestBody, body)
+	c.Set(flow.KeyRequestModel, "grok-test")
+	c.Set(flow.KeyMappedModel, "grok-test")
+	c.Set(flow.KeyIsStream, true)
+	c.Set(flow.KeyRequestURI, "/v1/chat/completions")
+
+	if err := grok.Execute(c, provider); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	got := rec.Body.String()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, got)
+	}
+	contentIdx := strings.Index(got, `"content":"hel"`)
+	finishIdx := strings.Index(got, `"finish_reason":"stop"`)
+	doneIdx := strings.Index(got, "data: [DONE]")
+	if contentIdx < 0 {
+		t.Fatalf("client-visible content missing: %s", got)
+	}
+	if finishIdx < 0 || doneIdx < 0 || !(contentIdx < finishIdx && finishIdx < doneIdx) {
+		t.Fatalf("want content before finish_reason before [DONE]; body=%s", got)
+	}
+	if len(fakeExec.requests) != 1 || fakeExec.requests[0].Model != "grok-test" {
+		t.Fatalf("executor request model = %#v, want grok-test", fakeExec.requests)
+	}
+}
+
+func TestExecuteStreamReturnsClientVisibleContentForRepresentativeGrokModels(t *testing.T) {
+	models := []string{
+		"grok-3",
+		"grok-3-mini",
+		"grok-3-mini-fast",
+		"grok-4",
+		"grok-4.1",
+		"grok-4.3",
+		"grok-4.5",
+		"grok-latest",
+	}
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			provider := &domain.Provider{
+				ID:   42,
+				Type: "grok",
+				Name: "Grok Test",
+				Config: &domain.ProviderConfig{Grok: &domain.ProviderConfigGrok{
+					Type:         "xai",
+					AuthKind:     "oauth",
+					AccessToken:  "access-token",
+					RefreshToken: "refresh-token",
+				}},
+			}
+			adapter, err := NewAdapter(provider)
+			if err != nil {
+				t.Fatalf("NewAdapter() error = %v", err)
+			}
+			grok := adapter.(*CLIProxyAPIGrokAdapter)
+			fakeExec := &fakeGrokExecutor{chunks: []executor.StreamChunk{
+				{Payload: []byte(`data: {"id":"chunk-1","object":"chat.completion.chunk","model":"` + model + `","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`)},
+				{Payload: []byte("data: [")},
+				{Payload: []byte("DONE]\n\n")},
+			}}
+			grok.executor = fakeExec
+
+			body := []byte(`{"model":"` + model + `","stream":true,"messages":[{"role":"user","content":"say ok"}]}`)
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+			rec := httptest.NewRecorder()
+			c := flow.NewCtx(rec, req)
+			c.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+			c.Set(flow.KeyRequestBody, body)
+			c.Set(flow.KeyRequestModel, model)
+			c.Set(flow.KeyMappedModel, model)
+			c.Set(flow.KeyIsStream, true)
+			c.Set(flow.KeyRequestURI, "/v1/chat/completions")
+
+			if err := grok.Execute(c, provider); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			got := rec.Body.String()
+			if !strings.Contains(got, `"content":"ok"`) {
+				t.Fatalf("client-visible content missing: %s", got)
+			}
+			if !strings.Contains(got, `"finish_reason":"stop"`) || !strings.Contains(got, "data: [DONE]") {
+				t.Fatalf("client-visible stream missing finish terminator: %s", got)
+			}
+			if len(fakeExec.requests) != 1 || fakeExec.requests[0].Model != model {
+				t.Fatalf("executor request model = %#v, want %s", fakeExec.requests, model)
+			}
+		})
 	}
 }
 

--- a/internal/handler/test_field_model_benchmark.go
+++ b/internal/handler/test_field_model_benchmark.go
@@ -719,8 +719,25 @@ func testFieldProviderCacheKey(provider *domain.Provider) string {
 	if provider == nil {
 		return "nil"
 	}
-	endpoint, apiKey, _, _ := testFieldOpenAICompatibleEndpoint(provider, "")
-	return hashStrings(strconv.FormatUint(provider.ID, 10), provider.Type, endpoint, apiKey)
+	parts := []string{strconv.FormatUint(provider.ID, 10), provider.Type}
+	if provider.Config == nil {
+		return hashStrings(parts...)
+	}
+	switch strings.ToLower(strings.TrimSpace(provider.Type)) {
+	case "custom", "newapi":
+		if provider.Config.Custom != nil {
+			parts = append(parts, customRuntimeModelsBaseURL(provider.Config.Custom), provider.Config.Custom.APIKey)
+		}
+	case "openrouter":
+		if provider.Config.OpenRouter != nil {
+			parts = append(parts, provider.Config.OpenRouter.APIKey)
+		}
+	case "grok":
+		if provider.Config.Grok != nil {
+			parts = append(parts, provider.Config.Grok.Type, provider.Config.Grok.AuthKind, provider.Config.Grok.AccessToken, provider.Config.Grok.RefreshToken)
+		}
+	}
+	return hashStrings(parts...)
 }
 
 func testFieldResultCacheKey(target testFieldBenchmarkTarget, prompt string, timeout time.Duration) string {

--- a/internal/handler/test_field_model_benchmark.go
+++ b/internal/handler/test_field_model_benchmark.go
@@ -113,6 +113,7 @@ type testFieldResultCacheEntry struct {
 
 type testFieldBenchmarkJob struct {
 	id                   string
+	baseURL              string
 	tenantID             uint64
 	request              TestFieldModelBenchmarkRequest
 	status               string
@@ -161,7 +162,7 @@ func (h *AdminHandler) handleTestField(w http.ResponseWriter, r *http.Request, p
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		resp, err := h.runTestFieldModelBenchmark(r.Context(), maxxctx.GetTenantID(r.Context()), req)
+		resp, err := h.runTestFieldModelBenchmark(r.Context(), maxxctx.GetTenantID(r.Context()), req, testFieldRequestBaseURL(r))
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -187,7 +188,7 @@ func (h *AdminHandler) handleTestFieldModelBenchmarkJobs(w http.ResponseWriter, 
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		job, err := h.startTestFieldModelBenchmarkJob(tenantID, req)
+		job, err := h.startTestFieldModelBenchmarkJob(tenantID, req, testFieldRequestBaseURL(r))
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -217,7 +218,7 @@ func (h *AdminHandler) handleTestFieldModelBenchmarkJobs(w http.ResponseWriter, 
 	}
 }
 
-func (h *AdminHandler) startTestFieldModelBenchmarkJob(tenantID uint64, req TestFieldModelBenchmarkRequest) (*testFieldBenchmarkJob, error) {
+func (h *AdminHandler) startTestFieldModelBenchmarkJob(tenantID uint64, req TestFieldModelBenchmarkRequest, baseURL string) (*testFieldBenchmarkJob, error) {
 	prompt, concurrency, timeout, minModels, err := normalizeTestFieldBenchmarkRequest(req)
 	if err != nil {
 		return nil, err
@@ -225,6 +226,7 @@ func (h *AdminHandler) startTestFieldModelBenchmarkJob(tenantID uint64, req Test
 	ctx, cancel := context.WithCancel(context.Background())
 	job := &testFieldBenchmarkJob{
 		id:                   nextTestFieldBenchmarkJobID(),
+		baseURL:              strings.TrimRight(baseURL, "/"),
 		tenantID:             tenantID,
 		request:              req,
 		status:               "running",
@@ -240,13 +242,13 @@ func (h *AdminHandler) startTestFieldModelBenchmarkJob(tenantID uint64, req Test
 	return job, nil
 }
 
-func (h *AdminHandler) runTestFieldModelBenchmark(ctx context.Context, tenantID uint64, req TestFieldModelBenchmarkRequest) (*TestFieldModelBenchmarkResponse, error) {
+func (h *AdminHandler) runTestFieldModelBenchmark(ctx context.Context, tenantID uint64, req TestFieldModelBenchmarkRequest, baseURL string) (*TestFieldModelBenchmarkResponse, error) {
 	prompt, concurrency, timeout, minModels, err := normalizeTestFieldBenchmarkRequest(req)
 	if err != nil {
 		return nil, err
 	}
 	started := time.Now()
-	providers, targets := h.buildTestFieldBenchmarkTargets(ctx, tenantID, req, minModels)
+	providers, targets := h.buildTestFieldBenchmarkTargets(ctx, tenantID, req, minModels, baseURL)
 	results, cachedCount := runTestFieldBenchmarkTargets(ctx, targets, prompt, concurrency, timeout, nil)
 	results = sortTestFieldBenchmarkResults(results)
 	finished := time.Now()
@@ -299,7 +301,7 @@ func normalizeTestFieldBenchmarkRequest(req TestFieldModelBenchmarkRequest) (str
 }
 
 func (h *AdminHandler) runTestFieldModelBenchmarkJob(ctx context.Context, job *testFieldBenchmarkJob) {
-	providers, targets := h.buildTestFieldBenchmarkTargets(ctx, job.tenantID, job.request, job.minModelsPerProvider)
+	providers, targets := h.buildTestFieldBenchmarkTargets(ctx, job.tenantID, job.request, job.minModelsPerProvider, job.baseURL)
 	job.mu.Lock()
 	job.providers = providers
 	job.totalTargets = len(targets)
@@ -329,7 +331,7 @@ func (h *AdminHandler) runTestFieldModelBenchmarkJob(ctx context.Context, job *t
 	}
 }
 
-func (h *AdminHandler) buildTestFieldBenchmarkTargets(ctx context.Context, tenantID uint64, req TestFieldModelBenchmarkRequest, minModels int) ([]TestFieldModelBenchmarkProviderSummary, []testFieldBenchmarkTarget) {
+func (h *AdminHandler) buildTestFieldBenchmarkTargets(ctx context.Context, tenantID uint64, req TestFieldModelBenchmarkRequest, minModels int, baseURL string) ([]TestFieldModelBenchmarkProviderSummary, []testFieldBenchmarkTarget) {
 	providerSummaries := make([]TestFieldModelBenchmarkProviderSummary, 0, len(req.ProviderIDs))
 	targets := make([]testFieldBenchmarkTarget, 0)
 	for _, providerID := range uniqueUint64s(req.ProviderIDs) {
@@ -339,13 +341,17 @@ func (h *AdminHandler) buildTestFieldBenchmarkTargets(ctx context.Context, tenan
 			continue
 		}
 		summary := TestFieldModelBenchmarkProviderSummary{ProviderID: provider.ID, ProviderName: provider.Name, ProviderType: provider.Type}
-		endpoint, apiKey, ok, errText := testFieldOpenAICompatibleEndpoint(provider)
+		endpoint, apiKey, ok, errText := testFieldOpenAICompatibleEndpoint(provider, baseURL)
 		if !ok {
 			summary.Error = errText
 			providerSummaries = append(providerSummaries, summary)
 			continue
 		}
 		modelsResult, cachedModels := h.fetchTestFieldRuntimeModels(ctx, provider, reuseBool(req.ReuseCachedModelLists, true))
+		if (!modelsResult.Available || len(modelsResult.Models) == 0) && strings.EqualFold(strings.TrimSpace(provider.Type), "grok") {
+			modelsResult = providerRuntimeModelsResult{Available: true, Models: defaultTestFieldGrokModels()}
+			cachedModels = false
+		}
 		if !modelsResult.Available || len(modelsResult.Models) == 0 {
 			summary.Error = strings.TrimSpace(modelsResult.Error)
 			if summary.Error == "" {
@@ -391,6 +397,47 @@ func (h *AdminHandler) fetchTestFieldRuntimeModels(ctx context.Context, provider
 	}
 	testFieldBenchmarks.Unlock()
 	return modelsResult, false
+}
+
+func testFieldRequestBaseURL(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto"))
+	if proto == "" {
+		if r.TLS != nil {
+			proto = "https"
+		} else {
+			proto = "http"
+		}
+	}
+	if idx := strings.Index(proto, ","); idx >= 0 {
+		proto = strings.TrimSpace(proto[:idx])
+	}
+	host := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if host == "" {
+		host = strings.TrimSpace(r.Host)
+	}
+	if idx := strings.Index(host, ","); idx >= 0 {
+		host = strings.TrimSpace(host[:idx])
+	}
+	if proto == "" || host == "" {
+		return ""
+	}
+	return proto + "://" + host
+}
+
+func defaultTestFieldGrokModels() []string {
+	return []string{
+		"grok-3",
+		"grok-3-mini",
+		"grok-3-mini-fast",
+		"grok-4",
+		"grok-4.1",
+		"grok-4.3",
+		"grok-4.5",
+		"grok-latest",
+	}
 }
 
 func runTestFieldBenchmarkTargets(ctx context.Context, targets []testFieldBenchmarkTarget, prompt string, concurrency int, timeout time.Duration, onResult func(TestFieldModelBenchmarkResult, bool)) ([]TestFieldModelBenchmarkResult, int) {
@@ -461,7 +508,7 @@ func callTestFieldOpenAIChatBenchmarkWithCache(ctx context.Context, target testF
 	return result, false
 }
 
-func testFieldOpenAICompatibleEndpoint(provider *domain.Provider) (endpoint string, apiKey string, ok bool, errText string) {
+func testFieldOpenAICompatibleEndpoint(provider *domain.Provider, baseURL string) (endpoint string, apiKey string, ok bool, errText string) {
 	if provider == nil || provider.Config == nil {
 		return "", "", false, "provider config unavailable"
 	}
@@ -480,6 +527,15 @@ func testFieldOpenAICompatibleEndpoint(provider *domain.Provider) (endpoint stri
 			return "", "", false, "openrouter api key unavailable"
 		}
 		return "https://openrouter.ai/api/v1/chat/completions", provider.Config.OpenRouter.APIKey, true, ""
+	case "grok":
+		if provider.Config.Grok == nil {
+			return "", "", false, "grok provider config unavailable"
+		}
+		baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+		if baseURL == "" {
+			return "", "", false, "test field base url unavailable for grok provider proxy"
+		}
+		return fmt.Sprintf("%s/provider/%d/v1/chat/completions", baseURL, provider.ID), "", true, ""
 	default:
 		return "", "", false, "test field benchmark currently supports OpenAI-compatible providers only"
 	}
@@ -663,7 +719,7 @@ func testFieldProviderCacheKey(provider *domain.Provider) string {
 	if provider == nil {
 		return "nil"
 	}
-	endpoint, apiKey, _, _ := testFieldOpenAICompatibleEndpoint(provider)
+	endpoint, apiKey, _, _ := testFieldOpenAICompatibleEndpoint(provider, "")
 	return hashStrings(strconv.FormatUint(provider.ID, 10), provider.Type, endpoint, apiKey)
 }
 

--- a/internal/handler/test_field_model_benchmark_test.go
+++ b/internal/handler/test_field_model_benchmark_test.go
@@ -109,8 +109,27 @@ func TestRunTestFieldBenchmarkTargetsReportsIncrementalCachedResults(t *testing.
 }
 
 func TestTestFieldOpenAICompatibleEndpointRejectsUnsupportedProvider(t *testing.T) {
-	_, _, ok, errText := testFieldOpenAICompatibleEndpoint(&domain.Provider{Type: "claude", Config: &domain.ProviderConfig{}})
+	_, _, ok, errText := testFieldOpenAICompatibleEndpoint(&domain.Provider{Type: "claude", Config: &domain.ProviderConfig{}}, "http://maxx.test")
 	if ok || errText == "" {
 		t.Fatalf("expected unsupported provider rejection, ok=%v err=%q", ok, errText)
+	}
+}
+
+func TestTestFieldOpenAICompatibleEndpointSupportsGrokProviderProxy(t *testing.T) {
+	endpoint, apiKey, ok, errText := testFieldOpenAICompatibleEndpoint(&domain.Provider{
+		ID:   42,
+		Type: "grok",
+		Config: &domain.ProviderConfig{Grok: &domain.ProviderConfigGrok{
+			Type:         "xai",
+			AuthKind:     "oauth",
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+		}},
+	}, "http://maxx.test")
+	if !ok || errText != "" {
+		t.Fatalf("expected grok provider proxy endpoint, ok=%v err=%q", ok, errText)
+	}
+	if endpoint != "http://maxx.test/provider/42/v1/chat/completions" || apiKey != "" {
+		t.Fatalf("unexpected endpoint/apiKey: %q %q", endpoint, apiKey)
 	}
 }

--- a/web/e2e/provider-delete-presets-regression.spec.ts
+++ b/web/e2e/provider-delete-presets-regression.spec.ts
@@ -90,11 +90,6 @@ async function screenshot(page: Page, name: string) {
   await page.screenshot({ path: `${SCREENSHOT_DIR}/${name}.png`, fullPage: true });
 }
 
-async function selectCustomProvider(page: Page) {
-  await page.goto('/providers/create');
-  await page.getByRole('button', { name: /Custom|自定义/ }).click();
-}
-
 test.use({ viewport: { width: 1920, height: 1400 }, locale: 'zh-CN' });
 
 test.describe('Provider delete and preset regression', () => {

--- a/web/e2e/provider-delete-presets-regression.spec.ts
+++ b/web/e2e/provider-delete-presets-regression.spec.ts
@@ -101,8 +101,10 @@ test.describe('Provider delete and preset regression', () => {
   test('quick templates fill Zhipu and DeepSeek compatibility URLs', async ({ page }) => {
     await installCommonMocks(page);
 
-    await selectCustomProvider(page);
-    await page.getByRole('button', { name: /智谱|Zhipu/i }).click();
+    await page.goto('/providers/create');
+    const zhipuTemplate = page.getByRole('button', { name: /智谱|Zhipu/i });
+    await expect(zhipuTemplate).toBeVisible();
+    await zhipuTemplate.click();
     await expect(page).toHaveURL(/\/providers\/create\/custom/);
     await expect(page.locator('input[value="https://open.bigmodel.cn/api/paas/v4"]')).toBeVisible();
     await expect(
@@ -110,8 +112,10 @@ test.describe('Provider delete and preset regression', () => {
     ).toBeVisible();
     await screenshot(page, '01-zhipu-claude-openai-preset-filled');
 
-    await selectCustomProvider(page);
-    await page.getByRole('button', { name: /DeepSeek.*Claude.*OpenAI/i }).click();
+    await page.goto('/providers/create');
+    const deepSeekTemplate = page.getByRole('button', { name: /DeepSeek.*Claude.*OpenAI/i });
+    await expect(deepSeekTemplate).toBeVisible();
+    await deepSeekTemplate.click();
     await expect(page.locator('input[value="https://api.deepseek.com"]')).toBeVisible();
     await expect(page.locator('input[value="https://api.deepseek.com/anthropic"]')).toBeVisible();
     await screenshot(page, '02-deepseek-claude-openai-preset-filled');

--- a/web/e2e/route-exposure-docs-user-panel.spec.ts
+++ b/web/e2e/route-exposure-docs-user-panel.spec.ts
@@ -181,20 +181,22 @@ test.describe('route exposure follows public route settings', () => {
   test('user panel endpoint hints and quickstart follow route exposure settings', async ({ page }, testInfo) => {
     const hits = await installRouteExposureMocks(page, filteredSettings, 'user');
     await page.goto('/');
-    await expect(page.getByText('OpenAI / Codex')).toBeVisible();
-    await expect(page.getByText('Gemini')).toBeVisible();
-    await expect(page.getByText('Claude')).not.toBeVisible();
+    await expect(page.getByText('OpenAI', { exact: true })).toBeVisible();
+    await expect(page.getByText('Codex', { exact: true })).not.toBeVisible();
+    await expect(page.getByText('Gemini', { exact: true })).toBeVisible();
+    await expect(page.getByText('Claude', { exact: true })).not.toBeVisible();
     await expect(page.getByText('/v1beta/models/{model}:generateContent')).toBeVisible();
-    await expect(page.getByText('/v1/chat/completions')).toBeVisible();
+    await expect(page.getByText(/\/v1$/)).toBeVisible();
     await attachMockEvidence(page, 'user panel filtered route exposure', filteredSettings, hits);
     await page.screenshot({ path: testInfo.outputPath('03-user-panel-filtered-endpoints.png'), fullPage: true });
 
     const disabledPage = await page.context().newPage();
     const disabledHits = await installRouteExposureMocks(disabledPage, allOpenAiAndCodexDisabledSettings, 'user');
     await disabledPage.goto('/');
-    await expect(disabledPage.getByText('OpenAI / Codex')).not.toBeVisible();
-    await expect(disabledPage.getByText('/v1/chat/completions')).not.toBeVisible();
-    await expect(disabledPage.getByText('Gemini')).toBeVisible();
+    await expect(disabledPage.getByText('OpenAI', { exact: true })).not.toBeVisible();
+    await expect(disabledPage.getByText('Codex', { exact: true })).not.toBeVisible();
+    await expect(disabledPage.getByText(/\/v1$/)).not.toBeVisible();
+    await expect(disabledPage.getByText('Gemini', { exact: true })).toBeVisible();
     await attachMockEvidence(
       disabledPage,
       'user panel OpenAI and Codex disabled',

--- a/web/e2e/stream-timeouts.spec.ts
+++ b/web/e2e/stream-timeouts.spec.ts
@@ -24,7 +24,10 @@ test.describe('stream timeout settings', () => {
   test('keeps upstream stream timeouts opt-in and persists user values', async ({ page }) => {
     await page.goto('/settings');
 
-    await expect(page.getByText('OpenAI Chat stream timeouts', { exact: true })).toBeVisible();
+    const streamTimeoutsTitle = page.getByText('OpenAI Chat stream timeouts', { exact: true });
+    await expect(streamTimeoutsTitle).toBeAttached({ timeout: 15000 });
+    await streamTimeoutsTitle.scrollIntoViewIfNeeded();
+    await expect(streamTimeoutsTitle).toBeVisible();
     const enabledSwitch = page.getByRole('switch', {
       name: 'Enable OpenAI Chat upstream stream timeouts',
     });
@@ -45,21 +48,18 @@ test.describe('stream timeout settings', () => {
     await idleInput.fill('55000');
     const saveButton = page.getByRole('button', { name: 'Save', exact: true });
     await expect(saveButton).toBeEnabled();
+    const saveResponses = Promise.all(
+      SETTINGS.map((key) =>
+        page.waitForResponse(
+          (response) =>
+            response.url().includes(`/api/admin/settings/${key}`) &&
+            response.request().method() === 'PUT' &&
+            response.ok(),
+        ),
+      ),
+    );
     await saveButton.click();
-
-    await expect
-      .poll(async () => {
-        return page.evaluate(async () => {
-          const resp = await fetch('/api/admin/settings');
-          const settings = await resp.json();
-          return {
-            enabled: settings.openai_chat_stream_timeouts_enabled,
-            first: settings.openai_chat_stream_first_event_timeout_ms,
-            idle: settings.openai_chat_stream_idle_timeout_ms,
-          };
-        });
-      })
-      .toEqual({ enabled: 'true', first: '15000', idle: '55000' });
+    await saveResponses;
 
     await page.reload();
     await expect(enabledSwitch).toBeChecked();

--- a/web/e2e/stream-timeouts.spec.ts
+++ b/web/e2e/stream-timeouts.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from '@playwright/test';
 
 const SETTINGS = [
-  'stream_timeouts_enabled',
-  'stream_first_event_timeout_ms',
-  'stream_idle_timeout_ms',
+  'openai_chat_stream_timeouts_enabled',
+  'openai_chat_stream_first_event_timeout_ms',
+  'openai_chat_stream_idle_timeout_ms',
 ];
 
 async function resetStreamTimeoutSettings(request: Parameters<typeof test>[0]['request']) {
@@ -24,10 +24,12 @@ test.describe('stream timeout settings', () => {
   test('keeps upstream stream timeouts opt-in and persists user values', async ({ page }) => {
     await page.goto('/settings');
 
-    await expect(page.getByText('Stream timeouts', { exact: true })).toBeVisible();
-    const enabledSwitch = page.getByRole('switch', { name: 'Enable upstream stream timeouts' });
-    const firstEventInput = page.getByLabel('First event timeout');
-    const idleInput = page.getByLabel('Event idle timeout');
+    await expect(page.getByText('OpenAI Chat stream timeouts', { exact: true })).toBeVisible();
+    const enabledSwitch = page.getByRole('switch', {
+      name: 'Enable OpenAI Chat upstream stream timeouts',
+    });
+    const firstEventInput = page.getByLabel('OpenAI Chat first event timeout');
+    const idleInput = page.getByLabel('OpenAI Chat event idle timeout');
 
     await expect(enabledSwitch).not.toBeChecked();
     await expect(firstEventInput).toBeDisabled();
@@ -51,9 +53,9 @@ test.describe('stream timeout settings', () => {
           const resp = await fetch('/api/admin/settings');
           const settings = await resp.json();
           return {
-            enabled: settings.stream_timeouts_enabled,
-            first: settings.stream_first_event_timeout_ms,
-            idle: settings.stream_idle_timeout_ms,
+            enabled: settings.openai_chat_stream_timeouts_enabled,
+            first: settings.openai_chat_stream_first_event_timeout_ms,
+            idle: settings.openai_chat_stream_idle_timeout_ms,
           };
         });
       })

--- a/web/e2e/test-field-grok-benchmark-regression.spec.ts
+++ b/web/e2e/test-field-grok-benchmark-regression.spec.ts
@@ -1,0 +1,239 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const now = new Date().toISOString();
+
+type Call = {
+  time: string;
+  method: string;
+  path: string;
+  status: number;
+  note: string;
+  body?: unknown;
+};
+
+async function json(route: Route, body: unknown, status = 200, note = '') {
+  await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  return { status, note };
+}
+
+function providerFixture() {
+  return [
+    {
+      id: 42,
+      createdAt: now,
+      updatedAt: now,
+      tenantID: 1,
+      name: 'Mock Grok OAuth Provider',
+      type: 'grok',
+      isEnabled: true,
+      maxConcurrency: 2,
+      supportedClientTypes: ['openai'],
+      config: {
+        grok: {
+          type: 'xai',
+          authKind: 'oauth',
+          accessToken: '',
+          refreshToken: '',
+          idToken: '',
+        },
+      },
+    },
+    {
+      id: 99,
+      createdAt: now,
+      updatedAt: now,
+      tenantID: 1,
+      name: 'Unsupported Claude Provider',
+      type: 'claude',
+      isEnabled: true,
+      supportedClientTypes: ['claude'],
+      config: {},
+    },
+  ];
+}
+
+async function installTestFieldMocks(page: Page, calls: Call[]) {
+  await page.addInitScript(() => {
+    localStorage.setItem('maxx-admin-token', 'mock-token');
+    localStorage.setItem('maxx-ui-language', 'zh');
+  });
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+    const method = request.method();
+    const body = request.postData() ? request.postDataJSON() : undefined;
+    let outcome: { status: number; note: string };
+
+    if (path === '/api/settings' || path === '/api/admin/settings') {
+      outcome = await json(
+        route,
+        {
+          api_token_auth_enabled: 'true',
+          force_project_binding: 'false',
+          ui_multitenant_enabled: 'false',
+          ui_test_field_tab_enabled: 'true',
+        },
+        200,
+        'settings expose test field tab',
+      );
+    } else if (path === '/api/admin/auth/status') {
+      outcome = await json(
+        route,
+        {
+          authEnabled: true,
+          user: { id: 1, username: 'admin', tenantID: 1, role: 'admin' },
+        },
+        200,
+        'authenticated admin',
+      );
+    } else if (path === '/api/admin/proxy-status' || path === '/api/proxy-status') {
+      outcome = await json(
+        route,
+        { running: true, address: '127.0.0.1', port: 9880, version: 'e2e-test-field' },
+        200,
+        'proxy visible in layout',
+      );
+    } else if (path === '/api/admin/providers' || path === '/api/providers') {
+      outcome = await json(route, providerFixture(), 200, 'provider list includes grok');
+    } else if (path === '/api/admin/test-field/model-benchmark-jobs' && method === 'POST') {
+      expect(body).toMatchObject({
+        providerIDs: [42],
+        concurrency: 1,
+        timeoutMs: 5000,
+        minModelsPerProvider: 2,
+        reuseCachedModelLists: true,
+        reuseCachedResults: true,
+      });
+      outcome = await json(route, { jobID: 'mock-grok-job-1' }, 202, 'benchmark job accepted');
+    } else if (path === '/api/admin/test-field/model-benchmark-jobs/mock-grok-job-1' && method === 'GET') {
+      outcome = await json(
+        route,
+        {
+          jobID: 'mock-grok-job-1',
+          status: 'completed',
+          prompt: '端到端回归：请返回 mock-grok-ok',
+          concurrency: 1,
+          timeoutMs: 5000,
+          minModelsPerProvider: 2,
+          startedAt: now,
+          finishedAt: new Date(Date.now() + 12).toISOString(),
+          providers: [
+            {
+              providerID: 42,
+              providerName: 'Mock Grok OAuth Provider',
+              providerType: 'grok',
+              available: true,
+              modelCount: 8,
+              testedCount: 2,
+              cachedModels: false,
+            },
+          ],
+          results: [
+            {
+              providerID: 42,
+              providerName: 'Mock Grok OAuth Provider',
+              providerType: 'grok',
+              model: 'grok-4',
+              available: true,
+              durationMs: 37,
+              statusCode: 200,
+              response: 'mock-grok-ok via /provider/42/v1/chat/completions',
+              startedAt: now,
+              finishedAt: new Date(Date.now() + 37).toISOString(),
+            },
+            {
+              providerID: 42,
+              providerName: 'Mock Grok OAuth Provider',
+              providerType: 'grok',
+              model: 'grok-latest',
+              available: true,
+              durationMs: 42,
+              statusCode: 200,
+              response: 'mock-grok-latest-ok',
+              startedAt: now,
+              finishedAt: new Date(Date.now() + 42).toISOString(),
+            },
+          ],
+          totalTargets: 2,
+          completedTargets: 2,
+          cachedResultCount: 0,
+        },
+        200,
+        'benchmark completed with grok results',
+      );
+    } else {
+      outcome = await json(route, {}, 200, 'fallback empty mock');
+    }
+
+    calls.push({ time: new Date().toISOString(), method, path, status: outcome.status, note: outcome.note, body });
+  });
+}
+
+async function attachMockEvidence(page: Page, calls: Call[]) {
+  await page.evaluate((mockCalls) => {
+    document.querySelector('[data-e2e-mock-ledger]')?.remove();
+    const el = document.createElement('div');
+    el.dataset.e2eMockLedger = 'true';
+    el.style.cssText = [
+      'position:fixed',
+      'right:16px',
+      'bottom:16px',
+      'z-index:99999',
+      'width:520px',
+      'max-height:340px',
+      'overflow:auto',
+      'padding:12px',
+      'border-radius:12px',
+      'background:rgba(2,6,23,0.92)',
+      'color:white',
+      'font:12px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace',
+      'box-shadow:0 12px 40px rgba(0,0,0,0.35)',
+      'white-space:pre-wrap',
+    ].join(';');
+    el.textContent = `Test Field Grok E2E Mock Ledger\n${JSON.stringify(mockCalls, null, 2)}`;
+    document.body.appendChild(el);
+  }, calls);
+}
+
+test.use({ viewport: { width: 1440, height: 1000 }, locale: 'zh-CN' });
+
+test('test field runs a Grok provider benchmark without blank-screening', async ({ page }, testInfo) => {
+  const calls: Call[] = [];
+  await installTestFieldMocks(page, calls);
+
+  await page.goto('/test-field');
+  await expect(page.getByRole('heading', { name: /测试场|Test Field/ })).toBeVisible();
+  await expect(page.getByText('Mock Grok OAuth Provider')).toBeHidden();
+
+  const providerInput = page.getByRole('combobox').first();
+  await providerInput.click();
+  await page.getByRole('option', { name: /Mock Grok OAuth Provider · grok · #42/ }).click();
+  await page.getByRole('button', { name: /添加|Add/ }).click();
+  await expect(page.getByText('Mock Grok OAuth Provider · grok · #42')).toBeVisible();
+  await expect(page.getByText(/暂不支持|Unsupported/)).toHaveCount(0);
+
+  await page.getByLabel(/Prompt|提示词|测试提示/).fill('端到端回归：请返回 mock-grok-ok');
+  await page.getByLabel(/Concurrency|并发/).fill('1');
+  await page.getByLabel(/Timeout|超时/).fill('5000');
+  await page.getByLabel(/Models|模型/).fill('2');
+
+  await attachMockEvidence(page, calls);
+  await page.screenshot({ path: testInfo.outputPath('01-before-run-grok-provider-selected.png'), fullPage: true });
+
+  await page.getByRole('button', { name: /Run|运行|开始测试|开始/ }).click();
+
+  await expect(page.getByText(/mock-grok-ok via \/provider\/42\/v1\/chat\/completions/)).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText('grok-4')).toBeVisible();
+  await expect(page.getByText('grok-latest')).toBeVisible();
+  await expect(page.getByText(/2\/2|completed: 2|已完成/)).toBeVisible();
+
+  expect(calls.some((call) => call.path === '/api/admin/test-field/model-benchmark-jobs' && call.method === 'POST')).toBe(true);
+  expect(calls.some((call) => call.path === '/api/admin/test-field/model-benchmark-jobs/mock-grok-job-1' && call.method === 'GET')).toBe(true);
+
+  await attachMockEvidence(page, calls);
+  await page.screenshot({ path: testInfo.outputPath('02-after-run-grok-results-and-mock-ledger.png'), fullPage: true });
+});

--- a/web/e2e/test-field-grok-benchmark-regression.spec.ts
+++ b/web/e2e/test-field-grok-benchmark-regression.spec.ts
@@ -210,14 +210,14 @@ test('test field runs a Grok provider benchmark without blank-screening', async 
   const providerInput = page.getByRole('combobox').first();
   await providerInput.click();
   await page.getByRole('option', { name: /Mock Grok OAuth Provider · grok · #42/ }).click();
-  await page.getByRole('button', { name: /添加|Add/ }).click();
+  await page.getByRole('button', { name: /新增|Add/ }).click();
   await expect(page.getByText('Mock Grok OAuth Provider · grok · #42')).toBeVisible();
-  await expect(page.getByText(/暂不支持|Unsupported/)).toHaveCount(0);
+  await expect(page.getByRole('button', { name: /Run|运行|开始测试|开始/ })).toBeEnabled();
 
-  await page.getByLabel(/Prompt|提示词|测试提示/).fill('端到端回归：请返回 mock-grok-ok');
-  await page.getByLabel(/Concurrency|并发/).fill('1');
-  await page.getByLabel(/Timeout|超时/).fill('5000');
-  await page.getByLabel(/Models|模型/).fill('2');
+  await page.getByLabel(/^测试问题$/).fill('端到端回归：请返回 mock-grok-ok');
+  await page.getByLabel(/^并发数$/).fill('1');
+  await page.getByLabel(/^单模型超时 ms$/).fill('5000');
+  await page.getByLabel(/^每个提供商最少测试模型数$/).fill('2');
 
   await attachMockEvidence(page, calls);
   await page.screenshot({ path: testInfo.outputPath('01-before-run-grok-provider-selected.png'), fullPage: true });
@@ -227,8 +227,8 @@ test('test field runs a Grok provider benchmark without blank-screening', async 
   await expect(page.getByText(/mock-grok-ok via \/provider\/42\/v1\/chat\/completions/)).toBeVisible({
     timeout: 10_000,
   });
-  await expect(page.getByText('grok-4')).toBeVisible();
-  await expect(page.getByText('grok-latest')).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'grok-4', exact: true })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'grok-latest', exact: true })).toBeVisible();
   await expect(page.getByText(/2\/2|completed: 2|已完成/)).toBeVisible();
 
   expect(calls.some((call) => call.path === '/api/admin/test-field/model-benchmark-jobs' && call.method === 'POST')).toBe(true);

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -142,6 +142,7 @@ export function SettingsPage() {
           {isAdmin && (
             <>
               <SupportModelRoutingSection />
+              <OpenAIChatStreamTimeoutSection />
               <TestFieldTabSection />
               <MultiTenantUISection />
               <TimezoneSection />

--- a/web/src/pages/test-field/index.tsx
+++ b/web/src/pages/test-field/index.tsx
@@ -32,7 +32,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useProviders } from '@/hooks/queries';
 import { getTransport, type Provider, type TestFieldModelBenchmarkResponse } from '@/lib/transport';
 
-const SUPPORTED_PROVIDER_TYPES = new Set(['custom', 'newapi', 'openrouter']);
+const SUPPORTED_PROVIDER_TYPES = new Set(['custom', 'newapi', 'openrouter', 'grok']);
 
 function formatDuration(durationMs: number) {
   if (!Number.isFinite(durationMs) || durationMs < 0) return '-';
@@ -87,6 +87,8 @@ export function TestFieldPage() {
     cachedBenchmarkState?.activeJobID ?? null,
   );
   const [error, setError] = useState<string | null>(null);
+  const safeResultProviders = Array.isArray(result?.providers) ? result.providers : [];
+  const safeResultRows = Array.isArray(result?.results) ? result.results : [];
   const isRunning = result?.status === 'running' || activeJobID !== null;
   const activeJobIDRef = useRef<string | null>(activeJobID);
   const resultsCardRef = useRef<HTMLDivElement | null>(null);
@@ -416,7 +418,7 @@ export function TestFieldPage() {
                 </CardTitle>
                 <CardDescription>
                   {t('testField.benchmark.resultsDescription', {
-                    count: result.results.length,
+                    count: safeResultRows.length,
                     concurrency: result.concurrency,
                     completed: result.completedTargets,
                     total: result.totalTargets,
@@ -427,7 +429,7 @@ export function TestFieldPage() {
               </CardHeader>
               <CardContent className="space-y-4 p-6">
                 <div className="grid gap-2 md:grid-cols-2">
-                  {result.providers.map((provider) => (
+                  {safeResultProviders.map((provider) => (
                     <div
                       key={provider.providerID}
                       className="rounded-md border border-border p-3 text-sm"
@@ -463,7 +465,7 @@ export function TestFieldPage() {
                       </TableRow>
                     </TableHeader>
                     <TableBody>
-                      {result.results.map((item, index) => (
+                      {safeResultRows.map((item, index) => (
                         <TableRow key={`${item.providerID}:${item.model}`}>
                           <TableCell>{index + 1}</TableCell>
                           <TableCell>{item.providerName}</TableCell>


### PR DESCRIPTION
## Summary
- add adapter-entry regression for OpenAI client → maxx Grok provider streaming
- assert the HTTP response body contains client-visible content, `finish_reason:"stop"`, and `[DONE]` in order
- run the same client-visible stream contract across representative Grok model IDs
- extract the Grok executor behind a small package-local interface so tests can inject deterministic stream chunks without live credentials

## Verification
- `go test ./internal/adapter/provider/cliproxyapi_grok -run 'ExecuteStreamReturns|EnsureOpenAI|GrokImages|GrokRequestMetadata' -count=1 -v`
- `go test ./internal/adapter/provider/cliproxyapi_grok ./internal/adapter/client ./internal/handler ./tests/e2e -run 'Grok|Images|Image|OpenAI|Proxy|Stream|Chat|ExecuteStreamReturns' -count=1`
- `go test ./...`

## Live boundary
Live Grok OAuth testing is still blocked by upstream `personal-team-blocked:spending-limit` for the provided credentials; this PR verifies the maxx-side OpenAI-client-visible contract without pretending that blocked live credentials succeeded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 优化 Grok 模型流式响应，正确展示内容、结束原因与完成标记。
  - 支持更多 Grok 模型及代理端点，可在测试字段页面选择并运行 Grok 基准测试。
  - 增强测试结果校验，避免异常数据导致页面渲染错误。
  - 新增 OpenAI Chat 流式超时设置入口。

- **测试**
  - 增加 Grok 流式执行、OAuth 配置、代理端点及基准测试回归覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->