### PR TITLE
fix(proxy): allow async video paths through project/provider proxy

### DIFF
--- a/internal/handler/provider_proxy_test.go
+++ b/internal/handler/provider_proxy_test.go
@@ -148,6 +148,8 @@ func TestProjectAndProviderAllowlistsAgree(t *testing.T) {
 		"/v1/chat/completions", "/v1/chat/completions/extra", "/v1/chat/completionsXYZ",
 		"/v1/images", "/v1/images/", "/v1/images/generations", "/v1/images/edits",
 		"/v1/images/variations", "/v1/images/generations/extra",
+		"/v1/video/generations", "/v1/video/generations/task123", "/v1/video/generationsX",
+		"/video/generations", "/video/generations/task123", "/video/generationsX",
 		"/responses", "/responses/items", "/responses123",
 		"/v1/responses", "/v1/responses/abc", "/v1/responsesXYZ",
 		"/v1/models", "/v1/models/list", "/v1/models-debug",
@@ -188,6 +190,33 @@ func TestIsModelListAPIPath(t *testing.T) {
 		if isModelListAPIPath(path) {
 			t.Fatalf("did not expect %q to be a model-list API path", path)
 		}
+	}
+}
+
+// TestProjectAPIPathAllowsVideoGenerations pins that the async video surface —
+// POST /v1/video/generations (submit) and GET /v1/video/generations/{task_id}
+// (poll), plus the /video/generations root alias — is reachable under the
+// /project/<slug>/ and /provider/<id>/ prefixes. proxy_routes.go registers these
+// at the root mux; before this entry the allowlist omitted video, so project- and
+// provider-scoped video requests 404'd with "invalid project proxy path" even
+// though the direct root route worked.
+func TestProjectAPIPathAllowsVideoGenerations(t *testing.T) {
+	for _, path := range []string{
+		"/v1/video/generations",
+		"/v1/video/generations/01a0482e-e839-74c3-9bbe-450e7c7eb41e",
+		"/video/generations",
+		"/video/generations/01a0482e-e839-74c3-9bbe-450e7c7eb41e",
+	} {
+		if !isValidAPIPath(path) {
+			t.Fatalf("expected %q to be valid for project proxy URLs", path)
+		}
+		if !isValidProviderAPIPath(path) {
+			t.Fatalf("expected %q to be valid for provider proxy URLs", path)
+		}
+	}
+	// Guard the subtree boundary: a look-alike must not leak through.
+	if isValidAPIPath("/v1/video/generationsX") {
+		t.Fatal("did not expect /v1/video/generationsX to be valid")
 	}
 }
 

--- a/internal/handler/proxy_api_paths.go
+++ b/internal/handler/proxy_api_paths.go
@@ -39,6 +39,8 @@ var proxyAPIEndpoints = []proxyAPIEndpoint{
 	{path: "/v1/images/generations", subtree: false}, // OpenAI Images API
 	{path: "/v1/images/edits", subtree: false},       // OpenAI Images API
 	{path: "/v1/images", subtree: false},             // OpenRouter unified image API
+	{path: "/v1/video/generations", subtree: true},   // Async video API (submit + /{task_id} poll)
+	{path: "/video/generations", subtree: true},      // Async video API (root alias)
 	{path: "/responses", subtree: true},              // Codex API
 	{path: "/v1/responses", subtree: true},           // Codex API
 	{path: "/v1/models", subtree: true},              // Model list API


### PR DESCRIPTION
## Problem

The async video-generation surface (`POST /v1/video/generations` submit + `GET /v1/video/generations/{task_id}` poll, added in #824) is registered at the root mux but was **missing from the project/provider proxy allowlist** (`internal/handler/proxy_api_paths.go`).

Because maxx routing is **project-scoped**, real traffic goes through `/project/<slug>/...` (or `/provider/<id>/...`). Those prefixed paths validate the sub-path against `proxyAPIEndpoints`, which listed messages/chat/images/responses/models but **not video** — so every project-scoped video request was rejected with `404 "invalid project proxy path"`, even though the bare root route worked. This made the video surface effectively unreachable for project-scoped tokens.

## Fix

Add to the shared `proxyAPIEndpoints` table:
- `/v1/video/generations` (`subtree: true`, so the `/{task_id}` poll passes)
- `/video/generations` (root alias, matching how `proxy_routes.go` registers both)

Consistent with the existing images/messages/responses entries; the project and provider allowlists derive from the same table so they stay in agreement.

## Verification

- New `TestProjectAPIPathAllowsVideoGenerations` pins submit + poll + alias validity across both project and provider allowlists, and guards the subtree boundary (`/v1/video/generationsX` stays rejected). Added video cases to `TestProjectAndProviderAllowlistsAgree` too.
- **End-to-end against real fal** through `/project/<slug>/v1/video/generations`: submit → task_id round-trip → poll `IN_PROGRESS` → poll `SUCCESS` with a real `.mp4` URL. (Discovered while validating the new fal provider #834; the gap is in the #824 video surface itself and is independent of fal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)