### PR TITLE
fix(custom): treat HTTP 200 error-body responses as failures

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -526,19 +526,15 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 
 	eventChan := flow.GetEventChan(c)
 
-	if eventChan != nil {
-		eventChan.SendResponseInfo(&domain.ResponseInfo{
-			Status:  resp.StatusCode,
-			Headers: flattenHeaders(resp.Header),
-			Body:    string(body),
-		})
-	}
-
 	// Some upstreams answer HTTP 200 while the body is actually an error
-	// envelope. Detect that before writing anything to the client so the
-	// request fails (and can be retried / cooled down) instead of forwarding a
-	// success. Nothing has been written to c.Writer yet at this point, so
-	// returning an error here is safe. Only attempt on a JSON object body.
+	// envelope. Detect that before writing anything to the client — and before
+	// emitting the success-shaped ResponseInfo event below — so the request
+	// fails (and can be retried / cooled down) instead of being recorded and
+	// forwarded as a success. Nothing has been written to c.Writer yet at this
+	// point, so returning an error here is safe. The returned ProxyError's
+	// message is persisted on the attempt (attempt.Error), so the upstream
+	// failure is still captured without a misleading 200 response event. Only
+	// attempt on a JSON object body.
 	if len(bytes.TrimSpace(body)) > 0 {
 		var payload map[string]interface{}
 		if jsonutil.Unmarshal(body, &payload) == nil {
@@ -546,6 +542,14 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 				return proxyErr
 			}
 		}
+	}
+
+	if eventChan != nil {
+		eventChan.SendResponseInfo(&domain.ResponseInfo{
+			Status:  resp.StatusCode,
+			Headers: flattenHeaders(resp.Header),
+			Body:    string(body),
+		})
 	}
 
 	// Extract and send token usage metrics

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -534,6 +534,20 @@ func (a *CustomAdapter) handleNonStreamResponse(c *flow.Ctx, resp *http.Response
 		})
 	}
 
+	// Some upstreams answer HTTP 200 while the body is actually an error
+	// envelope. Detect that before writing anything to the client so the
+	// request fails (and can be retried / cooled down) instead of forwarding a
+	// success. Nothing has been written to c.Writer yet at this point, so
+	// returning an error here is safe. Only attempt on a JSON object body.
+	if len(bytes.TrimSpace(body)) > 0 {
+		var payload map[string]interface{}
+		if jsonutil.Unmarshal(body, &payload) == nil {
+			if proxyErr := classifyBodyError(payload, "upstream 200 body error"); proxyErr != nil {
+				return proxyErr
+			}
+		}
+	}
+
 	// Extract and send token usage metrics
 	if metrics := usage.ExtractFromResponseWithOptions(string(body), a.usageExtractOptions(clientType)); metrics != nil {
 		// Adjust for client-specific quirks (e.g., Codex input_tokens includes cached tokens)
@@ -689,61 +703,12 @@ func (a *CustomAdapter) handleStreamResponse(c *flow.Ctx, resp *http.Response, c
 	}
 
 	// Helper to inspect an already decoded SSE payload for provider errors.
+	// Returns nil (not a typed nil *ProxyError) for normal frames to avoid the
+	// nil-interface trap when the result is assigned to an `error`.
 	parseSSEErrorPayload := func(payload map[string]interface{}) error {
-		// Check for Claude-style error: {"type": "error", "error": {...}}
-		if payloadType, ok := payload["type"].(string); ok && payloadType == "error" {
-			if errObj, ok := payload["error"].(map[string]interface{}); ok {
-				msg := "SSE error"
-				if m, ok := errObj["message"].(string); ok {
-					msg = m
-				}
-				code := 0
-				if c, ok := errObj["code"].(float64); ok {
-					code = int(c)
-				}
-				errType := ""
-				if t, ok := errObj["type"].(string); ok {
-					errType = t
-				}
-				proxyErr := domain.NewProxyErrorWithMessage(
-					fmt.Errorf("SSE error (code=%d): %s", code, msg),
-					isRetryableSSEError(code, errType, msg),
-					msg,
-				)
-				proxyErr.Scope = domain.ScopeProvider
-				proxyErr.Reason = domain.CooldownReasonServerError
-				return proxyErr
-			}
+		if proxyErr := classifyBodyError(payload, "SSE error"); proxyErr != nil {
+			return proxyErr
 		}
-
-		// Check for OpenAI-style error: {"error": {"message": "...", "type": "..."}}
-		// This format is used by some upstream providers (e.g., Poe, OpenAI-compatible APIs)
-		if errObj, ok := payload["error"].(map[string]interface{}); ok {
-			// Ensure this is an error object, not a normal response that happens to have an "error" field
-			if _, hasMsg := errObj["message"]; hasMsg {
-				msg := "SSE error"
-				if m, ok := errObj["message"].(string); ok {
-					msg = m
-				}
-				code := 0
-				if c, ok := errObj["code"].(float64); ok {
-					code = int(c)
-				}
-				errType := ""
-				if t, ok := errObj["type"].(string); ok {
-					errType = t
-				}
-				proxyErr := domain.NewProxyErrorWithMessage(
-					fmt.Errorf("SSE error (code=%d): %s", code, msg),
-					isRetryableSSEError(code, errType, msg),
-					msg,
-				)
-				proxyErr.Scope = domain.ScopeProvider
-				proxyErr.Reason = domain.CooldownReasonServerError
-				return proxyErr
-			}
-		}
-
 		return nil
 	}
 
@@ -1307,6 +1272,60 @@ func copyResponseHeaders(dst, src http.Header) {
 			dst.Add(key, v)
 		}
 	}
+}
+
+// classifyBodyError inspects an already-decoded JSON payload and returns a
+// ProxyError when it represents an upstream error envelope rather than a
+// successful result. Some upstreams (and OpenAI-compatible gateways) answer
+// with HTTP 200 while the body is actually an error — this lets callers treat
+// those as failures so retry / cooldown logic can kick in. It recognizes:
+//   - Claude-style: {"type": "error", "error": {...}}
+//   - OpenAI/Gemini-style: {"error": {"message": "...", "type": "..."}}
+//
+// label describes the source (e.g. "SSE error", "upstream 200 body error") and
+// is woven into the resulting message. It returns nil for normal payloads,
+// including ones that merely carry a null/absent "error" field.
+func classifyBodyError(payload map[string]interface{}, label string) *domain.ProxyError {
+	// Claude-style error: {"type": "error", "error": {...}}
+	if payloadType, _ := payload["type"].(string); payloadType == "error" {
+		if errObj, ok := payload["error"].(map[string]interface{}); ok {
+			return proxyErrorFromErrObj(errObj, label)
+		}
+	}
+
+	// OpenAI-style error: {"error": {"message": "...", "type": "..."}}
+	// Ensure this is an error object, not a normal response that happens to
+	// carry an "error" field (e.g. "error": null).
+	if errObj, ok := payload["error"].(map[string]interface{}); ok {
+		if _, hasMsg := errObj["message"]; hasMsg {
+			return proxyErrorFromErrObj(errObj, label)
+		}
+	}
+
+	return nil
+}
+
+// proxyErrorFromErrObj builds a provider-scoped ProxyError from an error object
+// ({"message":..., "type":..., "code":...}), reusing the same retryability
+// heuristic as SSE error frames.
+func proxyErrorFromErrObj(errObj map[string]interface{}, label string) *domain.ProxyError {
+	msg := label
+	if m, ok := errObj["message"].(string); ok && m != "" {
+		msg = m
+	}
+	code := 0
+	if c, ok := errObj["code"].(float64); ok {
+		code = int(c)
+	}
+	errType, _ := errObj["type"].(string)
+	proxyErr := domain.NewProxyErrorWithMessage(
+		fmt.Errorf("%s (code=%d): %s", label, code, msg),
+		isRetryableSSEError(code, errType, msg),
+		msg,
+	)
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonServerError
+	return proxyErr
 }
 
 // classifyHTTPError creates a structured ProxyError from an HTTP error response.

--- a/internal/adapter/provider/custom/nonstream_body_error_test.go
+++ b/internal/adapter/provider/custom/nonstream_body_error_test.go
@@ -1,0 +1,88 @@
+package custom
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// mkNonStreamResp builds a minimal 200 JSON response for handleNonStreamResponse.
+func mkNonStreamResp(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestNonStreamDetectsClaudeErrorBodyOn200(t *testing.T) {
+	adapter := newTestCustomAdapter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeClaude)
+
+	resp := mkNonStreamResp(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
+
+	err := adapter.handleNonStreamResponse(ctx, resp, domain.ClientTypeClaude, false)
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("error = %T %v, want *domain.ProxyError", err, err)
+	}
+	if proxyErr.Scope != domain.ScopeProvider || proxyErr.Reason != domain.CooldownReasonServerError {
+		t.Fatalf("scope/reason = %s/%s, want provider/server_error", proxyErr.Scope, proxyErr.Reason)
+	}
+	if proxyErr.Message != "Overloaded" {
+		t.Fatalf("message = %q, want %q", proxyErr.Message, "Overloaded")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("error body was forwarded to client: %q", rec.Body.String())
+	}
+}
+
+func TestNonStreamDetectsOpenAIErrorBodyOn200(t *testing.T) {
+	adapter := newTestCustomAdapter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	resp := mkNonStreamResp(`{"error":{"message":"insufficient upstream capacity","type":"server_error","code":500}}`)
+
+	err := adapter.handleNonStreamResponse(ctx, resp, domain.ClientTypeOpenAI, false)
+	proxyErr, ok := err.(*domain.ProxyError)
+	if !ok {
+		t.Fatalf("error = %T %v, want *domain.ProxyError", err, err)
+	}
+	if proxyErr.Message != "insufficient upstream capacity" {
+		t.Fatalf("message = %q", proxyErr.Message)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("error body was forwarded to client: %q", rec.Body.String())
+	}
+}
+
+func TestNonStreamForwardsNormalBody(t *testing.T) {
+	adapter := newTestCustomAdapter()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	ctx := flow.NewCtx(rec, req)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	// A normal success body that carries a null "error" field must NOT be
+	// treated as an error.
+	success := `{"id":"cmpl-1","object":"chat.completion","error":null,"choices":[{"message":{"role":"assistant","content":"hi"}}]}`
+	resp := mkNonStreamResp(success)
+
+	if err := adapter.handleNonStreamResponse(ctx, resp, domain.ClientTypeOpenAI, false); err != nil {
+		t.Fatalf("handleNonStreamResponse error = %v, want nil", err)
+	}
+	if !strings.Contains(rec.Body.String(), `"content":"hi"`) {
+		t.Fatalf("normal body was not forwarded: %q", rec.Body.String())
+	}
+}

--- a/internal/adapter/provider/custom/nonstream_body_error_test.go
+++ b/internal/adapter/provider/custom/nonstream_body_error_test.go
@@ -20,12 +20,24 @@ func mkNonStreamResp(body string) *http.Response {
 	}
 }
 
+// drainEvents closes an event channel and collects every event that was sent.
+func drainEvents(ch domain.AdapterEventChan) []*domain.AdapterEvent {
+	ch.Close()
+	var events []*domain.AdapterEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	return events
+}
+
 func TestNonStreamDetectsClaudeErrorBodyOn200(t *testing.T) {
 	adapter := newTestCustomAdapter()
 	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
 	ctx.Set(flow.KeyClientType, domain.ClientTypeClaude)
+	eventChan := domain.NewAdapterEventChan()
+	ctx.Set(flow.KeyEventChan, eventChan)
 
 	resp := mkNonStreamResp(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`)
 
@@ -42,6 +54,13 @@ func TestNonStreamDetectsClaudeErrorBodyOn200(t *testing.T) {
 	}
 	if rec.Body.Len() != 0 {
 		t.Fatalf("error body was forwarded to client: %q", rec.Body.String())
+	}
+	// A 200-body error must NOT emit a success-shaped ResponseInfo event, which
+	// would record the upstream error as a successful 200 response.
+	for _, ev := range drainEvents(eventChan) {
+		if ev.Type == domain.EventResponseInfo {
+			t.Fatalf("error envelope emitted a ResponseInfo event: %+v", ev.ResponseInfo)
+		}
 	}
 }
 
@@ -73,6 +92,8 @@ func TestNonStreamForwardsNormalBody(t *testing.T) {
 	rec := httptest.NewRecorder()
 	ctx := flow.NewCtx(rec, req)
 	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+	eventChan := domain.NewAdapterEventChan()
+	ctx.Set(flow.KeyEventChan, eventChan)
 
 	// A normal success body that carries a null "error" field must NOT be
 	// treated as an error.
@@ -84,5 +105,16 @@ func TestNonStreamForwardsNormalBody(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"content":"hi"`) {
 		t.Fatalf("normal body was not forwarded: %q", rec.Body.String())
+	}
+	// The success path must still emit a ResponseInfo event (the reorder only
+	// suppresses it for error envelopes).
+	sawResponseInfo := false
+	for _, ev := range drainEvents(eventChan) {
+		if ev.Type == domain.EventResponseInfo {
+			sawResponseInfo = true
+		}
+	}
+	if !sawResponseInfo {
+		t.Fatal("normal body did not emit a ResponseInfo event")
 	}
 }


### PR DESCRIPTION
## 问题

有些上游(以及 OpenAI 兼容网关)会返回 HTTP `200 OK`,但 body 其实是一个错误信封,例如:

- Claude 风格:`{"type":"error","error":{...}}`
- OpenAI/Gemini 风格:`{"error":{"message":...}}`

**流式**路径本来就会通过 SSE 错误帧检测这类错误并当作失败处理。但**非流式**路径(`handleNonStreamResponse`)只要 HTTP 状态码 `< 400` 就直接把 body 转发给客户端 —— 于是这种「假成功」被记录并计费为 OK,既不重试也不进冷却。

## 改动

- 把原本内嵌在 SSE 处理里的错误信封识别逻辑抽成包级共享函数 `classifyBodyError(payload, label)`(以及 `proxyErrorFromErrObj`),同时识别 Claude 风格与 OpenAI/Gemini 风格。
- 把已有的 SSE 闭包改为调用该共享函数(行为不变,顺带去重约 50 行)。
- 在 `handleNonStreamResponse` 中,**向客户端写任何内容之前**解析 body,若为错误信封则返回 provider 级的 `ProxyError`。此时尚未写入 `c.Writer`,因此可以安全地故障转移到其它路由,现有的 error-fixer 也能介入。

安全边界:仅在 body 为 JSON 对象时检测;正常成功响应携带的 `{"error": null}` **不会**被误判为错误。

## 范围

改动集中在 `custom` adapter,它是 `custom` / `openrouter` / `newapi` 三种 provider 类型的共用基础 —— 正是这些 OpenAI 兼容网关最容易返回「200 带错误 body」。原生第一方 adapter(claude/bedrock/codex/grok)对接的 API 使用正确的 HTTP 状态码,未纳入本次改动。

## 测试

新增 `nonstream_body_error_test.go`:
- Claude 风格 200-error → 返回 error 且不转发给客户端
- OpenAI 风格 200-error → 返回 error 且不转发给客户端
- 带 `"error":null` 的正常成功 body → 正常转发,无 error

`go vet` 与整个 custom 包测试均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 改进非流式响应的错误识别：即使 HTTP 状态为 200，也能正确识别错误内容并转换为代理错误。
  * 统一流式与非流式响应的错误处理，保留错误消息、错误码、类型及重试信息。
  * 支持多种常见错误响应格式，避免正常响应被误判。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->