### PR TITLE
fix(executor): stop retry amplification on non-retryable 4xx + hard attempt ceiling

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -678,17 +678,59 @@ func TestDisabledErrorCooldownDoesNotRetryBedrockAdaptiveThinkingSchemaError(t *
 	}
 }
 
-func TestDisabledErrorCooldownStillRetriesOrdinaryHTTP400(t *testing.T) {
-	proxyErr := domain.NewProxyErrorWithMessage(
-		errors.New(`{"error":{"message":"temporary upstream 400"}}`),
-		false,
-		"upstream returned status 400",
-	)
-	proxyErr.Scope = domain.ScopeRequest
-	proxyErr.HTTPStatusCode = http.StatusBadRequest
+func TestDisabledErrorCooldownDoesNotRetryClientErrorStatusCodes(t *testing.T) {
+	// Client-request (4xx) errors must NOT be force-retried under
+	// disableErrorCooldown. Retrying a bad request on the same or another
+	// provider cannot succeed and only amplifies upstream load. Regression for
+	// the production outage where a single non-retryable 4xx retried 151,780
+	// times over 4 hours.
+	nonRetryable := []int{
+		http.StatusBadRequest,            // 400 — e.g. "invalid image"
+		http.StatusUnauthorized,          // 401
+		http.StatusForbidden,             // 403
+		http.StatusNotFound,              // 404 — e.g. "No endpoints found that support tool use"
+		http.StatusMethodNotAllowed,      // 405
+		http.StatusConflict,              // 409
+		http.StatusRequestEntityTooLarge, // 413
+		http.StatusUnsupportedMediaType,  // 415
+		http.StatusUnprocessableEntity,   // 422
+	}
+	for _, code := range nonRetryable {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			errors.New(`{"error":{"message":"client request error"}}`),
+			false,
+			"upstream returned status",
+		)
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.HTTPStatusCode = code
+		if isDisabledErrorCooldownRetryableError(proxyErr) {
+			t.Fatalf("HTTP %d should NOT be retryable under disableErrorCooldown", code)
+		}
+	}
+}
 
-	if !isDisabledErrorCooldownRetryableError(proxyErr) {
-		t.Fatal("ordinary HTTP 400 should still follow disableErrorCooldown retry policy")
+func TestDisabledErrorCooldownStillRetriesUpstreamFailures(t *testing.T) {
+	// 5xx server errors, 429 rate limit and 408 upstream timeout remain
+	// retryable/failover-worthy under disableErrorCooldown.
+	retryable := []int{
+		http.StatusRequestTimeout,      // 408
+		http.StatusTooManyRequests,     // 429
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+	}
+	for _, code := range retryable {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			errors.New(`{"error":{"message":"upstream failure"}}`),
+			false,
+			"upstream returned status",
+		)
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.HTTPStatusCode = code
+		if !isDisabledErrorCooldownRetryableError(proxyErr) {
+			t.Fatalf("HTTP %d should remain retryable under disableErrorCooldown", code)
+		}
 	}
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -442,10 +442,41 @@ func isDisabledErrorCooldownRetryableError(proxyErr *domain.ProxyError) bool {
 	if isBedrockAdaptiveThinkingSchemaError(proxyErr) {
 		return false
 	}
-	if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+	// Non-retryable client errors (4xx) must NOT be force-retried, even under
+	// disableErrorCooldown. Retrying or failing over on a bad client request
+	// (400 invalid image, 404 "No endpoints found that support tool use",
+	// 413/415/422 payload rejects, 401/403 auth) cannot succeed — the request
+	// itself is the problem, so retrying only amplifies load. A single such
+	// request once retried 151,780 times over 4 hours before this guard existed.
+	//
+	// Genuinely retryable upstream-side failures keep the escape hatch:
+	//   - 5xx server errors (provider is transiently broken)
+	//   - 429 rate limit / 408 request timeout (worth retry / failover)
+	//   - network + committed-stream-read errors (no HTTP status)
+	if code := proxyErr.HTTPStatusCode; code >= 400 && code < 500 {
+		if isRetryable4xxStatusCode(code) {
+			return true
+		}
+		return isCommittedStreamReadRetryableError(proxyErr)
+	}
+	if proxyErr.HTTPStatusCode >= 500 && proxyErr.HTTPStatusCode < 600 {
 		return true
 	}
 	return isCommittedStreamReadRetryableError(proxyErr)
+}
+
+// isRetryable4xxStatusCode reports whether a 4xx status is worth retrying or
+// failing over. Only rate limiting (429) and upstream request timeouts (408)
+// qualify; every other 4xx is a client-request error where the same request on
+// any provider yields the same rejection.
+func isRetryable4xxStatusCode(code int) bool {
+	switch code {
+	case http.StatusTooManyRequests, // 429 — rate limit, back off / fail over
+		http.StatusRequestTimeout: // 408 — upstream timed out before responding
+		return true
+	default:
+		return false
+	}
 }
 
 func applyCommittedStreamReadRetryPolicy(proxyErr *domain.ProxyError) {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -18,6 +18,18 @@ import (
 	"github.com/awsl-project/maxx/internal/sticky"
 )
 
+// maxUpstreamAttemptsPerRequest is a hard safety ceiling on the total number of
+// upstream calls a single inbound request may generate across ALL routes,
+// providers, model candidates and retries combined. It is a backstop against
+// pathological retry/failover amplification — e.g. a provider with
+// disableErrorCooldown that (before the retry-classification fix) retried a
+// single non-retryable 4xx 151,780 times over 4 hours. Correct classification
+// should stop such loops long before this cap; the cap exists so that no
+// classification bug or misconfiguration can ever turn one request into tens of
+// thousands of upstream calls again. 200 is far above any legitimate
+// route×retry fan-out yet orders of magnitude below the observed blowups.
+const maxUpstreamAttemptsPerRequest = 200
+
 func (e *Executor) dispatch(c *flow.Ctx) {
 	state, ok := getExecState(c)
 	if !ok {
@@ -55,6 +67,12 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 		wg.Wait()
 	}
 
+	// totalUpstreamAttempts counts every upstream dispatch this inbound request
+	// has made across all routes/providers/candidates/retries. It backs the
+	// hard ceiling (maxUpstreamAttemptsPerRequest) that guarantees a single
+	// request can never amplify into a runaway upstream-call storm.
+	totalUpstreamAttempts := 0
+
 routeLoop:
 	for _, matchedRoute := range state.routes {
 		if ctx.Err() != nil {
@@ -83,6 +101,16 @@ routeLoop:
 				state.lastErr = ctx.Err()
 				c.Err = state.lastErr
 				return
+			}
+			if totalUpstreamAttempts >= maxUpstreamAttemptsPerRequest {
+				log.Printf("[Executor] Hard attempt ceiling reached: %d upstream attempts for a single request (provider %d); aborting to prevent retry amplification. lastErr=%v",
+					totalUpstreamAttempts, matchedRoute.Provider.ID, state.lastErr)
+				if state.lastErr == nil {
+					proxyErr := domain.NewProxyErrorWithMessage(domain.ErrAllRoutesFailed, false, "upstream attempt ceiling reached")
+					proxyErr.Scope = domain.ScopeRequest
+					state.lastErr = proxyErr
+				}
+				break routeLoop
 			}
 			if modelCandidateIndex >= len(modelCandidates) {
 				break
@@ -209,6 +237,7 @@ routeLoop:
 			state.currentAttempt = attemptRecord
 
 			proxyReq.ProxyUpstreamAttemptCount++
+			totalUpstreamAttempts++
 			if e.broadcaster != nil {
 				e.broadcaster.BroadcastProxyRequest(proxyReq)
 				e.broadcaster.BroadcastProxyUpstreamAttempt(attemptRecord)

--- a/internal/executor/retry_amplification_test.go
+++ b/internal/executor/retry_amplification_test.go
@@ -1,0 +1,297 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+// classifiedErrorAdapter always returns a pre-classified ProxyError and counts
+// how many times Execute is invoked. It mirrors what the real custom adapter's
+// classifyHTTPError produces for a given upstream status, so dispatch-level
+// retry/failover behaviour can be exercised end-to-end.
+type classifiedErrorAdapter struct {
+	calls int
+	build func() *domain.ProxyError
+}
+
+func (a *classifiedErrorAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *classifiedErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	// Return a genuine nil error on success — returning a typed-nil
+	// *domain.ProxyError would produce a non-nil error interface and be
+	// mistaken for a failure.
+	if pe := a.build(); pe != nil {
+		return pe
+	}
+	return nil
+}
+
+func newAmplificationDispatchCtx(disableErrorCooldown bool, adapter *classifiedErrorAdapter) (*flow.Ctx, *recordingProxyRequestRepo) {
+	proxyRepo := &recordingProxyRequestRepo{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         900,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeOpenAI,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-image-model",
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeOpenAI},
+				Provider: &domain.Provider{
+					ID:       20,
+					TenantID: domain.DefaultTenantID,
+					Type:     "custom",
+					Name:     "custom-disabled-cooldown-amplification",
+					Config:   &domain.ProviderConfig{DisableErrorCooldown: disableErrorCooldown},
+				},
+				ProviderAdapter: adapter,
+				// InitialInterval 0 reproduces the production config (empty
+				// retry_configs → 0 backoff) that let the loop spin at ~10/sec.
+				RetryConfig: &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	return c, proxyRepo
+}
+
+// TestDispatchDoesNotAmplify404ToolUseError reproduces proxy_request_id=54414:
+// a 404 "No endpoints found that support tool use" against an image provider
+// with disableErrorCooldown. Before the fix this retried 151,780 times; it must
+// now fail after a single upstream call.
+func TestDispatchDoesNotAmplify404ToolUseError(t *testing.T) {
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		// Mirrors custom.classifyHTTPError(404, "No endpoints found that
+		// support tool use"): no "model"/"not found" substring → ScopeEndpoint,
+		// Retryable=false.
+		pe := domain.NewProxyErrorWithMessage(
+			errors.New(`{"error":{"message":"No endpoints found that support tool use"}}`),
+			false,
+			"upstream returned status 404",
+		)
+		pe.Scope = domain.ScopeEndpoint
+		pe.Reason = domain.CooldownReasonServerError
+		pe.HTTPStatusCode = http.StatusNotFound
+		return pe
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail on non-retryable 404")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1 (404 tool-use must not amplify)", adapter.calls)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// TestDispatchDoesNotAmplifyInvalidImageError reproduces the 400 "invalid
+// image" case (11 requests → 4,321 calls before the fix).
+func TestDispatchDoesNotAmplifyInvalidImageError(t *testing.T) {
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		pe := domain.NewProxyErrorWithMessage(
+			errors.New(`{"error":{"message":"The image data you provided does not represent a valid image"}}`),
+			false,
+			"upstream returned status 400",
+		)
+		pe.Scope = domain.ScopeRequest
+		pe.HTTPStatusCode = http.StatusBadRequest
+		return pe
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail on non-retryable 400")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1 (invalid-image 400 must not amplify)", adapter.calls)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// TestDispatchHardCapsRunawayRetryableErrors is the backstop test: even a
+// genuinely-retryable error that (via a classification bug or misconfiguration)
+// never stops retrying must be bounded by the hard per-request ceiling, instead
+// of running for hours.
+func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		// A 5xx under disableErrorCooldown retries forever-until-success by
+		// design; here it never succeeds, so only the hard cap can stop it.
+		pe := domain.NewProxyErrorWithMessage(
+			errors.New("upstream returned 500"),
+			true,
+			"upstream returned status 500",
+		)
+		pe.Scope = domain.ScopeProvider
+		pe.Reason = domain.CooldownReasonServerError
+		pe.HTTPStatusCode = http.StatusInternalServerError
+		return pe
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail once the hard cap is hit")
+	}
+	if adapter.calls != maxUpstreamAttemptsPerRequest {
+		t.Fatalf("adapter calls = %d, want %d (hard ceiling)", adapter.calls, maxUpstreamAttemptsPerRequest)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// TestDispatchStillRetriesServerErrorUnderCap makes sure the fix does not
+// over-correct: a 5xx that eventually succeeds must still be retried/failed over
+// (not treated as a terminal client error).
+func TestDispatchStillRetriesServerErrorUnderCap(t *testing.T) {
+	calls := 0
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		calls++
+		if calls > 2 {
+			return nil // succeed on the 3rd attempt
+		}
+		pe := domain.NewProxyErrorWithMessage(
+			errors.New("upstream returned 503"),
+			true,
+			"upstream returned status 503",
+		)
+		pe.Scope = domain.ScopeProvider
+		pe.Reason = domain.CooldownReasonServerError
+		pe.HTTPStatusCode = http.StatusServiceUnavailable
+		return pe
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if adapter.calls != 3 {
+		t.Fatalf("adapter calls = %d, want 3 (retry until success)", adapter.calls)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "COMPLETED" {
+		t.Fatalf("final proxy status = %q, want COMPLETED", last)
+	}
+}
+
+// TestDispatchStopsPromptlyWhenInboundContextCanceled verifies the retry/
+// failover loop terminates soon after the inbound client disconnects, rather
+// than continuing to hammer upstream for hours.
+func TestDispatchStopsPromptlyWhenInboundContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         901,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeOpenAI,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	// The adapter cancels the inbound context on its first call, then returns a
+	// retryable error. Under disableErrorCooldown this error would otherwise be
+	// retried forever; the loop must instead observe the cancellation and stop.
+	// Cancelling from inside Execute (rather than a spinning reader goroutine)
+	// keeps the call counter race-free.
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		cancel()
+		pe := domain.NewProxyErrorWithMessage(
+			errors.New("upstream returned 500"),
+			true,
+			"upstream returned status 500",
+		)
+		pe.Scope = domain.ScopeProvider
+		pe.Reason = domain.CooldownReasonServerError
+		pe.HTTPStatusCode = http.StatusInternalServerError
+		return pe
+	}}
+	state := &execState{
+		ctx:          ctx,
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-4o",
+		routes: []*router.MatchedRoute{
+			{
+				Route: &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeOpenAI},
+				Provider: &domain.Provider{
+					ID:       20,
+					TenantID: domain.DefaultTenantID,
+					Type:     "custom",
+					Name:     "custom-disabled-cooldown-cancel",
+					Config:   &domain.ProviderConfig{DisableErrorCooldown: true},
+				},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	e := newDisabledCooldownStreamTestExecutor(&recordingProxyRequestRepo{}, &recordingAttemptRepo{})
+
+	done := make(chan struct{})
+	go func() {
+		e.dispatch(c)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("dispatch did not stop after context cancellation; adapter calls=%d", adapter.calls)
+	}
+
+	if !errors.Is(c.Err, context.Canceled) {
+		t.Fatalf("dispatch error = %v, want context.Canceled", c.Err)
+	}
+	// The loop must halt on cancellation, nowhere near the hard cap. Allowing a
+	// tiny margin for a race where the select picks the zero-wait branch once
+	// more before the top-of-loop ctx check fires.
+	if adapter.calls > 3 {
+		t.Fatalf("adapter calls = %d; loop should have stopped promptly on cancellation", adapter.calls)
+	}
+}
+
+func lastProxyStatus(repo *recordingProxyRequestRepo) string {
+	if len(repo.updated) == 0 {
+		return ""
+	}
+	return repo.updated[len(repo.updated)-1].Status
+}

--- a/tests/e2e/disable_error_cooldown_retry_test.go
+++ b/tests/e2e/disable_error_cooldown_retry_test.go
@@ -9,24 +9,30 @@ import (
 	"testing"
 )
 
-// TestDisableErrorCooldownRetriesBeyondRetryPolicy verifies the provider switch
-// contract: when disableErrorCooldown is enabled, matching upstream HTTP errors
-// neither create cooldown state nor obey the retry-attempt limit. The same
-// provider keeps retrying until it succeeds or the request context is cancelled.
+// TestDisableErrorCooldownRetriesBeyondRetryPolicy verifies the updated
+// contract: when disableErrorCooldown is enabled, retry-attempt limits are
+// still ignored, but only genuinely retryable classes keep retrying on the
+// same provider. Most 4xx errors must fail over immediately; 429 and 5xx may
+// continue retrying until success or context cancellation.
 func TestDisableErrorCooldownRetriesBeyondRetryPolicy(t *testing.T) {
 	cases := []struct {
-		status int
-		name   string
+		status               int
+		name                 string
+		expectStatus         int
+		expectFailingHits    int64
+		expectFallbackHits   int64
+		expectProviderBody   string
+		expectCooldownAbsent bool
 	}{
-		{status: http.StatusBadRequest, name: "400_request_error"},
-		{status: http.StatusUnauthorized, name: "401_auth_error"},
-		{status: http.StatusForbidden, name: "403_auth_error"},
-		{status: http.StatusNotFound, name: "404_not_found"},
-		{status: http.StatusPaymentRequired, name: "402_quota_error"},
-		{status: http.StatusTeapot, name: "418_other_client_error"},
-		{status: http.StatusUnprocessableEntity, name: "422_request_error"},
-		{status: http.StatusTooManyRequests, name: "429_rate_limit"},
-		{status: http.StatusInternalServerError, name: "500_server_error"},
+		{status: http.StatusBadRequest, name: "400_request_error", expectStatus: http.StatusBadRequest, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusUnauthorized, name: "401_auth_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
+		{status: http.StatusForbidden, name: "403_auth_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
+		{status: http.StatusNotFound, name: "404_not_found", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
+		{status: http.StatusPaymentRequired, name: "402_quota_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
+		{status: http.StatusTeapot, name: "418_other_client_error", expectStatus: http.StatusTeapot, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusUnprocessableEntity, name: "422_request_error", expectStatus: http.StatusUnprocessableEntity, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusTooManyRequests, name: "429_rate_limit", expectStatus: http.StatusOK, expectFailingHits: 5, expectFallbackHits: 0, expectProviderBody: "eventual-success", expectCooldownAbsent: true},
+		{status: http.StatusInternalServerError, name: "500_server_error", expectStatus: http.StatusOK, expectFailingHits: 5, expectFallbackHits: 0, expectProviderBody: "eventual-success", expectCooldownAbsent: true},
 	}
 
 	for _, tt := range cases {
@@ -88,18 +94,37 @@ func TestDisableErrorCooldownRetriesBeyondRetryPolicy(t *testing.T) {
 			body, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("final status=%d body=%s, want 200 from retried provider", resp.StatusCode, body)
+			if resp.StatusCode != tt.expectStatus {
+				t.Fatalf("final status=%d body=%s, want %d", resp.StatusCode, body, tt.expectStatus)
 			}
-			if failingHits.Load() != 5 {
-				t.Fatalf("status %d provider hits=%d, want 5 (4 failures beyond retry limit + success)", tt.status, failingHits.Load())
+			if failingHits.Load() != tt.expectFailingHits {
+				t.Fatalf("status %d provider hits=%d, want %d", tt.status, failingHits.Load(), tt.expectFailingHits)
 			}
-			if fallbackHits.Load() != 0 {
-				t.Fatalf("status %d fallback hits=%d, want 0 when disabled freeze keeps retrying same provider", tt.status, fallbackHits.Load())
+			if fallbackHits.Load() != tt.expectFallbackHits {
+				t.Fatalf("status %d fallback hits=%d, want %d", tt.status, fallbackHits.Load(), tt.expectFallbackHits)
 			}
-			assertNoCooldownForProvider(t, env, resilientID)
+			if tt.expectProviderBody != "" && !jsonBodyContainsContent(body, tt.expectProviderBody) {
+				t.Fatalf("status %d body=%s, want content %q", tt.status, body, tt.expectProviderBody)
+			}
+			if tt.expectCooldownAbsent {
+				assertNoCooldownForProvider(t, env, resilientID)
+			}
 		})
 	}
+}
+
+func jsonBodyContainsContent(body []byte, want string) bool {
+	var payload struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	return len(payload.Choices) > 0 && payload.Choices[0].Message.Content == want
 }
 
 func createDisableErrorCooldownProvider(t *testing.T, env *ProxyTestEnv, name, baseURL string, disable bool) uint64 {


### PR DESCRIPTION
## The bug (production, v0.15.83, hubitos)

maxx retried non-retryable 4xx client errors effectively forever, and the retry/failover loop did not reliably stop when the inbound client had already disconnected.

- A single request (`proxy_request_id=54414`) retried **151,780 times over 4 hours** (12:19:52 → 16:18:06), even though the calling client (hubitos-api) has a 120s timeout and had disconnected long before.
- 24h aggregate: **969,675 upstream calls / 1,874 real requests = 517x amplification**. Successful requests were 1.0 call/request — amplification only happened on the persistently-failing path.
- Two concrete non-retryable cases:
  - HTTP 404 `"No endpoints found that support tool use"` (request carried `tools`, image model doesn't support tool use) → the 151,780-retry case.
  - HTTP 400 `"The image data you provided does not represent a valid image"` → 11 requests amplified to 4,321 calls.
- **Consequence:** 970k full failure-detail rows (image requests carry ~18KB base64 each) filled a 20GiB RDS → Postgres refused connections → maxx CrashLoopBackOff (32x) → k8s Service endpoints emptied → **domain down 14 hours**.

## Root cause (verified)

For providers with `Config.DisableErrorCooldown=true`, `applyDisabledErrorCooldownRetryPolicy()` force-set `proxyErr.Retryable = true` for **any** `HTTPStatusCode` in `[400,600)` via `isDisabledErrorCooldownRetryableError()` (`internal/executor/executor.go`).

The provider adapter's `classifyHTTPError()` (`internal/adapter/provider/custom/adapter.go`) **already** classifies these correctly as non-retryable (404 no-tool-use → `ScopeEndpoint`, `Retryable=false`; 400 invalid-image → `ScopeRequest`, `Retryable=false`). The executor overrode that.

The amplification loop is the nested `routeLoop` + inner `for attempt` loop in `internal/executor/middleware_dispatch.go`:
- Under `DisableErrorCooldown`, the budget exit `attempt > MaxRetries` is **disabled** (`&& !shouldSkipErrorCooldown(...)`), so the only remaining exit is `!proxyErr.Retryable`.
- The override defeated that exit → the loop never breaks.
- `retry_configs` is empty (`MaxRetries:0`, `InitialInterval:0`, no backoff), so the loop spun at ~10/sec. The single model candidate never advanced. Switching provider can't help — it's a client-request error, identical result on any provider.

This is **not** route-level retry (route `retryConfigID=0`); it's the provider-fail → force-retryable → failover loop, exactly as reported.

## The fix (one coherent amplification fix)

**1. Correct retry classification** (`executor.go`) — 4xx is now non-retryable under `DisableErrorCooldown`, with a narrow retryable allowlist. Decision table:

| Status | Retryable under DisableErrorCooldown? | Rationale |
|---|---|---|
| 400, 405, 406, 409, 413, 415, 422, other 4xx | **No** | Client-request error; same request fails identically anywhere |
| 401, 403 | **No** | Auth — retrying the same bad request can't succeed |
| 404 | **No** | Endpoint/model/tool-use mismatch is a request property |
| **408** | **Yes** | Upstream timed out before responding |
| **429** | **Yes** | Rate limit — back off / fail over is legitimate |
| 5xx (500/502/503/504…) | **Yes** | Provider transiently broken |
| network / stream-read / upstream-stream (no HTTP status) | **Yes** | Transient transport failure |

Note on 401/403: kept non-retryable. Failover to *another* provider is still possible via normal (non-`DisableErrorCooldown`) routing where the adapter's own scope/cooldown drives it; the escape-hatch force-retry that this PR removes was hammering the *same* provider, which auth failures can never satisfy. Only the `DisableErrorCooldown` force-retry path is changed — normal providers already honored the adapter's `Retryable` flag, so their behavior is unchanged.

**2. Hard ceiling on total upstream attempts per inbound request** (`middleware_dispatch.go`) — `maxUpstreamAttemptsPerRequest = 200` bounds the total across all routes/providers/candidates/retries combined. Correct classification stops the real loops long before this; the cap guarantees no future classification bug or misconfiguration can ever produce a 150k-call storm again. 200 is far above any legitimate route×retry fan-out and orders of magnitude below the observed blowups.

**3. Follow inbound context cancellation** — the loop already checks `ctx.Err()` at the top of both loops and on the retry-wait `select`; verified and regression-tested that it stops promptly once the inbound client disconnects. The hard cap is the reliable backstop for the L4-only case where TCP disconnect may not immediately cancel `r.Context()`.

The two remaining `HTTPStatusCode >= 400 && < 600` branches in `middleware_dispatch.go` (lines ~497, ~592) only copy the upstream status onto `proxyReq.StatusCode` for persistence and do not affect retry decisions — left unchanged.

## Tests

`internal/executor/retry_amplification_test.go` (new) + `disabled_error_cooldown_test.go` (updated):
- `TestDispatchDoesNotAmplify404ToolUseError` — 404 no-tool-use → **1** upstream call, FAILED.
- `TestDispatchDoesNotAmplifyInvalidImageError` — 400 invalid-image → **1** upstream call, FAILED.
- `TestDispatchHardCapsRunawayRetryableErrors` — never-succeeding retryable 5xx → bounded at the hard cap.
- `TestDispatchStillRetriesServerErrorUnderCap` — 5xx that later succeeds → still retried (no over-correction).
- `TestDispatchStopsPromptlyWhenInboundContextCanceled` — canceled inbound context → loop stops promptly (race-clean).
- `TestDisabledErrorCooldownDoesNotRetryClientErrorStatusCodes` / `TestDisabledErrorCooldownStillRetriesUpstreamFailures` — table tests for the full decision table.

Replaced `TestDisabledErrorCooldownStillRetriesOrdinaryHTTP400`, which asserted the buggy "400 is retryable" behavior.

`go build ./internal/...`, `go vet`, and `go test ./internal/executor/...` all pass.

### Note for reviewer
`TestDispatchDoesNotRetryAfterRequestContextCanceled` has a **pre-existing** test-harness data race (a spinning `for adapter.calls == 0` reader) that surfaces only under `go test -race` — confirmed present on `main` before this change. Left untouched to keep this PR focused; worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化错误处理：大多数客户端错误（如 400、401、403、404、422）不再进行无效重试。
  - 对 408、429 及服务器端 5xx 错误继续支持重试或故障转移。
  - 改进备用服务切换，减少请求失败和重复调用。

- **可靠性**
  - 限制单个请求的最大上游调用次数，避免异常情况下产生过多重复请求。
  - 请求取消后可及时停止重试并返回取消状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->