### PR TITLE
fix(router): reconcile provider adapters after cache invalidation

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -237,6 +237,10 @@ func main() {
 	cachedAPITokenRepo := cached.NewAPITokenRepository(apiTokenRepo)
 	cachedModelMappingRepo := cached.NewModelMappingRepository(modelMappingRepo)
 
+	// Create router before wiring invalidation so provider changes from peers
+	// can reload both the provider cache and the runtime adapter map.
+	r := router.NewRouter(cachedRouteRepo, cachedProviderRepo, cachedRoutingStrategyRepo, cachedRetryConfigRepo, cachedProjectRepo, settingRepo)
+
 	// Wire cross-instance cache invalidation. AttachCachedReposToCoordinator
 	// 是 desktop launcher 也走的同一个 helper,保证两条启动路径行为一致。
 	core.AttachCachedReposToCoordinator(coordCtx, coord, &core.DatabaseRepos{
@@ -248,7 +252,7 @@ func main() {
 		CachedAPITokenRepo:        cachedAPITokenRepo,
 		CachedModelMappingRepo:    cachedModelMappingRepo,
 		CachedSessionRepo:         cachedSessionRepo,
-	})
+	}, r)
 
 	// Load cached data
 	startupStep = time.Now()
@@ -275,9 +279,6 @@ func main() {
 		log.Printf("Warning: Failed to load model mappings cache: %v", err)
 	}
 	log.Printf("[Startup] Caches loaded (%v)", time.Since(startupStep))
-
-	// Create router
-	r := router.NewRouter(cachedRouteRepo, cachedProviderRepo, cachedRoutingStrategyRepo, cachedRetryConfigRepo, cachedProjectRepo, settingRepo)
 
 	// Initialize provider adapters
 	startupStep = time.Now()

--- a/internal/core/coordinator_setup.go
+++ b/internal/core/coordinator_setup.go
@@ -11,6 +11,12 @@ import (
 	"github.com/awsl-project/maxx/internal/sticky"
 )
 
+// ProviderAdapterReconciler is implemented by Router. It keeps runtime
+// provider adapters in sync with the cached provider repository.
+type ProviderAdapterReconciler interface {
+	ReconcileAdapters() error
+}
+
 // CoordinatorComponents 是 SetupCoordinator 的输出。
 // Cleanup 是收尾函数,顺序为 Unregister → Cancel → Close。
 type CoordinatorComponents struct {
@@ -80,7 +86,7 @@ func SetupCoordinator(parentCtx context.Context, instanceID string, forceStandal
 //
 // 必须在 repos.CachedXxxRepo.Load() 之前调用,这样订阅 goroutine 就位后
 // 任何后续 mutation 都会被广播。
-func AttachCachedReposToCoordinator(ctx context.Context, coord coordinator.Coordinator, repos *DatabaseRepos) {
+func AttachCachedReposToCoordinator(ctx context.Context, coord coordinator.Coordinator, repos *DatabaseRepos, adapterReconciler ProviderAdapterReconciler) {
 	repos.CachedProviderRepo.SetCoordinator(coord)
 	repos.CachedRouteRepo.SetCoordinator(coord)
 	repos.CachedRetryConfigRepo.SetCoordinator(coord)
@@ -93,6 +99,12 @@ func AttachCachedReposToCoordinator(ctx context.Context, coord coordinator.Coord
 	cached.AttachInvalidation(ctx, coord, cached.InvalidateProvider, func() {
 		if err := repos.CachedProviderRepo.Load(); err != nil {
 			log.Printf("[Cache] reload providers failed: %v", err)
+			return
+		}
+		if adapterReconciler != nil {
+			if err := adapterReconciler.ReconcileAdapters(); err != nil {
+				log.Printf("[Cache] reconcile provider adapters failed: %v", err)
+			}
 		}
 	})
 	cached.AttachInvalidation(ctx, coord, cached.InvalidateRoute, func() {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -244,8 +244,6 @@ func InitializeServerComponents(
 			coordComp.Cleanup()
 		}
 	}()
-	AttachCachedReposToCoordinator(coordComp.Ctx, coordComp.Coordinator, repos)
-
 	log.Printf("[Core] Marking stale requests as failed")
 	alive, err := coordComp.Coordinator.ListAliveInstances(coordComp.Ctx)
 	if err != nil {
@@ -272,6 +270,18 @@ func InitializeServerComponents(
 	} else if count > 0 {
 		log.Printf("[Core] Fixed %d failed attempts without end_time", count)
 	}
+
+	log.Printf("[Core] Creating router")
+	r := router.NewRouter(
+		repos.CachedRouteRepo,
+		repos.CachedProviderRepo,
+		repos.CachedRoutingStrategyRepo,
+		repos.CachedRetryConfigRepo,
+		repos.CachedProjectRepo,
+		repos.SettingRepo,
+	)
+
+	AttachCachedReposToCoordinator(coordComp.Ctx, coordComp.Coordinator, repos, r)
 
 	log.Printf("[Core] Loading cached data")
 	if err := repos.CachedProviderRepo.Load(); err != nil {
@@ -300,15 +310,6 @@ func InitializeServerComponents(
 	if err := InitializeModelPrices(repos.ModelPriceRepo); err != nil {
 		log.Printf("[Core] Warning: Failed to initialize model prices: %v", err)
 	}
-
-	log.Printf("[Core] Creating router")
-	r := router.NewRouter(
-		repos.CachedRouteRepo,
-		repos.CachedProviderRepo,
-		repos.CachedRoutingStrategyRepo,
-		repos.CachedRetryConfigRepo,
-		repos.CachedProjectRepo,
-	)
 
 	log.Printf("[Core] Initializing provider adapters")
 	if err := r.InitAdapters(); err != nil {

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
@@ -13,7 +14,10 @@ import (
 const (
 	wsRouterNativeType   = "responses-ws-router-native-test"
 	wsRouterHTTPOnlyType = "responses-ws-router-http-only-test"
+	wsRouterStatefulType = "responses-ws-router-stateful-test"
 )
+
+var wsRouterStatefulFactoryCalls atomic.Int64
 
 func init() {
 	provideradapter.RegisterAdapterFactory(wsRouterNativeType, func(p *domain.Provider) (provideradapter.ProviderAdapter, error) {
@@ -21,6 +25,12 @@ func init() {
 	})
 	provideradapter.RegisterAdapterFactory(wsRouterHTTPOnlyType, func(*domain.Provider) (provideradapter.ProviderAdapter, error) {
 		return wsRouterHTTPOnlyAdapter{}, nil
+	})
+	provideradapter.RegisterAdapterFactory(wsRouterStatefulType, func(p *domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return &wsRouterStatefulAdapter{
+			providerID: p.ID,
+			instance:   wsRouterStatefulFactoryCalls.Add(1),
+		}, nil
 	})
 }
 
@@ -51,6 +61,17 @@ func (wsRouterHTTPOnlyAdapter) SupportedClientTypes() []domain.ClientType {
 }
 
 func (wsRouterHTTPOnlyAdapter) Execute(*flow.Ctx, *domain.Provider) error { return nil }
+
+type wsRouterStatefulAdapter struct {
+	providerID uint64
+	instance   int64
+}
+
+func (wsRouterStatefulAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeCodex}
+}
+
+func (wsRouterStatefulAdapter) Execute(*flow.Ctx, *domain.Provider) error { return nil }
 
 type wsRouterRouteRepo struct{ routes []*domain.Route }
 
@@ -219,6 +240,119 @@ func matchedProviderIDs(result *MatchResult) []uint64 {
 		ids = append(ids, mr.Provider.ID)
 	}
 	return ids
+}
+
+func TestReconcileAdaptersPreservesUnchangedStatefulAdapters(t *testing.T) {
+	wsRouterStatefulFactoryCalls.Store(0)
+	provideradapter.MarkResponsesWebSocketTransportUnavailable(101)
+	provideradapter.MarkResponsesWebSocketTransportUnavailable(102)
+	t.Cleanup(func() {
+		provideradapter.ClearResponsesWebSocketTransportCooldown(101)
+		provideradapter.ClearResponsesWebSocketTransportCooldown(102)
+	})
+
+	providers := &wsRouterProviderRepo{providers: []*domain.Provider{
+		{
+			ID:                   101,
+			TenantID:             1,
+			Type:                 wsRouterStatefulType,
+			Name:                 "keep-state",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+			Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{APIKey: "keep"}},
+		},
+		{
+			ID:                   102,
+			TenantID:             1,
+			Type:                 wsRouterStatefulType,
+			Name:                 "changed",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+			Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{APIKey: "before"}},
+		},
+	}}
+
+	providerRepo := cached.NewProviderRepository(providers)
+	if err := providerRepo.Load(); err != nil {
+		t.Fatalf("load providers: %v", err)
+	}
+	r := NewRouter(
+		cached.NewRouteRepository(&wsRouterRouteRepo{}),
+		providerRepo,
+		cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{}),
+		cached.NewRetryConfigRepository(wsRouterRetryRepo{}),
+		cached.NewProjectRepository(&wsRouterProjectRepo{}),
+	)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+	originalKeep, ok := r.GetAdapter(101)
+	if !ok {
+		t.Fatal("missing initial unchanged provider adapter")
+	}
+	originalChanged, ok := r.GetAdapter(102)
+	if !ok {
+		t.Fatal("missing initial changed provider adapter")
+	}
+
+	providers.providers = []*domain.Provider{
+		{
+			ID:                   101,
+			TenantID:             1,
+			Type:                 wsRouterStatefulType,
+			Name:                 "keep-state-renamed",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+			Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{APIKey: "keep"}},
+		},
+		{
+			ID:                   102,
+			TenantID:             1,
+			Type:                 wsRouterStatefulType,
+			Name:                 "changed",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+			Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{APIKey: "after"}},
+		},
+		{
+			ID:                   103,
+			TenantID:             1,
+			Type:                 wsRouterStatefulType,
+			Name:                 "added",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+			Config:               &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{APIKey: "new"}},
+		},
+	}
+	if err := providerRepo.Load(); err != nil {
+		t.Fatalf("reload providers: %v", err)
+	}
+	if err := r.ReconcileAdapters(); err != nil {
+		t.Fatalf("ReconcileAdapters: %v", err)
+	}
+
+	kept, ok := r.GetAdapter(101)
+	if !ok {
+		t.Fatal("unchanged provider adapter disappeared")
+	}
+	if kept != originalKeep {
+		t.Fatal("unchanged provider adapter was replaced")
+	}
+	if provideradapter.ResponsesWebSocketTransportAvailable(101) {
+		t.Fatal("unchanged provider websocket transport cooldown was cleared")
+	}
+
+	replaced, ok := r.GetAdapter(102)
+	if !ok {
+		t.Fatal("changed provider adapter disappeared")
+	}
+	if replaced == originalChanged {
+		t.Fatal("changed provider adapter was not replaced")
+	}
+	if !provideradapter.ResponsesWebSocketTransportAvailable(102) {
+		t.Fatal("changed provider websocket transport cooldown was not cleared")
+	}
+	if _, ok := r.GetAdapter(103); !ok {
+		t.Fatal("added provider adapter was not created")
+	}
+	if got := wsRouterStatefulFactoryCalls.Load(); got != 4 {
+		t.Fatalf("adapter factory calls = %d, want 4", got)
+	}
 }
 
 func TestHasResponsesWebSocketProvider(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"log"
 	"math/rand"
 	"os"
@@ -75,9 +76,10 @@ type Router struct {
 	settingRepo         repository.SystemSettingRepository
 
 	// Adapter cache
-	adapters map[uint64]provider.ProviderAdapter
-	mu       sync.RWMutex
-	limiter  *ProviderLimiter
+	adapters            map[uint64]provider.ProviderAdapter
+	adapterFingerprints map[uint64]string
+	mu                  sync.RWMutex
+	limiter             *ProviderLimiter
 
 	// Cooldown manager
 	cooldownManager *cooldown.Manager
@@ -104,6 +106,7 @@ func NewRouter(
 		projectRepo:         projectRepo,
 		settingRepo:         settings,
 		adapters:            make(map[uint64]provider.ProviderAdapter),
+		adapterFingerprints: make(map[uint64]string),
 		limiter:             NewProviderLimiter(),
 		cooldownManager:     cooldown.Default(),
 	}
@@ -124,8 +127,8 @@ func (r *Router) isProviderAtConcurrencyLimit(p *domain.Provider) bool {
 // InitAdapters initializes adapters for all providers
 func (r *Router) InitAdapters() error {
 	providers := r.providerRepo.GetAll()
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	next := make(map[uint64]provider.ProviderAdapter, len(providers))
+	nextFingerprints := make(map[uint64]string, len(providers))
 
 	for _, p := range providers {
 		factory, ok := provider.GetAdapterFactory(p.Type)
@@ -137,7 +140,71 @@ func (r *Router) InitAdapters() error {
 			return err
 		}
 		r.injectProviderUpdate(a, p)
-		r.adapters[p.ID] = a
+		next[p.ID] = a
+		nextFingerprints[p.ID] = adapterFingerprint(p)
+	}
+
+	r.mu.Lock()
+	r.adapters = next
+	r.adapterFingerprints = nextFingerprints
+	r.mu.Unlock()
+	return nil
+}
+
+// ReconcileAdapters refreshes the adapter map to match the current provider
+// cache. It is used after cross-instance provider invalidation: reloading the
+// provider repository alone is not enough because Match also requires a live
+// adapter for each candidate provider.
+func (r *Router) ReconcileAdapters() error {
+	providers := r.providerRepo.GetAll()
+	r.mu.RLock()
+	currentAdapters := make(map[uint64]provider.ProviderAdapter, len(r.adapters))
+	for id, adapter := range r.adapters {
+		currentAdapters[id] = adapter
+	}
+	currentFingerprints := make(map[uint64]string, len(r.adapterFingerprints))
+	for id, fingerprint := range r.adapterFingerprints {
+		currentFingerprints[id] = fingerprint
+	}
+	r.mu.RUnlock()
+
+	next := make(map[uint64]provider.ProviderAdapter, len(providers))
+	nextFingerprints := make(map[uint64]string, len(providers))
+	var changedProviderIDs []uint64
+	for _, p := range providers {
+		fingerprint := adapterFingerprint(p)
+		if current, ok := currentAdapters[p.ID]; ok && currentFingerprints[p.ID] == fingerprint {
+			next[p.ID] = current
+			nextFingerprints[p.ID] = fingerprint
+			continue
+		}
+
+		factory, ok := provider.GetAdapterFactory(p.Type)
+		if !ok {
+			changedProviderIDs = append(changedProviderIDs, p.ID)
+			continue
+		}
+		a, err := factory(p)
+		if err != nil {
+			return err
+		}
+		r.injectProviderUpdate(a, p)
+		next[p.ID] = a
+		nextFingerprints[p.ID] = fingerprint
+		changedProviderIDs = append(changedProviderIDs, p.ID)
+	}
+	for id := range currentAdapters {
+		if _, ok := providers[id]; !ok {
+			changedProviderIDs = append(changedProviderIDs, id)
+		}
+	}
+
+	r.mu.Lock()
+	r.adapters = next
+	r.adapterFingerprints = nextFingerprints
+	r.mu.Unlock()
+	for _, providerID := range changedProviderIDs {
+		provider.ClearResponsesWebSocketTransportCooldown(providerID)
 	}
 	return nil
 }
@@ -156,6 +223,7 @@ func (r *Router) RefreshAdapter(p *domain.Provider) error {
 	provider.ClearResponsesWebSocketTransportCooldown(p.ID)
 	r.mu.Lock()
 	r.adapters[p.ID] = a
+	r.adapterFingerprints[p.ID] = adapterFingerprint(p)
 	r.mu.Unlock()
 	return nil
 }
@@ -165,6 +233,7 @@ func (r *Router) RemoveAdapter(providerID uint64) {
 	provider.ClearResponsesWebSocketTransportCooldown(providerID)
 	r.mu.Lock()
 	delete(r.adapters, providerID)
+	delete(r.adapterFingerprints, providerID)
 	r.mu.Unlock()
 }
 
@@ -558,6 +627,31 @@ func (r *Router) isModelSupported(model string, supportModels []string) bool {
 		}
 	}
 	return false
+}
+
+// adapterFingerprint covers the provider fields captured by adapter
+// construction. Route-only fields such as SupportModels intentionally stay out
+// so unrelated routing edits do not drop stateful adapter instances.
+func adapterFingerprint(p *domain.Provider) string {
+	if p == nil {
+		return ""
+	}
+	supportedClientTypes := append([]domain.ClientType(nil), p.SupportedClientTypes...)
+	sort.Slice(supportedClientTypes, func(i, j int) bool {
+		return supportedClientTypes[i] < supportedClientTypes[j]
+	})
+	payload := struct {
+		Type                 string
+		Config               *domain.ProviderConfig
+		SupportedClientTypes []domain.ClientType
+	}{
+		Type:                 p.Type,
+		Config:               p.Config,
+		SupportedClientTypes: supportedClientTypes,
+	}
+	data, _ := json.Marshal(payload)
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }
 
 func (r *Router) getRoutingStrategy(tenantID uint64, projectID uint64) *domain.RoutingStrategy {

--- a/tests/multiinstance/cache_test.go
+++ b/tests/multiinstance/cache_test.go
@@ -17,6 +17,7 @@ func TestProviderCreateInvalidatesPeer(t *testing.T) {
 		TenantID: domain.DefaultTenantID,
 		Name:     "shared-claude",
 		Type:     "claude",
+		Config:   &domain.ProviderConfig{Claude: &domain.ProviderConfigClaude{}},
 	}
 	if err := a.Comp.Provider.Create(p); err != nil {
 		t.Fatalf("Create provider on A: %v", err)

--- a/tests/multiinstance/project_routing_test.go
+++ b/tests/multiinstance/project_routing_test.go
@@ -1,0 +1,88 @@
+package multiinstance
+
+import (
+	"testing"
+	"time"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+type multiinstanceTestAdapter struct{}
+
+func (a *multiinstanceTestAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeClaude}
+}
+
+func (a *multiinstanceTestAdapter) Execute(*flow.Ctx, *domain.Provider) error {
+	return nil
+}
+
+// A freshly-created project route on instance A must become matchable on
+// instance B. This covers both metadata cache invalidation and provider adapter
+// reconciliation, which are both required before Router.Match can return a
+// usable upstream candidate.
+func TestProjectRouteCreateInvalidatesPeerAndReconcilesAdapter(t *testing.T) {
+	provideradapter.RegisterAdapterFactory("multiinstance-test", func(*domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return &multiinstanceTestAdapter{}, nil
+	})
+
+	c := newCluster(t)
+	a := c.newInstance(t, "inst-A")
+	b := c.newInstance(t, "inst-B")
+
+	project := &domain.Project{
+		TenantID:            domain.DefaultTenantID,
+		Name:                "special-aws",
+		Slug:                "aws",
+		EnabledCustomRoutes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+	if err := a.Comp.Project.Create(project); err != nil {
+		t.Fatalf("Create project on A: %v", err)
+	}
+
+	provider := &domain.Provider{
+		TenantID:             domain.DefaultTenantID,
+		Name:                 "shared-upstream",
+		Type:                 "multiinstance-test",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude},
+	}
+	if err := a.Comp.Provider.Create(provider); err != nil {
+		t.Fatalf("Create provider on A: %v", err)
+	}
+
+	route := &domain.Route{
+		TenantID:   domain.DefaultTenantID,
+		ProjectID:  project.ID,
+		ProviderID: provider.ID,
+		ClientType: domain.ClientTypeClaude,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+	}
+	if err := a.Comp.Route.Create(route); err != nil {
+		t.Fatalf("Create route on A: %v", err)
+	}
+
+	if !waitFor(t, time.Second, func() bool {
+		projectOnB, err := b.Comp.Project.GetBySlug(domain.DefaultTenantID, "aws")
+		if err != nil || projectOnB == nil {
+			return false
+		}
+		result, err := b.Router.Match(&router.MatchContext{
+			TenantID:     domain.DefaultTenantID,
+			ClientType:   domain.ClientTypeClaude,
+			ProjectID:    projectOnB.ID,
+			RequestModel: "claude-sonnet-5",
+		})
+		return err == nil &&
+			result != nil &&
+			len(result.Routes) == 1 &&
+			result.Routes[0].Provider.ID == provider.ID &&
+			result.Routes[0].ProviderAdapter != nil
+	}) {
+		t.Fatal("instance B never matched the project route created on A")
+	}
+}

--- a/tests/multiinstance/rolling_update_test.go
+++ b/tests/multiinstance/rolling_update_test.go
@@ -37,6 +37,7 @@ func TestSeamlessRollingUpdate(t *testing.T) {
 		TenantID: domain.DefaultTenantID,
 		Name:     "rolling-update-claude",
 		Type:     "claude",
+		Config:   &domain.ProviderConfig{Claude: &domain.ProviderConfigClaude{}},
 	}
 	if err := a.Comp.Provider.Create(prov); err != nil {
 		t.Fatalf("seed provider: %v", err)

--- a/tests/multiinstance/setup_test.go
+++ b/tests/multiinstance/setup_test.go
@@ -16,25 +16,31 @@ import (
 
 	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/coordinator"
+	"github.com/awsl-project/maxx/internal/core"
 	"github.com/awsl-project/maxx/internal/repository/cached"
 	"github.com/awsl-project/maxx/internal/repository/sqlite"
+	"github.com/awsl-project/maxx/internal/router"
 )
 
 // instance 是单进程视图。生产中由 cmd/maxx 装配;这里我们只装配集成测试
 // 实际涉及的子系统:DB、coordinator、cooldown.Manager、cached repos。
 type instance struct {
-	ID    string
-	Coord coordinator.Coordinator
-	DB    *sqlite.DB
-	Mgr   *cooldown.Manager
-	Comp  *componentSet
-	ctx   context.Context
-	stop  context.CancelFunc
+	ID     string
+	Coord  coordinator.Coordinator
+	DB     *sqlite.DB
+	Mgr    *cooldown.Manager
+	Comp   *componentSet
+	Router *router.Router
+	ctx    context.Context
+	stop   context.CancelFunc
 }
 
 type componentSet struct {
 	Provider     *cached.ProviderRepository
 	Route        *cached.RouteRepository
+	RetryConfig  *cached.RetryConfigRepository
+	Strategy     *cached.RoutingStrategyRepository
+	Project      *cached.ProjectRepository
 	Session      *cached.SessionRepository
 	APIToken     *cached.APITokenRepository
 	ModelMapping *cached.ModelMappingRepository
@@ -113,6 +119,9 @@ func (c *cluster) newInstance(t testing.TB, instanceID string) *instance {
 	comp := &componentSet{
 		Provider:     cached.NewProviderRepository(sqlite.NewProviderRepository(db)),
 		Route:        cached.NewRouteRepository(sqlite.NewRouteRepository(db)),
+		RetryConfig:  cached.NewRetryConfigRepository(sqlite.NewRetryConfigRepository(db)),
+		Strategy:     cached.NewRoutingStrategyRepository(sqlite.NewRoutingStrategyRepository(db)),
+		Project:      cached.NewProjectRepository(sqlite.NewProjectRepository(db)),
 		Session:      cached.NewSessionRepository(sqlite.NewSessionRepository(db)),
 		APIToken:     cached.NewAPITokenRepository(sqlite.NewAPITokenRepository(db)),
 		ModelMapping: cached.NewModelMappingRepository(sqlite.NewModelMappingRepository(db)),
@@ -121,30 +130,55 @@ func (c *cluster) newInstance(t testing.TB, instanceID string) *instance {
 
 	comp.Provider.SetCoordinator(coord)
 	comp.Route.SetCoordinator(coord)
+	comp.RetryConfig.SetCoordinator(coord)
+	comp.Strategy.SetCoordinator(coord)
+	comp.Project.SetCoordinator(coord)
 	comp.Session.SetCoordinator(coord, time.Hour)
 	comp.APIToken.SetCoordinator(coord)
 	comp.ModelMapping.SetCoordinator(coord)
 
-	// 订阅失效事件
-	cached.AttachInvalidation(ctx, coord, cached.InvalidateProvider, func() { _ = comp.Provider.Load() })
-	cached.AttachInvalidation(ctx, coord, cached.InvalidateRoute, func() { _ = comp.Route.Load() })
-	cached.AttachInvalidation(ctx, coord, cached.InvalidateAPIToken, func() { _ = comp.APIToken.Load() })
-	cached.AttachInvalidation(ctx, coord, cached.InvalidateModelMapping, func() { _ = comp.ModelMapping.Load() })
+	r := router.NewRouter(comp.Route, comp.Provider, comp.Strategy, comp.RetryConfig, comp.Project)
+
+	core.AttachCachedReposToCoordinator(ctx, coord, &core.DatabaseRepos{
+		CachedProviderRepo:        comp.Provider,
+		CachedRouteRepo:           comp.Route,
+		CachedRetryConfigRepo:     comp.RetryConfig,
+		CachedRoutingStrategyRepo: comp.Strategy,
+		CachedProjectRepo:         comp.Project,
+		CachedAPITokenRepo:        comp.APIToken,
+		CachedModelMappingRepo:    comp.ModelMapping,
+		CachedSessionRepo:         comp.Session,
+	}, r)
 
 	// 预加载缓存
-	_ = comp.Provider.Load()
-	_ = comp.Route.Load()
-	_ = comp.APIToken.Load()
-	_ = comp.ModelMapping.Load()
+	loadSteps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"providers", comp.Provider.Load},
+		{"routes", comp.Route.Load},
+		{"retry configs", comp.RetryConfig.Load},
+		{"routing strategies", comp.Strategy.Load},
+		{"projects", comp.Project.Load},
+		{"api tokens", comp.APIToken.Load},
+		{"model mappings", comp.ModelMapping.Load},
+		{"provider adapters", r.InitAdapters},
+	}
+	for _, step := range loadSteps {
+		if err := step.fn(); err != nil {
+			t.Fatalf("load %s: %v", step.name, err)
+		}
+	}
 
 	inst := &instance{
-		ID:    instanceID,
-		Coord: coord,
-		DB:    db,
-		Mgr:   mgr,
-		Comp:  comp,
-		ctx:   ctx,
-		stop:  cancel,
+		ID:     instanceID,
+		Coord:  coord,
+		DB:     db,
+		Mgr:    mgr,
+		Comp:   comp,
+		Router: r,
+		ctx:    ctx,
+		stop:   cancel,
 	}
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- rebuild router provider adapters after cross-instance provider cache invalidation
- wire provider invalidation to reload provider cache and reconcile runtime adapters
- add a multi-instance integration test for project route visibility and adapter availability across instances

## Tests
- /usr/local/go/bin/go test ./tests/multiinstance
- /usr/local/go/bin/go test ./internal/core ./internal/router ./cmd/maxx
- /usr/local/go/bin/go test ./... (fails only for root package: web/dist embed directory is missing; remaining packages pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 多实例环境下，提供商配置变更可自动同步缓存，并更新运行时适配器映射。
  * 项目、提供商与路由信息可在实例间及时同步，确保请求匹配正确的路由和适配器。
* **错误修复**
  * 修复提供商变更后路由或适配器状态未及时更新的问题。
  * 提升跨实例项目路由创建与访问的一致性和可靠性。
* **测试**
  * 新增多实例场景验证，覆盖项目创建、缓存失效、路由匹配及适配器初始化流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->