### PR TITLE
fix(gemini): route Gemini image requests through OpenAI, not Claude

### DIFF
--- a/internal/executor/converting_writer.go
+++ b/internal/executor/converting_writer.go
@@ -296,6 +296,21 @@ func GetPreferredTargetType(supportedTypes []domain.ClientType, originalType dom
 		}
 	}
 
+	// A Gemini client converts most faithfully to OpenAI: the Gemini<->OpenAI
+	// pair is the one that carries generated-image output (Gemini inlineData <->
+	// OpenAI message.images). The Anthropic Messages protocol has no
+	// generated-image representation, so routing a Gemini image request through
+	// Claude silently drops the image the model produced. Prefer OpenAI over
+	// Claude for a Gemini source; providers without OpenAI support (e.g.
+	// claude-only) still fall through to Claude below.
+	if originalType == domain.ClientTypeGemini {
+		for _, t := range supportedTypes {
+			if t == domain.ClientTypeOpenAI {
+				return t
+			}
+		}
+	}
+
 	// Prefer Gemini as target (best fit for Antigravity)
 	for _, t := range supportedTypes {
 		if t == domain.ClientTypeGemini {

--- a/internal/executor/converting_writer_test.go
+++ b/internal/executor/converting_writer_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestGetPreferredTargetType(t *testing.T) {
+	// OpenRouter's canonical capability set. It natively speaks these three but
+	// NOT the Gemini API, so a Gemini client must be converted to one of them.
+	openrouter := []domain.ClientType{
+		domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex,
+	}
+
+	cases := []struct {
+		name         string
+		supported    []domain.ClientType
+		original     domain.ClientType
+		providerType string
+		want         domain.ClientType
+	}{
+		{
+			// The bug fix: a Gemini image request routed to OpenRouter must convert
+			// via OpenAI (which carries generated images in message.images), not via
+			// Claude (Anthropic Messages cannot represent a generated image, so it is
+			// silently dropped).
+			name:         "gemini source to openrouter prefers openai over claude",
+			supported:    openrouter,
+			original:     domain.ClientTypeGemini,
+			providerType: "openrouter",
+			want:         domain.ClientTypeOpenAI,
+		},
+		{
+			// A provider that only speaks Claude still has to use Claude for a Gemini
+			// source — the OpenAI preference must not break claude-only providers.
+			name:         "gemini source to claude-only provider falls back to claude",
+			supported:    []domain.ClientType{domain.ClientTypeClaude},
+			original:     domain.ClientTypeGemini,
+			providerType: "claude",
+			want:         domain.ClientTypeClaude,
+		},
+		{
+			// No conversion when the provider already speaks the client's protocol.
+			name:         "gemini source to gemini-capable provider stays gemini",
+			supported:    []domain.ClientType{domain.ClientTypeGemini, domain.ClientTypeClaude},
+			original:     domain.ClientTypeGemini,
+			providerType: "antigravity",
+			want:         domain.ClientTypeGemini,
+		},
+		{
+			// The OpenAI-for-Gemini preference must not affect other source clients:
+			// a Claude client to OpenRouter still passes through as Claude.
+			name:         "claude source to openrouter stays claude",
+			supported:    openrouter,
+			original:     domain.ClientTypeClaude,
+			providerType: "openrouter",
+			want:         domain.ClientTypeClaude,
+		},
+		{
+			// A Codex provider still prefers Codex regardless of source.
+			name:         "codex provider prefers codex",
+			supported:    []domain.ClientType{domain.ClientTypeCodex, domain.ClientTypeOpenAI},
+			original:     domain.ClientTypeOpenAI,
+			providerType: "codex",
+			want:         domain.ClientTypeOpenAI, // originalType supported → no conversion
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetPreferredTargetType(tc.supported, tc.original, tc.providerType)
+			if got != tc.want {
+				t.Fatalf("GetPreferredTargetType(%v, %q, %q) = %q, want %q",
+					tc.supported, tc.original, tc.providerType, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/executor/gemini_image_dispatch_test.go
+++ b/internal/executor/gemini_image_dispatch_test.go
@@ -1,0 +1,163 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+	"github.com/tidwall/gjson"
+)
+
+// tinyPNGDataURL is a 1x1 PNG as a data URL — the shape OpenRouter returns a
+// generated image in (message.images[].image_url.url).
+const tinyPNGDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+// openRouterLikeConversionAdapter mimics an OpenRouter provider: it natively
+// speaks Claude AND OpenAI (but not the Gemini API), captures the request it
+// receives, and returns a canned OpenAI chat.completion.
+type openRouterLikeConversionAdapter struct {
+	calls           int
+	seenClientType  domain.ClientType
+	seenRequestURI  string
+	seenRequestBody []byte
+	responseBody    string
+}
+
+func (a *openRouterLikeConversionAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeOpenAI}
+}
+
+func (a *openRouterLikeConversionAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	a.seenClientType = flow.GetClientType(c)
+	a.seenRequestURI = flow.GetRequestURI(c)
+	a.seenRequestBody = append([]byte(nil), flow.GetRequestBody(c)...)
+
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, err := c.Writer.Write([]byte(a.responseBody))
+	return err
+}
+
+// A native Gemini image request routed to an OpenRouter-like provider (speaks
+// Claude + OpenAI, not Gemini) must convert through OpenAI, because only the
+// Gemini<->OpenAI pair carries a generated image. Converting through Claude
+// (Anthropic Messages) silently drops it. This locks the full dispatch path:
+// target selection (GetPreferredTargetType) + request/response conversion.
+func TestDispatchGeminiImageRequestConvertsThroughOpenAINotClaude(t *testing.T) {
+	adapter := &openRouterLikeConversionAdapter{responseBody: `{
+		"id":"gen-1","object":"chat.completion","created":1700000000,
+		"model":"google/gemini-2.5-flash-image","provider":"Google",
+		"choices":[{"index":0,"message":{"role":"assistant","content":"here you go",
+			"images":[{"type":"image_url","image_url":{"url":"` + tinyPNGDataURL + `"}}]},
+			"finish_reason":"stop"}],
+		"usage":{"prompt_tokens":6,"completion_tokens":1300,"total_tokens":1306}
+	}`}
+
+	geminiReq := `{"contents":[{"role":"user","parts":[{"text":"a red apple"}]}],` +
+		`"generationConfig":{"responseModalities":["IMAGE"]}}`
+	c, proxyRepo, attemptRepo := newGeminiImageDispatchCtx(t, geminiReq, adapter)
+	e := &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &stubModelMappingRepo{},
+		settingsRepo:     &stubExecutorSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	}
+
+	// The upstream must be reached as OpenAI on the chat endpoint — NOT Claude.
+	if adapter.seenClientType != domain.ClientTypeOpenAI {
+		t.Fatalf("upstream client type = %s, want openai (must not route Gemini image through Claude)", adapter.seenClientType)
+	}
+	if adapter.seenRequestURI != "/v1/chat/completions" {
+		t.Fatalf("upstream URI = %q, want /v1/chat/completions", adapter.seenRequestURI)
+	}
+	// The converted request must ask OpenRouter for image output.
+	if mods := gjson.GetBytes(adapter.seenRequestBody, "modalities"); !mods.Exists() {
+		t.Fatalf("converted request dropped modalities: %s", adapter.seenRequestBody)
+	}
+
+	// The client must receive the generated image back as a Gemini inlineData part.
+	body := c.Writer.(*httptest.ResponseRecorder).Body.Bytes()
+	mime := gjson.GetBytes(body, "candidates.0.content.parts.#(inlineData.mimeType!=).inlineData.mimeType").String()
+	data := gjson.GetBytes(body, "candidates.0.content.parts.#(inlineData.data!=).inlineData.data").String()
+	if mime != "image/png" {
+		t.Fatalf("client did not receive inlineData image (mime=%q); body=%s", mime, body)
+	}
+	if data == "" {
+		t.Fatalf("generated image dropped on the way back to the Gemini client; body=%s", body)
+	}
+	// The text preamble must survive too.
+	if !strings.Contains(string(body), "here you go") {
+		t.Fatalf("text preamble lost: %s", body)
+	}
+
+	if len(attemptRepo.updated) == 0 || attemptRepo.updated[len(attemptRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed attempt, got %#v", attemptRepo.updated)
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request, got %#v", proxyRepo.updated)
+	}
+}
+
+func newGeminiImageDispatchCtx(t *testing.T, requestBody string, adapter *openRouterLikeConversionAdapter) (*flow.Ctx, *recordingProxyRequestRepo, *recordingAttemptRepo) {
+	t.Helper()
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	rec := httptest.NewRecorder()
+	const uri = "/v1beta/models/gemini-2.5-flash-image:generateContent"
+	req := httptest.NewRequest(http.MethodPost, uri, strings.NewReader(requestBody)).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:           202,
+		TenantID:     domain.DefaultTenantID,
+		ClientType:   domain.ClientTypeGemini,
+		RequestModel: "gemini-2.5-flash-image",
+		Status:       "IN_PROGRESS",
+		StartTime:    time.Now(),
+	}
+	state := &execState{
+		ctx:                 context.Background(),
+		proxyReq:            proxyReq,
+		tenantID:            domain.DefaultTenantID,
+		clientType:          domain.ClientTypeGemini,
+		requestModel:        "gemini-2.5-flash-image",
+		isStream:            false,
+		requestBody:         []byte(requestBody),
+		originalRequestBody: []byte(requestBody),
+		requestHeaders:      http.Header{"Content-Type": []string{"application/json"}},
+		requestURI:          uri,
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 32, TenantID: domain.DefaultTenantID, ProviderID: 42, ClientType: domain.ClientTypeGemini},
+				Provider: &domain.Provider{
+					ID:                   42,
+					TenantID:             domain.DefaultTenantID,
+					Type:                 "openrouter",
+					Name:                 "openrouter-like",
+					SupportedClientTypes: []domain.ClientType{domain.ClientTypeClaude, domain.ClientTypeOpenAI},
+				},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c, proxyRepo, attemptRepo
+}


### PR DESCRIPTION
## Problem

A native Gemini image request (`POST /v1beta/models/{model}:generateContent`) routed to an **OpenRouter** provider silently returns **no image** — the response `parts` contains only the text preamble, even though the upstream model generated the image (~1300 image tokens are billed). The openai-format path (`/v1/chat/completions`) for the same model works fine.

## Root cause

Not the converters — `openai_to_gemini_response.go` / `openai_to_gemini_stream.go` already convert `message.images[]` → Gemini `inlineData`, and `gemini_to_openai.go` already carries `responseModalities`/`imageConfig`. The bug is in **target-protocol selection**.

OpenRouter's canonical capability set is `[claude, openai, codex]` (`domain.CanonicalSupportedClientTypes`) — it does **not** natively speak the Gemini API, so a Gemini client must be converted to one of those. `GetPreferredTargetType`'s fallback order put **Claude ahead of OpenAI**, so a Gemini request was converted to the **Anthropic Messages** protocol and sent to `/v1/messages`.

The Anthropic Messages protocol has **no representation for a generated image**, so the image is dropped in the `claude → gemini` response conversion. Only the text preamble survives.

## Fix

Prefer **OpenAI over Claude** for a Gemini source client. The Gemini↔OpenAI converter pair is the maintained image path (Gemini `inlineData` ↔ OpenAI `message.images`), and OpenRouter's `chat/completions` endpoint returns generated images. Providers without OpenAI support (e.g. claude-only like kiro) still fall through to Claude, so no other routing changes.

## Verification

Against live OpenRouter (`gemini-2.5-flash-image`, `gemini-3-pro-image`):
- openai-format request → `message.images: 1` (image present, ~1.6 MB data URL) ✅
- native `/v1beta` request **pre-fix** → `parts` text-only, image dropped ❌
- OpenRouter returns the image on `chat/completions` with `modalities:["image"]`, `["image","text"]`, or none — so no request-side modality change is needed.

Adds `TestGetPreferredTargetType` covering the fix plus non-regressions: claude-only provider still uses Claude for Gemini, gemini-capable provider stays Gemini, Claude source to OpenRouter stays Claude, codex provider unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 Gemini 请求的目标协议选择：在支持 OpenAI 时优先使用 OpenAI。
  * 当 OpenAI 不可用时，将按兼容性顺序回退至 Gemini、Claude 或其他可用协议。
  * 保持现有 Claude、Codex 及原协议请求的处理行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->