### PR TITLE
fix(newapi): normalize Markdown-embedded generated images to message.images

### DIFF
--- a/internal/executor/responsemodifier/newapi_image_response_modifier.go
+++ b/internal/executor/responsemodifier/newapi_image_response_modifier.go
@@ -74,11 +74,25 @@ func (m *newapiImageResponseModifier) modifyStreamEvent(event []byte) []byte {
 // there is no Markdown data image, when the body isn't a JSON object, or when a data
 // URL is split across stream chunks (best effort: only complete matches are lifted).
 func rewriteMarkdownImages(body []byte) []byte {
-	if !bytes.Contains(body, []byte("](data:image/")) {
+	// Fast path: skip the JSON parse only when the body cannot possibly contain a
+	// data-URL image. Guard on the minimal substring every match shares ("data:image")
+	// rather than the full "](data:image/" — the regex tolerates whitespace after the
+	// paren (`![image](  data:...`) and JSON may escape the slash (`data:image\/png`),
+	// so a stricter guard would drop matches the extraction below would otherwise make.
+	if !bytes.Contains(body, []byte("data:image")) {
 		return body
 	}
+	// UseNumber so untouched extension fields (e.g. large integer ids/usage counters)
+	// round-trip byte-for-byte instead of being coerced to float64 and re-encoded with
+	// precision loss. Reject trailing non-JSON data so a non-object payload is passed
+	// through untouched rather than partially parsed.
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
 	var object map[string]any
-	if err := json.Unmarshal(body, &object); err != nil {
+	if err := decoder.Decode(&object); err != nil {
+		return body
+	}
+	if decoder.More() {
 		return body
 	}
 	choices, ok := object["choices"].([]any)

--- a/internal/executor/responsemodifier/newapi_image_response_modifier.go
+++ b/internal/executor/responsemodifier/newapi_image_response_modifier.go
@@ -1,0 +1,135 @@
+package responsemodifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// new-api / one-api relays proxy Gemini image models through Google's
+// OpenAI-compatibility layer, but instead of emitting the generated image in the
+// standard OpenAI `message.images[]` array (the OpenRouter convention that maxx's
+// converters read), they embed it as a Markdown image inside `message.content`:
+//
+//	"Here's a red apple!\n![image](data:image/png;base64,iVBORw0K...)"
+//
+// A client reading `message.images[]` therefore gets nothing, and the Gemini
+// response converter (openai_to_gemini) has no image to lift into an inlineData
+// part. This modifier normalizes that non-standard shape back to the standard one:
+// it pulls every Markdown data-URL image out of the assistant content and into
+// `message.images[]`, leaving the surrounding prose intact. Downstream this means an
+// OpenAI client receives the standard images array, and — since it runs before the
+// client-facing bytes are produced — a Gemini client's openai->gemini conversion can
+// carry the image as inlineData just like it does for OpenRouter.
+//
+// It is scoped to new-api providers on the OpenAI protocol: a native Gemini
+// (/v1beta) request to the same upstream already returns inlineData and never hits
+// this path, and other provider types don't produce the Markdown shape.
+
+// markdownDataImageRE matches a Markdown image whose URL is a base64 data URI,
+// e.g. ![image](data:image/png;base64,AAAA). Group 1 is the data URI itself.
+var markdownDataImageRE = regexp.MustCompile(`!\[[^\]]*\]\(\s*(data:image/[A-Za-z0-9.+-]+;base64,[A-Za-z0-9+/=]+)\s*\)`)
+
+// newapiSSEDataLineRE isolates the JSON payload of an SSE `data:` line so streamed
+// chunks can be rewritten in place, preserving the exact prefix/newline framing.
+var newapiSSEDataLineRE = regexp.MustCompile(`(?m)^(\s*data:\s*)(.*?)(\r?\n?)$`)
+
+type newapiImageResponseModifier struct{}
+
+func newNewapiImageResponseModifier(provider *domain.Provider, clientType domain.ClientType) *newapiImageResponseModifier {
+	if provider == nil || provider.Type != "newapi" || clientType != domain.ClientTypeOpenAI {
+		return nil
+	}
+	return &newapiImageResponseModifier{}
+}
+
+func (m *newapiImageResponseModifier) modifyBody(body []byte) []byte {
+	return rewriteMarkdownImages(body)
+}
+
+func (m *newapiImageResponseModifier) modifyStreamEvent(event []byte) []byte {
+	return newapiSSEDataLineRE.ReplaceAllFunc(event, func(line []byte) []byte {
+		parts := newapiSSEDataLineRE.FindSubmatch(line)
+		if len(parts) != 4 || bytes.Equal(bytes.TrimSpace(parts[2]), []byte("[DONE]")) {
+			return line
+		}
+		payload := rewriteMarkdownImages(parts[2])
+		if bytes.Equal(payload, parts[2]) {
+			return line
+		}
+		out := make([]byte, 0, len(parts[1])+len(payload)+len(parts[3]))
+		out = append(out, parts[1]...)
+		out = append(out, payload...)
+		out = append(out, parts[3]...)
+		return out
+	})
+}
+
+// rewriteMarkdownImages lifts Markdown data-URL images out of every choice's
+// content (non-stream `message`) or incremental content (stream `delta`) into that
+// object's `images[]` array. It is a no-op — returning the input unchanged — when
+// there is no Markdown data image, when the body isn't a JSON object, or when a data
+// URL is split across stream chunks (best effort: only complete matches are lifted).
+func rewriteMarkdownImages(body []byte) []byte {
+	if !bytes.Contains(body, []byte("](data:image/")) {
+		return body
+	}
+	var object map[string]any
+	if err := json.Unmarshal(body, &object); err != nil {
+		return body
+	}
+	choices, ok := object["choices"].([]any)
+	if !ok {
+		return body
+	}
+	changed := false
+	for _, raw := range choices {
+		choice, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"message", "delta"} {
+			if obj, ok := choice[key].(map[string]any); ok && liftMarkdownImages(obj) {
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return body
+	}
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(object); err != nil {
+		return body
+	}
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
+}
+
+// liftMarkdownImages moves any Markdown data-URL images from obj["content"] into
+// obj["images"] (appending to any already present), returning whether it changed
+// anything. The surrounding prose is preserved with the image markup removed.
+func liftMarkdownImages(obj map[string]any) bool {
+	content, ok := obj["content"].(string)
+	if !ok || content == "" {
+		return false
+	}
+	matches := markdownDataImageRE.FindAllStringSubmatch(content, -1)
+	if len(matches) == 0 {
+		return false
+	}
+
+	images, _ := obj["images"].([]any)
+	for _, match := range matches {
+		images = append(images, map[string]any{
+			"type":      "image_url",
+			"image_url": map[string]any{"url": match[1]},
+		})
+	}
+	obj["images"] = images
+	obj["content"] = strings.TrimSpace(markdownDataImageRE.ReplaceAllString(content, ""))
+	return true
+}

--- a/internal/executor/responsemodifier/newapi_image_response_modifier_test.go
+++ b/internal/executor/responsemodifier/newapi_image_response_modifier_test.go
@@ -1,0 +1,168 @@
+package responsemodifier
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+const dataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+func newapiProvider() *domain.Provider { return &domain.Provider{Type: "newapi"} }
+
+func TestNewapiImageModifier_Gating(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   *domain.Provider
+		clientType domain.ClientType
+		wantNil    bool
+	}{
+		{"newapi + openai -> active", newapiProvider(), domain.ClientTypeOpenAI, false},
+		{"newapi + gemini -> nil (native inlineData, no markdown)", newapiProvider(), domain.ClientTypeGemini, true},
+		{"custom provider -> nil", &domain.Provider{Type: "custom"}, domain.ClientTypeOpenAI, true},
+		{"openrouter provider -> nil", &domain.Provider{Type: "openrouter"}, domain.ClientTypeOpenAI, true},
+		{"nil provider -> nil", nil, domain.ClientTypeOpenAI, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := newNewapiImageResponseModifier(tc.provider, tc.clientType)
+			if (got == nil) != tc.wantNil {
+				t.Fatalf("newNewapiImageResponseModifier nil=%v, want nil=%v", got == nil, tc.wantNil)
+			}
+		})
+	}
+}
+
+func TestNewapiImageModifier_LiftsMarkdownImageFromContent(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	body := []byte(`{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Here's a red apple!\n![image](` + dataURL + `)"},"finish_reason":"stop"}]}`)
+
+	out := m.modifyBody(body)
+
+	// image lifted into the standard images[] array
+	if got := gjson.GetBytes(out, "choices.0.message.images.0.image_url.url").String(); got != dataURL {
+		t.Fatalf("images[0].image_url.url = %q, want the data URL\n%s", got, out)
+	}
+	if got := gjson.GetBytes(out, "choices.0.message.images.0.type").String(); got != "image_url" {
+		t.Fatalf("images[0].type = %q, want image_url", got)
+	}
+	// prose preserved, markdown image removed
+	if got := gjson.GetBytes(out, "choices.0.message.content").String(); got != "Here's a red apple!" {
+		t.Fatalf("content = %q, want prose without the markdown image", got)
+	}
+}
+
+func TestNewapiImageModifier_MultipleImagesAndExistingImages(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	// one image already present + two markdown images in content
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"a ![image](` + dataURL + `) b ![image](` + dataURL + `)","images":[{"type":"image_url","image_url":{"url":"pre"}}]}}]}`)
+
+	out := m.modifyBody(body)
+
+	imgs := gjson.GetBytes(out, "choices.0.message.images").Array()
+	if len(imgs) != 3 {
+		t.Fatalf("images len = %d, want 3 (1 pre-existing + 2 lifted)\n%s", len(imgs), out)
+	}
+	if imgs[0].Get("image_url.url").String() != "pre" {
+		t.Fatalf("pre-existing image must be preserved first, got %s", imgs[0].Raw)
+	}
+	if got := gjson.GetBytes(out, "choices.0.message.content").String(); got != "a  b" {
+		t.Fatalf("content = %q, want prose with both images removed", got)
+	}
+}
+
+func TestNewapiImageModifier_NoImageIsPassthrough(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"just text, no image"}}]}`)
+	if out := m.modifyBody(body); string(out) != string(body) {
+		t.Fatalf("body without an image must pass through unchanged\n got: %s\nwant: %s", out, body)
+	}
+}
+
+func TestNewapiImageModifier_MalformedBodyIsPassthrough(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	// contains the trigger substring but is not valid JSON
+	body := []byte(`not json ![image](data:image/png;base64,AAAA)`)
+	if out := m.modifyBody(body); string(out) != string(body) {
+		t.Fatalf("malformed body must pass through unchanged, got %s", out)
+	}
+}
+
+func TestNewapiImageModifier_StreamEventLiftsCompleteDelta(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	event := []byte("data: {\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"![image](" + dataURL + ")\"}}]}\n\n")
+
+	out := m.modifyStreamEvent(event)
+
+	url := gjson.GetBytes([]byte(sseData(string(out))), "choices.0.delta.images.0.image_url.url").String()
+	if url != dataURL {
+		t.Fatalf("stream delta image not lifted; url=%q\n%s", url, out)
+	}
+	// SSE framing preserved
+	if got := string(out); got[:6] != "data: " || got[len(got)-2:] != "\n\n" {
+		t.Fatalf("SSE framing not preserved: %q", got)
+	}
+}
+
+func TestNewapiImageModifier_StreamDoneAndPlainPassthrough(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	for _, ev := range []string{"data: [DONE]\n\n", "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"} {
+		if got := string(m.modifyStreamEvent([]byte(ev))); got != ev {
+			t.Fatalf("event should pass through unchanged\n got: %q\nwant: %q", got, ev)
+		}
+	}
+}
+
+// End-to-end through the writer: the factory must select the newapi modifier for a
+// newapi+openai response and Finalize must emit the normalized body to the client.
+func TestResponseModifierWriter_NewapiImageNonStream(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writer := NewResponseModifierWriter(rr, newapiProvider(), domain.ClientTypeOpenAI, false)
+	if writer == nil {
+		t.Fatal("expected a writer (newapi+openai should select the image modifier)")
+	}
+	writer.WriteHeader(200)
+	_, _ = writer.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"apple\n![image](` + dataURL + `)"}}]}`))
+	if err := writer.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+	got := rr.Body.Bytes()
+	if url := gjson.GetBytes(got, "choices.0.message.images.0.image_url.url").String(); url != dataURL {
+		t.Fatalf("client did not receive lifted image; body=%s", got)
+	}
+	if c := gjson.GetBytes(got, "choices.0.message.content").String(); c != "apple" {
+		t.Fatalf("content = %q, want \"apple\"", c)
+	}
+}
+
+// sseData returns the JSON payload of the first SSE data line.
+func sseData(s string) string {
+	for _, line := range splitSSELines(s) {
+		if len(line) > 6 && line[:6] == "data: " {
+			return line[6:]
+		}
+	}
+	return ""
+}
+
+func splitSSELines(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		if r == '\r' {
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/executor/responsemodifier/newapi_image_response_modifier_test.go
+++ b/internal/executor/responsemodifier/newapi_image_response_modifier_test.go
@@ -73,6 +73,63 @@ func TestNewapiImageModifier_MultipleImagesAndExistingImages(t *testing.T) {
 	}
 }
 
+func TestNewapiImageModifier_WhitespaceAndEscapedSlashDataURL(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	cases := []struct {
+		name    string
+		content string
+	}{
+		// whitespace after the opening paren — the regex allows it, so the fast-path
+		// guard must not skip it.
+		{"whitespace before data url", `![image](   ` + dataURL + `)`},
+		// JSON may escape the forward slash in data:image/...
+		{"escaped slash", `![image](` + `data:image\/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==` + `)`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{"choices":[{"message":{"role":"assistant","content":"` + tc.content + `"}}]}`)
+			out := m.modifyBody(body)
+			if url := gjson.GetBytes(out, "choices.0.message.images.0.image_url.url").String(); url == "" {
+				t.Fatalf("image not lifted for %s; body=%s", tc.name, out)
+			}
+			if c := gjson.GetBytes(out, "choices.0.message.content").String(); c != "" {
+				t.Fatalf("content = %q, want empty after lifting the sole image", c)
+			}
+		})
+	}
+}
+
+func TestNewapiImageModifier_PreservesLargeIntegerFields(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	// 19-digit id far beyond float64's exact-integer range (2^53); default
+	// encoding/json would round-trip it as 1.2345678901234568e+18.
+	const bigID = "1234567890123456789"
+	body := []byte(`{"id":` + bigID + `,"usage":{"total_tokens":9007199254740993},` +
+		`"choices":[{"message":{"role":"assistant","content":"x ![image](` + dataURL + `)"}}]}`)
+
+	out := m.modifyBody(body)
+
+	// the image was lifted (so the object WAS re-encoded, exercising the number path)
+	if gjson.GetBytes(out, "choices.0.message.images.0.image_url.url").String() != dataURL {
+		t.Fatalf("image not lifted; body=%s", out)
+	}
+	if got := gjson.GetBytes(out, "id").String(); got != bigID {
+		t.Fatalf("large id corrupted: got %q, want %q", got, bigID)
+	}
+	if got := gjson.GetBytes(out, "usage.total_tokens").String(); got != "9007199254740993" {
+		t.Fatalf("large token count corrupted: got %q", got)
+	}
+}
+
+func TestNewapiImageModifier_TrailingDataIsPassthrough(t *testing.T) {
+	m := &newapiImageResponseModifier{}
+	// valid object followed by trailing junk containing the trigger substring
+	body := []byte(`{"choices":[{"message":{"content":"![image](` + dataURL + `)"}}]} trailing data:image junk`)
+	if out := m.modifyBody(body); string(out) != string(body) {
+		t.Fatalf("body with trailing data must pass through unchanged, got %s", out)
+	}
+}
+
 func TestNewapiImageModifier_NoImageIsPassthrough(t *testing.T) {
 	m := &newapiImageResponseModifier{}
 	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"just text, no image"}}]}`)

--- a/internal/executor/responsemodifier/response_modifier_writer.go
+++ b/internal/executor/responsemodifier/response_modifier_writer.go
@@ -35,11 +35,13 @@ func newResponseModifier(provider *domain.Provider, clientType domain.ClientType
 	if provider == nil {
 		return nil
 	}
-	modifier := newClaudeResponseModifier(provider, clientType)
-	if modifier == nil {
-		return nil
+	if modifier := newClaudeResponseModifier(provider, clientType); modifier != nil {
+		return modifier
 	}
-	return modifier
+	if modifier := newNewapiImageResponseModifier(provider, clientType); modifier != nil {
+		return modifier
+	}
+	return nil
 }
 
 func (w *ResponseModifierWriter) Header() http.Header {


### PR DESCRIPTION
## Problem

new-api / one-api relays proxy Gemini image models through Google's OpenAI-compat layer, but emit the generated image as a **Markdown data-URL embedded in `message.content`**:

```
"Here's a red apple!\n![image](data:image/png;base64,iVBORw0K...)"
```

instead of the standard OpenAI `message.images[]` array (the OpenRouter convention maxx's converters read). So:
- an OpenAI client reading `message.images[]` gets **nothing** (image is buried in text);
- the `openai->gemini` converter has **no image** to lift into an `inlineData` part.

Net: a Gemini image request routed to a new-api provider (e.g. hubitos `code0-gemini`) silently returns text only. This is why gemini image models are currently kept on OpenRouter instead of the cheaper code0 channel.

## Fix

A provider-scoped **response modifier** (via the existing `internal/executor/responsemodifier` mechanism) that lifts every Markdown data-URL image out of the assistant content into `message.images[]`, preserving the surrounding prose. It runs before the client-facing bytes are produced, so:
- an **OpenAI** client receives the standard `message.images[]`;
- a **Gemini** client's `openai->gemini` conversion carries it as `inlineData` — the same path OpenRouter already uses.

**Scope:** new-api providers on the OpenAI protocol only. A native Gemini (`/v1beta`) request to the same upstream already returns `inlineData` and never hits this path; other provider types don't produce the Markdown shape. Wired into the responsemodifier factory after the claude modifier (mutually exclusive by provider/client type).

- **Non-stream:** fully normalized.
- **Stream:** best-effort — only a complete data URL within a single SSE `delta` is lifted; a URL split across chunks passes through unchanged (no worse than today).
- No-image responses and malformed bodies pass through untouched (fast-path substring guard + JSON-parse guard).

## Verification

Exact Markdown shape confirmed against **live code0 (new-api)**: `message` keys were `[role, content]` only (no `images`), content = `"Here's a crisp red apple for you! \n![image](data:image/png;base64,<1.6MB>)"`.

Tests (`newapi_image_response_modifier_test.go`): gating (newapi+openai active; gemini/custom/openrouter/nil → inactive), single/multiple image lift, pre-existing `images` preserved, prose retention, no-image & malformed passthrough, stream complete-delta lift + `[DONE]`/plain passthrough + SSE framing, and an end-to-end pass through `ResponseModifierWriter`.

## Follow-up (config, separate)

Once deployed, gemini image models can be added back to `code0-gemini` (prov5) supportModels + slug mappings so they route to code0 instead of OpenRouter. Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持从 NewAPI 的 OpenAI 响应中识别 Markdown 格式的 Base64 图片。
  - 自动将图片提取为独立图片内容，同时保留周围文本及已有图片。
  - 支持普通响应和流式响应，流式输出可保持正常展示格式。
- **兼容性**
  - 无图片、无效内容及结束事件将保持原样返回。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->