### PR TITLE
feat(video): async video-generation proxy surface (Seedance via new-api)

### DIFF
--- a/internal/adapter/client/adapter.go
+++ b/internal/adapter/client/adapter.go
@@ -51,6 +51,10 @@ func (a *Adapter) Match(req *http.Request) (domain.ClientType, bool) {
 		// OpenAI Images API (generations/edits). Body carries no messages/input,
 		// so body-detection can't classify it — key off the path.
 		return domain.ClientTypeOpenAI, true
+	case IsVideoGenerationsPath(path):
+		// Async video generation (submit POST / poll GET). Poll has no body, so
+		// key off the path.
+		return domain.ClientTypeVideo, true
 	case strings.HasPrefix(path, "/v1beta/models/"):
 		return domain.ClientTypeGemini, true
 	case strings.HasPrefix(path, "/v1internal/models/"):
@@ -187,6 +191,10 @@ func (a *Adapter) DetectClientType(req *http.Request, body []byte) domain.Client
 		// OpenAI Images API (generations/edits). Body carries no messages/input,
 		// so body-detection can't classify it — key off the path.
 		return domain.ClientTypeOpenAI
+	case IsVideoGenerationsPath(path):
+		// Async video generation (submit POST / poll GET). Poll has no body, so
+		// key off the path.
+		return domain.ClientTypeVideo
 	case strings.HasPrefix(path, "/v1beta/models/"):
 		return domain.ClientTypeGemini
 	case strings.HasPrefix(path, "/v1internal/models/"):
@@ -246,6 +254,15 @@ func isOpenAIImagesPath(path string) bool {
 	// body-based detection returns "" and the request 400s.
 	return path == "/v1/images" || path == "/images" ||
 		strings.HasPrefix(path, "/v1/images/") || strings.HasPrefix(path, "/images/")
+}
+
+// IsVideoGenerationsPath matches the async video-generation surface: the exact
+// submit path (POST /v1/video/generations) and the poll subpath
+// (GET /v1/video/generations/{task_id}). The poll carries no body/model, so it
+// must be classified by path. Exported so the ingress gate can allow GET polls.
+func IsVideoGenerationsPath(path string) bool {
+	return path == "/v1/video/generations" || strings.HasPrefix(path, "/v1/video/generations/") ||
+		path == "/video/generations" || strings.HasPrefix(path, "/video/generations/")
 }
 
 func isClaudeUserAgent(userAgent string) bool {

--- a/internal/adapter/client/adapter.go
+++ b/internal/adapter/client/adapter.go
@@ -265,6 +265,18 @@ func IsVideoGenerationsPath(path string) bool {
 		path == "/video/generations" || strings.HasPrefix(path, "/video/generations/")
 }
 
+// IsVideoPollPath reports whether path is a video-generation POLL — the
+// collection path plus a non-empty task id (e.g. /v1/video/generations/task_abc).
+// Only the poll is a GET; the bare collection path is submit-only (POST).
+func IsVideoPollPath(path string) bool {
+	for _, base := range []string{"/v1/video/generations/", "/video/generations/"} {
+		if strings.HasPrefix(path, base) && strings.TrimPrefix(path, base) != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func isClaudeUserAgent(userAgent string) bool {
 	return strings.HasPrefix(userAgent, "claude-cli")
 }

--- a/internal/adapter/client/adapter_test.go
+++ b/internal/adapter/client/adapter_test.go
@@ -115,6 +115,27 @@ func TestDetectClientTypeRecognizesVideoGenerationsPath(t *testing.T) {
 	}
 }
 
+// Only the poll (collection path + a non-empty task id) may be a GET; the bare
+// submit endpoints stay POST-only, so the method gate must not treat them as polls.
+func TestIsVideoPollPath(t *testing.T) {
+	polls := []string{"/v1/video/generations/task_abc123", "/video/generations/task_abc123"}
+	for _, p := range polls {
+		if !IsVideoPollPath(p) {
+			t.Fatalf("IsVideoPollPath(%s) = false, want true", p)
+		}
+	}
+	notPolls := []string{
+		"/v1/video/generations", "/video/generations",
+		"/v1/video/generations/", "/video/generations/", // trailing slash, no task id
+		"/v1/chat/completions",
+	}
+	for _, p := range notPolls {
+		if IsVideoPollPath(p) {
+			t.Fatalf("IsVideoPollPath(%s) = true, want false", p)
+		}
+	}
+}
+
 func TestImagesEdits_MultipartModelExtraction(t *testing.T) {
 	adapter := NewAdapter()
 

--- a/internal/adapter/client/adapter_test.go
+++ b/internal/adapter/client/adapter_test.go
@@ -82,6 +82,39 @@ func TestDetectClientTypeRecognizesBareImagesPath(t *testing.T) {
 	}
 }
 
+func TestDetectClientTypeRecognizesVideoGenerationsPath(t *testing.T) {
+	adapter := NewAdapter()
+
+	// Submit: POST with a JSON body carrying the model.
+	submitBody := []byte(`{"model":"doubao-seedance-2-0-260128","prompt":"a cat runs"}`)
+	for _, path := range []string{"/v1/video/generations", "/video/generations"} {
+		req := httptest.NewRequest("POST", path, strings.NewReader(string(submitBody)))
+		if got := adapter.DetectClientType(req, submitBody); got != domain.ClientTypeVideo {
+			t.Fatalf("DetectClientType(POST %s) = %s, want %s", path, got, domain.ClientTypeVideo)
+		}
+		if got, ok := adapter.Match(req); !ok || got != domain.ClientTypeVideo {
+			t.Fatalf("Match(POST %s) = (%s, %v), want (%s, true)", path, got, ok, domain.ClientTypeVideo)
+		}
+		if got := adapter.ExtractModel(req, submitBody, domain.ClientTypeVideo); got != "doubao-seedance-2-0-260128" {
+			t.Fatalf("ExtractModel(%s) = %q, want the seedance model", path, got)
+		}
+	}
+
+	// Poll: GET /{task_id} with no body — classified by path, model is empty.
+	for _, path := range []string{"/v1/video/generations/task_abc123", "/video/generations/task_abc123"} {
+		req := httptest.NewRequest("GET", path, nil)
+		if got := adapter.DetectClientType(req, nil); got != domain.ClientTypeVideo {
+			t.Fatalf("DetectClientType(GET %s) = %s, want %s", path, got, domain.ClientTypeVideo)
+		}
+		if got, ok := adapter.Match(req); !ok || got != domain.ClientTypeVideo {
+			t.Fatalf("Match(GET %s) = (%s, %v), want (%s, true)", path, got, ok, domain.ClientTypeVideo)
+		}
+		if got := adapter.ExtractModel(req, nil, domain.ClientTypeVideo); got != "" {
+			t.Fatalf("ExtractModel(poll %s) = %q, want empty", path, got)
+		}
+	}
+}
+
 func TestImagesEdits_MultipartModelExtraction(t *testing.T) {
 	adapter := NewAdapter()
 

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -125,8 +125,14 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		upstreamURL = addClaudeQueryParams(upstreamURL)
 	}
 
-	// Create upstream request
-	upstreamReq, err := http.NewRequestWithContext(ctx, "POST", upstreamURL, bytes.NewReader(requestBody))
+	// Create upstream request. Preserve the inbound method so the async
+	// video-generation poll (GET /v1/video/generations/{task_id}) is forwarded as
+	// GET; everything else is POST.
+	method := http.MethodPost
+	if request != nil && request.Method != "" {
+		method = request.Method
+	}
+	upstreamReq, err := http.NewRequestWithContext(ctx, method, upstreamURL, bytes.NewReader(requestBody))
 	if err != nil {
 		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to create upstream request")
 		proxyErr.Scope = domain.ScopeEndpoint
@@ -223,6 +229,16 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 		// Gemini: Use Gemini-style headers with passthrough support
 		applyGeminiHeaders(upstreamReq, request, a.provider.Config.Custom.APIKey)
 		targetUserAgent = geminiUserAgent
+	case domain.ClientTypeVideo:
+		// Async video generation: forward the client's headers, then force the
+		// provider's bearer key so both submit (POST) and poll (GET) authenticate
+		// even if the client omitted Authorization.
+		originalHeaders := flow.GetRequestHeaders(c)
+		upstreamReq.Header = make(http.Header)
+		copyHeadersFiltered(upstreamReq.Header, originalHeaders)
+		if a.provider.Config.Custom.APIKey != "" {
+			setAuthHeader(upstreamReq, clientType, a.provider.Config.Custom.APIKey, true)
+		}
 	default:
 		// Other types: Preserve original header forwarding logic
 		originalHeaders := flow.GetRequestHeaders(c)
@@ -1083,8 +1099,8 @@ func setAuthHeader(req *http.Request, clientType domain.ClientType, apiKey strin
 	// even if the original request didn't have it (e.g., Claude x-api-key -> OpenAI Authorization)
 	if forceCreate {
 		switch clientType {
-		case domain.ClientTypeOpenAI, domain.ClientTypeCodex:
-			// OpenAI/Codex-style: Authorization: Bearer <key>
+		case domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeVideo:
+			// OpenAI/Codex/Video-style: Authorization: Bearer <key>
 			req.Header.Set("Authorization", "Bearer "+apiKey)
 		case domain.ClientTypeClaude:
 			// Claude-style: x-api-key

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -232,10 +232,16 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	case domain.ClientTypeVideo:
 		// Async video generation: forward the client's headers, then force the
 		// provider's bearer key so both submit (POST) and poll (GET) authenticate
-		// even if the client omitted Authorization.
+		// even if the client omitted Authorization. Strip every client auth header
+		// first — setAuthHeader only sets Authorization for video, so a client's
+		// x-api-key / x-goog-api-key / Proxy-Authorization (any of which may carry
+		// the maxx token) would otherwise leak to the upstream provider.
 		originalHeaders := flow.GetRequestHeaders(c)
 		upstreamReq.Header = make(http.Header)
 		copyHeadersFiltered(upstreamReq.Header, originalHeaders)
+		for _, h := range []string{"Authorization", "Proxy-Authorization", "x-api-key", "x-goog-api-key"} {
+			upstreamReq.Header.Del(h)
+		}
 		if a.provider.Config.Custom.APIKey != "" {
 			setAuthHeader(upstreamReq, clientType, a.provider.Config.Custom.APIKey, true)
 		}
@@ -1038,6 +1044,8 @@ func normalizeOpenAIUpstreamRequestPath(requestPath string) string {
 	// OpenRouter unified image endpoint. Both need the /v1 prefix when the
 	// provider path arrives without one (e.g. /provider/{slug}/images).
 	case requestPath == "/images" || strings.HasPrefix(requestPath, "/images/") || strings.HasPrefix(requestPath, "/images?"):
+		return "/v1" + requestPath
+	case requestPath == "/video/generations" || strings.HasPrefix(requestPath, "/video/generations/"):
 		return "/v1" + requestPath
 	case requestPath == "/models" || strings.HasPrefix(requestPath, "/models?"):
 		return "/v1" + requestPath

--- a/internal/adapter/provider/custom/adapter_url_test.go
+++ b/internal/adapter/provider/custom/adapter_url_test.go
@@ -60,6 +60,24 @@ func TestBuildUpstreamURLNormalizesOpenAIBaseRoots(t *testing.T) {
 			requestPath: "/v1/images",
 			want:        "https://openrouter.ai/api/v1/images",
 		},
+		{
+			name:        "root-style video submit path gains v1",
+			baseURL:     "https://code0.ai",
+			requestPath: "/video/generations",
+			want:        "https://code0.ai/v1/video/generations",
+		},
+		{
+			name:        "root-style video poll path gains v1",
+			baseURL:     "https://code0.ai",
+			requestPath: "/video/generations/task_abc",
+			want:        "https://code0.ai/v1/video/generations/task_abc",
+		},
+		{
+			name:        "canonical v1 video poll path unchanged",
+			baseURL:     "https://code0.ai",
+			requestPath: "/v1/video/generations/task_abc",
+			want:        "https://code0.ai/v1/video/generations/task_abc",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/provider/custom/adapter_video_test.go
+++ b/internal/adapter/provider/custom/adapter_video_test.go
@@ -1,6 +1,7 @@
 package custom
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,11 +41,14 @@ func TestCustomAdapterExecuteVideoSubmitAndPoll(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var gotMethod, gotPath, gotAuth string
+			var gotMethod, gotPath, gotAuth, gotAPIKey, gotGoog, gotProxyAuth string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotMethod = r.Method
 				gotPath = r.URL.Path
 				gotAuth = r.Header.Get("Authorization")
+				gotAPIKey = r.Header.Get("x-api-key")
+				gotGoog = r.Header.Get("x-goog-api-key")
+				gotProxyAuth = r.Header.Get("Proxy-Authorization")
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = io.WriteString(w, `{"task_id":"task_abc123","status":"queued"}`)
 			}))
@@ -65,9 +69,13 @@ func TestCustomAdapterExecuteVideoSubmitAndPoll(t *testing.T) {
 				t.Fatalf("NewAdapter error: %v", err)
 			}
 
-			req, _ := http.NewRequest(tc.method, "http://localhost"+tc.requestURI, nil)
-			// The client sends its maxx token; the adapter must rewrite it to the key.
+			req, _ := http.NewRequestWithContext(context.Background(), tc.method, "http://localhost"+tc.requestURI, nil)
+			// The client may present its maxx token in any accepted auth header; none
+			// of them must reach the upstream — only the provider key does.
 			req.Header.Set("Authorization", "Bearer sk-maxx-client-token")
+			req.Header.Set("x-api-key", "sk-maxx-client-token")
+			req.Header.Set("x-goog-api-key", "sk-maxx-client-token")
+			req.Header.Set("Proxy-Authorization", "Bearer sk-maxx-client-token")
 
 			rec := httptest.NewRecorder()
 			ctx := flow.NewCtx(rec, req)
@@ -89,6 +97,10 @@ func TestCustomAdapterExecuteVideoSubmitAndPoll(t *testing.T) {
 			}
 			if gotAuth != "Bearer sk-seedance" {
 				t.Fatalf("upstream Authorization = %q, want %q", gotAuth, "Bearer sk-seedance")
+			}
+			// The client's token must not leak through any alternate auth header.
+			if gotAPIKey != "" || gotGoog != "" || gotProxyAuth != "" {
+				t.Fatalf("client auth leaked upstream: x-api-key=%q x-goog-api-key=%q Proxy-Authorization=%q", gotAPIKey, gotGoog, gotProxyAuth)
 			}
 		})
 	}

--- a/internal/adapter/provider/custom/adapter_video_test.go
+++ b/internal/adapter/provider/custom/adapter_video_test.go
@@ -1,0 +1,95 @@
+package custom
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// The async video-generation surface must be forwarded verbatim: the inbound
+// HTTP method (POST submit / GET poll) is preserved, the request URI — including
+// the /{task_id} suffix on a poll — is passed through unchanged, and the
+// provider's bearer key is injected.
+func TestCustomAdapterExecuteVideoSubmitAndPoll(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     string
+		requestURI string
+		body       []byte
+		wantPath   string
+	}{
+		{
+			name:       "submit",
+			method:     http.MethodPost,
+			requestURI: "/v1/video/generations",
+			body:       []byte(`{"model":"doubao-seedance-2-0-260128","prompt":"a cat runs"}`),
+			wantPath:   "/v1/video/generations",
+		},
+		{
+			name:       "poll",
+			method:     http.MethodGet,
+			requestURI: "/v1/video/generations/task_abc123",
+			body:       nil,
+			wantPath:   "/v1/video/generations/task_abc123",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotAuth string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				gotAuth = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"task_id":"task_abc123","status":"queued"}`)
+			}))
+			defer server.Close()
+
+			adapter, err := NewAdapter(&domain.Provider{
+				Name:                 "code0-seedance",
+				Type:                 "custom",
+				SupportedClientTypes: []domain.ClientType{domain.ClientTypeVideo},
+				Config: &domain.ProviderConfig{
+					Custom: &domain.ProviderConfigCustom{
+						BaseURL: server.URL,
+						APIKey:  "sk-seedance",
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewAdapter error: %v", err)
+			}
+
+			req, _ := http.NewRequest(tc.method, "http://localhost"+tc.requestURI, nil)
+			// The client sends its maxx token; the adapter must rewrite it to the key.
+			req.Header.Set("Authorization", "Bearer sk-maxx-client-token")
+
+			rec := httptest.NewRecorder()
+			ctx := flow.NewCtx(rec, req)
+			ctx.Set(flow.KeyClientType, domain.ClientTypeVideo)
+			ctx.Set(flow.KeyRequestURI, tc.requestURI)
+			ctx.Set(flow.KeyRequestBody, tc.body)
+
+			if err := adapter.Execute(ctx, &domain.Provider{}); err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			if gotMethod != tc.method {
+				t.Fatalf("upstream method = %q, want %q", gotMethod, tc.method)
+			}
+			if gotPath != tc.wantPath {
+				t.Fatalf("upstream path = %q, want %q", gotPath, tc.wantPath)
+			}
+			if gotAuth != "Bearer sk-seedance" {
+				t.Fatalf("upstream Authorization = %q, want %q", gotAuth, "Bearer sk-seedance")
+			}
+		})
+	}
+}

--- a/internal/core/proxy_routes.go
+++ b/internal/core/proxy_routes.go
@@ -42,6 +42,12 @@ func RegisterProxyRoutes(mux *http.ServeMux, handlers ProxyRouteHandlers) {
 		// OpenRouter unified image API (POST /v1/images → data[].b64_json)
 		mux.Handle("/v1/images", handlers.ProxyHandler)
 		mux.Handle("/images", handlers.ProxyHandler)
+		// Async video generation (new-api style): POST submit + GET /{task_id} poll.
+		// The trailing-slash subtree pattern matches the /{task_id} poll path.
+		mux.Handle("/v1/video/generations", handlers.ProxyHandler)
+		mux.Handle("/v1/video/generations/", handlers.ProxyHandler)
+		mux.Handle("/video/generations", handlers.ProxyHandler)
+		mux.Handle("/video/generations/", handlers.ProxyHandler)
 		// Codex API
 		mux.Handle("/responses", responsesHandler)
 		mux.Handle("/responses/", responsesHandler)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -13,6 +13,10 @@ var (
 	ClientTypeCodex  ClientType = "codex"
 	ClientTypeGemini ClientType = "gemini"
 	ClientTypeOpenAI ClientType = "openai"
+	// ClientTypeVideo is the async video-generation surface (new-api style:
+	// POST /v1/video/generations to submit, GET /v1/video/generations/{task_id}
+	// to poll). The client drives the polling; maxx stays a stateless proxy.
+	ClientTypeVideo ClientType = "video"
 )
 
 type ProviderConfigCustom struct {

--- a/internal/executor/converting_writer_video_test.go
+++ b/internal/executor/converting_writer_video_test.go
@@ -1,0 +1,32 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// A video request routed to a video-native provider must never be converted:
+// there is no video converter, and the Gemini/Claude "preferred target"
+// fallbacks must not hijack it.
+func TestGetPreferredTargetTypeVideoStaysVideo(t *testing.T) {
+	got := GetPreferredTargetType([]domain.ClientType{domain.ClientTypeVideo}, domain.ClientTypeVideo, "newapi")
+	if got != domain.ClientTypeVideo {
+		t.Fatalf("GetPreferredTargetType = %s, want %s", got, domain.ClientTypeVideo)
+	}
+
+	// Even if the provider happens to advertise other types alongside video, an
+	// exact match on the original type wins first.
+	got = GetPreferredTargetType(
+		[]domain.ClientType{domain.ClientTypeOpenAI, domain.ClientTypeVideo},
+		domain.ClientTypeVideo, "newapi")
+	if got != domain.ClientTypeVideo {
+		t.Fatalf("GetPreferredTargetType (mixed) = %s, want %s", got, domain.ClientTypeVideo)
+	}
+}
+
+func TestNeedsConversionVideoToVideoIsFalse(t *testing.T) {
+	if NeedsConversion(domain.ClientTypeVideo, domain.ClientTypeVideo) {
+		t.Fatalf("NeedsConversion(video, video) = true, want false")
+	}
+}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -189,7 +189,9 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		defer tracker.Done()
 	}
 
-	if r.Method != http.MethodPost {
+	// The proxy surface is POST-only, except the async video-generation poll
+	// (GET /v1/video/generations/{task_id}) which the client drives.
+	if r.Method != http.MethodPost && !(r.Method == http.MethodGet && client.IsVideoGenerationsPath(r.URL.Path)) {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		c.Abort()
 		return

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -190,8 +190,11 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 	}
 
 	// The proxy surface is POST-only, except the async video-generation poll
-	// (GET /v1/video/generations/{task_id}) which the client drives.
-	if r.Method != http.MethodPost && !(r.Method == http.MethodGet && client.IsVideoGenerationsPath(r.URL.Path)) {
+	// (GET /v1/video/generations/{task_id}) which the client drives. The bare
+	// submit endpoint stays POST-only.
+	methodAllowed := r.Method == http.MethodPost ||
+		(r.Method == http.MethodGet && client.IsVideoPollPath(r.URL.Path))
+	if !methodAllowed {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		c.Abort()
 		return

--- a/internal/handler/token_auth.go
+++ b/internal/handler/token_auth.go
@@ -81,7 +81,7 @@ func (m *TokenAuthMiddleware) ExtractToken(req *http.Request, clientType domain.
 				return parts[1]
 			}
 		}
-	case domain.ClientTypeOpenAI, domain.ClientTypeCodex:
+	case domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeVideo:
 		if auth := req.Header.Get("Authorization"); auth != "" {
 			if parts := strings.Fields(auth); len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") {
 				return parts[1]

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -989,7 +989,7 @@ func projectHasCustomRoutes(project *domain.Project, clientType domain.ClientTyp
 
 func isValidRouteClientType(clientType domain.ClientType) bool {
 	switch clientType {
-	case domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeGemini:
+	case domain.ClientTypeClaude, domain.ClientTypeOpenAI, domain.ClientTypeCodex, domain.ClientTypeGemini, domain.ClientTypeVideo:
 		return true
 	default:
 		return false

--- a/internal/service/route_clienttype_video_test.go
+++ b/internal/service/route_clienttype_video_test.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// A "video" route must be creatable via the admin API, so the client-type
+// validation has to accept it alongside the chat surfaces.
+func TestIsValidRouteClientTypeIncludesVideo(t *testing.T) {
+	valid := []domain.ClientType{
+		domain.ClientTypeClaude,
+		domain.ClientTypeOpenAI,
+		domain.ClientTypeCodex,
+		domain.ClientTypeGemini,
+		domain.ClientTypeVideo,
+	}
+	for _, ct := range valid {
+		if !isValidRouteClientType(ct) {
+			t.Fatalf("isValidRouteClientType(%s) = false, want true", ct)
+		}
+	}
+	if isValidRouteClientType(domain.ClientType("bogus")) {
+		t.Fatalf("isValidRouteClientType(bogus) = true, want false")
+	}
+}


### PR DESCRIPTION
## What

Adds a dedicated `video` client type so maxx can proxy the new-api-style **async video-generation API** used by upstreams like code0 (ByteDance **Seedance** / doubao):

```
POST /v1/video/generations        -> submit, returns a task id
GET  /v1/video/generations/{id}   -> poll for status + result URL
```

The **client drives the polling**, so maxx stays a stateless reverse proxy — no async task storage. Both calls get auth injection, routing, model mapping and stats like any other request.

## Why

Users want Seedance video generation through maxx. code0 exposes 4 seedance models (`doubao-seedance-2-0-260128`, `-2-0-fast-260128`, `-2-0-mini-260615`, `-2-5-260628`) on the new-api async video endpoint. maxx previously only supported 4 chat-style client types and its proxy surface was POST-only, so video requests couldn't be routed.

## How

- **domain**: add `ClientTypeVideo`.
- **client adapter**: classify `/v1/video/generations` (+ `/{task_id}` subpath, + no-`/v1` alias) as `ClientTypeVideo` by path — the poll has no body/model.
- **proxy_routes**: register submit + poll subtree.
- **proxy ingress**: allow `GET` for the video poll (surface is otherwise POST-only).
- **custom adapter**: preserve the inbound HTTP method (poll forwards as GET, not POST) and force bearer auth for video.
- **admin / token_auth**: accept `video` as a route client type and bearer surface.

Routing: a video request routes by client-type chain. A single video provider with **empty `supportModels`** is a catch-all, so both the model-bearing submit and the model-less poll land on it. No format conversion (video is native; `GetPreferredTargetType`/`NeedsConversion` short-circuit). `newapi` delegates to this same custom `Execute`, so it works for `custom` and `newapi` provider types alike.

## Tests

- Path detection: submit POST + poll GET → `ClientTypeVideo`.
- Model extraction: model on submit, empty on poll.
- Custom adapter: correct upstream method/path/bearer for both submit and poll.
- `GetPreferredTargetType`/`NeedsConversion` leave video unconverted.
- Admin route client-type validation accepts `video`.

All `./internal/...` tests pass (28 packages, 0 failures).

## Runtime config (after deploy)

Create a `custom` (or `newapi`) provider pointing at the video upstream (`baseURL`, key, `supportedClientTypes:["video"]`, empty `supportModels`), and a `video` route → that provider. Model IDs pass through verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增异步视频生成 API，支持视频提交与任务状态轮询。
  - 兼容 `/v1` 和非 `/v1` 路径，并自动识别视频请求类型。
  - 支持视频请求的 Bearer 认证及提供商密钥转发。
- **改进**
  - 轮询请求支持 `GET` 方法并保留任务路径。
  - 视频请求可直接转发，无需额外格式转换。
- **测试**
  - 增加视频提交、轮询、路由识别、认证和请求转发验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->