### PR TITLE
feat(providers): add native fal (fal.ai) provider — image + video generation

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/claude"     // Register claude adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/custom"     // Register custom adapter
+	_ "github.com/awsl-project/maxx/internal/adapter/provider/fal"        // Register fal (fal.ai) adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/grok"       // Register grok adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/kiro"       // Register kiro adapter
 	_ "github.com/awsl-project/maxx/internal/adapter/provider/newapi"     // Register newapi adapter

--- a/internal/adapter/provider/fal/adapter.go
+++ b/internal/adapter/provider/fal/adapter.go
@@ -1,0 +1,222 @@
+// Package fal implements a first-class provider adapter for fal (fal.ai), a
+// queue-based inference platform that is NOT OpenAI-compatible. fal routes models
+// by URL PATH (e.g. https://fal.run/fal-ai/flux/dev) and authenticates with an
+// "Authorization: Key <id>:<secret>" header (NOT Bearer). Unlike the openrouter/
+// zai adapters — which merely synthesize a custom config and delegate to the
+// custom proxy core — fal needs a genuine TRANSLATION layer: maxx makes fal look
+// like OpenAI (images) and new-api (async video) to clients, translating request
+// and response shapes in both directions and calling fal directly.
+//
+// Two surfaces, two fal shapes:
+//
+//   - Image (ClientTypeOpenAI, POST /v1/images/generations): fal image models are
+//     SYNCHRONOUS. maxx POSTs to https://fal.run/{model} (blocks ~1-2s) and
+//     translates the OpenAI images request/response on the fly.
+//   - Video (ClientTypeVideo, POST /v1/video/generations submit + GET
+//     /v1/video/generations/{task_id} poll): fal video models are ASYNC via the
+//     queue at https://queue.fal.run/{model}. maxx encodes the fal result URL into
+//     the returned task_id so polling stays STATELESS (maxx stores nothing), and
+//     translates to the new-api video envelope clients already speak.
+//
+// The mapped model (executor.mapModel → e.g. "fal-ai/flux/dev") is the URL path
+// segment; slashes are fine in the path.
+package fal
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+)
+
+// fal's fixed API roots. Image models are served synchronously from fal.run; the
+// async queue (video) lives on queue.fal.run. Both are redirectable via env vars
+// so tests can point at a mock upstream.
+const (
+	defaultSyncBaseURL  = "https://fal.run"
+	defaultQueueBaseURL = "https://queue.fal.run"
+)
+
+func resolveSyncBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("MAXX_FAL_BASE_URL")); v != "" {
+		return v
+	}
+	return defaultSyncBaseURL
+}
+
+func resolveQueueBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("MAXX_FAL_QUEUE_BASE_URL")); v != "" {
+		return v
+	}
+	return defaultQueueBaseURL
+}
+
+func init() {
+	provider.RegisterAdapterFactory("fal", NewAdapter)
+}
+
+// Adapter is a first-class fal provider that translates maxx's OpenAI (image) and
+// new-api (video) surfaces to fal's queue-based API and back.
+type Adapter struct {
+	apiKey   string
+	provider *domain.Provider
+	client   *http.Client
+}
+
+// NewAdapter builds a fal adapter from the fal config (the full "id:secret" key).
+func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
+	if p.Config == nil || p.Config.Fal == nil {
+		return nil, fmt.Errorf("provider %s missing fal config", p.Name)
+	}
+	return &Adapter{
+		apiKey:   p.Config.Fal.APIKey,
+		provider: p,
+		client:   &http.Client{Timeout: 10 * time.Minute},
+	}, nil
+}
+
+// SupportedClientTypes reports fal's native surfaces: OpenAI (images) and Video.
+func (a *Adapter) SupportedClientTypes() []domain.ClientType {
+	return domain.CanonicalSupportedClientTypes("fal", a.provider.SupportedClientTypes)
+}
+
+// Execute routes to the image or video translator based on the inbound client
+// type. Any client-supplied auth header is stripped before forwarding — only
+// fal's provider key ("Authorization: Key <id:secret>") reaches upstream.
+func (a *Adapter) Execute(c *flow.Ctx, _ *domain.Provider) error {
+	switch flow.GetClientType(c) {
+	case domain.ClientTypeVideo:
+		return a.executeVideo(c)
+	default:
+		// ClientTypeOpenAI (images). fal is only advertised for openai+video, so
+		// routing never sends other client types here.
+		return a.executeImage(c)
+	}
+}
+
+// authHeader injects fal's non-Bearer auth. fal expects the FULL id:secret string
+// verbatim after "Key ".
+func (a *Adapter) authHeader(req *http.Request) {
+	if a.apiKey != "" {
+		req.Header.Set("Authorization", "Key "+a.apiKey)
+	}
+}
+
+// doJSON performs an authenticated fal HTTP call and returns the raw body. It
+// classifies transport failures and >=400 responses as provider/request errors so
+// routing can retry or cool down appropriately.
+func (a *Adapter) doJSON(ctx context.Context, method, url string, body []byte) ([]byte, int, error) {
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to create fal request")
+		proxyErr.Scope = domain.ScopeEndpoint
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return nil, 0, proxyErr
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	a.authHeader(req)
+
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, 0, domain.NewUpstreamConnectionError("failed to connect to fal")
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		proxyErr := domain.NewProxyErrorWithMessage(
+			fmt.Errorf("fal upstream error: %s", string(respBody)),
+			isRetryableStatus(resp.StatusCode),
+			fmt.Sprintf("fal returned status %d", resp.StatusCode),
+		)
+		proxyErr.HTTPStatusCode = resp.StatusCode
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			proxyErr.Scope = domain.ScopeKey
+			proxyErr.Reason = domain.CooldownReasonAuthFailure
+			proxyErr.Retryable = false
+		} else if resp.StatusCode >= 500 {
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonServerError
+		} else {
+			proxyErr.Scope = domain.ScopeRequest
+			proxyErr.Retryable = false
+		}
+		return respBody, resp.StatusCode, proxyErr
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+func isRetryableStatus(code int) bool {
+	switch code {
+	case 429, 500, 502, 503, 504:
+		return true
+	default:
+		return false
+	}
+}
+
+// writeJSON writes a JSON response to the client, mirroring the event bookkeeping
+// the custom core does so request logging stays consistent.
+func writeJSON(c *flow.Ctx, status int, body []byte) error {
+	if eventChan := flow.GetEventChan(c); eventChan != nil {
+		eventChan.SendResponseInfo(&domain.ResponseInfo{
+			Status:  status,
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    string(body),
+		})
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.WriteHeader(status)
+	if _, err := c.Writer.Write(body); err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "client disconnected")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+	return nil
+}
+
+func (a *Adapter) sendRequestInfo(c *flow.Ctx, method, url string, body []byte) {
+	if eventChan := flow.GetEventChan(c); eventChan != nil {
+		eventChan.SendRequestInfo(&domain.RequestInfo{
+			Method:  method,
+			URL:     url,
+			Headers: map[string]string{"Authorization": "Key ***"},
+			Body:    string(body),
+		})
+	}
+}
+
+// base64url without padding — used to encode the fal result URL into the video
+// task id so polling is stateless (maxx recovers everything it needs from the id).
+var b64url = base64.RawURLEncoding
+
+func encodeTaskID(parts ...string) string {
+	return b64url.EncodeToString([]byte(strings.Join(parts, "\n")))
+}
+
+func decodeTaskID(taskID string) ([]string, error) {
+	raw, err := b64url.DecodeString(taskID)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(raw), "\n"), nil
+}
+
+// b64Std standard-base64-encodes bytes (with padding) — the encoding OpenAI's
+// b64_json image field uses.
+func b64Std(data []byte) string {
+	return base64.StdEncoding.EncodeToString(data)
+}

--- a/internal/adapter/provider/fal/adapter_test.go
+++ b/internal/adapter/provider/fal/adapter_test.go
@@ -1,0 +1,381 @@
+package fal
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/tidwall/gjson"
+)
+
+const testKey = "id-part:secret-part"
+
+func newFalAdapter(t *testing.T) *Adapter {
+	t.Helper()
+	a, err := NewAdapter(&domain.Provider{
+		Name: "fal-test",
+		Type: "fal",
+		Config: &domain.ProviderConfig{
+			Fal: &domain.ProviderConfigFal{APIKey: testKey},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAdapter: %v", err)
+	}
+	return a.(*Adapter)
+}
+
+// newVideoCtx wires a flow.Ctx that mimics the proxy: it stashes the client-facing
+// auth headers (which must be stripped) plus the URI/body/client-type keys.
+func newCtx(method, uri string, body []byte, ct domain.ClientType) (*flow.Ctx, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(method, "http://localhost"+uri, nil)
+	req.Header.Set("Authorization", "Bearer sk-maxx-client-token")
+	req.Header.Set("x-api-key", "sk-maxx-client-token")
+	req.Header.Set("x-goog-api-key", "sk-maxx-client-token")
+	req.Header.Set("Proxy-Authorization", "Bearer sk-maxx-client-token")
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	c.Set(flow.KeyClientType, ct)
+	c.Set(flow.KeyRequestURI, uri)
+	c.Set(flow.KeyRequestBody, body)
+	c.Set(flow.KeyRequestHeaders, req.Header)
+	return c, rec
+}
+
+func TestNewAdapterRequiresFalConfig(t *testing.T) {
+	for _, p := range []*domain.Provider{
+		{Name: "f", Config: nil},
+		{Name: "f", Config: &domain.ProviderConfig{}},
+	} {
+		if _, err := NewAdapter(p); err == nil {
+			t.Fatalf("expected error for missing fal config")
+		}
+	}
+}
+
+func TestSupportedClientTypes(t *testing.T) {
+	a := newFalAdapter(t)
+	got := a.SupportedClientTypes()
+	want := map[domain.ClientType]bool{domain.ClientTypeOpenAI: true, domain.ClientTypeVideo: true}
+	if len(got) != 2 {
+		t.Fatalf("SupportedClientTypes = %v, want openai+video", got)
+	}
+	for _, ct := range got {
+		if !want[ct] {
+			t.Fatalf("unexpected client type %q", ct)
+		}
+	}
+}
+
+// ---- Image ----
+
+func TestImageGenerationURLAuthAndTranslation(t *testing.T) {
+	var gotPath, gotAuth, gotAPIKey, gotGoog, gotProxyAuth string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotGoog = r.Header.Get("x-goog-api-key")
+		gotProxyAuth = r.Header.Get("Proxy-Authorization")
+		gotBody, _ = readAll(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"images":[{"url":"https://fal.media/out.jpg","width":1024,"height":1024}],"seed":42,"prompt":"a red cube"}`))
+	}))
+	defer server.Close()
+	t.Setenv("MAXX_FAL_BASE_URL", server.URL)
+
+	a := newFalAdapter(t)
+	body := []byte(`{"model":"ignored","prompt":"a red cube","size":"512x768","num_inference_steps":4,"response_format":"url"}`)
+	c, rec := newCtx(http.MethodPost, "/v1/images/generations", body, domain.ClientTypeOpenAI)
+	c.Set(flow.KeyMappedModel, "fal-ai/flux/dev")
+
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// URL path = mapped model (slashes preserved).
+	if gotPath != "/fal-ai/flux/dev" {
+		t.Fatalf("upstream path = %q, want /fal-ai/flux/dev", gotPath)
+	}
+	// fal auth header set, client auth stripped.
+	if gotAuth != "Key "+testKey {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, "Key "+testKey)
+	}
+	if gotAPIKey != "" || gotGoog != "" || gotProxyAuth != "" {
+		t.Fatalf("client auth leaked: x-api-key=%q x-goog=%q proxy=%q", gotAPIKey, gotGoog, gotProxyAuth)
+	}
+	// size -> image_size{width,height}; OpenAI-only fields stripped; extras kept.
+	if w := gjson.GetBytes(gotBody, "image_size.width").Int(); w != 512 {
+		t.Fatalf("image_size.width = %d, want 512", w)
+	}
+	if h := gjson.GetBytes(gotBody, "image_size.height").Int(); h != 768 {
+		t.Fatalf("image_size.height = %d, want 768", h)
+	}
+	if gjson.GetBytes(gotBody, "model").Exists() || gjson.GetBytes(gotBody, "size").Exists() ||
+		gjson.GetBytes(gotBody, "response_format").Exists() {
+		t.Fatalf("OpenAI-only fields not stripped: %s", gotBody)
+	}
+	if n := gjson.GetBytes(gotBody, "num_inference_steps").Int(); n != 4 {
+		t.Fatalf("num_inference_steps not passed through: %s", gotBody)
+	}
+	// Response: fal images -> OpenAI data[].url
+	out := rec.Body.Bytes()
+	if u := gjson.GetBytes(out, "data.0.url").String(); u != "https://fal.media/out.jpg" {
+		t.Fatalf("data.0.url = %q, want fal media url; body=%s", u, out)
+	}
+	if !gjson.GetBytes(out, "created").Exists() {
+		t.Fatalf("response missing created: %s", out)
+	}
+}
+
+func TestImageNativeImageSizeWins(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = readAll(r)
+		_, _ = w.Write([]byte(`{"images":[{"url":"https://fal.media/x.jpg"}]}`))
+	}))
+	defer server.Close()
+	t.Setenv("MAXX_FAL_BASE_URL", server.URL)
+
+	a := newFalAdapter(t)
+	// Client sent a fal-native image_size preset AND an OpenAI size — the preset wins.
+	body := []byte(`{"prompt":"p","image_size":"square_hd","size":"512x512"}`)
+	c, _ := newCtx(http.MethodPost, "/v1/images/generations", body, domain.ClientTypeOpenAI)
+	c.Set(flow.KeyMappedModel, "fal-ai/flux/schnell")
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if s := gjson.GetBytes(gotBody, "image_size").String(); s != "square_hd" {
+		t.Fatalf("image_size = %q, want square_hd (native preset preserved); body=%s", s, gotBody)
+	}
+}
+
+func TestImageB64JsonFetchesBytes(t *testing.T) {
+	imgBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/media/img.png", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(imgBytes)
+	})
+	var falBaseURL string
+	mux.HandleFunc("/fal-ai/flux/dev", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"images":[{"url":"` + falBaseURL + `/media/img.png"}]}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	falBaseURL = server.URL
+	t.Setenv("MAXX_FAL_BASE_URL", server.URL)
+
+	a := newFalAdapter(t)
+	body := []byte(`{"prompt":"p","response_format":"b64_json"}`)
+	c, rec := newCtx(http.MethodPost, "/v1/images/generations", body, domain.ClientTypeOpenAI)
+	c.Set(flow.KeyMappedModel, "fal-ai/flux/dev")
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := rec.Body.Bytes()
+	if gjson.GetBytes(out, "data.0.url").Exists() {
+		t.Fatalf("b64_json response should not carry url: %s", out)
+	}
+	got := gjson.GetBytes(out, "data.0.b64_json").String()
+	want := base64.StdEncoding.EncodeToString(imgBytes)
+	if got != want {
+		t.Fatalf("b64_json = %q, want %q", got, want)
+	}
+}
+
+// ---- Video submit ----
+
+func TestVideoSubmitEncodesTaskAndStripsAuth(t *testing.T) {
+	var gotPath, gotAuth, gotAPIKey string
+	var gotBody []byte
+	var queueBase string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotBody, _ = readAll(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"IN_QUEUE","request_id":"req-123","response_url":"` +
+			queueBase + `/fal-ai/veo3/requests/req-123"}`))
+	}))
+	defer server.Close()
+	queueBase = server.URL
+	t.Setenv("MAXX_FAL_QUEUE_BASE_URL", server.URL)
+
+	a := newFalAdapter(t)
+	body := []byte(`{"model":"ignored","prompt":"a cat walking","duration":"8s"}`)
+	c, rec := newCtx(http.MethodPost, "/v1/video/generations", body, domain.ClientTypeVideo)
+	c.Set(flow.KeyMappedModel, "fal-ai/veo3/fast")
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if gotPath != "/fal-ai/veo3/fast" {
+		t.Fatalf("queue submit path = %q, want /fal-ai/veo3/fast", gotPath)
+	}
+	if gotAuth != "Key "+testKey {
+		t.Fatalf("Authorization = %q, want fal key", gotAuth)
+	}
+	if gotAPIKey != "" {
+		t.Fatalf("client x-api-key leaked upstream: %q", gotAPIKey)
+	}
+	if gjson.GetBytes(gotBody, "model").Exists() {
+		t.Fatalf("model not stripped from fal input: %s", gotBody)
+	}
+	if p := gjson.GetBytes(gotBody, "prompt").String(); p != "a cat walking" {
+		t.Fatalf("prompt not passed through: %s", gotBody)
+	}
+
+	out := rec.Body.Bytes()
+	taskID := gjson.GetBytes(out, "task_id").String()
+	if taskID == "" || gjson.GetBytes(out, "id").String() != taskID {
+		t.Fatalf("submit response task id malformed: %s", out)
+	}
+	// task_id round-trips to the fal response_url.
+	parts, err := decodeTaskID(taskID)
+	if err != nil {
+		t.Fatalf("decodeTaskID: %v", err)
+	}
+	wantURL := queueBase + "/fal-ai/veo3/requests/req-123"
+	if len(parts) == 0 || parts[0] != wantURL {
+		t.Fatalf("decoded task id = %v, want response_url %q", parts, wantURL)
+	}
+}
+
+// ---- Video poll ----
+
+func TestVideoPollCompletes(t *testing.T) {
+	var statusHits, resultHits int
+	var gotStatusAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fal-ai/veo3/requests/req-123/status", func(w http.ResponseWriter, r *http.Request) {
+		statusHits++
+		gotStatusAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":"COMPLETED","request_id":"req-123"}`))
+	})
+	mux.HandleFunc("/fal-ai/veo3/requests/req-123", func(w http.ResponseWriter, r *http.Request) {
+		resultHits++
+		_, _ = w.Write([]byte(`{"video":{"url":"https://fal.media/final.mp4","content_type":"video/mp4"}}`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	responseURL := server.URL + "/fal-ai/veo3/requests/req-123"
+	taskID := encodeTaskID(responseURL)
+
+	a := newFalAdapter(t)
+	uri := "/v1/video/generations/" + taskID
+	c, rec := newCtx(http.MethodGet, uri, nil, domain.ClientTypeVideo)
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if statusHits != 1 || resultHits != 1 {
+		t.Fatalf("expected 1 status + 1 result hit, got %d/%d", statusHits, resultHits)
+	}
+	if gotStatusAuth != "Key "+testKey {
+		t.Fatalf("status Authorization = %q, want fal key", gotStatusAuth)
+	}
+	out := rec.Body.Bytes()
+	if s := gjson.GetBytes(out, "data.status").String(); s != statusSuccess {
+		t.Fatalf("data.status = %q, want %q; body=%s", s, statusSuccess, out)
+	}
+	if u := gjson.GetBytes(out, "data.data.url").String(); u != "https://fal.media/final.mp4" {
+		t.Fatalf("lifted mp4 url = %q; body=%s", u, out)
+	}
+	if u := gjson.GetBytes(out, "data.data.video.url").String(); u != "https://fal.media/final.mp4" {
+		t.Fatalf("nested fal payload not preserved; body=%s", out)
+	}
+}
+
+func TestVideoPollInProgress(t *testing.T) {
+	mux := http.NewServeMux()
+	var resultHit bool
+	mux.HandleFunc("/fal-ai/veo3/requests/req-9/status", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"IN_PROGRESS","request_id":"req-9"}`))
+	})
+	mux.HandleFunc("/fal-ai/veo3/requests/req-9", func(w http.ResponseWriter, r *http.Request) {
+		resultHit = true
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	taskID := encodeTaskID(server.URL + "/fal-ai/veo3/requests/req-9")
+	a := newFalAdapter(t)
+	c, rec := newCtx(http.MethodGet, "/v1/video/generations/"+taskID, nil, domain.ClientTypeVideo)
+	if err := a.Execute(c, &domain.Provider{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if resultHit {
+		t.Fatalf("must NOT fetch result while IN_PROGRESS")
+	}
+	if s := gjson.GetBytes(rec.Body.Bytes(), "data.status").String(); s != statusInProgress {
+		t.Fatalf("data.status = %q, want %q", s, statusInProgress)
+	}
+}
+
+func TestVideoPollInvalidTaskID(t *testing.T) {
+	a := newFalAdapter(t)
+	c, _ := newCtx(http.MethodGet, "/v1/video/generations/!!!not-base64!!!", nil, domain.ClientTypeVideo)
+	err := a.Execute(c, &domain.Provider{})
+	if err == nil {
+		t.Fatalf("expected error for invalid task id")
+	}
+	if pe, ok := err.(*domain.ProxyError); ok && pe.Scope != domain.ScopeRequest {
+		t.Fatalf("invalid task id should be request-scoped, got %v", pe.Scope)
+	}
+}
+
+func TestParseWxH(t *testing.T) {
+	cases := []struct {
+		in      string
+		w, h    int
+		ok      bool
+	}{
+		{"1024x1024", 1024, 1024, true},
+		{"512x768", 512, 768, true},
+		{"square", 0, 0, false},
+		{"axb", 0, 0, false},
+		{"0x0", 0, 0, false},
+	}
+	for _, tc := range cases {
+		w, h, ok := parseWxH(tc.in)
+		if ok != tc.ok || w != tc.w || h != tc.h {
+			t.Fatalf("parseWxH(%q) = (%d,%d,%v), want (%d,%d,%v)", tc.in, w, h, ok, tc.w, tc.h, tc.ok)
+		}
+	}
+}
+
+func TestExtractVideoURLFallback(t *testing.T) {
+	// Non-standard fal shape: url nested under a differently-named object.
+	body := []byte(`{"output":{"url":"https://fal.media/z.mp4"}}`)
+	if got := extractVideoURL(body); got != "https://fal.media/z.mp4" {
+		t.Fatalf("extractVideoURL fallback = %q", got)
+	}
+}
+
+// readAll reads a request body for assertions.
+func readAll(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	return io.ReadAll(r.Body)
+}
+
+// Guard: the encoded task id is URL-safe (no '/', '+', '=' padding) so it can be
+// carried verbatim in the poll path.
+func TestTaskIDIsURLSafe(t *testing.T) {
+	id := encodeTaskID("https://queue.fal.run/fal-ai/veo3/requests/abc-123")
+	if strings.ContainsAny(id, "/+=") {
+		t.Fatalf("task id not URL-safe: %q", id)
+	}
+	if _, err := decodeTaskID(id); err != nil {
+		t.Fatalf("decode round-trip failed: %v", err)
+	}
+}

--- a/internal/adapter/provider/fal/image.go
+++ b/internal/adapter/provider/fal/image.go
@@ -1,0 +1,196 @@
+package fal
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// executeImage translates an OpenAI images request into a fal SYNC image call and
+// the fal image response back into an OpenAI images response.
+//
+//	client  POST /v1/images/generations {model,prompt,n,size,response_format,...}
+//	  ->    POST https://fal.run/{mappedModel} {prompt,image_size,...}
+//	  <-    {"images":[{"url":...}], "seed":..., ...}
+//	client  <- {"created":<unix>,"data":[{"url":...}]}   (or b64_json)
+func (a *Adapter) executeImage(c *flow.Ctx) error {
+	model := flow.GetMappedModel(c)
+	if model == "" {
+		model = gjson.GetBytes(flow.GetRequestBody(c), "model").String()
+	}
+	if strings.TrimSpace(model) == "" {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "fal image request missing model")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+
+	inBody := flow.GetRequestBody(c)
+	responseFormat := strings.ToLower(strings.TrimSpace(gjson.GetBytes(inBody, "response_format").String()))
+
+	falInput, err := buildFalImageInput(inBody)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to build fal image input")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+
+	url := strings.TrimRight(resolveSyncBaseURL(), "/") + "/" + strings.TrimLeft(model, "/")
+	ctx := context.Background()
+	if c.Request != nil {
+		ctx = c.Request.Context()
+	}
+
+	a.sendRequestInfo(c, http.MethodPost, url, falInput)
+	respBody, _, err := a.doJSON(ctx, http.MethodPost, url, falInput)
+	if err != nil {
+		return err
+	}
+
+	openaiResp, err := a.buildOpenAIImageResponse(ctx, respBody, responseFormat)
+	if err != nil {
+		return err
+	}
+	return writeJSON(c, http.StatusOK, openaiResp)
+}
+
+// buildFalImageInput converts the OpenAI images body into fal's input JSON. The
+// prompt passes through; sizing is translated (a client-supplied fal-native
+// image_size wins, else the OpenAI "WxH" size becomes {width,height}); and every
+// other client field is preserved so fal-native params (num_inference_steps,
+// guidance_scale, seed, ...) are never dropped. OpenAI-only fields that fal does
+// not understand (model, n, response_format, size) are stripped.
+func buildFalImageInput(inBody []byte) ([]byte, error) {
+	// Start from the client body so unknown/fal-native fields carry through.
+	out := inBody
+	if !gjson.ValidBytes(out) || strings.TrimSpace(string(out)) == "" {
+		out = []byte("{}")
+	}
+
+	clientImageSize := gjson.GetBytes(out, "image_size")
+	size := strings.TrimSpace(gjson.GetBytes(out, "size").String())
+
+	var err error
+	// Strip OpenAI-only fields fal doesn't consume.
+	for _, f := range []string{"model", "n", "response_format", "size"} {
+		out, err = sjson.DeleteBytes(out, f)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sizing: a fal-native image_size (string preset like "square"/"square_hd" or
+	// object {width,height}) that the client already sent takes precedence. Only
+	// when it's absent do we translate the OpenAI "WxH" size to fal's
+	// {width,height} object.
+	if !clientImageSize.Exists() && size != "" {
+		if w, h, ok := parseWxH(size); ok {
+			out, err = sjson.SetBytes(out, "image_size.width", w)
+			if err != nil {
+				return nil, err
+			}
+			out, err = sjson.SetBytes(out, "image_size.height", h)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return out, nil
+}
+
+// parseWxH parses an OpenAI-style "1024x1024" size into integer width/height.
+func parseWxH(size string) (int, int, bool) {
+	parts := strings.SplitN(strings.ToLower(size), "x", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err1 != nil || err2 != nil || w <= 0 || h <= 0 {
+		return 0, 0, false
+	}
+	return w, h, true
+}
+
+// buildOpenAIImageResponse translates fal's {"images":[{"url":...}]} into an
+// OpenAI images response {"created":<unix>,"data":[...]}. For response_format
+// "b64_json" it fetches each image's bytes from the fal URL and base64-encodes
+// them; otherwise it returns the fal URL directly.
+func (a *Adapter) buildOpenAIImageResponse(ctx context.Context, falBody []byte, responseFormat string) ([]byte, error) {
+	images := gjson.GetBytes(falBody, "images")
+	if !images.Exists() || len(images.Array()) == 0 {
+		// Some fal models return a single "image" object instead of an "images"
+		// array — accept both.
+		if single := gjson.GetBytes(falBody, "image"); single.Exists() {
+			images = gjson.Parse("[" + single.Raw + "]")
+		}
+	}
+
+	wantB64 := responseFormat == "b64_json"
+	out := []byte(`{"data":[]}`)
+	var err error
+	out, err = sjson.SetBytes(out, "created", time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+
+	idx := 0
+	for _, img := range images.Array() {
+		url := img.Get("url").String()
+		if url == "" {
+			continue
+		}
+		if wantB64 {
+			b64data, ferr := a.fetchAsBase64(ctx, url)
+			if ferr != nil {
+				return nil, ferr
+			}
+			out, err = sjson.SetBytes(out, "data."+strconv.Itoa(idx)+".b64_json", b64data)
+		} else {
+			out, err = sjson.SetBytes(out, "data."+strconv.Itoa(idx)+".url", url)
+		}
+		if err != nil {
+			return nil, err
+		}
+		// Preserve fal's revised prompt hint if present (OpenAI compat field).
+		if rp := gjson.GetBytes(falBody, "prompt").String(); rp != "" {
+			out, _ = sjson.SetBytes(out, "data."+strconv.Itoa(idx)+".revised_prompt", rp)
+		}
+		idx++
+	}
+	return out, nil
+}
+
+// fetchAsBase64 downloads an image from a fal media URL (no auth needed) and
+// returns its base64-encoded bytes for response_format=b64_json.
+func (a *Adapter) fetchAsBase64(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		proxyErr := domain.NewProxyErrorWithMessage(err, false, "failed to build fal image fetch")
+		proxyErr.Scope = domain.ScopeRequest
+		return "", proxyErr
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", domain.NewUpstreamConnectionError("failed to fetch fal image")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, isRetryableStatus(resp.StatusCode), "fal image fetch failed")
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.HTTPStatusCode = resp.StatusCode
+		return "", proxyErr
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", domain.NewUpstreamConnectionError("failed to read fal image bytes")
+	}
+	return b64Std(data), nil
+}

--- a/internal/adapter/provider/fal/video.go
+++ b/internal/adapter/provider/fal/video.go
@@ -1,0 +1,198 @@
+package fal
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/awsl-project/maxx/internal/adapter/client"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// new-api video status vocabulary (see seedance/code0 poll shape). fal statuses
+// map onto these: IN_QUEUE/IN_PROGRESS -> IN_PROGRESS; COMPLETED -> SUCCESS.
+const (
+	statusInProgress = "IN_PROGRESS"
+	statusSuccess    = "SUCCESS"
+	statusFailed     = "FAILED"
+)
+
+// executeVideo dispatches the async video surface: POST = submit, GET = poll.
+func (a *Adapter) executeVideo(c *flow.Ctx) error {
+	uri := flow.GetRequestURI(c)
+	if client.IsVideoPollPath(uri) {
+		return a.executeVideoPoll(c, uri)
+	}
+	return a.executeVideoSubmit(c)
+}
+
+// executeVideoSubmit translates a new-api submit into a fal queue submit.
+//
+//	client  POST /v1/video/generations {model,prompt,...}
+//	  ->    POST https://queue.fal.run/{mappedModel} {prompt,...}
+//	  <-    {"request_id":"...","response_url":"https://queue.fal.run/{app}/requests/{id}"}
+//	client  <- {"id":task,"task_id":task,"status":"queued"}
+//
+// task_id = base64url("{response_url}") so the poll is STATELESS — everything
+// needed to reach the fal result/status URL is recovered from the id, and maxx
+// stores nothing. We encode fal's returned response_url (not {model}) because fal
+// strips a model's sub-route (e.g. fal-ai/veo3/fast -> fal-ai/veo3) in the queue
+// request path; reconstructing from the mapped model would 404 on multi-segment
+// ids.
+func (a *Adapter) executeVideoSubmit(c *flow.Ctx) error {
+	model := flow.GetMappedModel(c)
+	if model == "" {
+		model = gjson.GetBytes(flow.GetRequestBody(c), "model").String()
+	}
+	if strings.TrimSpace(model) == "" {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "fal video submit missing model")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+
+	falInput := buildFalVideoInput(flow.GetRequestBody(c))
+	url := strings.TrimRight(resolveQueueBaseURL(), "/") + "/" + strings.TrimLeft(model, "/")
+	ctx := reqCtx(c)
+
+	a.sendRequestInfo(c, http.MethodPost, url, falInput)
+	respBody, _, err := a.doJSON(ctx, http.MethodPost, url, falInput)
+	if err != nil {
+		return err
+	}
+
+	requestID := gjson.GetBytes(respBody, "request_id").String()
+	responseURL := gjson.GetBytes(respBody, "response_url").String()
+	if requestID == "" || responseURL == "" {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, true, "fal submit response missing request_id/response_url")
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		return proxyErr
+	}
+
+	taskID := encodeTaskID(responseURL)
+	out := []byte(`{}`)
+	out, _ = sjson.SetBytes(out, "id", taskID)
+	out, _ = sjson.SetBytes(out, "task_id", taskID)
+	out, _ = sjson.SetBytes(out, "status", "queued")
+	return writeJSON(c, http.StatusOK, out)
+}
+
+// executeVideoPoll decodes the task_id back into fal's result URL, checks status,
+// and — once COMPLETED — fetches the result and returns the new-api poll envelope.
+//
+//	client  GET /v1/video/generations/{task_id}
+//	  ->    GET {responseURL}/status   (fal: IN_QUEUE|IN_PROGRESS|COMPLETED)
+//	  ->    GET {responseURL}          (when COMPLETED: {"video":{"url":...}})
+//	client  <- {"code":"success","data":{"status":"IN_PROGRESS|SUCCESS",...,"data":{...}}}
+func (a *Adapter) executeVideoPoll(c *flow.Ctx, uri string) error {
+	taskID := pollTaskID(uri)
+	parts, err := decodeTaskID(taskID)
+	if err != nil || len(parts) == 0 || parts[0] == "" {
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "invalid fal video task id")
+		proxyErr.Scope = domain.ScopeRequest
+		return proxyErr
+	}
+	responseURL := parts[0]
+	ctx := reqCtx(c)
+
+	a.sendRequestInfo(c, http.MethodGet, responseURL+"/status", nil)
+	statusBody, _, err := a.doJSON(ctx, http.MethodGet, responseURL+"/status", nil)
+	if err != nil {
+		return err
+	}
+	falStatus := strings.ToUpper(strings.TrimSpace(gjson.GetBytes(statusBody, "status").String()))
+
+	switch falStatus {
+	case "COMPLETED":
+		a.sendRequestInfo(c, http.MethodGet, responseURL, nil)
+		resultBody, _, err := a.doJSON(ctx, http.MethodGet, responseURL, nil)
+		if err != nil {
+			return err
+		}
+		return writeJSON(c, http.StatusOK, buildVideoPollEnvelope(taskID, statusSuccess, resultBody))
+	case "IN_QUEUE", "IN_PROGRESS", "":
+		return writeJSON(c, http.StatusOK, buildVideoPollEnvelope(taskID, statusInProgress, statusBody))
+	default:
+		// Any other terminal fal state (e.g. an error status) is surfaced as FAILED
+		// so the polling client can stop.
+		return writeJSON(c, http.StatusOK, buildVideoPollEnvelope(taskID, statusFailed, statusBody))
+	}
+}
+
+// buildFalVideoInput strips new-api-only fields (model) and passes every other
+// client field through to fal so fal-native params (duration, resolution,
+// aspect_ratio, seed, image_url, ...) are preserved.
+func buildFalVideoInput(inBody []byte) []byte {
+	out := inBody
+	if !gjson.ValidBytes(out) || strings.TrimSpace(string(out)) == "" {
+		out = []byte("{}")
+	}
+	out, _ = sjson.DeleteBytes(out, "model")
+	return out
+}
+
+// buildVideoPollEnvelope wraps a status + optional fal payload in the nested
+// new-api poll shape clients expect: {"code":"success","data":{status, task_id,
+// data:{...}}}. On SUCCESS it copies the fal result into data.data and lifts the
+// resolved mp4 URL to data.data.url so simple clients can read it directly.
+func buildVideoPollEnvelope(taskID, status string, falPayload []byte) []byte {
+	out := []byte(`{"code":"success"}`)
+	out, _ = sjson.SetBytes(out, "data.status", status)
+	out, _ = sjson.SetBytes(out, "data.task_id", taskID)
+	if len(falPayload) > 0 && gjson.ValidBytes(falPayload) {
+		out, _ = sjson.SetRawBytes(out, "data.data", falPayload)
+	}
+	if status == statusSuccess {
+		if url := extractVideoURL(falPayload); url != "" {
+			out, _ = sjson.SetBytes(out, "data.data.url", url)
+		}
+	}
+	return out
+}
+
+// extractVideoURL walks a fal video result for the resolved media URL. fal's
+// common shape is {"video":{"url":...}}; some models nest it differently, so fall
+// back to any top-level *.url string.
+func extractVideoURL(body []byte) string {
+	if u := gjson.GetBytes(body, "video.url").String(); u != "" {
+		return u
+	}
+	if u := gjson.GetBytes(body, "video_url").String(); u != "" {
+		return u
+	}
+	// Last resort: first *.url string field anywhere in the payload.
+	var found string
+	gjson.ParseBytes(body).ForEach(func(_, value gjson.Result) bool {
+		if u := value.Get("url").String(); u != "" {
+			found = u
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// pollTaskID extracts the {task_id} segment from a video poll path
+// (/v1/video/generations/{task_id} or /video/generations/{task_id}).
+func pollTaskID(uri string) string {
+	for _, base := range []string{"/v1/video/generations/", "/video/generations/"} {
+		if strings.HasPrefix(uri, base) {
+			id := strings.TrimPrefix(uri, base)
+			if i := strings.IndexAny(id, "/?"); i >= 0 {
+				id = id[:i]
+			}
+			return id
+		}
+	}
+	return ""
+}
+
+func reqCtx(c *flow.Ctx) context.Context {
+	if c.Request != nil {
+		return c.Request.Context()
+	}
+	return context.Background()
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -383,6 +383,21 @@ type ProviderConfigZai struct {
 	Plan string `json:"plan,omitempty"`
 }
 
+// ProviderConfigFal 是 fal（fal.ai）一级供应商的配置。fal 不是 OpenAI 兼容的：它是
+// 队列式、按路径路由模型的推理平台，鉴权用 Authorization: Key <id:secret>（不是 Bearer）。
+// maxx 通过一个翻译层把 fal 暴露成既有的 OpenAI 图片接口（/v1/images/generations，同步）和
+// 异步视频接口（/v1/video/generations，new-api 风格）。运行时由 fal 适配器把客户端请求翻译成
+// fal 输入，直接向 fal 发起 HTTP 调用并把响应翻译回 OpenAI/new-api 形状，无需 custom 适配器
+// 的透传逻辑。
+//
+// 只保留 APIKey：模型映射走通用的 ModelMapping 实体（executor.mapModel），映射后的模型 id
+// （如 fal-ai/flux/dev、fal-ai/veo3.1）成为 fal 的 URL 路径段。
+type ProviderConfigFal struct {
+	// API Key —— 完整的 "id:secret" 字符串（fal 控制台生成）。适配器把它原样注入
+	// Authorization: Key <apiKey>。
+	APIKey string `json:"apiKey"`
+}
+
 // ProviderConfigGrok stores xAI/Grok OAuth credentials exported by CLIProxyAPI.
 // Sensitive token fields are stored server-side and must be redacted before any UI display/export.
 type ProviderConfigGrok struct {
@@ -424,6 +439,7 @@ type ProviderConfig struct {
 	Claude      *ProviderConfigClaude      `json:"claude,omitempty"`
 	OpenRouter  *ProviderConfigOpenRouter  `json:"openrouter,omitempty"`
 	Zai         *ProviderConfigZai         `json:"zai,omitempty"`
+	Fal         *ProviderConfigFal         `json:"fal,omitempty"`
 	Grok        *ProviderConfigGrok        `json:"grok,omitempty"`
 
 	// Reasoning is the provider-scoped outbound reasoning-effort policy, applied

--- a/internal/domain/provider_capability.go
+++ b/internal/domain/provider_capability.go
@@ -36,6 +36,17 @@ func CanonicalSupportedClientTypes(providerType string, configured []ClientType)
 	case "grok":
 		return []ClientType{ClientTypeOpenAI}
 
+	case "fal":
+		// fal (fal.ai) is a queue-based inference platform, NOT OpenAI-compatible.
+		// maxx exposes it through two existing surfaces via a translation layer:
+		// synchronous image generation (ClientTypeOpenAI, /v1/images/generations)
+		// and async video generation (ClientTypeVideo, /v1/video/generations). Both
+		// are native fal capabilities, so advertise both unconditionally — a video
+		// route and an image route can each reach a fal provider without a
+		// hand-authored capability set. fal model ids are reached via ModelMapping
+		// (executor.mapModel) and become the URL path segment.
+		return []ClientType{ClientTypeOpenAI, ClientTypeVideo}
+
 	case "custom", "newapi":
 		if len(configured) == 0 {
 			return []ClientType{ClientTypeOpenAI}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -549,6 +549,15 @@ func preserveEmptyProviderSecrets(existing, incoming *domain.Provider) {
 				incoming.Config.Zai.APIKey = existing.Config.Zai.APIKey
 			}
 		}
+	case "fal":
+		if existing.Config.Fal != nil {
+			if incoming.Config.Fal == nil {
+				fal := *existing.Config.Fal
+				incoming.Config.Fal = &fal
+			} else if incoming.Config.Fal.APIKey == "" {
+				incoming.Config.Fal.APIKey = existing.Config.Fal.APIKey
+			}
+		}
 	case "grok":
 		if existing.Config.Grok != nil {
 			if incoming.Config.Grok == nil {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -101,6 +101,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --provider-grok: oklch(0.62 0.18 285); /* xAI/Grok 紫色 */
   --provider-newapi: oklch(0.62 0.17 230); /* new-api/one-api 蓝色 */
   --provider-ollama: oklch(0.55 0.02 260); /* Ollama 石墨灰 */
+  --provider-fal: oklch(0.68 0.19 25); /* fal.ai 珊瑚红/橙色 */
 
   /* Client 品牌色 (引用 Provider 颜色) */
   --client-claude: var(--provider-anthropic);
@@ -391,6 +392,7 @@ input[type='password']::-webkit-credentials-auto-fill-button {
   --color-provider-grok: var(--provider-grok);
   --color-provider-newapi: var(--provider-newapi);
   --color-provider-ollama: var(--provider-ollama);
+  --color-provider-fal: var(--provider-fal);
 
   /* Client 颜色映射 (Tailwind 可用) */
   --color-client-claude: var(--client-claude);

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -25,7 +25,8 @@ export type ProviderType =
   | 'zai'
   | 'grok'
   | 'newapi'
-  | 'ollama';
+  | 'ollama'
+  | 'fal';
 
 /**
  * Client 类型定义

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -134,6 +134,15 @@ export interface ProviderConfigZai {
   plan?: 'coding' | 'api';
 }
 
+// fal（fal.ai）一级供应商配置。fal 不是 OpenAI 兼容的：队列式、按 URL 路径路由模型，鉴权用
+// Authorization: Key <id:secret>。后端通过翻译层把 fal 暴露成 OpenAI 图片接口（同步）和 new-api
+// 异步视频接口。映射后的模型 id（如 fal-ai/flux/dev）成为 fal 的 URL 路径段，走通用的
+// ModelMapping 实体，不放在 config 里。
+export interface ProviderConfigFal {
+  // 完整的 "id:secret" 字符串。
+  apiKey: string;
+}
+
 export interface ProviderConfigGrok {
   type?: 'xai';
   authKind?: 'oauth';
@@ -260,6 +269,7 @@ export interface ProviderConfig {
   claude?: ProviderConfigClaude;
   openrouter?: ProviderConfigOpenRouter;
   zai?: ProviderConfigZai;
+  fal?: ProviderConfigFal;
   grok?: ProviderConfigGrok;
 }
 

--- a/web/src/pages/providers/components/fal-config-step.tsx
+++ b/web/src/pages/providers/components/fal-config-step.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useCreateProvider } from '@/hooks/queries';
+import type { CreateProviderData } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { useProviderNavigation } from '../hooks/use-provider-navigation';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
+
+// fal (fal.ai) is a queue-based inference platform, NOT OpenAI-compatible. maxx
+// exposes it via a translation layer over two existing surfaces: OpenAI images
+// (/v1/images/generations, synchronous) and async video (/v1/video/generations).
+// The backend sets supportedClientTypes canonically (openai + video), so this
+// step collects only the API key (the full id:secret string) — model routing is
+// via the generic ModelMapping (mapped model id becomes the fal URL path segment,
+// e.g. fal-ai/flux/dev, fal-ai/veo3.1).
+export function FalConfigStep() {
+  const { t } = useTranslation();
+  const { goToSelectType, goToProviders } = useProviderNavigation();
+  const createProvider = useCreateProvider();
+
+  const [name, setName] = useState('fal.ai');
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(false);
+  const [maxConcurrency, setMaxConcurrency] = useState(0);
+  const [blackBox, setBlackBox] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const isValid = () => name.trim() !== '' && apiKey.trim() !== '';
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+    setSaving(true);
+    setSaveStatus('idle');
+    try {
+      const data: CreateProviderData = {
+        type: 'fal',
+        name: name.trim(),
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
+        config: {
+          disableErrorCooldown,
+          fal: {
+            apiKey: apiKey.trim(),
+          },
+        },
+        // supportedClientTypes omitted: the backend normalizes fal to
+        // [openai (images), video] regardless of what the UI sends.
+        excludeFromExport: blackBox,
+        blackBox,
+      };
+
+      await createProvider.mutateAsync(data);
+      setSaveStatus('success');
+      goToProviders();
+    } catch (error) {
+      console.error('Failed to create provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={goToSelectType} />}
+        title="fal.ai"
+        description={t('addProvider.fal.description', {
+          defaultValue:
+            'fal.ai image (synchronous) + video (async) generation, exposed via OpenAI images and new-api video surfaces.',
+        })}
+      >
+        <Button onClick={goToProviders} variant="secondary">
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.create')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-text-primary block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="fal.ai"
+                  className="w-full"
+                />
+              </div>
+
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('addProvider.fal.apiKey', { defaultValue: 'API Key' })}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder="id:secret"
+                    className="w-full pr-10 font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowApiKey(!showApiKey)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                    tabIndex={-1}
+                    aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                  >
+                    {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                  </button>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('addProvider.fal.apiKeyHint', {
+                    defaultValue:
+                      'The full fal key in "id:secret" format. Sent upstream as "Authorization: Key <id:secret>".',
+                  })}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {/* Visibility */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-text-primary border-b border-border pb-2">
+              {t('provider.visibilityAndExport')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">{t('provider.blackBox')}</div>
+                <p className="text-xs text-muted-foreground mt-1">{t('provider.blackBoxDesc')}</p>
+              </div>
+              <Switch checked={blackBox} onCheckedChange={setBlackBox} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.createError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/fal-provider-view.tsx
+++ b/web/src/pages/providers/components/fal-provider-view.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react';
+import { ChevronLeft, Key, Check, Eye, EyeOff, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUpdateProvider } from '@/hooks/queries';
+import type { CreateProviderData, Provider } from '@/lib/transport';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+import { PageHeader } from '@/components/layout/page-header';
+import { ProviderProxyURLCard } from './provider-proxy-url-card';
+import { ProviderModelMappings } from './provider-model-mappings';
+import {
+  normalizeMaxConcurrency,
+  ProviderMaxConcurrencyField,
+} from './provider-max-concurrency-field';
+
+interface FalProviderViewProps {
+  provider: Provider;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+// Edit view for a fal (fal.ai) provider. fal's supported client types (openai
+// images + video) are set canonically by the backend, so this view exposes only
+// the API key (full id:secret) and standard provider knobs. Model routing is via
+// the generic ModelMapping (mapped model id becomes the fal URL path segment).
+export function FalProviderView({ provider, onDelete, onClose }: FalProviderViewProps) {
+  const { t } = useTranslation();
+  const updateProvider = useUpdateProvider();
+
+  // Secrets are redacted on read whenever the provider is export-excluded, so the
+  // apiKey arrives blank; a blank submit preserves the stored key (the backend
+  // keeps the existing secret when the incoming apiKey is empty — see
+  // preserveEmptyProviderSecrets case "fal").
+  const secretsAreWriteOnly = !!provider.excludeFromExport;
+
+  const [name, setName] = useState(provider.name);
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [disableErrorCooldown, setDisableErrorCooldown] = useState(
+    !!provider.config?.disableErrorCooldown,
+  );
+  const [maxConcurrency, setMaxConcurrency] = useState(
+    normalizeMaxConcurrency(provider.maxConcurrency),
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle');
+
+  const isValid = () => name.trim() !== '';
+
+  const handleSave = async () => {
+    if (!isValid()) return;
+    setSaving(true);
+    setSaveStatus('idle');
+    try {
+      const data: Partial<CreateProviderData> = {
+        name: name.trim(),
+        type: 'fal',
+        maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
+        config: {
+          disableErrorCooldown,
+          fal: {
+            // Blank preserves the stored key (backend keeps existing secret).
+            apiKey: apiKey.trim(),
+          },
+        },
+      };
+
+      await updateProvider.mutateAsync({ id: Number(provider.id), data });
+      setSaveStatus('success');
+      setTimeout(() => onClose(), 500);
+    } catch (error) {
+      console.error('Failed to update provider:', error);
+      setSaveStatus('error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader
+        icon={<ChevronLeft className="cursor-pointer" onClick={onClose} />}
+        title={t('provider.edit')}
+        description={t('addProvider.fal.description', {
+          defaultValue:
+            'fal.ai image (synchronous) + video (async) generation, exposed via OpenAI images and new-api video surfaces.',
+        })}
+      >
+        <Button onClick={onDelete} variant="destructive">
+          <Trash2 size={14} />
+          {t('provider.delete')}
+        </Button>
+        <Button onClick={onClose} variant="secondary">
+          {t('provider.cancel')}
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !isValid()} variant="default">
+          {saving ? (
+            t('common.saving')
+          ) : saveStatus === 'success' ? (
+            <>
+              <Check size={14} /> {t('common.saved')}
+            </>
+          ) : (
+            t('provider.saveChanges')
+          )}
+        </Button>
+      </PageHeader>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-7xl space-y-8">
+          <ProviderProxyURLCard provider={provider} />
+
+          {/* Basic Info */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.basicInfo')}
+            </h3>
+            <div className="grid gap-6">
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  {t('provider.displayName')}
+                </label>
+                <Input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="fal.ai"
+                  className="w-full"
+                />
+              </div>
+
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
+
+              <div>
+                <label className="text-sm font-medium text-foreground block mb-2">
+                  <div className="flex items-center gap-2">
+                    <Key size={14} />
+                    <span>{t('provider.apiKeyEdit')}</span>
+                  </div>
+                </label>
+                <div className="relative">
+                  <Input
+                    type={showApiKey && !secretsAreWriteOnly ? 'text' : 'password'}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={
+                      secretsAreWriteOnly ? t('provider.keyPlaceholderWriteOnly') : 'id:secret'
+                    }
+                    className="w-full pr-10 font-mono"
+                  />
+                  {!secretsAreWriteOnly && (
+                    <button
+                      type="button"
+                      onClick={() => setShowApiKey(!showApiKey)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      aria-label={showApiKey ? t('common.hide') : t('common.show')}
+                    >
+                      {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  )}
+                </div>
+                {secretsAreWriteOnly && (
+                  <div className="mt-2 p-3 bg-muted/50 border border-border rounded-lg text-xs text-muted-foreground">
+                    {t('provider.apiKeyExcludedHint')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Model Mappings (provider-scoped ModelMapping entities) */}
+          <ProviderModelMappings provider={provider} />
+
+          {/* Error Cooldown */}
+          <div className="space-y-6">
+            <h3 className="text-lg font-semibold text-foreground border-b border-border pb-2">
+              {t('provider.errorCooldownTitle')}
+            </h3>
+            <div className="flex items-center justify-between p-4 bg-card border border-border rounded-xl">
+              <div className="pr-4">
+                <div className="text-sm font-medium text-foreground">
+                  {t('provider.disableErrorCooldown')}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('provider.disableErrorCooldownDesc')}
+                </p>
+              </div>
+              <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
+            </div>
+          </div>
+
+          {saveStatus === 'error' && (
+            <div className="p-4 bg-error/10 border border-error/30 rounded-lg text-sm text-error flex items-center gap-2">
+              <div className="w-1.5 h-1.5 rounded-full bg-error" />
+              {t('provider.updateError')}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -46,6 +46,7 @@ import { CodexProviderView } from './codex-provider-view';
 import { ClaudeProviderView } from './claude-provider-view';
 import { OpenRouterProviderView } from './openrouter-provider-view';
 import { ZaiProviderView } from './zai-provider-view';
+import { FalProviderView } from './fal-provider-view';
 import { NewApiProviderView } from './newapi-provider-view';
 import { OllamaProviderView } from './ollama-provider-view';
 import { GrokProviderView } from './grok-provider-view';
@@ -981,6 +982,26 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     return (
       <>
         <ZaiProviderView
+          provider={provider}
+          onDelete={() => setShowDeleteConfirm(true)}
+          onClose={onClose}
+        />
+        <DeleteConfirmModal
+          providerName={provider.name}
+          deleting={deleting}
+          open={showDeleteConfirm}
+          onConfirm={handleDelete}
+          onCancel={() => setShowDeleteConfirm(false)}
+        />
+      </>
+    );
+  }
+
+  // fal (fal.ai) provider
+  if (provider.type === 'fal') {
+    return (
+      <>
+        <FalProviderView
           provider={provider}
           onDelete={() => setShowDeleteConfirm(true)}
           onClose={onClose}

--- a/web/src/pages/providers/components/select-type-step.tsx
+++ b/web/src/pages/providers/components/select-type-step.tsx
@@ -12,6 +12,7 @@ import {
   Bot,
   Network,
   Boxes,
+  Film,
 } from 'lucide-react';
 import { quickTemplates, PROVIDER_TYPE_CONFIGS, type ProviderFormData } from '../types';
 import openrouterLogo from '@/assets/icons/openrouter.svg';
@@ -415,6 +416,39 @@ export function SelectTypeStep() {
                   )}
                 </div>
               </Button>
+
+              {!PROVIDER_TYPE_CONFIGS.fal.hidden && (
+                <Button
+                  onClick={() => handleSelectType('fal')}
+                  variant="ghost"
+                  className={`group p-0 rounded-xl border text-left h-auto w-full overflow-hidden transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                    formData.type === 'fal'
+                      ? 'border-provider-fal bg-provider-fal/10 shadow-sm'
+                      : 'border-border bg-card hover:bg-muted hover:border-accent/30 hover:shadow-sm'
+                  }`}
+                >
+                  <div className="p-4 sm:p-5 flex items-center gap-3 sm:gap-4 min-w-0 w-full">
+                    <div className="size-10 sm:size-11 md:size-12 rounded-lg bg-provider-fal/15 flex items-center justify-center shrink-0 transition-transform duration-200 group-hover:scale-105">
+                      <Film className="size-5 md:size-6 text-provider-fal" />
+                    </div>
+
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <h3 className="text-sm sm:text-base font-semibold text-foreground leading-tight truncate">
+                        {t('addProvider.fal.name', { defaultValue: 'fal.ai' })}
+                      </h3>
+                      <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed line-clamp-2">
+                        {t('addProvider.fal.description', {
+                          defaultValue: 'Image + video generation (fal.ai)',
+                        })}
+                      </p>
+                    </div>
+
+                    {formData.type === 'fal' && (
+                      <CheckCircle2 className="size-5 text-provider-fal shrink-0 self-center animate-in zoom-in-50 duration-200" />
+                    )}
+                  </div>
+                </Button>
+              )}
             </div>
           </div>
 

--- a/web/src/pages/providers/create-layout.tsx
+++ b/web/src/pages/providers/create-layout.tsx
@@ -12,6 +12,7 @@ import { OpenRouterConfigStep } from './components/openrouter-config-step';
 import { ZaiConfigStep } from './components/zai-config-step';
 import { NewApiConfigStep } from './components/newapi-config-step';
 import { OllamaConfigStep } from './components/ollama-config-step';
+import { FalConfigStep } from './components/fal-config-step';
 
 export function ProviderCreateLayout() {
   return (
@@ -24,6 +25,7 @@ export function ProviderCreateLayout() {
         <Route path="zai" element={<ZaiConfigStep />} />
         <Route path="newapi" element={<NewApiConfigStep />} />
         <Route path="ollama" element={<OllamaConfigStep />} />
+        <Route path="fal" element={<FalConfigStep />} />
         <Route path="antigravity" element={<AntigravityTokenImport />} />
         <Route path="kiro" element={<KiroTokenImport />} />
         <Route path="codex" element={<CodexTokenImport />} />

--- a/web/src/pages/providers/hooks/use-provider-navigation.ts
+++ b/web/src/pages/providers/hooks/use-provider-navigation.ts
@@ -13,6 +13,7 @@ export const PROVIDER_CREATE_PATHS: Record<ProviderTypeKey, string> = {
   newapi: '/providers/create/newapi',
   ollama: '/providers/create/ollama',
   grok: '/providers/create/grok',
+  fal: '/providers/create/fal',
 };
 
 export function getProviderCreatePath(type: ProviderTypeKey): string {
@@ -35,6 +36,7 @@ export function useProviderNavigation() {
     goToNewApi: () => navigate(PROVIDER_CREATE_PATHS.newapi),
     goToOllama: () => navigate(PROVIDER_CREATE_PATHS.ollama),
     goToGrok: () => navigate(PROVIDER_CREATE_PATHS.grok),
+    goToFal: () => navigate(PROVIDER_CREATE_PATHS.fal),
     goToProviderConfig: (type: ProviderTypeKey) => navigate(getProviderCreatePath(type)),
     goToProviders: () => navigate('/providers'),
     goBack: () => navigate(-1),

--- a/web/src/pages/providers/types.test.ts
+++ b/web/src/pages/providers/types.test.ts
@@ -20,6 +20,7 @@ describe('provider type helpers', () => {
       'grok',
       'newapi',
       'ollama',
+      'fal',
       'custom',
     ]);
   });

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -15,6 +15,7 @@ import {
   Network,
   Boxes,
   Gem,
+  Film,
 } from 'lucide-react';
 import duckcodingLogo from '@/assets/icons/duckcoding.gif';
 import freeDuckLogo from '@/assets/icons/free-duck.gif';
@@ -38,7 +39,8 @@ export type ProviderTypeKey =
   | 'zai'
   | 'grok'
   | 'newapi'
-  | 'ollama';
+  | 'ollama'
+  | 'fal';
 
 export interface ProviderTypeConfig {
   key: ProviderTypeKey;
@@ -138,6 +140,14 @@ export const PROVIDER_TYPE_CONFIGS: Record<ProviderTypeKey, ProviderTypeConfig> 
     color: getProviderColorVar('ollama'),
     isAccountBased: false,
     getDisplayInfo: (p) => p.config?.custom?.baseURL || 'Not configured',
+  },
+  fal: {
+    key: 'fal',
+    label: 'fal.ai',
+    icon: Film,
+    color: getProviderColorVar('fal'),
+    isAccountBased: false,
+    getDisplayInfo: () => 'fal.ai · image + video',
   },
   custom: {
     key: 'custom',
@@ -357,7 +367,8 @@ export type ProviderFormData = {
     | 'zai'
     | 'grok'
     | 'newapi'
-    | 'ollama';
+    | 'ollama'
+    | 'fal';
   name: string;
   selectedTemplate: string | null;
   baseURL: string;


### PR DESCRIPTION
## What

Adds a first-class **`fal`** (fal.ai) provider type covering **both image and video generation**.

fal.ai is **NOT OpenAI-compatible**: it is a queue-based inference platform with **PATH-based model routing** (`https://fal.run/{model}`) and **`Authorization: Key <id:secret>`** auth (not Bearer). Rather than a new client protocol, this exposes fal through maxx's **existing** surfaces via a **translation layer** — maxx makes fal look like OpenAI (images) and new-api (async video) to clients.

Mirrors how `openrouter`/`zai` are built as first-class types, but fal needs a genuine translation (request+response rewriting, direct HTTP calls) rather than pure delegation to the custom core.

## Design

### Image — SYNCHRONOUS (`ClientTypeOpenAI`, `POST /v1/images/generations`)
- Translate OpenAI images body → fal input: `prompt` passes through; a client-supplied fal-native `image_size` wins, else OpenAI `size` `"WxH"` → `{"width":W,"height":H}`; OpenAI-only fields (`model`, `n`, `response_format`, `size`) stripped; **all other client fields preserved** (fal-native `num_inference_steps`, `guidance_scale`, `seed`, …).
- `POST https://fal.run/{mappedModel}` (blocks ~1-2s).
- Translate fal `{"images":[{"url":…}]}` → OpenAI `{"created":<unix>,"data":[{"url":…}]}`. For `response_format=="b64_json"`, fetch the image bytes from the fal URL and return `{"b64_json":…}`.

### Video — ASYNC queue (`ClientTypeVideo`)
- **Submit** (`POST /v1/video/generations`): translate to fal input, `POST https://queue.fal.run/{mappedModel}`. Return a new-api-style submit response whose `task_id = base64url(response_url)`.
- **Poll** (`GET /v1/video/generations/{task_id}`): base64url-decode → `GET {responseURL}/status`; when `COMPLETED`, `GET {responseURL}` for the result → nested new-api poll envelope `{"code":"success","data":{"status":…,"data":{…,"url":<mp4>}}}`.
- **Status mapping:** fal `IN_QUEUE`/`IN_PROGRESS` → new-api `IN_PROGRESS`; `COMPLETED` → `SUCCESS`; other terminal → `FAILED`.

### Stateless task_id — important nuance verified against real fal
The task_id encodes fal's returned **`response_url`**, NOT `{model}`. Real fal **strips a model's sub-route** in the queue request path: submitting `fal-ai/veo3/fast` yields a `response_url` of `.../fal-ai/veo3/requests/{id}` (no `/fast`), and reconstructing `{mappedModel}/requests/{id}/status` **404s** for multi-segment model ids. Encoding fal's own `response_url` avoids this and keeps polling **stateless** (maxx stores nothing).

### Auth
The adapter injects `Authorization: Key <apiKey>` (the full `id:secret`) and **strips every client-supplied auth header** (`Authorization`, `x-api-key`, `x-goog-api-key`, `Proxy-Authorization`) before forwarding — mirrors the guarantee in the existing custom video test.

## Files touched
- `internal/domain/model.go` — `ProviderConfigFal{APIKey}` + `Fal *ProviderConfigFal` in the union.
- `internal/domain/provider_capability.go` — `case "fal"` → `[openai, video]`.
- `internal/adapter/provider/fal/{adapter,image,video}.go` — new adapter (+ `adapter_test.go`).
- `cmd/maxx/main.go` — register the fal adapter.
- `internal/service/admin.go` — `preserveEmptyProviderSecrets` `case "fal"`.
- Web: provider-type dropdown + config/edit forms (`web/src/pages/providers/*`, `types.ts`, transport `types.ts`, `theme.ts`, `index.css`, select-type + create-layout + nav hook).

## Tests
httptest-mocked fal upstreams (no real fal, no key in tests):
- Image: correct fal URL/path, `Authorization: Key …` set + client auth stripped, `size`→`image_size` translation (and native `image_size` wins), fal `{images}`→OpenAI `{data}`, both `url` and `b64_json`.
- Video submit: correct queue URL, `task_id` encodes `response_url` and round-trips, model stripped from fal input, client auth not leaked.
- Video poll: task_id decodes, hits fal status/result URLs, `COMPLETED`→`SUCCESS` with lifted mp4 url; `IN_PROGRESS` does not fetch result; invalid task id → request-scoped error.

`go build ./internal/... ./cmd/...`, `go vet`, and `go test` for touched packages are green. Frontend `tsc` typecheck and the providers vitest suite pass.

**Verified against real fal** (throwaway build-tagged smoke, since deleted; no key committed): image sync returns a real media URL in OpenAI shape; video submit returns a round-trippable task_id; poll decodes and reports `IN_PROGRESS`. The image-sync schema, the async queue submit/status/result shapes, and the sub-route-stripping behavior were all confirmed with real curl calls.

## Deferred
- `/v1/images/edits` (image-to-image via fal `image_url`) is **not** wired yet — text-to-image is the must-have and is complete. Left as a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 fal.ai 提供商支持，可进行同步图像生成和异步视频生成。
  * 支持图像 URL、Base64 响应，以及视频任务提交、状态轮询和结果获取。
  * 新增 fal.ai 提供商创建与编辑界面，可配置 API 密钥、并发数、模型映射及错误冷却。
  * 在提供商列表和类型选择器中加入 fal.ai，并提供专属品牌样式。
  * 更新配置保存逻辑，保留未重新填写的已有 API 密钥。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->