### PR TITLE
fix(executor): remember last successful smart mapping

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/converter"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
@@ -239,6 +241,128 @@ func TestDispatchSmartMappingRetrySwitchesMappedModelAfterLimit(t *testing.T) {
 	}
 	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
 		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+type configurableSmartMappingRetryAdapter struct {
+	succeedOn string
+	models    []string
+}
+
+func (a *configurableSmartMappingRetryAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *configurableSmartMappingRetryAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	model := flow.GetMappedModel(c)
+	a.models = append(a.models, model)
+	if model == a.succeedOn {
+		return nil
+	}
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New("upstream returned 500"), true, "upstream returned 500")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonServerError
+	proxyErr.HTTPStatusCode = http.StatusInternalServerError
+	return proxyErr
+}
+
+func newSmartMappingRetryDispatchCtx(proxyReqID uint64, adapter provider.ProviderAdapter) *flow.Ctx {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         proxyReqID,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeOpenAI,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "requested-model",
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 22, ClientType: domain.ClientTypeOpenAI},
+				Provider: &domain.Provider{
+					ID:       22,
+					TenantID: domain.DefaultTenantID,
+					Type:     "custom",
+					Name:     "custom-smart-mapping-last-success",
+					Config: &domain.ProviderConfig{
+						DisableErrorCooldown:     true,
+						SmartMappingRetryEnabled: true,
+						SmartMappingRetryLimit:   1,
+					},
+				},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c
+}
+
+func TestDispatchSmartMappingRetryStartsWithLastSuccessfulMappedModel(t *testing.T) {
+	proxyRepo := &recordingProxyRequestRepo{}
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+	e.modelMappingRepo = &stubModelMappingRepo{mappings: []*domain.ModelMapping{
+		{Pattern: "requested-*", Target: "mapped-a"},
+		{Pattern: "requested-*", Target: "mapped-b"},
+		{Pattern: "requested-*", Target: "mapped-c"},
+	}}
+
+	firstAdapter := &configurableSmartMappingRetryAdapter{succeedOn: "mapped-b"}
+	firstCtx := newSmartMappingRetryDispatchCtx(201, firstAdapter)
+	e.dispatch(firstCtx)
+	if firstCtx.Err != nil {
+		t.Fatalf("first dispatch returned error: %v", firstCtx.Err)
+	}
+	if want := []string{"mapped-a", "mapped-b"}; !reflect.DeepEqual(firstAdapter.models, want) {
+		t.Fatalf("first dispatch models = %#v, want %#v", firstAdapter.models, want)
+	}
+
+	secondAdapter := &configurableSmartMappingRetryAdapter{succeedOn: "mapped-b"}
+	secondCtx := newSmartMappingRetryDispatchCtx(202, secondAdapter)
+	e.dispatch(secondCtx)
+	if secondCtx.Err != nil {
+		t.Fatalf("second dispatch returned error: %v", secondCtx.Err)
+	}
+	if want := []string{"mapped-b"}; !reflect.DeepEqual(secondAdapter.models, want) {
+		t.Fatalf("second dispatch models = %#v, want %#v", secondAdapter.models, want)
+	}
+}
+
+func TestDispatchSmartMappingRetryIgnoresLastSuccessAfterCandidateListChanges(t *testing.T) {
+	proxyRepo := &recordingProxyRequestRepo{}
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+	e.modelMappingRepo = &stubModelMappingRepo{mappings: []*domain.ModelMapping{
+		{Pattern: "requested-*", Target: "mapped-a"},
+		{Pattern: "requested-*", Target: "mapped-b"},
+	}}
+
+	firstAdapter := &configurableSmartMappingRetryAdapter{succeedOn: "mapped-b"}
+	firstCtx := newSmartMappingRetryDispatchCtx(203, firstAdapter)
+	e.dispatch(firstCtx)
+	if firstCtx.Err != nil {
+		t.Fatalf("first dispatch returned error: %v", firstCtx.Err)
+	}
+
+	e.modelMappingRepo = &stubModelMappingRepo{mappings: []*domain.ModelMapping{
+		{Pattern: "requested-*", Target: "mapped-a"},
+		{Pattern: "requested-*", Target: "mapped-c"},
+	}}
+	secondAdapter := &configurableSmartMappingRetryAdapter{succeedOn: "mapped-c"}
+	secondCtx := newSmartMappingRetryDispatchCtx(204, secondAdapter)
+	e.dispatch(secondCtx)
+	if secondCtx.Err != nil {
+		t.Fatalf("second dispatch returned error: %v", secondCtx.Err)
+	}
+	if want := []string{"mapped-a", "mapped-c"}; !reflect.DeepEqual(secondAdapter.models, want) {
+		t.Fatalf("second dispatch models = %#v, want %#v", secondAdapter.models, want)
 	}
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/converter"
@@ -36,6 +37,9 @@ type Executor struct {
 	engine           *flow.Engine
 	middlewares      []flow.HandlerFunc
 	cooldownSem      chan struct{} // semaphore to limit concurrent cooldown update goroutines
+
+	smartMappingMu      sync.RWMutex
+	smartMappingSuccess map[string]string
 }
 
 // NewExecutor creates a new executor
@@ -53,20 +57,21 @@ func NewExecutor(
 	instanceID string,
 ) *Executor {
 	return &Executor{
-		router:           r,
-		proxyRequestRepo: prr,
-		attemptRepo:      ar,
-		apiTokenRepo:     apiTokenRepo,
-		retryConfigRepo:  rcr,
-		sessionRepo:      sessionRepo,
-		modelMappingRepo: modelMappingRepo,
-		settingsRepo:     settingsRepo,
-		broadcaster:      bc,
-		projectWaiter:    projectWaiter,
-		instanceID:       instanceID,
-		converter:        converter.GetGlobalRegistry(),
-		engine:           flow.NewEngine(),
-		cooldownSem:      make(chan struct{}, 10),
+		router:              r,
+		proxyRequestRepo:    prr,
+		attemptRepo:         ar,
+		apiTokenRepo:        apiTokenRepo,
+		retryConfigRepo:     rcr,
+		sessionRepo:         sessionRepo,
+		modelMappingRepo:    modelMappingRepo,
+		settingsRepo:        settingsRepo,
+		broadcaster:         bc,
+		projectWaiter:       projectWaiter,
+		instanceID:          instanceID,
+		converter:           converter.GetGlobalRegistry(),
+		engine:              flow.NewEngine(),
+		cooldownSem:         make(chan struct{}, 10),
+		smartMappingSuccess: make(map[string]string),
 	}
 }
 
@@ -152,6 +157,61 @@ func (e *Executor) mapModelCandidates(tenantID uint64, requestModel string, rout
 		return []string{requestModel}
 	}
 	return candidates
+}
+
+func smartMappingCacheKey(tenantID uint64, requestModel string, route *domain.Route, provider *domain.Provider, clientType domain.ClientType, projectID uint64, apiTokenID uint64, candidates []string) string {
+	routeID := uint64(0)
+	providerID := uint64(0)
+	providerType := ""
+	if route != nil {
+		routeID = route.ID
+	}
+	if provider != nil {
+		providerID = provider.ID
+		providerType = provider.Type
+	}
+	parts := []string{
+		strconv.FormatUint(tenantID, 10),
+		strconv.FormatUint(projectID, 10),
+		strconv.FormatUint(apiTokenID, 10),
+		strconv.FormatUint(routeID, 10),
+		strconv.FormatUint(providerID, 10),
+		providerType,
+		string(clientType),
+		requestModel,
+		strings.Join(candidates, "\x00"),
+	}
+	return strings.Join(parts, "\x1f")
+}
+
+func (e *Executor) smartMappingStartIndex(key string, candidates []string) int {
+	if e == nil || key == "" || len(candidates) == 0 {
+		return 0
+	}
+	e.smartMappingMu.RLock()
+	last := e.smartMappingSuccess[key]
+	e.smartMappingMu.RUnlock()
+	if last == "" {
+		return 0
+	}
+	for i, candidate := range candidates {
+		if candidate == last {
+			return i
+		}
+	}
+	return 0
+}
+
+func (e *Executor) recordSmartMappingSuccess(key string, mappedModel string) {
+	if e == nil || key == "" || mappedModel == "" {
+		return
+	}
+	e.smartMappingMu.Lock()
+	if e.smartMappingSuccess == nil {
+		e.smartMappingSuccess = make(map[string]string)
+	}
+	e.smartMappingSuccess[key] = mappedModel
+	e.smartMappingMu.Unlock()
 }
 
 func (e *Executor) getRetryConfig(tenantID uint64, config *domain.RetryConfig) *domain.RetryConfig {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -67,7 +67,12 @@ routeLoop:
 		modelCandidates := e.mapModelCandidates(state.tenantID, state.requestModel, matchedRoute.Route, matchedRoute.Provider, clientType, state.projectID, state.apiTokenID)
 		useSmartMappingRetry := shouldUseSmartMappingRetry(matchedRoute.Provider, len(modelCandidates))
 		smartMappingRetryLimit := getSmartMappingRetryLimit(matchedRoute.Provider)
+		smartMappingKey := ""
 		modelCandidateIndex := 0
+		if useSmartMappingRetry {
+			smartMappingKey = smartMappingCacheKey(state.tenantID, state.requestModel, matchedRoute.Route, matchedRoute.Provider, clientType, state.projectID, state.apiTokenID, modelCandidates)
+			modelCandidateIndex = e.smartMappingStartIndex(smartMappingKey, modelCandidates)
+		}
 		retryConfig := e.getRetryConfig(state.tenantID, matchedRoute.RetryConfig)
 
 		for attempt := 0; ; {
@@ -308,6 +313,9 @@ routeLoop:
 				state.currentAttempt = nil
 
 				cooldown.Default().RecordSuccess(matchedRoute.Provider.ID, string(currentClientType), mappedModel)
+				if useSmartMappingRetry {
+					e.recordSmartMappingSuccess(smartMappingKey, mappedModel)
+				}
 
 				// Sticky write-back: bind this session to the provider that
 				// just succeeded. Overwrites any previous binding (e.g. when


### PR DESCRIPTION
## Summary
- remember the last successful smart-mapping candidate per executor scope
- start later smart-mapping retries from that last successful mapped model instead of always from the first candidate
- invalidate the remembered candidate automatically when the candidate list/scope changes

## Validation
- `go test ./internal/executor`
- `go test ./internal/executor ./tests/e2e ./tests/multiinstance`

## Notes
- `go test ./...` was also run; all listed packages completed, but the root package setup failed because `main.go` embeds `all:web/dist` and `web/dist` is not present in this local checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 智能映射重试会优先使用最近一次成功的模型，提升后续请求的处理效率。
  * 当候选模型列表发生变化时，系统会自动忽略已失效的历史成功记录。

* **稳定性**
  * 增强并发场景下的模型映射状态管理，提升请求调度的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->