### PR TITLE
fix(proxy): handle Claude probe requests locally

### DIFF
--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -301,6 +301,19 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		}
 	}
 
+	if isClaudeCountTokensRequest(r, clientType) {
+		log.Printf("[Proxy] Handling Claude count_tokens locally")
+		writeClaudeCountTokensResponse(w, body)
+		c.Abort()
+		return
+	}
+	if isClaudeWarmupRequest(r, body, clientType) {
+		log.Printf("[Proxy] Handling Claude warmup probe locally")
+		writeClaudeWarmupResponse(w, body)
+		c.Abort()
+		return
+	}
+
 	requestModel := h.clientAdapter.ExtractModel(r, body, clientType)
 	log.Printf("[Proxy] Extracted model: %s (path: %s)", requestModel, r.URL.Path)
 	sessionID := h.clientAdapter.ExtractSessionID(r, body, clientType)
@@ -610,6 +623,248 @@ func writeStreamError(w http.ResponseWriter, err *domain.ProxyError) {
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+func isClaudeCountTokensRequest(req *http.Request, clientType domain.ClientType) bool {
+	return clientType == domain.ClientTypeClaude && req != nil && req.URL.Path == "/v1/messages/count_tokens"
+}
+
+func writeClaudeCountTokensResponse(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]int{
+		"input_tokens": estimateClaudeInputTokens(body),
+	})
+}
+
+func isClaudeWarmupRequest(req *http.Request, body []byte, clientType domain.ClientType) bool {
+	if clientType != domain.ClientTypeClaude || req == nil || req.URL.Path != "/v1/messages" {
+		return false
+	}
+	if req.Header.Get("anthropic-beta") == "" {
+		return false
+	}
+
+	var claudeReq converter.ClaudeRequest
+	if err := json.Unmarshal(body, &claudeReq); err != nil {
+		return false
+	}
+	if len(claudeReq.Tools) > 0 {
+		return false
+	}
+	return !isClaudeCompactRequest(claudeReq) && isClaudeWarmupProbePayload(claudeReq)
+}
+
+func isClaudeWarmupProbePayload(req converter.ClaudeRequest) bool {
+	if !req.Stream || req.MaxTokens != 1 || req.System != nil || len(req.Messages) != 1 {
+		return false
+	}
+	msg := req.Messages[0]
+	if msg.Role != "user" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(extractClaudeText(msg.Content))) {
+	case "hi", "hello", "ok", "say hi", "say hello":
+		return true
+	default:
+		return false
+	}
+}
+
+func isClaudeCompactRequest(req converter.ClaudeRequest) bool {
+	if strings.HasPrefix(extractClaudeText(req.System), "You are a helpful AI assistant tasked with summarizing conversations") {
+		return true
+	}
+	if len(req.Messages) == 0 {
+		return false
+	}
+	last := req.Messages[len(req.Messages)-1]
+	if last.Role != "user" {
+		return false
+	}
+	text := extractClaudeText(last.Content)
+	return strings.Contains(text, "CRITICAL: Respond with TEXT ONLY. Do NOT call any tools.") ||
+		(strings.Contains(text, "Pending Tasks:") && strings.Contains(text, "Current Work:"))
+}
+
+func writeClaudeWarmupResponse(w http.ResponseWriter, body []byte) {
+	var req converter.ClaudeRequest
+	_ = json.Unmarshal(body, &req)
+	model := req.Model
+	if model == "" {
+		model = "claude"
+	}
+	if req.Stream {
+		writeClaudeWarmupStreamResponse(w, model)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(converter.ClaudeResponse{
+		ID:    "msg_maxx_warmup",
+		Type:  "message",
+		Role:  "assistant",
+		Model: model,
+		Content: []converter.ClaudeContentBlock{{
+			Type: "text",
+			Text: "ok",
+		}},
+		StopReason: "end_turn",
+		Usage: converter.ClaudeUsage{
+			InputTokens:  estimateClaudeInputTokens(body),
+			OutputTokens: 1,
+		},
+	})
+}
+
+func writeClaudeWarmupStreamResponse(w http.ResponseWriter, model string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+
+	writeClaudeSSE(w, "message_start", map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id":            "msg_maxx_warmup",
+			"type":          "message",
+			"role":          "assistant",
+			"model":         model,
+			"content":       []interface{}{},
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage": map[string]int{
+				"input_tokens":  0,
+				"output_tokens": 0,
+			},
+		},
+	})
+	writeClaudeSSE(w, "content_block_start", map[string]interface{}{
+		"type":  "content_block_start",
+		"index": 0,
+		"content_block": map[string]string{
+			"type": "text",
+			"text": "",
+		},
+	})
+	writeClaudeSSE(w, "content_block_delta", map[string]interface{}{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]string{
+			"type": "text_delta",
+			"text": "ok",
+		},
+	})
+	writeClaudeSSE(w, "content_block_stop", map[string]interface{}{
+		"type":  "content_block_stop",
+		"index": 0,
+	})
+	writeClaudeSSE(w, "message_delta", map[string]interface{}{
+		"type": "message_delta",
+		"delta": map[string]interface{}{
+			"stop_reason":   "end_turn",
+			"stop_sequence": nil,
+		},
+		"usage": map[string]int{
+			"output_tokens": 1,
+		},
+	})
+	writeClaudeSSE(w, "message_stop", map[string]string{
+		"type": "message_stop",
+	})
+}
+
+func writeClaudeSSE(w http.ResponseWriter, event string, payload interface{}) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	_, _ = w.Write([]byte("event: " + event + "\n"))
+	_, _ = w.Write([]byte("data: "))
+	_, _ = w.Write(data)
+	_, _ = w.Write([]byte("\n\n"))
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func extractClaudeText(v interface{}) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case []interface{}:
+		var b strings.Builder
+		for _, item := range x {
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(extractClaudeText(item))
+		}
+		return b.String()
+	case map[string]interface{}:
+		if text, ok := x["text"].(string); ok {
+			return text
+		}
+		if content, ok := x["content"]; ok {
+			return extractClaudeText(content)
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+func estimateClaudeInputTokens(body []byte) int {
+	var req converter.ClaudeRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return estimateTextTokens(string(body))
+	}
+
+	total := 4
+	total += estimateJSONTokens(req.System)
+	for _, msg := range req.Messages {
+		total += 3
+		total += estimateJSONTokens(msg.Content)
+	}
+	for _, tool := range req.Tools {
+		total += 16
+		total += estimateTextTokens(tool.Name)
+		total += estimateTextTokens(tool.Description)
+		total += estimateJSONTokens(tool.InputSchema)
+	}
+	if total < 1 {
+		return 1
+	}
+	return total
+}
+
+func estimateJSONTokens(v interface{}) int {
+	switch x := v.(type) {
+	case nil:
+		return 0
+	case string:
+		return estimateTextTokens(x)
+	default:
+		data, err := json.Marshal(x)
+		if err != nil {
+			return 0
+		}
+		return estimateTextTokens(string(data))
+	}
+}
+
+func estimateTextTokens(text string) int {
+	runes := len([]rune(text))
+	if runes == 0 {
+		return 0
+	}
+	tokens := (runes + 3) / 4
+	if tokens < 1 {
+		return 1
+	}
+	return tokens
 }
 
 func isOpenAIChatCompletionsPath(path string) bool {

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1338,6 +1338,285 @@ func TestProxyMatchedRouteWithUnsupportedModelAndCooldownProviderRecords503(t *t
 	assertRouteMatchRejectionRecorded(t, env, 2, "no available providers", http.StatusServiceUnavailable)
 }
 
+func TestProxyHandlesClaudeCountTokensLocally(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages/count_tokens", map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"system": []map[string]any{{
+			"type": "text",
+			"text": "You are concise.",
+		}},
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Count this locally.",
+		}},
+		"tools": []map[string]any{{
+			"name":        "lookup",
+			"description": "Lookup a value.",
+			"input_schema": map[string]any{
+				"type": "object",
+			},
+		}},
+	}, nil)
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	var result struct {
+		InputTokens int `json:"input_tokens"`
+	}
+	DecodeJSON(t, resp, &result)
+	if result.InputTokens <= 0 {
+		t.Fatalf("input_tokens = %d, want positive local estimate", result.InputTokens)
+	}
+	if method, path, _, _ := captured.Get(); method != "" || path != "" {
+		t.Fatalf("count_tokens reached upstream: method=%q path=%q", method, path)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func TestProxyHandlesClaudeCountTokensLocallyWithoutSystem(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages/count_tokens", map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Count this locally without system.",
+		}},
+	}, nil)
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	var result struct {
+		InputTokens int `json:"input_tokens"`
+	}
+	DecodeJSON(t, resp, &result)
+	if result.InputTokens <= 0 {
+		t.Fatalf("input_tokens = %d, want positive local estimate", result.InputTokens)
+	}
+	if method, path, _, _ := captured.Get(); method != "" || path != "" {
+		t.Fatalf("count_tokens reached upstream: method=%q path=%q", method, path)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func TestProxyDoesNotShortCircuitClaudeCountTokensSubpath(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages/count_tokens/extra", map[string]any{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "This subpath should not be handled locally.",
+		}},
+	}, nil)
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if method, path, _, _ := captured.Get(); method != http.MethodPost || path != "/v1/messages/count_tokens/extra" {
+		t.Fatalf("Claude count_tokens subpath did not reach upstream: method=%q path=%q", method, path)
+	}
+	requests := getProxyRequests(t, env)
+	if len(requests) != 1 {
+		t.Fatalf("Claude count_tokens subpath should be recorded, got %d requests", len(requests))
+	}
+}
+
+func TestProxyHandlesClaudeWarmupProbeLocally(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := proxyStreamPost(t, env, "/v1/messages", map[string]any{
+		"model":      "claude-sonnet-4-20250514",
+		"max_tokens": 1,
+		"stream":     true,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Hello",
+		}},
+	}, map[string]string{
+		"anthropic-beta": "prompt-caching-scope-2026-01-05",
+	})
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if got := resp.Header.Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "event: message_stop") {
+		t.Fatalf("warmup stream missing message_stop: %s", string(body))
+	}
+	if method, path, _, _ := captured.Get(); method != "" || path != "" {
+		t.Fatalf("warmup probe reached upstream: method=%q path=%q", method, path)
+	}
+	assertNoProxyRequestsRecorded(t, env)
+}
+
+func TestProxyDoesNotShortCircuitOrdinaryClaudeBetaNoToolsRequest(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages", map[string]any{
+		"model":      "claude-sonnet-4-20250514",
+		"max_tokens": 64,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Write a short greeting.",
+		}},
+	}, map[string]string{
+		"anthropic-beta": "prompt-caching-scope-2026-01-05",
+	})
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if method, path, _, _ := captured.Get(); method != http.MethodPost || path != "/v1/messages" {
+		t.Fatalf("ordinary Claude beta request did not reach upstream: method=%q path=%q", method, path)
+	}
+	requests := getProxyRequests(t, env)
+	if len(requests) != 1 {
+		t.Fatalf("ordinary Claude beta request should be recorded, got %d requests", len(requests))
+	}
+}
+
+func TestProxyDoesNotShortCircuitClaudeRequestWithTools(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages", map[string]any{
+		"model":      "claude-sonnet-4-20250514",
+		"max_tokens": 64,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Hello",
+		}},
+		"tools": []map[string]any{{
+			"name":        "Read",
+			"description": "Read a file",
+			"input_schema": map[string]any{
+				"type": "object",
+			},
+		}},
+	}, map[string]string{
+		"anthropic-beta": "prompt-caching-scope-2026-01-05",
+	})
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if method, path, _, _ := captured.Get(); method != http.MethodPost || path != "/v1/messages" {
+		t.Fatalf("Claude request with tools did not reach upstream: method=%q path=%q", method, path)
+	}
+	requests := getProxyRequests(t, env)
+	if len(requests) != 1 {
+		t.Fatalf("Claude request with tools should be recorded, got %d requests", len(requests))
+	}
+}
+
+func TestProxyDoesNotShortCircuitClaudeCompactRequest(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := env.ProxyPost("/v1/messages", map[string]any{
+		"model":      "claude-sonnet-4-20250514",
+		"max_tokens": 1024,
+		"system":     "You are a helpful AI assistant tasked with summarizing conversations for continuation.",
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Pending Tasks:\n- keep testing\n\nCurrent Work:\ncompact context",
+		}},
+	}, map[string]string{
+		"anthropic-beta": "prompt-caching-scope-2026-01-05",
+	})
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if method, path, _, _ := captured.Get(); method != http.MethodPost || path != "/v1/messages" {
+		t.Fatalf("Claude compact request did not reach upstream: method=%q path=%q", method, path)
+	}
+	requests := getProxyRequests(t, env)
+	if len(requests) != 1 {
+		t.Fatalf("Claude compact request should be recorded, got %d requests", len(requests))
+	}
+}
+
+func TestProxyDoesNotShortCircuitOrdinarySmallClaudeMessages(t *testing.T) {
+	captured := &capturedRequest{}
+	mock := newMockClaudeUpstream(t, captured)
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-claude", mock.URL, []string{"claude"})
+	createRoute(t, env, "claude", providerID)
+
+	resp := proxyStreamPost(t, env, "/v1/messages", map[string]any{
+		"model":      "claude-3-5-haiku-20241022",
+		"max_tokens": 1,
+		"stream":     true,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": "Who are you?",
+		}},
+	}, nil)
+	defer resp.Body.Close()
+
+	AssertStatus(t, resp, http.StatusOK)
+	if method, path, _, _ := captured.Get(); method != http.MethodPost || path != "/v1/messages" {
+		t.Fatalf("ordinary small Claude message did not reach upstream: method=%q path=%q", method, path)
+	}
+	requests := getProxyRequests(t, env)
+	if len(requests) != 1 {
+		t.Fatalf("ordinary small Claude message should be recorded, got %d requests", len(requests))
+	}
+}
+
+func assertNoProxyRequestsRecorded(t *testing.T, env *ProxyTestEnv) {
+	t.Helper()
+
+	requests := getProxyRequests(t, env)
+	if len(requests) != 0 {
+		t.Fatalf("expected local probe handling to stay out of requests tab, got %d requests: %#v", len(requests), requests)
+	}
+}
+
 func assertRouteMatchRejectionRecorded(t *testing.T, env *ProxyTestEnv, wantTotal int, wantErrorPart string, wantStatus int) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- handle Claude `/v1/messages/count_tokens` locally with an estimated token count
- short-circuit Claude warmup probes locally before session/executor/upstream dispatch
- add e2e coverage for local probe handling plus negative cases for tools, compact, and ordinary short requests

## Sensitive data check
- scanned the committed diff for the production password, bearer tokens, Maxx API tokens, and observed production request identifiers/IPs; no sensitive values are present

## Tests
- `/usr/local/go/bin/go test ./internal/handler ./tests/e2e -run 'TestProxy(HandlesClaudeCountTokensLocally|HandlesClaudeWarmupProbeLocally|DoesNotShortCircuitClaudeRequestWithTools|DoesNotShortCircuitClaudeCompactRequest|DoesNotShortCircuitOrdinarySmallClaudeMessages|CrossProtocolConversions|CodexToGeminiStreamingSSE|GeminiStreamingToCodexSSE)'`\n- `git diff --check`\n- pre-commit hook: `pnpm tsc --build --force`, `pnpm lint-staged`\n\nNote: `go test ./...` currently fails at the root package because `web/dist` is missing in this worktree (`pattern all:web/dist: no matching files found`); other Go packages passed in that run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Claude `count_tokens` 请求现在可本地返回输入令牌估算结果，无需访问上游。
  * Claude warmup 探测请求支持本地返回同步或流式响应，减少不必要的上游调用。

* **改进**
  * 普通 Claude 请求、带工具请求及 compact 请求仍会正常转发并记录。
  * 本地处理的探测与令牌计算请求不会访问上游或写入请求记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->