### PR TITLE
fix(openrouter): pin Codex Responses passthrough to /v1/responses

### DIFF
--- a/internal/adapter/provider/openrouter/adapter.go
+++ b/internal/adapter/provider/openrouter/adapter.go
@@ -116,5 +116,16 @@ func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
 			c.Set(flow.KeyRequestBody, nb)
 		}
 	}
+	// Pin the Codex Responses passthrough to OpenRouter's /v1/responses endpoint.
+	// OpenRouter serves the OpenAI Responses API at <base>/v1/responses (base is
+	// https://openrouter.ai/api). The custom core echoes the client's original
+	// Responses path upstream, but a Codex client whose base_url omits /v1 reaches
+	// maxx at /responses — which would forward to https://openrouter.ai/api/responses,
+	// a 200 HTML SPA page (not the API), so Codex silently gets empty output. Unlike
+	// the OpenAI path (/v1/chat/completions carries its own /v1), the Responses path
+	// varies by client, so force the correct one here regardless of base_url config.
+	if flow.GetClientType(c) == domain.ClientTypeCodex {
+		c.Set(flow.KeyResponsesClientPath, "/v1/responses")
+	}
 	return a.inner.Execute(c, a.synth)
 }

--- a/internal/adapter/provider/openrouter/adapter.go
+++ b/internal/adapter/provider/openrouter/adapter.go
@@ -116,16 +116,37 @@ func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
 			c.Set(flow.KeyRequestBody, nb)
 		}
 	}
-	// Pin the Codex Responses passthrough to OpenRouter's /v1/responses endpoint.
+	// Pin the Codex Responses passthrough under OpenRouter's /v1 API root.
 	// OpenRouter serves the OpenAI Responses API at <base>/v1/responses (base is
 	// https://openrouter.ai/api). The custom core echoes the client's original
 	// Responses path upstream, but a Codex client whose base_url omits /v1 reaches
 	// maxx at /responses — which would forward to https://openrouter.ai/api/responses,
 	// a 200 HTML SPA page (not the API), so Codex silently gets empty output. Unlike
 	// the OpenAI path (/v1/chat/completions carries its own /v1), the Responses path
-	// varies by client, so force the correct one here regardless of base_url config.
+	// varies by client, so force the /v1 prefix here regardless of base_url config,
+	// while preserving any sub-path (/responses/{id}) and query string.
 	if flow.GetClientType(c) == domain.ClientTypeCodex {
-		c.Set(flow.KeyResponsesClientPath, "/v1/responses")
+		c.Set(flow.KeyResponsesClientPath, openRouterResponsesPath(c))
 	}
 	return a.inner.Execute(c, a.synth)
+}
+
+// openRouterResponsesPath returns the upstream Responses path for a Codex request,
+// guaranteeing the /v1 prefix OpenRouter requires while preserving the original
+// sub-path (/responses/{id}) and query string. It prefers the client's original
+// Responses path (flow captures it before the proxy normalizes /v1/responses down
+// to /responses); if absent it falls back to the current request URI.
+func openRouterResponsesPath(c *flow.Ctx) string {
+	p := flow.GetResponsesClientPath(c)
+	if p == "" {
+		p = flow.GetRequestURI(c)
+	}
+	switch {
+	case strings.HasPrefix(p, "/v1/responses"):
+		return p // already versioned; keep sub-path + query
+	case strings.HasPrefix(p, "/responses"):
+		return "/v1" + p // /responses[/...][?...] -> /v1/responses[/...][?...]
+	default:
+		return "/v1/responses"
+	}
 }

--- a/internal/adapter/provider/openrouter/adapter_test.go
+++ b/internal/adapter/provider/openrouter/adapter_test.go
@@ -1,10 +1,43 @@
 package openrouter
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
 )
+
+// TestOpenRouterResponsesPath guards the Codex Responses path pinning: OpenRouter
+// serves the Responses API only under /v1, so the upstream path must always carry
+// the /v1 prefix while preserving any sub-path (/responses/{id}) and query string.
+func TestOpenRouterResponsesPath(t *testing.T) {
+	cases := []struct{ name, clientPath, requestURI, want string }{
+		{"bare responses gets v1", "/responses", "/responses", "/v1/responses"},
+		{"already versioned kept", "/v1/responses", "/responses", "/v1/responses"},
+		{"query preserved", "/responses?foo=bar", "/responses", "/v1/responses?foo=bar"},
+		{"sub-path preserved", "/responses/abc", "/responses", "/v1/responses/abc"},
+		{"versioned sub-path+query kept", "/v1/responses/abc?x=1", "/responses", "/v1/responses/abc?x=1"},
+		{"empty client path falls back to requestURI", "", "/responses", "/v1/responses"},
+		{"empty both defaults", "", "", "/v1/responses"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://x/responses", nil)
+			c := flow.NewCtx(httptest.NewRecorder(), req)
+			if tc.clientPath != "" {
+				c.Set(flow.KeyResponsesClientPath, tc.clientPath)
+			}
+			if tc.requestURI != "" {
+				c.Set(flow.KeyRequestURI, tc.requestURI)
+			}
+			if got := openRouterResponsesPath(c); got != tc.want {
+				t.Errorf("openRouterResponsesPath = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestNewAdapterRequiresOpenRouterConfig(t *testing.T) {
 	cases := []struct {

--- a/tests/e2e/openrouter_mock_test.go
+++ b/tests/e2e/openrouter_mock_test.go
@@ -45,6 +45,18 @@ func newOpenRouterMock(t *testing.T, captured *capturedRequest, calls *int64) *h
 			writeOpenRouterMockStream(t, w, isMessages)
 			return
 		}
+		// Codex Responses API: shape a native /v1/responses reply so the passthrough
+		// path round-trips cleanly (OpenRouter serves this at /v1/responses only).
+		if strings.Contains(r.URL.Path, "/responses") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "resp_or", "object": "response", "status": "completed",
+				"model":  "openai/gpt-5.5",
+				"output": []map[string]any{{"type": "message", "role": "assistant", "content": []map[string]any{{"type": "output_text", "text": "hi"}}}},
+				"usage":  map[string]any{"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+			})
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		if isMessages {
 			_ = json.NewEncoder(w).Encode(map[string]any{
@@ -174,6 +186,36 @@ func TestOpenRouterMockDelegation(t *testing.T) {
 	}
 	if strings.Contains(string(upBody), "cache_control") {
 		t.Errorf("disguise should be off: upstream body must not contain cache_control: %s", upBody)
+	}
+}
+
+// Codex passthrough must reach OpenRouter's Responses API at /v1/responses even
+// when the Codex client hits maxx at the bare /responses path (a base_url without
+// /v1). Otherwise the request forwards to https://openrouter.ai/api/responses — a
+// 200 HTML SPA page, not the API — and Codex silently gets empty output.
+func TestOpenRouterMockCodexResponsesPath(t *testing.T) {
+	captured := &capturedRequest{}
+	var calls int64
+	mock := newOpenRouterMock(t, captured, &calls)
+	defer mock.Close()
+	t.Setenv("MAXX_OPENROUTER_BASE_URL", mock.URL)
+
+	env := NewProxyTestEnv(t)
+	pid := createORProvider(t, env, "or-codex", "sk-test-key", []string{"codex"})
+	createRouteAt(t, env, "codex", pid, 1)
+
+	// Post to the bare /responses (no /v1) — the client misconfiguration that
+	// silently broke Codex on OpenRouter before the path was pinned.
+	resp := env.ProxyPost("/responses", map[string]any{
+		"model":  "gpt-5.5",
+		"input":  []map[string]any{{"type": "message", "role": "user", "content": []map[string]any{{"type": "input_text", "text": "hi"}}}},
+		"stream": false,
+	}, map[string]string{"Authorization": "Bearer client-placeholder"})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	if _, path, _, _ := captured.Get(); path != "/v1/responses" {
+		t.Errorf("codex upstream path = %s, want /v1/responses (OpenRouter serves the Responses API only at /v1/responses)", path)
 	}
 }
 


### PR DESCRIPTION
## The bug: Codex on OpenRouter returned 200 but empty

OpenRouter serves the OpenAI **Responses API only at `/api/v1/responses`**. A quick probe with a real key:

| URL | result |
|---|---|
| `https://openrouter.ai/api/responses` | **HTTP 200, `text/html`** — the OpenRouter website SPA (~130KB), not the API |
| `https://openrouter.ai/api/v1/responses` | native Responses API JSON (incl. `custom_tool_call` for code-mode tools) |

maxx accepts Codex at both `/responses` and `/v1/responses`, and the custom core echoes the client's *original* Responses path upstream (`flow.KeyResponsesClientPath = r.URL.RequestURI()`). A Codex client whose `base_url` omits `/v1` therefore reaches maxx at bare `/responses` → forwarded to `openrouter.ai/api/responses` → **HTML page** → Codex parses no output and returns **empty**, while the request logs as **COMPLETED / 200**.

This is the "OpenRouter 200 but all broken" report: on a live instance ~**33% of codex→OpenRouter requests came back empty**, the stored upstream body being 130KB of HTML.

The OpenAI path is unaffected because `/v1/chat/completions` carries its own `/v1`; only the Responses path varies by client `base_url`.

## Fix

In the OpenRouter adapter, pin the Codex Responses passthrough to `/v1/responses` regardless of the client path (OpenRouter-specific knowledge: its API root is `/api/v1`). One line in `Execute`, gated on `clientType == codex`.

## Test

`TestOpenRouterMockCodexResponsesPath` posts to the bare `/responses` and asserts the mock upstream is hit at `/v1/responses`. Confirmed it **fails without the fix** (`upstream path = /responses`) and passes with it.

## Relation to #814 / #815

#814 defaulted codex→OpenRouter to native `/responses` passthrough; #815 made every OpenRouter provider advertise codex. Both correct, but they exposed this path bug — the passthrough was hitting the wrong OpenRouter path. The kill switch `codex_openrouter_bridge_enabled=true` remains a stopgap (reverts to the chat bridge); this PR makes native passthrough actually work so it can stay off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复 Codex 请求在 OpenRouter 上的路径转发问题，确保请求发送至正确的 Responses API 地址。
  - 保持其他客户端请求路径不变，提升 Codex 请求处理的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->