### PR TITLE
fix(custom): don't cool the provider on a per-request 402 (max_tokens too big)

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -1358,13 +1358,24 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 		proxyErr.Reason = domain.CooldownReasonAuthFailure
 		proxyErr.Retryable = false
 
-	// 402 — account/key has no remaining balance. Treat it as key-level
-	// quota exhaustion so routing can fail over to another provider instead of
-	// aborting the whole request as a client/request error.
+	// 402 — payment required. Two very different meanings:
+	//   (a) the key/account balance is exhausted → key-level quota cooldown so
+	//       routing fails over and stops hammering a dry key.
+	//   (b) THIS single request is too expensive for the remaining balance — e.g.
+	//       OpenRouter returns "This request requires more credits, or fewer
+	//       max_tokens. You requested up to N tokens, but can only afford M". The key
+	//       still works fine for cheaper requests, so cooling the whole provider would
+	//       wrongly take out a healthy fallback for everyone else. Treat it as a
+	//       request-scoped failure: fail this oversized request WITHOUT any cooldown.
 	case statusCode == http.StatusPaymentRequired:
-		proxyErr.Scope = domain.ScopeKey
-		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
-		proxyErr.Retryable = false
+		if isPerRequestAffordability402(bodyLower) {
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.Retryable = false
+		} else {
+			proxyErr.Scope = domain.ScopeKey
+			proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+			proxyErr.Retryable = false
+		}
 
 	// 403 — check if model-specific or account-level
 	case statusCode == 403:
@@ -1478,6 +1489,18 @@ func classify429Error(proxyErr *domain.ProxyError, body []byte, bodyLower string
 		proxyErr.Scope = domain.ScopeModel
 		proxyErr.Model = model
 	}
+}
+
+// isPerRequestAffordability402 reports whether a 402 body means THIS request is too
+// expensive for the remaining balance (rather than the key being fully out of funds).
+// OpenRouter returns this when max_tokens exceeds what the leftover credits can cover:
+// "This request requires more credits, or fewer max_tokens. You requested up to N
+// tokens, but can only afford M." The key still serves cheaper requests, so this must
+// NOT cool the whole provider. Genuine balance-exhausted 402s ("insufficient balance",
+// "no remaining", etc.) do not match and keep the key-level quota cooldown.
+func isPerRequestAffordability402(bodyLower string) bool {
+	return containsAny(bodyLower, "fewer max_tokens", "can only afford") ||
+		(strings.Contains(bodyLower, "more credits") && strings.Contains(bodyLower, "max_tokens"))
 }
 
 // containsAny returns true if s contains any of the substrings.

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -1371,6 +1371,12 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 		if isPerRequestAffordability402(bodyLower) {
 			proxyErr.Scope = domain.ScopeRequest
 			proxyErr.Retryable = false
+			// A request-scoped failure must never cool the provider. Retry-After
+			// parsing runs before this switch, so if the affordability 402 carried
+			// a Retry-After header those fields are already populated — clear them
+			// so no downstream path can turn this into a cooldown.
+			proxyErr.RetryAfter = 0
+			proxyErr.CooldownUntil = nil
 		} else {
 			proxyErr.Scope = domain.ScopeKey
 			proxyErr.Reason = domain.CooldownReasonQuotaExhausted
@@ -1499,8 +1505,17 @@ func classify429Error(proxyErr *domain.ProxyError, body []byte, bodyLower string
 // NOT cool the whole provider. Genuine balance-exhausted 402s ("insufficient balance",
 // "no remaining", etc.) do not match and keep the key-level quota cooldown.
 func isPerRequestAffordability402(bodyLower string) bool {
-	return containsAny(bodyLower, "fewer max_tokens", "can only afford") ||
-		(strings.Contains(bodyLower, "more credits") && strings.Contains(bodyLower, "max_tokens"))
+	// "fewer max_tokens" only ever appears in the per-request affordability message
+	// and is unambiguous on its own.
+	if strings.Contains(bodyLower, "fewer max_tokens") {
+		return true
+	}
+	// Otherwise require an affordability phrase AND explicit per-request token
+	// context. A bare "can only afford" (or "more credits") without a token count
+	// could be an account/key-level 402, which must keep the quota cooldown.
+	affordability := containsAny(bodyLower, "can only afford", "more credits")
+	tokenContext := containsAny(bodyLower, "max_tokens", "requested up to")
+	return affordability && tokenContext
 }
 
 // containsAny returns true if s contains any of the substrings.

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -56,6 +56,49 @@ func TestClassifyHTTPError402InsufficientBalanceIsKeyQuota(t *testing.T) {
 	}
 }
 
+// OpenRouter returns 402 when a single request's max_tokens exceeds what the
+// remaining credits can cover, even though the key still works for cheaper
+// requests. This must be request-scoped (no cooldown) so one oversized request
+// can't take the whole provider — a shared fallback — offline for everyone.
+func TestClassifyHTTPError402PerRequestAffordabilityIsRequestScoped(t *testing.T) {
+	headers := make(http.Header)
+	body := []byte(`{"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 16000 tokens, but can only afford 7217. To increase, visit https://openrouter.ai/settings/credits and add more credits","code":402,"metadata":{"limit_source":"openrouter_credits"}}}`)
+
+	proxyErr := classifyHTTPError(http.StatusPaymentRequired, body, headers, domain.ClientTypeOpenAI, "openai/gpt-5.5")
+
+	if proxyErr.Scope != domain.ScopeRequest {
+		t.Fatalf("Scope = %v, want ScopeRequest (must not cool the provider)", proxyErr.Scope)
+	}
+	if proxyErr.Reason == domain.CooldownReasonQuotaExhausted {
+		t.Fatal("per-request affordability 402 must not be quota_exhausted (that cools the key)")
+	}
+	if proxyErr.Retryable {
+		t.Fatal("oversized request should not retry the same provider")
+	}
+}
+
+func TestIsPerRequestAffordability402(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"openrouter fewer max_tokens", "requires more credits, or fewer max_tokens", true},
+		{"can only afford", "you requested up to 16000 tokens, but can only afford 7217", true},
+		{"more credits + max_tokens", "needs more credits for these max_tokens", true},
+		{"insufficient balance", "insufficient balance", false},
+		{"no remaining balance", "account has no remaining balance", false},
+		{"generic payment", "payment required", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPerRequestAffordability402(tc.body); got != tc.want {
+				t.Errorf("isPerRequestAffordability402(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestClassifyHTTPError401AuthFailure(t *testing.T) {
 	headers := make(http.Header)
 	proxyErr := classifyHTTPError(401, []byte(`{"error":{"message":"invalid api key"}}`), headers, domain.ClientTypeOpenAI, "gpt-4")

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -77,6 +77,27 @@ func TestClassifyHTTPError402PerRequestAffordabilityIsRequestScoped(t *testing.T
 	}
 }
 
+// Even if the affordability 402 arrives with a Retry-After header (parsed before
+// classification), the request-scoped branch must clear the cooldown metadata so a
+// single oversized request can't cool the shared provider.
+func TestClassifyHTTPError402PerRequestAffordabilityClearsRetryAfter(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Retry-After", "30")
+	body := []byte(`{"error":{"message":"This request requires more credits, or fewer max_tokens. You requested up to 16000 tokens, but can only afford 7217","code":402}}`)
+
+	proxyErr := classifyHTTPError(http.StatusPaymentRequired, body, headers, domain.ClientTypeOpenAI, "openai/gpt-5.5")
+
+	if proxyErr.Scope != domain.ScopeRequest {
+		t.Fatalf("Scope = %v, want ScopeRequest", proxyErr.Scope)
+	}
+	if proxyErr.RetryAfter != 0 {
+		t.Fatalf("RetryAfter = %v, want 0 (request-scoped must not cool the provider)", proxyErr.RetryAfter)
+	}
+	if proxyErr.CooldownUntil != nil {
+		t.Fatalf("CooldownUntil = %v, want nil", *proxyErr.CooldownUntil)
+	}
+}
+
 func TestIsPerRequestAffordability402(t *testing.T) {
 	cases := []struct {
 		name string
@@ -86,6 +107,8 @@ func TestIsPerRequestAffordability402(t *testing.T) {
 		{"openrouter fewer max_tokens", "requires more credits, or fewer max_tokens", true},
 		{"can only afford", "you requested up to 16000 tokens, but can only afford 7217", true},
 		{"more credits + max_tokens", "needs more credits for these max_tokens", true},
+		{"can only afford without token context", "your plan can only afford the basic tier", false},
+		{"more credits without token context", "please add more credits to your account", false},
 		{"insufficient balance", "insufficient balance", false},
 		{"no remaining balance", "account has no remaining balance", false},
 		{"generic payment", "payment required", false},


### PR DESCRIPTION
## The bug

maxx classified **every** upstream 402 as key-level `quota_exhausted`, which cools the whole provider (per client type) for ~12 minutes. That's right when the account balance is truly gone — but OpenRouter also returns 402 when a **single request's `max_tokens` is too big for the remaining credits**:

> This request requires more credits, or fewer max_tokens. You requested up to 16000 tokens, but can only afford 7217. (`metadata.limit_source: openrouter_credits`)

The key still serves cheaper requests fine. Cooling the whole provider on this is wrong — and on a **shared fallback** provider it's severe:

1. One oversized request (e.g. `max_tokens=16000`) 402s.
2. maxx cools OpenRouter-for-openai across the board for ~12 min.
3. Every model the primary (code0) can't serve then fails/rejects for the whole window → looks like an outage.

It also blocked enabling **strict supportModels routing**: with the fallback cooled, a request whose primary was (correctly) skipped by the allowlist had nowhere to go → `no available providers`.

## Fix

In `classifyHTTPError`, split the 402 case:

- **Per-request affordability** (`fewer max_tokens` / `can only afford` / `more credits`+`max_tokens`) → **request-scoped, no cooldown**. The oversized request fails (client should lower `max_tokens`), but the provider stays available for everyone else. `handleCooldown` already returns early for `ScopeRequest`, and dispatch treats request-scoped non-retryable as a clean per-request failure.
- **Genuine balance exhaustion** (`insufficient balance`, etc.) → unchanged: key-level `quota_exhausted` cooldown.

## Tests

- `TestClassifyHTTPError402PerRequestAffordabilityIsRequestScoped` — real OpenRouter 402 body → `ScopeRequest`, not `quota_exhausted`, non-retryable.
- `TestIsPerRequestAffordability402` — table over affordability vs balance-exhausted vs generic phrasings.
- Existing `TestClassifyHTTPError402InsufficientBalanceIsKeyQuota` still passes (balance-exhausted stays key-scoped).

`gofmt`/`go vet` clean; full `custom` + `executor` packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 HTTP 402 错误处理，区分账户余额耗尽与单次请求额度不足。
  * 单次请求超出可负担额度时，将标记为不可重试，避免错误地触发服务冷却或重复请求。
* **Tests**
  * 新增多种额度不足场景的分类验证，提升错误处理的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->