### PR TITLE
fix(retention): finite default for request-detail retention (was -1 = forever)

### DIFF
--- a/internal/core/task.go
+++ b/internal/core/task.go
@@ -440,14 +440,32 @@ func (d *BackgroundTaskDeps) requestDetailRetentionConfig() (successSec, failedS
 		return n
 	}
 
+	// 统一键未设置时默认 -1（永久）：仅在运营者显式关闭 split（split=false）时生效。
+	unifiedRaw, _ := d.Settings.Get(domain.SettingKeyRequestDetailRetentionSeconds)
 	unified := parse(domain.SettingKeyRequestDetailRetentionSeconds, -1)
 
+	// split 默认开启（见 domain.DefaultRequestDetailRetentionSplitEnabled）：
+	// 未设置时按成功/失败分桶保留有限时长，避免历史 -1 永久默认撑爆磁盘。
+	// 运营者显式设为 "false" 可回退到统一键（含显式 -1 永久）。
 	splitVal, _ := d.Settings.Get(domain.SettingKeyRequestDetailRetentionSplitEnabled)
-	if splitVal != "true" {
+	split = domain.DefaultRequestDetailRetentionSplitEnabled
+	if splitVal != "" {
+		split = splitVal == "true"
+	}
+	if !split {
 		return unified, unified, false
 	}
-	return parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, unified),
-		parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, unified),
+	// split 生效时，成功/失败键未设置的回退：
+	//   - 若运营者显式设过统一键，尊重它作为回退（保留旧语义）
+	//   - 否则用各自的有限默认值（1 天 / 3 天），而非历史 -1 永久
+	successFallback := domain.DefaultRequestDetailRetentionSecondsSuccess
+	failedFallback := domain.DefaultRequestDetailRetentionSecondsFailed
+	if unifiedRaw != "" {
+		successFallback = unified
+		failedFallback = unified
+	}
+	return parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, successFallback),
+		parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, failedFallback),
 		true
 }
 

--- a/internal/core/task_test.go
+++ b/internal/core/task_test.go
@@ -301,14 +301,66 @@ func TestCleanupOldRequestDetails_SplitMode(t *testing.T) {
 		}
 	})
 
-	t.Run("retention=-1 (default) is no-op", func(t *testing.T) {
+	t.Run("all-unset defaults: split on, success 1d cleared, failed 3d retained", func(t *testing.T) {
+		// 事故修复回归：历史默认 -1（永久）撑爆磁盘。现默认 split 开启，
+		// 成功详情保留 1 天（86400s）、失败详情保留 3 天（259200s）。
+		// oldTime = now-2h：已过成功 1 天窗口？否——2h < 1d，成功应保留。
+		// 用一个超过 1 天但不足 3 天的时间戳来验证成功被清、失败仍保留。
 		db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
 		if err != nil {
 			t.Fatalf("open db: %v", err)
 		}
 		defer db.Close()
 		reqRepo := sqlite.NewProxyRequestRepository(db)
-		settings := &fakeSettingRepo{} // 全部默认（即 -1）
+		settings := &fakeSettingRepo{} // 全部默认
+		deps := BackgroundTaskDeps{
+			ProxyRequest: reqRepo,
+			Settings:     settings,
+		}
+
+		// 校验解析出来的默认值确实是有限的、分桶的
+		successSec, failedSec, split := deps.requestDetailRetentionConfig()
+		if !split {
+			t.Fatalf("default should enable split, got split=false")
+		}
+		if successSec != domain.DefaultRequestDetailRetentionSecondsSuccess {
+			t.Fatalf("default successSec = %d, want %d", successSec, domain.DefaultRequestDetailRetentionSecondsSuccess)
+		}
+		if failedSec != domain.DefaultRequestDetailRetentionSecondsFailed {
+			t.Fatalf("default failedSec = %d, want %d", failedSec, domain.DefaultRequestDetailRetentionSecondsFailed)
+		}
+
+		betweenOneAndThreeDays := now.Add(-48 * time.Hour) // 2 天：过成功 1 天窗口，未过失败 3 天窗口
+		okOld := seedRequest(t, db, reqRepo, "COMPLETED", betweenOneAndThreeDays, 1)
+		badOld := seedRequest(t, db, reqRepo, "FAILED", betweenOneAndThreeDays, 2)
+		// 很新的请求：两桶都应保留
+		okFresh := seedRequest(t, db, reqRepo, "COMPLETED", now.Add(-1*time.Minute), 3)
+
+		deps.cleanupOldRequestDetails()
+
+		if !reloadDetailEmpty(t, db, okOld.ID) {
+			t.Error("2-day-old COMPLETED should be cleared by default success=86400 (1d)")
+		}
+		if reloadDetailEmpty(t, db, badOld.ID) {
+			t.Error("2-day-old FAILED should be retained by default failed=259200 (3d)")
+		}
+		if reloadDetailEmpty(t, db, okFresh.ID) {
+			t.Error("fresh COMPLETED should be retained (within 1d window)")
+		}
+	})
+
+	t.Run("explicit unified -1 with split=false still means forever (opt-in preserved)", func(t *testing.T) {
+		// 运营者仍可显式选择永久保存：split=false + unified=-1
+		db, err := sqlite.NewDBWithDSN("sqlite://:memory:")
+		if err != nil {
+			t.Fatalf("open db: %v", err)
+		}
+		defer db.Close()
+		reqRepo := sqlite.NewProxyRequestRepository(db)
+		settings := &fakeSettingRepo{values: map[string]string{
+			domain.SettingKeyRequestDetailRetentionSplitEnabled: "false",
+			domain.SettingKeyRequestDetailRetentionSeconds:      "-1",
+		}}
 		deps := BackgroundTaskDeps{
 			ProxyRequest: reqRepo,
 			Settings:     settings,
@@ -320,10 +372,10 @@ func TestCleanupOldRequestDetails_SplitMode(t *testing.T) {
 		deps.cleanupOldRequestDetails()
 
 		if reloadDetailEmpty(t, db, ok.ID) {
-			t.Error("default -1 should retain")
+			t.Error("explicit -1 should retain COMPLETED forever")
 		}
 		if reloadDetailEmpty(t, db, bad.ID) {
-			t.Error("default -1 should retain")
+			t.Error("explicit -1 should retain FAILED forever")
 		}
 	})
 }
@@ -336,17 +388,17 @@ type fakeCoordinator struct {
 	err   error
 }
 
-func (f *fakeCoordinator) InstanceID() string                                       { return f.id }
-func (f *fakeCoordinator) Publish(context.Context, string, []byte) error            { return nil }
+func (f *fakeCoordinator) InstanceID() string                            { return f.id }
+func (f *fakeCoordinator) Publish(context.Context, string, []byte) error { return nil }
 func (f *fakeCoordinator) Subscribe(context.Context, string) (<-chan coordinator.Message, error) {
 	return nil, nil
 }
-func (f *fakeCoordinator) Get(context.Context, string) ([]byte, error)                { return nil, nil }
-func (f *fakeCoordinator) Set(context.Context, string, []byte, time.Duration) error   { return nil }
-func (f *fakeCoordinator) Del(context.Context, string) error                          { return nil }
-func (f *fakeCoordinator) RegisterInstance(context.Context, time.Duration) error      { return nil }
-func (f *fakeCoordinator) RefreshInstance(context.Context, time.Duration) error       { return nil }
-func (f *fakeCoordinator) UnregisterInstance(context.Context) error                   { return nil }
+func (f *fakeCoordinator) Get(context.Context, string) ([]byte, error)              { return nil, nil }
+func (f *fakeCoordinator) Set(context.Context, string, []byte, time.Duration) error { return nil }
+func (f *fakeCoordinator) Del(context.Context, string) error                        { return nil }
+func (f *fakeCoordinator) RegisterInstance(context.Context, time.Duration) error    { return nil }
+func (f *fakeCoordinator) RefreshInstance(context.Context, time.Duration) error     { return nil }
+func (f *fakeCoordinator) UnregisterInstance(context.Context) error                 { return nil }
 func (f *fakeCoordinator) ListAliveInstances(context.Context) ([]string, error) {
 	if f.err != nil {
 		return nil, f.err

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -992,10 +992,10 @@ const (
 	SettingKeyProxyPort                            = "proxy_port"                                // 代理服务器端口，默认 9880
 	SettingKeyRequestRetentionHours                = "request_retention_hours"                   // 请求记录保留小时数，默认 168 小时（7天），0 表示不清理
 	SettingKeySessionRetentionHours                = "session_retention_hours"                   // 请求会话保留小时数，默认 168 小时（7天），0 表示不清理
-	SettingKeyRequestDetailRetentionSeconds        = "request_detail_retention_seconds"          // 请求详情保留秒数（统一），-1=永久保存(默认)，0=不保存，>0=保留秒数；当 split=false 时使用
-	SettingKeyRequestDetailRetentionSplitEnabled   = "request_detail_retention_split_enabled"    // 是否分别配置成功/失败保留时长，"true" 或 "false"，默认 "false"
-	SettingKeyRequestDetailRetentionSecondsSuccess = "request_detail_retention_seconds_success"  // 成功请求详情保留秒数，仅在 split=true 时生效；语义同上，未设置回退到统一键
-	SettingKeyRequestDetailRetentionSecondsFailed  = "request_detail_retention_seconds_failed"   // 失败请求详情保留秒数，仅在 split=true 时生效；语义同上，未设置回退到统一键
+	SettingKeyRequestDetailRetentionSeconds        = "request_detail_retention_seconds"          // 请求详情保留秒数（统一），-1=永久保存，0=不保存，>0=保留秒数；当 split=false 时使用。未设置时不再默认永久保存，见下方 split 默认值
+	SettingKeyRequestDetailRetentionSplitEnabled   = "request_detail_retention_split_enabled"    // 是否分别配置成功/失败保留时长，"true" 或 "false"，默认 "true"（默认按成功/失败分桶保留）
+	SettingKeyRequestDetailRetentionSecondsSuccess = "request_detail_retention_seconds_success"  // 成功请求详情保留秒数，仅在 split=true 时生效；语义同上，未设置默认 86400（1 天）
+	SettingKeyRequestDetailRetentionSecondsFailed  = "request_detail_retention_seconds_failed"   // 失败请求详情保留秒数，仅在 split=true 时生效；语义同上，未设置默认 259200（3 天）
 	SettingKeyTimezone                             = "timezone"                                  // 时区设置，默认 Asia/Shanghai
 	SettingKeyQuotaRefreshInterval                 = "quota_refresh_interval"                    // Antigravity 配额刷新间隔（分钟），0 表示禁用
 	SettingKeyRateLimitCooldownDefaultSeconds      = "cooldown_rate_limit_default_seconds"       // 429 rate/concurrent limit 无 Retry-After 时默认冻结秒数，默认 5 秒
@@ -1023,6 +1023,27 @@ const (
 	SettingKeyEnablePprof                          = "enable_pprof"                              // 是否启用 pprof 性能分析，"true" 或 "false"，默认 "false"
 	SettingKeyPprofPort                            = "pprof_port"                                // pprof 服务端口，默认 6060
 	SettingKeyPprofPassword                        = "pprof_password"                            // pprof 访问密码，为空表示不需要密码
+)
+
+// 请求详情保留默认值。
+//
+// 背景：request_detail_retention_seconds 历史默认 -1（永久保存），配合
+// 失败详情放大 bug，图片请求携带 base64（约 18KB/条）产生约 97 万条失败详情，
+// 撑爆 20GiB RDS，Postgres 拒绝连接导致 maxx CrashLoopBackOff、域名 14 小时不可用。
+// 即使没有放大 bug，无上限的默认值也是潜在的磁盘耗尽风险。
+//
+// 现改为默认按成功/失败分桶保留有限时长（与生产事故中验证有效的缓解值一致）：
+//   - 成功详情：默认 1 天（86400s）
+//   - 失败详情：默认 3 天（259200s）——失败详情通常更需要保留用于排障
+//
+// 运营者仍可显式把任一保留值设为 -1 恢复“永久保存”，只是默认不再无上限。
+const (
+	// DefaultRequestDetailRetentionSplitEnabled 默认开启成功/失败分桶保留。
+	DefaultRequestDetailRetentionSplitEnabled = true
+	// DefaultRequestDetailRetentionSecondsSuccess 成功请求详情默认保留 1 天。
+	DefaultRequestDetailRetentionSecondsSuccess = 86400
+	// DefaultRequestDetailRetentionSecondsFailed 失败请求详情默认保留 3 天。
+	DefaultRequestDetailRetentionSecondsFailed = 259200
 )
 
 // ModelPrice 模型价格（每个模型可有多条记录，每条代表一个版本）

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -720,17 +720,33 @@ func (e *Executor) requestDetailRetentionConfig() (requestDetailRetentionConfig,
 		return n
 	}
 
+	// 语义必须与 core.BackgroundTaskDeps.requestDetailRetentionConfig 保持一致，
+	// 否则 ingress 即时清理与后台 cleanup 会对同一配置得出不同结论。
+	unifiedRaw, _ := e.settingsRepo.Get(domain.SettingKeyRequestDetailRetentionSeconds)
 	unified := parse(domain.SettingKeyRequestDetailRetentionSeconds, -1)
+
+	// split 默认开启：未设置时按成功/失败分桶保留有限时长（默认 1 天 / 3 天），
+	// 避免历史 -1 永久默认撑爆磁盘；显式 split=false 可回退到统一键（含显式 -1 永久）。
 	splitVal, _ := e.settingsRepo.Get(domain.SettingKeyRequestDetailRetentionSplitEnabled)
+	split := domain.DefaultRequestDetailRetentionSplitEnabled
+	if splitVal != "" {
+		split = splitVal == "true"
+	}
 	cfg := requestDetailRetentionConfig{
 		unified:    unified,
-		split:      splitVal == "true",
+		split:      split,
 		successSec: unified,
 		failedSec:  unified,
 	}
 	if cfg.split {
-		cfg.successSec = parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, unified)
-		cfg.failedSec = parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, unified)
+		successFallback := domain.DefaultRequestDetailRetentionSecondsSuccess
+		failedFallback := domain.DefaultRequestDetailRetentionSecondsFailed
+		if unifiedRaw != "" {
+			successFallback = unified
+			failedFallback = unified
+		}
+		cfg.successSec = parse(domain.SettingKeyRequestDetailRetentionSecondsSuccess, successFallback)
+		cfg.failedSec = parse(domain.SettingKeyRequestDetailRetentionSecondsFailed, failedFallback)
 	}
 	return cfg, true
 }

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -413,12 +413,23 @@ export function DataRetentionSection() {
   const requestRetentionHours = settings?.request_retention_hours ?? '168';
   const sessionRetentionHours = settings?.session_retention_hours ?? '168';
   const requestDetailRetentionSeconds = settings?.request_detail_retention_seconds ?? '-1';
+  // 详情保留默认按成功/失败分桶（split 默认开启），避免历史 -1 永久默认撑爆磁盘。
   const requestDetailRetentionSplitEnabled =
-    settings?.request_detail_retention_split_enabled === 'true';
+    settings?.request_detail_retention_split_enabled === undefined
+      ? true
+      : settings?.request_detail_retention_split_enabled === 'true';
+  // 未显式设置统一键时，成功/失败回退到各自的有限默认值（1 天 / 3 天）。
+  const requestDetailRetentionUnifiedFallback = settings?.request_detail_retention_seconds ?? '-1';
   const requestDetailRetentionSecondsSuccess =
-    settings?.request_detail_retention_seconds_success ?? requestDetailRetentionSeconds;
+    settings?.request_detail_retention_seconds_success ??
+    (settings?.request_detail_retention_seconds !== undefined
+      ? requestDetailRetentionUnifiedFallback
+      : '86400');
   const requestDetailRetentionSecondsFailed =
-    settings?.request_detail_retention_seconds_failed ?? requestDetailRetentionSeconds;
+    settings?.request_detail_retention_seconds_failed ??
+    (settings?.request_detail_retention_seconds !== undefined
+      ? requestDetailRetentionUnifiedFallback
+      : '259200');
 
   const [requestDraft, setRequestDraft] = useState('');
   const [sessionDraft, setSessionDraft] = useState('');


### PR DESCRIPTION
## Incident

`request_detail_retention_seconds` defaulted to **`-1` (retain forever)**, so full request/response details were persisted with no upper bound. Combined with a retry detail-amplification bug (separate PR), ~970k failure-detail rows — image requests carry base64 (~18KB each) — filled a **20GiB RDS**. Postgres then refused connections → maxx entered CrashLoopBackOff → the domain was down for ~14 hours (hubitos, v0.15.83).

Even without the amplification bug, an **unbounded default is a latent disk-exhaustion risk** for any deployment.

## What this PR changes

Split (per-outcome) retention **already existed** in the codebase (`request_detail_retention_split_enabled` + `_success` / `_failed` keys). This PR changes only the **DEFAULTS** — no schema, no new mechanism:

| Setting | Old default | New default |
| --- | --- | --- |
| `request_detail_retention_split_enabled` | `false` | `true` |
| `request_detail_retention_seconds_success` | (fell back to unified `-1` = forever) | `86400` (1 day) |
| `request_detail_retention_seconds_failed` | (fell back to unified `-1` = forever) | `259200` (3 days) |

Rationale: failure details are more valuable for debugging, so they get a longer window (3 days) than success details (1 day). These are exactly the values the reporter confirmed working in production, where the cleanup task then logged e.g. `[Task] Cleared details for 10000 success requests (retention=86400s)`. Maintainers can tune these constants in `internal/domain/model.go`.

## The "forever" option is preserved

Only the **default** changed. Operators can still opt into forever:
- Set any bucket (or the unified key with `split=false`) to `-1`.
- If an operator has explicitly set the **unified** `request_detail_retention_seconds`, that value still flows into both success/failed buckets (old semantics), so existing explicit configs behave identically.
- The per-outcome finite defaults only apply when **no** retention keys are set.

## Consistency

Both consumers of the config resolve it with identical logic so ingress immediate-clear and background cleanup never disagree:
- `internal/executor/executor.go` (`requestDetailRetentionConfig`)
- `internal/core/task.go` (`requestDetailRetentionConfig` → `cleanupOldRequestDetails` / `runRequestDetailCleanup`) — this is where the cleanup task lives.

Frontend defaults in `web/src/pages/settings/index.tsx` updated to match.

## Tests

`internal/core/task_test.go`:
- New: all-unset defaults → split on, a 2-day-old COMPLETED is cleared (success 1d), a 2-day-old FAILED is retained (failed 3d), a fresh COMPLETED is retained.
- New: explicit `-1` with `split=false` still retains forever (opt-in preserved).
- Asserts the resolved default config is `split=true, success=86400, failed=259200`.

`go build ./internal/...`, `go test ./internal/core/... ./internal/executor/...`, the retention e2e tests, and frontend `tsc` all pass. (`go build ./...` fails only on the pre-existing `web/dist` embed, unrelated to this change.)

Not touched: executor retry logic and header redaction (separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 请求详情默认启用成功/失败分开保留策略。
  * 成功详情默认保留 1 天，失败详情默认保留 3 天。

* **改进**
  * 未配置具体保留时间时，系统将采用上述有限期限，避免默认永久保留。
  * 仍可通过显式关闭分开策略并设置统一保留期限来保持统一管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->