### PR TITLE
feat(web): add model mapping debugger

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -978,6 +978,7 @@ const (
 	SettingKeyOpenAIChatStreamIdleTimeoutMS        = "openai_chat_stream_idle_timeout_ms"        // OpenAI Chat 路由 provider 事件间 idle 超时毫秒数，默认 45000，仅启用 openai_chat_stream_timeouts_enabled 时生效
 	SettingKeyRequestFailureDetailsEnabled         = "request_failure_details_enabled"           // 是否在请求详情 Metadata 中展示增强失败详情，"true" 或 "false"，默认 "false"
 	SettingKeyTestFieldTabEnabled                  = "ui_test_field_tab_enabled"                 // 是否显示测试场 tab，"true" 或 "false"，默认 "false"
+	SettingKeyModelMappingDebuggerEnabled          = "ui_model_mapping_debugger_enabled"         // 是否显示模型映射调试器，"true" 或 "false"，默认 "false"
 	SettingKeyStrictSupportModelsRoutingEnabled    = "strict_support_models_routing_enabled"     // 是否按提供商支持模型严格跳过不匹配路由，"true" 或 "false"，默认 "false"
 	SettingKeyCodexOpenRouterBridgeEnabled         = "codex_openrouter_bridge_enabled"           // 是否把 Codex→OpenRouter 请求桥接为 OpenAI Chat Completions；"false"（默认）走原生 /responses 透传，保留 custom/freeform 工具（code mode）；"true" 恢复旧的 chat 桥接作为应急开关
 	SettingKeyProxyRequestsDisabled                = "proxy_requests_disabled"                   // 是否全局禁用代理请求，"true" 或 "false"，默认 "false"

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -28,6 +28,7 @@ var publicSettingsAllowlist = map[string]struct{}{
 	"ui_multitenant_layout":                          {},
 	domain.SettingKeyRequestFailureDetailsEnabled:    {},
 	domain.SettingKeyTestFieldTabEnabled:             {},
+	domain.SettingKeyModelMappingDebuggerEnabled:     {},
 	domain.SettingKeyUserPanelDailyCheckInEnabled:    {},
 	domain.SettingKeyUserPanelDailyCheckInAmount:     {},
 	domain.SettingKeyProxyRouteClaudeMessagesEnabled: {},

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1533,7 +1533,11 @@
     "openAIChatStreamTimeoutInvalid": "Timeouts must be integers between 1000 and 600000 ms.",
     "openAIChatStreamTimeoutsHint": "Default is off for compatibility. Enable it and keep the idle timeout below client-side stall protection such as the AI SDK 60000 ms watchdog so Maxx can retry or fail over first.",
     "enableOpenAIChatStreamTimeouts": "Enable OpenAI Chat upstream stream timeouts",
-    "enableOpenAIChatStreamTimeoutsDesc": "Default off. When enabled, only provider requests reached through OpenAI Chat routes are affected."
+    "enableOpenAIChatStreamTimeoutsDesc": "Default off. When enabled, only provider requests reached through OpenAI Chat routes are affected.",
+    "modelMappingDebugger": "Model mapping debugger",
+    "modelMappingDebuggerDesc": "Controls whether the abnormal mapping debugger is shown on the Model Mappings page. Disabled by default to keep the normal configuration page simple.",
+    "modelMappingDebuggerLabel": "Show model mapping debugger",
+    "modelMappingDebuggerHint": "When enabled, the Model Mappings page can search mappings across all scopes by model, rule fragment, or ID and quickly delete abnormal rules."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1556,7 +1556,18 @@
     "scope": "Scope",
     "scopeGlobal": "Global",
     "scopeProvider": "Provider",
-    "scopeRoute": "Route"
+    "scopeRoute": "Route",
+    "debuggerTitle": "Model mapping debugger",
+    "debuggerDesc": "Enter a model name or rule fragment to find hidden mappings across all scopes and quickly remove abnormal rules.",
+    "debuggerPlaceholder": "Model / pattern / target / ID, e.g. glm-5",
+    "debuggerMatched": "{{count}} related mapping(s) found",
+    "debuggerEffectiveMatched": "{{count}} rule(s) match this model by pattern",
+    "debuggerNoMatches": "No related model mappings found.",
+    "debuggerEffective": "matches",
+    "debuggerHidden": "hidden from global list",
+    "debuggerDeleteAll": "Delete matched rules",
+    "debuggerConfirmDelete": "Delete model mapping #{{id}}: {{pattern}} → {{target}}? This cannot be undone.",
+    "debuggerConfirmDeleteAll": "Delete the {{count}} model mapping(s) currently matched by the debugger? This cannot be undone."
   },
   "responseModelMappings": {
     "title": "Response Model Mapping",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1530,7 +1530,11 @@
     "openAIChatStreamTimeoutInvalid": "超时时间必须是 1000 到 600000 ms 之间的整数。",
     "openAIChatStreamTimeoutsHint": "默认关闭以保持兼容。开启后建议让 idle timeout 小于 AI SDK 60000 ms 这类客户端保护阈值，这样 Maxx 能先触发重试或故障转移。",
     "enableOpenAIChatStreamTimeouts": "启用 OpenAI Chat 上游流式超时",
-    "enableOpenAIChatStreamTimeoutsDesc": "默认关闭。开启后仅对通过 OpenAI Chat 路由命中的 provider 请求生效。"
+    "enableOpenAIChatStreamTimeoutsDesc": "默认关闭。开启后仅对通过 OpenAI Chat 路由命中的 provider 请求生效。",
+    "modelMappingDebugger": "模型映射调试器",
+    "modelMappingDebuggerDesc": "控制模型映射页是否显示异常映射调试器。默认关闭，避免常规配置页变复杂。",
+    "modelMappingDebuggerLabel": "显示模型映射调试器",
+    "modelMappingDebuggerHint": "开启后可在模型映射页按模型名、规则片段或 ID 搜索所有作用域的映射，并快速删除异常规则。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1553,7 +1553,18 @@
     "scope": "作用域",
     "scopeGlobal": "全局",
     "scopeProvider": "供应商",
-    "scopeRoute": "路由"
+    "scopeRoute": "路由",
+    "debuggerTitle": "模型映射调试器",
+    "debuggerDesc": "输入模型名或规则片段，查出所有作用域里的隐藏映射，并快速删除异常规则。",
+    "debuggerPlaceholder": "输入模型名 / pattern / target / ID，例如 glm-5",
+    "debuggerMatched": "找到 {{count}} 条相关规则",
+    "debuggerEffectiveMatched": "其中 {{count}} 条会按 pattern 命中该模型",
+    "debuggerNoMatches": "没有找到相关模型映射。",
+    "debuggerEffective": "会命中",
+    "debuggerHidden": "全局列表不可见",
+    "debuggerDeleteAll": "删除命中规则",
+    "debuggerConfirmDelete": "删除模型映射 #{{id}}：{{pattern}} → {{target}}？此操作不可撤销。",
+    "debuggerConfirmDeleteAll": "删除当前调试器命中的 {{count}} 条模型映射？此操作不可撤销。"
   },
   "responseModelMappings": {
     "title": "返回值模型映射",

--- a/web/src/pages/model-mappings/index.tsx
+++ b/web/src/pages/model-mappings/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   DndContext,
@@ -39,8 +39,73 @@ import {
   useResetModelMappingsToDefaults,
 } from '@/hooks/queries';
 import type { ModelMapping, ModelMappingInput } from '@/lib/transport/types';
-import { Zap, Plus, Trash2, ArrowRight, RotateCcw, GripVertical } from 'lucide-react';
+import { Zap, Plus, Trash2, ArrowRight, RotateCcw, GripVertical, Search } from 'lucide-react';
 import { useDialog } from '@/contexts/dialog-context';
+
+function matchWildcard(pattern: string, input: string): boolean {
+  const trimmedPattern = pattern.trim();
+  const trimmedInput = input.trim();
+  if (!trimmedPattern) return false;
+  if (trimmedPattern === '*') return true;
+
+  let patternIndex = 0;
+  let inputIndex = 0;
+  let starIndex = -1;
+  let matchIndex = 0;
+
+  while (inputIndex < trimmedInput.length) {
+    if (
+      patternIndex < trimmedPattern.length &&
+      trimmedPattern[patternIndex] === trimmedInput[inputIndex]
+    ) {
+      patternIndex += 1;
+      inputIndex += 1;
+      continue;
+    }
+    if (patternIndex < trimmedPattern.length && trimmedPattern[patternIndex] === '*') {
+      starIndex = patternIndex;
+      matchIndex = inputIndex;
+      patternIndex += 1;
+      continue;
+    }
+    if (starIndex !== -1) {
+      patternIndex = starIndex + 1;
+      matchIndex += 1;
+      inputIndex = matchIndex;
+      continue;
+    }
+    return false;
+  }
+
+  while (patternIndex < trimmedPattern.length && trimmedPattern[patternIndex] === '*') {
+    patternIndex += 1;
+  }
+  return patternIndex === trimmedPattern.length;
+}
+
+function scopePriority(scope?: string): number {
+  if (scope === 'route') return 1;
+  if (scope === 'provider') return 2;
+  return 3;
+}
+
+function describeMappingScope(rule: ModelMapping, t: (key: string) => string) {
+  const scope = rule.scope || 'global';
+  const parts = [
+    scope === 'provider'
+      ? t('modelMappings.scopeProvider')
+      : scope === 'route'
+        ? t('modelMappings.scopeRoute')
+        : t('modelMappings.scopeGlobal'),
+  ];
+  if (rule.clientType) parts.push(`${t('modelMappings.client')}: ${rule.clientType}`);
+  if (rule.providerType) parts.push(`${t('modelMappings.providerType')}: ${rule.providerType}`);
+  if (rule.providerID) parts.push(`${t('modelMappings.providerID')}: ${rule.providerID}`);
+  if (rule.projectID) parts.push(`${t('modelMappings.projectID')}: ${rule.projectID}`);
+  if (rule.routeID) parts.push(`Route# ${rule.routeID}`);
+  if (rule.apiTokenID) parts.push(`Token# ${rule.apiTokenID}`);
+  return parts.join(' · ');
+}
 
 interface SortableRuleItemProps {
   id: string;
@@ -143,9 +208,42 @@ export function ModelMappingsPage() {
   const [newTarget, setNewTarget] = useState('');
   const [newClientType, setNewClientType] = useState('claude');
   const [newProviderType, setNewProviderType] = useState('antigravity');
+  const [debugModel, setDebugModel] = useState('');
 
   // Filter only global scope mappings
   const rules = (mappings || []).filter((m) => !m.scope || m.scope === 'global');
+  const debugQuery = debugModel.trim();
+  const debugMatches = useMemo(() => {
+    if (!debugQuery) return [];
+    const lowerQuery = debugQuery.toLowerCase();
+    return (mappings || [])
+      .filter((rule) => {
+        const textMatches = [
+          rule.id,
+          rule.scope,
+          rule.clientType,
+          rule.providerType,
+          rule.providerID,
+          rule.projectID,
+          rule.routeID,
+          rule.apiTokenID,
+          rule.pattern,
+          rule.target,
+        ]
+          .map((value) => String(value || '').toLowerCase())
+          .some((value) => value.includes(lowerQuery));
+        return textMatches || matchWildcard(rule.pattern, debugQuery);
+      })
+      .sort((a, b) => {
+        const scopeDiff = scopePriority(a.scope) - scopePriority(b.scope);
+        if (scopeDiff !== 0) return scopeDiff;
+        if (a.priority !== b.priority) return a.priority - b.priority;
+        return a.id - b.id;
+      });
+  }, [debugQuery, mappings]);
+  const effectiveDebugMatches = debugMatches.filter((rule) =>
+    matchWildcard(rule.pattern, debugQuery),
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -195,6 +293,37 @@ export function ModelMappingsPage() {
 
   const handleRemoveRule = async (id: number) => {
     await deleteMapping.mutateAsync(id);
+  };
+
+  const handleRemoveDebugRule = async (rule: ModelMapping) => {
+    const confirmed = await confirm({
+      title: t('common.confirm'),
+      description: t('modelMappings.debuggerConfirmDelete', {
+        id: rule.id,
+        pattern: rule.pattern,
+        target: rule.target,
+      }),
+      confirmText: t('common.delete'),
+      confirmVariant: 'destructive',
+    });
+    if (!confirmed) return;
+
+    await deleteMapping.mutateAsync(rule.id);
+  };
+
+  const handleRemoveAllDebugMatches = async () => {
+    if (debugMatches.length === 0) return;
+    const confirmed = await confirm({
+      title: t('common.confirm'),
+      description: t('modelMappings.debuggerConfirmDeleteAll', { count: debugMatches.length }),
+      confirmText: t('common.delete'),
+      confirmVariant: 'destructive',
+    });
+    if (!confirmed) return;
+
+    for (const rule of debugMatches) {
+      await deleteMapping.mutateAsync(rule.id);
+    }
   };
 
   const handleUpdateRule = async (rule: ModelMapping, data: Partial<ModelMappingInput>) => {
@@ -275,120 +404,223 @@ export function ModelMappingsPage() {
       />
 
       <div className="flex-1 overflow-y-auto p-6">
-        <Card className="border-border bg-card">
-          <CardContent className="p-6 space-y-4">
-            <p className="text-xs text-muted-foreground">{t('modelMappings.pageDesc')}</p>
-
-            {/* Header row */}
-            <div className="flex items-center gap-3 text-xs text-muted-foreground font-medium border-b pb-2">
-              <div className="w-6 shrink-0"></div>
-              <div className="w-6 shrink-0">#</div>
-              <div className="flex-1 min-w-0">{t('modelMappings.matchPattern')}</div>
-              <div className="w-3"></div>
-              <div className="flex-1 min-w-0">{t('modelMappings.targetModel')}</div>
-              <div className="w-[100px] shrink-0">{t('modelMappings.client')}</div>
-              <div className="w-[110px] shrink-0">{t('modelMappings.providerType')}</div>
-              <div className="w-[70px] shrink-0">{t('modelMappings.providerID')}</div>
-              <div className="w-[70px] shrink-0">{t('modelMappings.projectID')}</div>
-              <div className="w-8 shrink-0"></div>
-            </div>
-
-            {rules.length > 0 && (
-              <DndContext
-                sensors={sensors}
-                collisionDetection={closestCenter}
-                onDragStart={handleDragStart}
-                onDragEnd={handleDragEnd}
-              >
-                <SortableContext
-                  items={rules.map((r) => `rule-${r.id}`)}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <div className="space-y-0">
-                    {rules.map((rule, index) => (
-                      <SortableRuleItem
-                        key={`rule-${rule.id}`}
-                        id={`rule-${rule.id}`}
-                        index={index}
-                        rule={rule}
-                        onRemove={() => handleRemoveRule(rule.id)}
-                        onUpdate={(data) => handleUpdateRule(rule, data)}
-                        disabled={isPending}
-                      />
-                    ))}
+        <div className="space-y-4">
+          <Card className="border-border bg-card">
+            <CardContent className="p-6 space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2 font-medium">
+                    <Search className="h-4 w-4 text-primary" />
+                    {t('modelMappings.debuggerTitle')}
                   </div>
-                </SortableContext>
-              </DndContext>
-            )}
-
-            {rules.length === 0 && (
-              <div className="text-center py-8">
-                <p className="text-muted-foreground">{t('modelMappings.noMappings')}</p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t('modelMappings.noMappingsHint')}
-                </p>
+                  <p className="text-xs text-muted-foreground">{t('modelMappings.debuggerDesc')}</p>
+                </div>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleRemoveAllDebugMatches}
+                  disabled={!debugQuery || debugMatches.length === 0 || isPending}
+                >
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  {t('modelMappings.debuggerDeleteAll')}
+                </Button>
               </div>
-            )}
 
-            <div className="flex items-center gap-2 pt-4 border-t border-border">
               <ModelInput
-                value={newPattern}
-                onChange={setNewPattern}
-                placeholder={t('modelMappings.matchPattern')}
+                value={debugModel}
+                onChange={setDebugModel}
+                placeholder={t('modelMappings.debuggerPlaceholder')}
                 disabled={isPending}
-                className="flex-1 min-w-0 h-8 text-sm"
+                className="h-9 text-sm"
               />
-              <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
-              <ModelInput
-                value={newTarget}
-                onChange={setNewTarget}
-                placeholder={t('modelMappings.targetModel')}
-                disabled={isPending}
-                className="flex-1 min-w-0 h-8 text-sm"
-              />
-              <Select
-                value={newClientType || '_all'}
-                onValueChange={(v) => setNewClientType(v === '_all' ? '' : (v ?? ''))}
-                disabled={isPending}
-              >
-                <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_all">{t('modelMappings.allClients')}</SelectItem>
-                  <SelectItem value="claude">claude</SelectItem>
-                  <SelectItem value="openai">openai</SelectItem>
-                  <SelectItem value="gemini">gemini</SelectItem>
-                  <SelectItem value="codex">codex</SelectItem>
-                </SelectContent>
-              </Select>
-              <Select
-                value={newProviderType || '_all'}
-                onValueChange={(v) => setNewProviderType(v === '_all' ? '' : (v ?? ''))}
-                disabled={isPending}
-              >
-                <SelectTrigger className="w-[110px] h-8 text-xs shrink-0">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_all">{t('modelMappings.allProviderTypes')}</SelectItem>
-                  <SelectItem value="antigravity">antigravity</SelectItem>
-                  <SelectItem value="kiro">kiro</SelectItem>
-                  <SelectItem value="custom">custom</SelectItem>
-                </SelectContent>
-              </Select>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleAddRule}
-                disabled={!newPattern.trim() || !newTarget.trim() || isPending}
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                {t('common.add')}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+
+              {debugQuery && (
+                <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>
+                      {t('modelMappings.debuggerMatched', { count: debugMatches.length })}
+                    </span>
+                    <span>·</span>
+                    <span>
+                      {t('modelMappings.debuggerEffectiveMatched', {
+                        count: effectiveDebugMatches.length,
+                      })}
+                    </span>
+                  </div>
+
+                  {debugMatches.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      {t('modelMappings.debuggerNoMatches')}
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {debugMatches.map((rule) => {
+                        const effective = matchWildcard(rule.pattern, debugQuery);
+                        const hiddenFromGlobalList = rule.scope && rule.scope !== 'global';
+                        return (
+                          <div
+                            key={`debug-rule-${rule.id}`}
+                            className="rounded-md border border-border bg-background p-3 space-y-2"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 space-y-1">
+                                <div className="flex flex-wrap items-center gap-2 text-sm">
+                                  <span className="font-mono">#{rule.id}</span>
+                                  <span className="font-mono break-all">{rule.pattern}</span>
+                                  <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                                  <span className="font-mono break-all">{rule.target}</span>
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                  {describeMappingScope(rule, t)} · priority: {rule.priority}
+                                </p>
+                                <div className="flex flex-wrap gap-2 text-[11px]">
+                                  {effective && (
+                                    <span className="rounded bg-primary/10 px-2 py-0.5 text-primary">
+                                      {t('modelMappings.debuggerEffective')}
+                                    </span>
+                                  )}
+                                  {hiddenFromGlobalList && (
+                                    <span className="rounded bg-destructive/10 px-2 py-0.5 text-destructive">
+                                      {t('modelMappings.debuggerHidden')}
+                                    </span>
+                                  )}
+                                </div>
+                              </div>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleRemoveDebugRule(rule)}
+                                disabled={isPending}
+                                className="shrink-0"
+                              >
+                                <Trash2 className="h-4 w-4 text-destructive" />
+                              </Button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="border-border bg-card">
+            <CardContent className="p-6 space-y-4">
+              <p className="text-xs text-muted-foreground">{t('modelMappings.pageDesc')}</p>
+
+              {/* Header row */}
+              <div className="flex items-center gap-3 text-xs text-muted-foreground font-medium border-b pb-2">
+                <div className="w-6 shrink-0"></div>
+                <div className="w-6 shrink-0">#</div>
+                <div className="flex-1 min-w-0">{t('modelMappings.matchPattern')}</div>
+                <div className="w-3"></div>
+                <div className="flex-1 min-w-0">{t('modelMappings.targetModel')}</div>
+                <div className="w-[100px] shrink-0">{t('modelMappings.client')}</div>
+                <div className="w-[110px] shrink-0">{t('modelMappings.providerType')}</div>
+                <div className="w-[70px] shrink-0">{t('modelMappings.providerID')}</div>
+                <div className="w-[70px] shrink-0">{t('modelMappings.projectID')}</div>
+                <div className="w-8 shrink-0"></div>
+              </div>
+
+              {rules.length > 0 && (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleDragStart}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={rules.map((r) => `rule-${r.id}`)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className="space-y-0">
+                      {rules.map((rule, index) => (
+                        <SortableRuleItem
+                          key={`rule-${rule.id}`}
+                          id={`rule-${rule.id}`}
+                          index={index}
+                          rule={rule}
+                          onRemove={() => handleRemoveRule(rule.id)}
+                          onUpdate={(data) => handleUpdateRule(rule, data)}
+                          disabled={isPending}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              )}
+
+              {rules.length === 0 && (
+                <div className="text-center py-8">
+                  <p className="text-muted-foreground">{t('modelMappings.noMappings')}</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    {t('modelMappings.noMappingsHint')}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex items-center gap-2 pt-4 border-t border-border">
+                <ModelInput
+                  value={newPattern}
+                  onChange={setNewPattern}
+                  placeholder={t('modelMappings.matchPattern')}
+                  disabled={isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                <ModelInput
+                  value={newTarget}
+                  onChange={setNewTarget}
+                  placeholder={t('modelMappings.targetModel')}
+                  disabled={isPending}
+                  className="flex-1 min-w-0 h-8 text-sm"
+                />
+                <Select
+                  value={newClientType || '_all'}
+                  onValueChange={(v) => setNewClientType(v === '_all' ? '' : (v ?? ''))}
+                  disabled={isPending}
+                >
+                  <SelectTrigger className="w-[100px] h-8 text-xs shrink-0">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_all">{t('modelMappings.allClients')}</SelectItem>
+                    <SelectItem value="claude">claude</SelectItem>
+                    <SelectItem value="openai">openai</SelectItem>
+                    <SelectItem value="gemini">gemini</SelectItem>
+                    <SelectItem value="codex">codex</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select
+                  value={newProviderType || '_all'}
+                  onValueChange={(v) => setNewProviderType(v === '_all' ? '' : (v ?? ''))}
+                  disabled={isPending}
+                >
+                  <SelectTrigger className="w-[110px] h-8 text-xs shrink-0">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="_all">{t('modelMappings.allProviderTypes')}</SelectItem>
+                    <SelectItem value="antigravity">antigravity</SelectItem>
+                    <SelectItem value="kiro">kiro</SelectItem>
+                    <SelectItem value="custom">custom</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddRule}
+                  disabled={!newPattern.trim() || !newTarget.trim() || isPending}
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  {t('common.add')}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/model-mappings/index.tsx
+++ b/web/src/pages/model-mappings/index.tsx
@@ -37,10 +37,13 @@ import {
   useDeleteModelMapping,
   useClearAllModelMappings,
   useResetModelMappingsToDefaults,
+  usePublicSettings,
 } from '@/hooks/queries';
 import type { ModelMapping, ModelMappingInput } from '@/lib/transport/types';
 import { Zap, Plus, Trash2, ArrowRight, RotateCcw, GripVertical, Search } from 'lucide-react';
 import { useDialog } from '@/contexts/dialog-context';
+
+const MODEL_MAPPING_DEBUGGER_SETTING_KEY = 'ui_model_mapping_debugger_enabled';
 
 function matchWildcard(pattern: string, input: string): boolean {
   const trimmedPattern = pattern.trim();
@@ -198,6 +201,7 @@ export function ModelMappingsPage() {
   const { t } = useTranslation();
   const { confirm } = useDialog();
   const { data: mappings, isLoading } = useModelMappings();
+  const { data: publicSettings } = usePublicSettings();
   const createMapping = useCreateModelMapping();
   const updateMapping = useUpdateModelMapping();
   const reorderMappings = useReorderModelMappings();
@@ -209,6 +213,7 @@ export function ModelMappingsPage() {
   const [newClientType, setNewClientType] = useState('claude');
   const [newProviderType, setNewProviderType] = useState('antigravity');
   const [debugModel, setDebugModel] = useState('');
+  const debuggerEnabled = publicSettings?.[MODEL_MAPPING_DEBUGGER_SETTING_KEY] === 'true';
 
   // Filter only global scope mappings
   const rules = (mappings || []).filter((m) => !m.scope || m.scope === 'global');
@@ -405,106 +410,110 @@ export function ModelMappingsPage() {
 
       <div className="flex-1 overflow-y-auto p-6">
         <div className="space-y-4">
-          <Card className="border-border bg-card">
-            <CardContent className="p-6 space-y-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2 font-medium">
-                    <Search className="h-4 w-4 text-primary" />
-                    {t('modelMappings.debuggerTitle')}
-                  </div>
-                  <p className="text-xs text-muted-foreground">{t('modelMappings.debuggerDesc')}</p>
-                </div>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleRemoveAllDebugMatches}
-                  disabled={!debugQuery || debugMatches.length === 0 || isPending}
-                >
-                  <Trash2 className="h-4 w-4 mr-1" />
-                  {t('modelMappings.debuggerDeleteAll')}
-                </Button>
-              </div>
-
-              <ModelInput
-                value={debugModel}
-                onChange={setDebugModel}
-                placeholder={t('modelMappings.debuggerPlaceholder')}
-                disabled={isPending}
-                className="h-9 text-sm"
-              />
-
-              {debugQuery && (
-                <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                    <span>
-                      {t('modelMappings.debuggerMatched', { count: debugMatches.length })}
-                    </span>
-                    <span>·</span>
-                    <span>
-                      {t('modelMappings.debuggerEffectiveMatched', {
-                        count: effectiveDebugMatches.length,
-                      })}
-                    </span>
-                  </div>
-
-                  {debugMatches.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                      {t('modelMappings.debuggerNoMatches')}
-                    </p>
-                  ) : (
-                    <div className="space-y-2">
-                      {debugMatches.map((rule) => {
-                        const effective = matchWildcard(rule.pattern, debugQuery);
-                        const hiddenFromGlobalList = rule.scope && rule.scope !== 'global';
-                        return (
-                          <div
-                            key={`debug-rule-${rule.id}`}
-                            className="rounded-md border border-border bg-background p-3 space-y-2"
-                          >
-                            <div className="flex items-start justify-between gap-3">
-                              <div className="min-w-0 space-y-1">
-                                <div className="flex flex-wrap items-center gap-2 text-sm">
-                                  <span className="font-mono">#{rule.id}</span>
-                                  <span className="font-mono break-all">{rule.pattern}</span>
-                                  <ArrowRight className="h-3 w-3 text-muted-foreground" />
-                                  <span className="font-mono break-all">{rule.target}</span>
-                                </div>
-                                <p className="text-xs text-muted-foreground">
-                                  {describeMappingScope(rule, t)} · priority: {rule.priority}
-                                </p>
-                                <div className="flex flex-wrap gap-2 text-[11px]">
-                                  {effective && (
-                                    <span className="rounded bg-primary/10 px-2 py-0.5 text-primary">
-                                      {t('modelMappings.debuggerEffective')}
-                                    </span>
-                                  )}
-                                  {hiddenFromGlobalList && (
-                                    <span className="rounded bg-destructive/10 px-2 py-0.5 text-destructive">
-                                      {t('modelMappings.debuggerHidden')}
-                                    </span>
-                                  )}
-                                </div>
-                              </div>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleRemoveDebugRule(rule)}
-                                disabled={isPending}
-                                className="shrink-0"
-                              >
-                                <Trash2 className="h-4 w-4 text-destructive" />
-                              </Button>
-                            </div>
-                          </div>
-                        );
-                      })}
+          {debuggerEnabled && (
+            <Card className="border-border bg-card">
+              <CardContent className="p-6 space-y-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 font-medium">
+                      <Search className="h-4 w-4 text-primary" />
+                      {t('modelMappings.debuggerTitle')}
                     </div>
-                  )}
+                    <p className="text-xs text-muted-foreground">
+                      {t('modelMappings.debuggerDesc')}
+                    </p>
+                  </div>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={handleRemoveAllDebugMatches}
+                    disabled={!debugQuery || debugMatches.length === 0 || isPending}
+                  >
+                    <Trash2 className="h-4 w-4 mr-1" />
+                    {t('modelMappings.debuggerDeleteAll')}
+                  </Button>
                 </div>
-              )}
-            </CardContent>
-          </Card>
+
+                <ModelInput
+                  value={debugModel}
+                  onChange={setDebugModel}
+                  placeholder={t('modelMappings.debuggerPlaceholder')}
+                  disabled={isPending}
+                  className="h-9 text-sm"
+                />
+
+                {debugQuery && (
+                  <div className="rounded-md border border-border bg-muted/30 p-3 space-y-3">
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span>
+                        {t('modelMappings.debuggerMatched', { count: debugMatches.length })}
+                      </span>
+                      <span>·</span>
+                      <span>
+                        {t('modelMappings.debuggerEffectiveMatched', {
+                          count: effectiveDebugMatches.length,
+                        })}
+                      </span>
+                    </div>
+
+                    {debugMatches.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">
+                        {t('modelMappings.debuggerNoMatches')}
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {debugMatches.map((rule) => {
+                          const effective = matchWildcard(rule.pattern, debugQuery);
+                          const hiddenFromGlobalList = rule.scope && rule.scope !== 'global';
+                          return (
+                            <div
+                              key={`debug-rule-${rule.id}`}
+                              className="rounded-md border border-border bg-background p-3 space-y-2"
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0 space-y-1">
+                                  <div className="flex flex-wrap items-center gap-2 text-sm">
+                                    <span className="font-mono">#{rule.id}</span>
+                                    <span className="font-mono break-all">{rule.pattern}</span>
+                                    <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                                    <span className="font-mono break-all">{rule.target}</span>
+                                  </div>
+                                  <p className="text-xs text-muted-foreground">
+                                    {describeMappingScope(rule, t)} · priority: {rule.priority}
+                                  </p>
+                                  <div className="flex flex-wrap gap-2 text-[11px]">
+                                    {effective && (
+                                      <span className="rounded bg-primary/10 px-2 py-0.5 text-primary">
+                                        {t('modelMappings.debuggerEffective')}
+                                      </span>
+                                    )}
+                                    {hiddenFromGlobalList && (
+                                      <span className="rounded bg-destructive/10 px-2 py-0.5 text-destructive">
+                                        {t('modelMappings.debuggerHidden')}
+                                      </span>
+                                    )}
+                                  </div>
+                                </div>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => handleRemoveDebugRule(rule)}
+                                  disabled={isPending}
+                                  className="shrink-0"
+                                >
+                                  <Trash2 className="h-4 w-4 text-destructive" />
+                                </Button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           <Card className="border-border bg-card">
             <CardContent className="p-6 space-y-4">

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -70,6 +70,7 @@ const REQUEST_FAILURE_DETAILS_SETTING_KEY = 'request_failure_details_enabled';
 const STRICT_SUPPORT_MODELS_ROUTING_SETTING_KEY = 'strict_support_models_routing_enabled';
 const OPENAI_CHAT_STREAM_TIMEOUTS_ENABLED_SETTING_KEY = 'openai_chat_stream_timeouts_enabled';
 const TEST_FIELD_TAB_SETTING_KEY = 'ui_test_field_tab_enabled';
+const MODEL_MAPPING_DEBUGGER_SETTING_KEY = 'ui_model_mapping_debugger_enabled';
 const OPENAI_CHAT_STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY =
   'openai_chat_stream_first_event_timeout_ms';
 const OPENAI_CHAT_STREAM_IDLE_TIMEOUT_SETTING_KEY = 'openai_chat_stream_idle_timeout_ms';
@@ -144,6 +145,7 @@ export function SettingsPage() {
               <SupportModelRoutingSection />
               <OpenAIChatStreamTimeoutSection />
               <TestFieldTabSection />
+              <ModelMappingDebuggerSection />
               <MultiTenantUISection />
               <TimezoneSection />
             </>
@@ -1135,6 +1137,54 @@ export function TestFieldTabSection() {
           {t('settings.testFieldTabLabel')}
         </Label>
         <p className="text-xs text-muted-foreground">{t('settings.testFieldTabHint')}</p>
+        <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ModelMappingDebuggerSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+
+  const enabled = settings?.[MODEL_MAPPING_DEBUGGER_SETTING_KEY] === 'true';
+
+  const handleToggle = async (checked: boolean) => {
+    await updateSetting.mutateAsync({
+      key: MODEL_MAPPING_DEBUGGER_SETTING_KEY,
+      value: checked ? 'true' : 'false',
+    });
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-base font-medium flex items-center gap-2">
+              <Zap className="h-4 w-4 text-muted-foreground" />
+              {t('settings.modelMappingDebugger')}
+            </CardTitle>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.modelMappingDebuggerDesc')}
+            </p>
+          </div>
+          <Switch
+            aria-label={t('settings.modelMappingDebugger')}
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            disabled={updateSetting.isPending}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="p-6 space-y-2">
+        <Label className="text-sm font-medium text-foreground">
+          {t('settings.modelMappingDebuggerLabel')}
+        </Label>
+        <p className="text-xs text-muted-foreground">{t('settings.modelMappingDebuggerHint')}</p>
         <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- add a model mapping debugger panel to the Model Mappings page
- allow searching all mapping scopes by model/rule/id, including provider/route mappings hidden from the global list
- show effective wildcard matches and allow deleting single or matched abnormal mappings with confirmation
- add Chinese and English UI copy

## Validation
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`

## Notes
This targets the failure mode where a stale provider/route-scoped mapping still rewrites a model even though it is not visible in the global mapping list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增模型映射调试器，支持按文本或通配符搜索映射规则。
  * 支持按作用域和优先级查看匹配结果，并标识实际生效及隐藏规则。
  * 支持单条或批量删除映射，操作前提供确认提示。
  * 新增设置开关，管理员可控制调试器显示，默认关闭。
  * 优化模型映射管理页面布局，集中展示调试器与现有管理功能。
* **本地化**
  * 新增中英文搜索、匹配结果、状态说明及删除确认文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->