### PR TITLE
revert(executor): remove committed stream retry failover

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -25,10 +25,6 @@ type disabledCooldownHTTPErrorAdapter struct {
 	succeedAfter int
 }
 
-type interruptedResponseStreamRetryAdapter struct {
-	calls *int
-}
-
 func (a *disabledCooldownStreamRetryAdapter) SupportedClientTypes() []domain.ClientType {
 	return []domain.ClientType{domain.ClientTypeOpenAI}
 }
@@ -56,10 +52,6 @@ func (a *disabledCooldownHTTPErrorAdapter) SupportedClientTypes() []domain.Clien
 	return []domain.ClientType{domain.ClientTypeOpenAI}
 }
 
-func (a interruptedResponseStreamRetryAdapter) SupportedClientTypes() []domain.ClientType {
-	return []domain.ClientType{domain.ClientTypeOpenAI}
-}
-
 func (a *disabledCooldownHTTPErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
 	a.calls++
 	if a.succeedAfter > 0 && a.calls > a.succeedAfter {
@@ -72,124 +64,49 @@ func (a *disabledCooldownHTTPErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provid
 	return proxyErr
 }
 
-func (a interruptedResponseStreamRetryAdapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
-	*a.calls = *a.calls + 1
-	if *a.calls == 1 {
-		c.Writer.Header().Set("Content-Type", "text/event-stream")
-		_, _ = c.Writer.Write([]byte("data: partial\n\n"))
-		proxyErr := domain.NewProxyErrorWithMessage(
-			errors.New("stream transport reset"),
-			false,
-			"Upstream response stream was interrupted",
-		)
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonNetworkError
-		return proxyErr
-	}
-	c.Writer.Header().Set("Content-Type", "text/event-stream")
-	_, _ = c.Writer.Write([]byte("data: fallback\n\ndata: [DONE]\n\n"))
-	return nil
-}
-
-func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
+func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
 	c, adapter, attemptRepo, proxyRepo := newDisabledCooldownStreamDispatchCtx(true)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
 
 	e.dispatch(c)
 
-	if c.Err != nil {
-		t.Fatalf("dispatch returned error: %v", c.Err)
+	if c.Err == nil {
+		t.Fatal("expected committed stream read error")
 	}
-	if adapter.calls != 2 {
-		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
 	}
-	if len(attemptRepo.created) != 2 {
-		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
+	if len(attemptRepo.created) != 1 {
+		t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
 	}
-	if got := attemptRepo.updated[0].Status; got != "FAILED" {
-		t.Fatalf("first attempt status = %q, want FAILED", got)
+	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "FAILED" {
+		t.Fatalf("attempt status = %q, want FAILED", got)
 	}
-	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "COMPLETED" {
-		t.Fatalf("final attempt status = %q, want COMPLETED", got)
-	}
-	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\n" {
 		t.Fatalf("client body = %q", got)
 	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
-		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
 	}
 }
 
-func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
+func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
 	c, adapter, _, proxyRepo := newDisabledCooldownStreamDispatchCtx(false)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
 
 	e.dispatch(c)
 
-	if c.Err != nil {
-		t.Fatalf("dispatch returned error: %v", c.Err)
+	if c.Err == nil {
+		t.Fatal("expected committed stream read error")
 	}
-	if adapter.calls != 2 {
-		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
 	}
-	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\n" {
 		t.Fatalf("client body = %q", got)
 	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
-		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
-	}
-}
-
-func TestDispatchRetriesInterruptedResponseStreamError(t *testing.T) {
-	proxyRepo := &recordingProxyRequestRepo{}
-	attemptRepo := &recordingAttemptRepo{}
-	calls := 0
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
-	c := flow.NewCtx(rec, req)
-	proxyReq := &domain.ProxyRequest{
-		ID:         101,
-		TenantID:   domain.DefaultTenantID,
-		ClientType: domain.ClientTypeOpenAI,
-		Status:     "IN_PROGRESS",
-		StartTime:  time.Now(),
-	}
-	state := &execState{
-		ctx:          context.Background(),
-		proxyReq:     proxyReq,
-		tenantID:     domain.DefaultTenantID,
-		clientType:   domain.ClientTypeOpenAI,
-		requestModel: "gpt-4o",
-		isStream:     true,
-		routes: []*router.MatchedRoute{{
-			Route: &domain.Route{ID: 11, TenantID: domain.DefaultTenantID, ProviderID: 21, ClientType: domain.ClientTypeOpenAI},
-			Provider: &domain.Provider{
-				ID:       21,
-				TenantID: domain.DefaultTenantID,
-				Type:     "custom",
-				Name:     "custom-interrupted-stream",
-				Config:   &domain.ProviderConfig{DisableErrorCooldown: false},
-			},
-			ProviderAdapter: interruptedResponseStreamRetryAdapter{calls: &calls},
-			RetryConfig:     &domain.RetryConfig{MaxRetries: 1, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
-		}},
-	}
-	c.Set(flow.KeyExecutorState, state)
-	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
-
-	e.dispatch(c)
-
-	if c.Err != nil {
-		t.Fatalf("dispatch returned error: %v", c.Err)
-	}
-	if calls != 2 {
-		t.Fatalf("adapter calls = %d, want 2", calls)
-	}
-	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
-		t.Fatalf("client body = %q", got)
-	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
-		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
 	}
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -469,15 +469,11 @@ func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
 		msg += " " + proxyErr.Err.Error()
 	}
 	msg = strings.ToLower(msg)
-	return strings.Contains(msg, "stream read error") ||
-		strings.Contains(msg, "upstream stream") ||
-		strings.Contains(msg, "unexpected eof") ||
-		strings.Contains(msg, "upstream response stream was interrupted") ||
-		(strings.Contains(msg, "response stream") && strings.Contains(msg, "interrupt"))
+	return false
 }
 
 func shouldRetryCommittedResponseError(proxyErr *domain.ProxyError) bool {
-	return proxyErr != nil && proxyErr.Retryable && isCommittedStreamReadRetryableError(proxyErr)
+	return false
 }
 
 func isBedrockAdaptiveThinkingSchemaError(proxyErr *domain.ProxyError) bool {


### PR DESCRIPTION
## Why
PR #829 allowed committed stream read failures to transparently retry/fail over after bytes had already been written to the client. In real clients this breaks the stream contract: maxx may appear to retry internally while the client-side stream is already disconnected.

## What this reverts
- Remove transparent retry for provider/network stream failures after the response has already been committed to the client.
- Update executor regression coverage to lock the corrected behavior.

## Expected behavior after revert
- If upstream stream output has already started and then breaks, maxx will stop pretending it can transparently stitch a new upstream stream into the same client response.
- This avoids the false impression that retry succeeded while the client actually got disconnected.

## Validation
- `go test ./internal/executor/...`

## Related
- Reverts the committed-stream retry behavior introduced by #829.
