### PR TITLE
fix(provider): limit exception switch freeze to configured 429 cases

### DIFF
--- a/internal/cooldown/manager.go
+++ b/internal/cooldown/manager.go
@@ -215,7 +215,7 @@ func (m *Manager) RecordFailureAfterThreshold(providerID uint64, clientType stri
 		return failureCount, time.Time{}
 	}
 
-	until := time.Time{}
+	var until time.Time
 	if explicitUntil != nil {
 		until = *explicitUntil
 	} else if policy, ok := m.policies[reason]; ok {

--- a/internal/cooldown/manager.go
+++ b/internal/cooldown/manager.go
@@ -184,6 +184,53 @@ func (m *Manager) RecordFailure(providerID uint64, clientType string, model stri
 	return until
 }
 
+// RecordFailureAfterThreshold tracks consecutive failures for the same cooldown
+// key, but only writes cooldown state after threshold failures. It is used by
+// the provider "disable error cooldown" escape hatch to avoid pinning traffic to
+// a provider that is repeatedly returning transient upstream errors.
+func (m *Manager) RecordFailureAfterThreshold(providerID uint64, clientType string, model string, reason CooldownReason, scope domain.ErrorScope, explicitUntil *time.Time, threshold int) (int, time.Time) {
+	if scope == domain.ScopeRequest {
+		return 0, time.Time{}
+	}
+	if threshold <= 0 {
+		threshold = 3
+	}
+
+	effectiveClientType := clientType
+	effectiveModel := model
+	switch scope {
+	case domain.ScopeModel:
+	case domain.ScopeKey, domain.ScopeEndpoint:
+		effectiveModel = ""
+	case domain.ScopeProvider:
+		effectiveClientType = ""
+		effectiveModel = ""
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	failureCount := m.failureTracker.IncrementFailure(providerID, effectiveClientType, effectiveModel, reason)
+	if failureCount < threshold {
+		return failureCount, time.Time{}
+	}
+
+	until := time.Time{}
+	if explicitUntil != nil {
+		until = *explicitUntil
+	} else if policy, ok := m.policies[reason]; ok {
+		until = time.Now().Add(policy.CalculateCooldown(failureCount))
+	} else {
+		until = time.Now().Add(5 * time.Second)
+	}
+
+	m.setCooldownLocked(providerID, effectiveClientType, effectiveModel, until, reason, true)
+	log.Printf("[Cooldown] Provider %d (clientType=%s, model=%s): threshold cooldown until %s (reason=%s, scope=%s, failureCount=%d, threshold=%d)",
+		providerID, clientType, model, until.Format("2006-01-02 15:04:05"), reason, scope, failureCount, threshold)
+
+	return failureCount, until
+}
+
 // UpdateCooldown updates cooldown time without incrementing failure count
 // This is used for async updates (e.g., when quota reset time is fetched asynchronously)
 // Keeps the existing reason
@@ -248,6 +295,14 @@ func (m *Manager) RecordSuccess(providerID uint64, clientType string, model stri
 	m.bumpAndPublishLocked(providerID)
 
 	log.Printf("[Cooldown] Provider %d (clientType=%s, model=%s): Cleared model-level cooldown after successful request", providerID, clientType, model)
+}
+
+// ResetFailures clears failure counters matching the given provider/client/model
+// dimensions without changing cooldown state.
+func (m *Manager) ResetFailures(providerID uint64, clientType string, model string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failureTracker.ResetFailures(providerID, clientType, model)
 }
 
 // setCooldownLocked sets cooldown without acquiring lock (internal use only).
@@ -630,10 +685,10 @@ func (m *Manager) getCooldownUntilLocked(providerID uint64, clientType string, m
 
 	// Check all 4 hierarchical levels
 	keys := []CooldownKey{
-		{ProviderID: providerID},                                          // 1. provider-level
-		{ProviderID: providerID, ClientType: clientType},                  // 2. key/endpoint-level
-		{ProviderID: providerID, Model: model},                            // 3. model-level (all client types)
-		{ProviderID: providerID, ClientType: clientType, Model: model},    // 4. model+clientType-level
+		{ProviderID: providerID},                                       // 1. provider-level
+		{ProviderID: providerID, ClientType: clientType},               // 2. key/endpoint-level
+		{ProviderID: providerID, Model: model},                         // 3. model-level (all client types)
+		{ProviderID: providerID, ClientType: clientType, Model: model}, // 4. model+clientType-level
 	}
 
 	for _, key := range keys {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -426,6 +426,10 @@ type ProviderConfig struct {
 
 	// 禁用错误自动冷冻（只影响错误触发的冷冻）
 	DisableErrorCooldown bool `json:"disableErrorCooldown,omitempty"`
+	// 禁用错误自动冷冻时，连续上游错误超过阈值后临时冻结该 provider 并切换到后续 provider。
+	ConsecutiveErrorFreezeEnabled bool `json:"consecutiveErrorFreezeEnabled,omitempty"`
+	// 连续上游错误临时冻结阈值。<=0 时使用默认值 3。
+	ConsecutiveErrorFreezeThreshold int `json:"consecutiveErrorFreezeThreshold,omitempty"`
 	// 智能映射轮询重试：禁用错误自动冻结时，按候选映射模型轮询失败重试。
 	SmartMappingRetryEnabled bool `json:"smartMappingRetryEnabled,omitempty"`
 	// 每个映射模型失败多少次后切换到下一个候选模型。

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -79,6 +79,23 @@ func (a *disabledCooldownHTTPErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provid
 	return proxyErr
 }
 
+type disabledCooldown429Adapter struct {
+	calls int
+}
+
+func (a *disabledCooldown429Adapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *disabledCooldown429Adapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New("upstream returned 429"), false, "upstream returned 429")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonRateLimitExceeded
+	proxyErr.HTTPStatusCode = http.StatusTooManyRequests
+	return proxyErr
+}
+
 func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
 	c, adapter, attemptRepo, proxyRepo := newDisabledCooldownStreamDispatchCtx(true)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
@@ -183,7 +200,7 @@ func TestDispatchDisableErrorCooldownRetriesHTTPErrorBeyondRetryBudget(t *testin
 	}
 }
 
-func TestDispatchDisableErrorCooldownFreezesAfterConsecutiveErrorsAndFailsOver(t *testing.T) {
+func TestDispatchDisableErrorCooldownDoesNotFreezeOn500WhenConsecutiveFreezeEnabled(t *testing.T) {
 	cooldown.Default().ClearCooldown(31, "", "")
 	defer cooldown.Default().ClearCooldown(31, "", "")
 	cooldown.Default().ResetFailures(31, "", "")
@@ -191,10 +208,10 @@ func TestDispatchDisableErrorCooldownFreezesAfterConsecutiveErrorsAndFailsOver(t
 
 	proxyRepo := &recordingProxyRequestRepo{}
 	attemptRepo := &recordingAttemptRepo{}
-	firstAdapter := &disabledCooldownHTTPErrorAdapter{}
+	firstAdapter := &disabledCooldownHTTPErrorAdapter{succeedAfter: 1}
 	secondAdapter := &disabledCooldownSuccessAdapter{}
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", nil)
 	c := flow.NewCtx(rec, req)
 	proxyReq := &domain.ProxyRequest{ID: 103, TenantID: domain.DefaultTenantID, ClientType: domain.ClientTypeOpenAI, Status: "IN_PROGRESS", StartTime: time.Now()}
 	state := &execState{
@@ -230,11 +247,69 @@ func TestDispatchDisableErrorCooldownFreezesAfterConsecutiveErrorsAndFailsOver(t
 	if firstAdapter.calls != 2 {
 		t.Fatalf("first adapter calls = %d, want 2", firstAdapter.calls)
 	}
+	if secondAdapter.calls != 0 {
+		t.Fatalf("second adapter calls = %d, want 0", secondAdapter.calls)
+	}
+	if cooldown.Default().IsInCooldown(31, string(domain.ClientTypeOpenAI), "gpt-4o") {
+		t.Fatal("500 should not freeze provider when only 429 is configured")
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchDisableErrorCooldownFreezesAfterConsecutive429AndFailsOver(t *testing.T) {
+	cooldown.Default().ClearCooldown(31, "", "")
+	defer cooldown.Default().ClearCooldown(31, "", "")
+	cooldown.Default().ResetFailures(31, "", "")
+	defer cooldown.Default().ResetFailures(31, "", "")
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	firstAdapter := &disabledCooldown429Adapter{}
+	secondAdapter := &disabledCooldownSuccessAdapter{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/chat/completions", nil)
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{ID: 104, TenantID: domain.DefaultTenantID, ClientType: domain.ClientTypeOpenAI, Status: "IN_PROGRESS", StartTime: time.Now()}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-4o",
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 31, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: 31, TenantID: domain.DefaultTenantID, Type: "custom", Name: "rate-limited-provider", Config: &domain.ProviderConfig{DisableErrorCooldown: true, ConsecutiveErrorFreezeEnabled: true, ConsecutiveErrorFreezeThreshold: 2}},
+				ProviderAdapter: firstAdapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+			{
+				Route:           &domain.Route{ID: 11, TenantID: domain.DefaultTenantID, ProviderID: 32, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: 32, TenantID: domain.DefaultTenantID, Type: "custom", Name: "fallback-provider", Config: &domain.ProviderConfig{}},
+				ProviderAdapter: secondAdapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
+	e.settingsRepo = &stubExecutorSettingsRepo{values: map[string]string{domain.SettingKeyRateLimitCooldownDefaultSeconds: "15"}}
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if firstAdapter.calls != 2 {
+		t.Fatalf("first adapter calls = %d, want 2", firstAdapter.calls)
+	}
 	if secondAdapter.calls != 1 {
 		t.Fatalf("second adapter calls = %d, want 1", secondAdapter.calls)
 	}
 	if !cooldown.Default().IsInCooldown(31, string(domain.ClientTypeOpenAI), "gpt-4o") {
-		t.Fatal("first provider was not frozen after consecutive upstream errors")
+		t.Fatal("429 should freeze provider after consecutive threshold")
 	}
 	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
 		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
@@ -249,6 +324,18 @@ func TestConsecutiveErrorFreezeIgnoresRequestScopedClientErrors(t *testing.T) {
 
 	if shouldUseConsecutiveErrorFreeze(provider, proxyErr) {
 		t.Fatal("request-scoped 400 should not trigger consecutive provider freeze")
+	}
+}
+
+func TestConsecutiveErrorFreezeIgnoresProvider500Errors(t *testing.T) {
+	provider := &domain.Provider{Config: &domain.ProviderConfig{DisableErrorCooldown: true, ConsecutiveErrorFreezeEnabled: true}}
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New("upstream returned 500"), false, "upstream returned 500")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonServerError
+	proxyErr.HTTPStatusCode = http.StatusInternalServerError
+
+	if shouldUseConsecutiveErrorFreeze(provider, proxyErr) {
+		t.Fatal("500 should not trigger consecutive provider freeze when configured for explicit error codes")
 	}
 }
 

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -6,11 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/cooldown"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/router"
@@ -23,6 +25,10 @@ type disabledCooldownStreamRetryAdapter struct {
 type disabledCooldownHTTPErrorAdapter struct {
 	calls        int
 	succeedAfter int
+}
+
+type disabledCooldownSuccessAdapter struct {
+	calls int
 }
 
 func (a *disabledCooldownStreamRetryAdapter) SupportedClientTypes() []domain.ClientType {
@@ -50,6 +56,15 @@ func (a *disabledCooldownStreamRetryAdapter) Execute(c *flow.Ctx, _ *domain.Prov
 
 func (a *disabledCooldownHTTPErrorAdapter) SupportedClientTypes() []domain.ClientType {
 	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *disabledCooldownSuccessAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *disabledCooldownSuccessAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	return nil
 }
 
 func (a *disabledCooldownHTTPErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
@@ -165,6 +180,75 @@ func TestDispatchDisableErrorCooldownRetriesHTTPErrorBeyondRetryBudget(t *testin
 	}
 	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
 		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestDispatchDisableErrorCooldownFreezesAfterConsecutiveErrorsAndFailsOver(t *testing.T) {
+	cooldown.Default().ClearCooldown(31, "", "")
+	defer cooldown.Default().ClearCooldown(31, "", "")
+	cooldown.Default().ResetFailures(31, "", "")
+	defer cooldown.Default().ResetFailures(31, "", "")
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	firstAdapter := &disabledCooldownHTTPErrorAdapter{}
+	secondAdapter := &disabledCooldownSuccessAdapter{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{ID: 103, TenantID: domain.DefaultTenantID, ClientType: domain.ClientTypeOpenAI, Status: "IN_PROGRESS", StartTime: time.Now()}
+	state := &execState{
+		ctx:          context.Background(),
+		proxyReq:     proxyReq,
+		tenantID:     domain.DefaultTenantID,
+		clientType:   domain.ClientTypeOpenAI,
+		requestModel: "gpt-4o",
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 31, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: 31, TenantID: domain.DefaultTenantID, Type: "custom", Name: "bad-provider", Config: &domain.ProviderConfig{DisableErrorCooldown: true, ConsecutiveErrorFreezeEnabled: true, ConsecutiveErrorFreezeThreshold: 2}},
+				ProviderAdapter: firstAdapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+			{
+				Route:           &domain.Route{ID: 11, TenantID: domain.DefaultTenantID, ProviderID: 32, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: 32, TenantID: domain.DefaultTenantID, Type: "custom", Name: "fallback-provider", Config: &domain.ProviderConfig{}},
+				ProviderAdapter: secondAdapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
+	e.settingsRepo = &stubExecutorSettingsRepo{values: map[string]string{domain.SettingKeyRateLimitCooldownDefaultSeconds: "15"}}
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if firstAdapter.calls != 2 {
+		t.Fatalf("first adapter calls = %d, want 2", firstAdapter.calls)
+	}
+	if secondAdapter.calls != 1 {
+		t.Fatalf("second adapter calls = %d, want 1", secondAdapter.calls)
+	}
+	if !cooldown.Default().IsInCooldown(31, string(domain.ClientTypeOpenAI), "gpt-4o") {
+		t.Fatal("first provider was not frozen after consecutive upstream errors")
+	}
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	}
+}
+
+func TestConsecutiveErrorFreezeIgnoresRequestScopedClientErrors(t *testing.T) {
+	provider := &domain.Provider{Config: &domain.ProviderConfig{DisableErrorCooldown: true, ConsecutiveErrorFreezeEnabled: true}}
+	proxyErr := domain.NewProxyErrorWithMessage(errors.New("bad request"), false, "bad request")
+	proxyErr.Scope = domain.ScopeRequest
+	proxyErr.HTTPStatusCode = http.StatusBadRequest
+
+	if shouldUseConsecutiveErrorFreeze(provider, proxyErr) {
+		t.Fatal("request-scoped 400 should not trigger consecutive provider freeze")
 	}
 }
 
@@ -469,7 +553,7 @@ func TestDispatchDisableErrorCooldownKeepsSmartMappingRetryOnSameProvider(t *tes
 }
 
 type canceledContextRetryAdapter struct {
-	calls int
+	calls atomic.Int32
 }
 
 func (a *canceledContextRetryAdapter) SupportedClientTypes() []domain.ClientType {
@@ -477,7 +561,7 @@ func (a *canceledContextRetryAdapter) SupportedClientTypes() []domain.ClientType
 }
 
 func (a *canceledContextRetryAdapter) Execute(*flow.Ctx, *domain.Provider) error {
-	a.calls++
+	a.calls.Add(1)
 	proxyErr := domain.NewProxyErrorWithMessage(errors.New("upstream retryable error"), true, "upstream retryable error")
 	proxyErr.Scope = domain.ScopeProvider
 	proxyErr.Reason = domain.CooldownReasonNetworkError
@@ -516,7 +600,7 @@ func TestDispatchDoesNotRetryAfterRequestContextCanceled(t *testing.T) {
 	e := newDisabledCooldownStreamTestExecutor(&recordingProxyRequestRepo{}, &recordingAttemptRepo{})
 
 	go func() {
-		for adapter.calls == 0 {
+		for adapter.calls.Load() == 0 {
 			time.Sleep(time.Millisecond)
 		}
 		cancel()
@@ -524,8 +608,8 @@ func TestDispatchDoesNotRetryAfterRequestContextCanceled(t *testing.T) {
 
 	e.dispatch(c)
 
-	if adapter.calls != 1 {
-		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	if calls := adapter.calls.Load(); calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1", calls)
 	}
 	if !errors.Is(c.Err, context.Canceled) {
 		t.Fatalf("dispatch error = %v, want context.Canceled", c.Err)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -438,10 +438,7 @@ func isConsecutiveErrorFreezeError(proxyErr *domain.ProxyError) bool {
 	if proxyErr == nil || proxyErr.Scope == domain.ScopeRequest {
 		return false
 	}
-	if proxyErr.Reason == domain.CooldownReasonServerError || proxyErr.Reason == domain.CooldownReasonNetworkError || proxyErr.Reason == domain.CooldownReasonRateLimitExceeded || proxyErr.Reason == domain.CooldownReasonConcurrentLimit {
-		return true
-	}
-	return proxyErr.HTTPStatusCode == http.StatusTooManyRequests || proxyErr.HTTPStatusCode >= 500
+	return proxyErr.HTTPStatusCode == http.StatusTooManyRequests
 }
 
 func applyDisabledErrorCooldownRetryPolicy(provider *domain.Provider, proxyErr *domain.ProxyError) {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -417,7 +417,31 @@ func shouldSkipErrorCooldown(provider *domain.Provider) bool {
 }
 
 func shouldSkipErrorCooldownUpdate(provider *domain.Provider, proxyErr *domain.ProxyError) bool {
-	return shouldSkipErrorCooldown(provider)
+	return shouldSkipErrorCooldown(provider) && !shouldUseConsecutiveErrorFreeze(provider, proxyErr)
+}
+
+func shouldUseConsecutiveErrorFreeze(provider *domain.Provider, proxyErr *domain.ProxyError) bool {
+	return provider != nil && provider.Config != nil && provider.Config.DisableErrorCooldown && provider.Config.ConsecutiveErrorFreezeEnabled && isConsecutiveErrorFreezeError(proxyErr)
+}
+
+func consecutiveErrorFreezeThreshold(provider *domain.Provider) int {
+	if provider == nil || provider.Config == nil || provider.Config.ConsecutiveErrorFreezeThreshold <= 0 {
+		return 3
+	}
+	if provider.Config.ConsecutiveErrorFreezeThreshold > 100 {
+		return 100
+	}
+	return provider.Config.ConsecutiveErrorFreezeThreshold
+}
+
+func isConsecutiveErrorFreezeError(proxyErr *domain.ProxyError) bool {
+	if proxyErr == nil || proxyErr.Scope == domain.ScopeRequest {
+		return false
+	}
+	if proxyErr.Reason == domain.CooldownReasonServerError || proxyErr.Reason == domain.CooldownReasonNetworkError || proxyErr.Reason == domain.CooldownReasonRateLimitExceeded || proxyErr.Reason == domain.CooldownReasonConcurrentLimit {
+		return true
+	}
+	return proxyErr.HTTPStatusCode == http.StatusTooManyRequests || proxyErr.HTTPStatusCode >= 500
 }
 
 func applyDisabledErrorCooldownRetryPolicy(provider *domain.Provider, proxyErr *domain.ProxyError) {

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -520,7 +520,7 @@ routeLoop:
 						string(currentClientType),
 						mappedModel,
 						cooldown.CooldownReason(proxyErr.Reason),
-						domain.ScopeProvider,
+						proxyErr.Scope,
 						e.rateLimitDefaultCooldownUntil(),
 						consecutiveErrorFreezeThreshold(matchedRoute.Provider),
 					)

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -342,6 +342,9 @@ routeLoop:
 				state.currentAttempt = nil
 
 				cooldown.Default().RecordSuccess(matchedRoute.Provider.ID, string(currentClientType), mappedModel)
+				if matchedRoute.Provider != nil && matchedRoute.Provider.Config != nil && matchedRoute.Provider.Config.ConsecutiveErrorFreezeEnabled {
+					cooldown.Default().ResetFailures(matchedRoute.Provider.ID, "", "")
+				}
 				if useSmartMappingRetry {
 					e.recordSmartMappingSuccess(smartMappingKey, mappedModel)
 				}
@@ -507,10 +510,34 @@ routeLoop:
 				return
 			}
 
+			providerFrozenAfterThreshold := false
 			if ok && ctx.Err() != context.Canceled {
 				log.Printf("[Executor] ProxyError - Scope: %s, Reason: %s, Retryable: %v, Provider: %d",
 					proxyErr.Scope, proxyErr.Reason, proxyErr.Retryable, matchedRoute.Provider.ID)
-				if !shouldSkipErrorCooldownUpdate(matchedRoute.Provider, proxyErr) && !shouldDeferNetworkErrorCooldown(proxyErr, attempt, retryConfig) {
+				if shouldUseConsecutiveErrorFreeze(matchedRoute.Provider, proxyErr) {
+					failureCount, freezeUntil := cooldown.Default().RecordFailureAfterThreshold(
+						matchedRoute.Provider.ID,
+						string(currentClientType),
+						mappedModel,
+						cooldown.CooldownReason(proxyErr.Reason),
+						domain.ScopeProvider,
+						e.rateLimitDefaultCooldownUntil(),
+						consecutiveErrorFreezeThreshold(matchedRoute.Provider),
+					)
+					providerFrozenAfterThreshold = !freezeUntil.IsZero()
+					log.Printf("[Executor] Provider %d consecutive upstream failure count=%d threshold=%d frozen=%v until=%s",
+						matchedRoute.Provider.ID,
+						failureCount,
+						consecutiveErrorFreezeThreshold(matchedRoute.Provider),
+						providerFrozenAfterThreshold,
+						freezeUntil.Format(time.RFC3339),
+					)
+					if providerFrozenAfterThreshold && e.broadcaster != nil {
+						e.broadcaster.BroadcastMessage("cooldown_update", map[string]interface{}{
+							"providerID": matchedRoute.Provider.ID,
+						})
+					}
+				} else if !shouldSkipErrorCooldownUpdate(matchedRoute.Provider, proxyErr) && !shouldDeferNetworkErrorCooldown(proxyErr, attempt, retryConfig) {
 					e.handleCooldown(proxyErr, matchedRoute.Provider, currentClientType, mappedModel)
 					if e.broadcaster != nil {
 						e.broadcaster.BroadcastMessage("cooldown_update", map[string]interface{}{
@@ -522,6 +549,11 @@ routeLoop:
 				log.Printf("[Executor] Client disconnected, skipping cooldown for Provider: %d", matchedRoute.Provider.ID)
 			} else if !ok {
 				log.Printf("[Executor] Error is not ProxyError, type: %T, error: %v", err, err)
+			}
+
+			if providerFrozenAfterThreshold {
+				log.Printf("[Executor] Provider %d reached consecutive error freeze threshold; failing over to next provider", matchedRoute.Provider.ID)
+				continue routeLoop
 			}
 
 			if !ok || !proxyErr.Retryable {

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -258,6 +258,8 @@ export interface ProviderModelCheckResponse {
 export interface ProviderConfig {
   quotaEnabled?: boolean;
   disableErrorCooldown?: boolean;
+  consecutiveErrorFreezeEnabled?: boolean;
+  consecutiveErrorFreezeThreshold?: number;
   smartMappingRetryEnabled?: boolean;
   smartMappingRetryLimit?: number;
   reasoning?: ReasoningPolicy;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1907,7 +1907,7 @@
     "consecutiveErrorFreeze": "Temporarily freeze after consecutive errors",
     "consecutiveErrorFreezeDesc": "When enabled, this provider is temporarily frozen after consecutive upstream-attributed errors reach the threshold, then routing falls through to later providers.",
     "consecutiveErrorFreezeThreshold": "Consecutive error threshold",
-    "consecutiveErrorFreezeHint": "Only upstream errors such as 5xx, 429, connection failures, timeouts, and stream interruptions are counted. 400/401/403, model-not-found, and invalid request errors do not freeze the provider. Freeze duration reuses the default cooldown setting."
+    "consecutiveErrorFreezeHint": "Only non-request-level HTTP 429 responses are counted. All other errors do not trigger this consecutive-error freeze. Freeze duration reuses the default cooldown setting."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1903,7 +1903,11 @@
       "max": "Max"
     },
     "quotaEnabled": "Enable Quota Check",
-    "quotaEnabledDesc": "When enabled, requests through this provider require the matching API token to have quota; tokens without quota are rejected."
+    "quotaEnabledDesc": "When enabled, requests through this provider require the matching API token to have quota; tokens without quota are rejected.",
+    "consecutiveErrorFreeze": "Temporarily freeze after consecutive errors",
+    "consecutiveErrorFreezeDesc": "When enabled, this provider is temporarily frozen after consecutive upstream-attributed errors reach the threshold, then routing falls through to later providers.",
+    "consecutiveErrorFreezeThreshold": "Consecutive error threshold",
+    "consecutiveErrorFreezeHint": "Only upstream errors such as 5xx, 429, connection failures, timeouts, and stream interruptions are counted. 400/401/403, model-not-found, and invalid request errors do not freeze the provider. Freeze duration reuses the default cooldown setting."
   },
   "cooldown": {
     "title": "Cooldown Protection",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1904,7 +1904,7 @@
     "consecutiveErrorFreeze": "连续错误后临时冻结",
     "consecutiveErrorFreezeDesc": "开启后，当该提供商连续发生可归因于上游的错误达到阈值时，会按全局冷却时间临时冻结，并切到后续提供商。",
     "consecutiveErrorFreezeThreshold": "连续错误阈值",
-    "consecutiveErrorFreezeHint": "只统计 5xx、429、连接失败、超时和流式中断等上游错误；400/401/403、模型不存在和参数错误不会触发冻结。冻结时长复用设置里的默认冷却时间。"
+    "consecutiveErrorFreezeHint": "只统计非请求级的 HTTP 429 错误；其他错误都不会触发这条连续错误冻结。冻结时长复用设置里的默认冷却时间。"
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1900,7 +1900,11 @@
       "max": "最高"
     },
     "quotaEnabled": "启用额度检查",
-    "quotaEnabledDesc": "开启后，使用该提供商的请求会检查对应 API 令牌的额度；令牌无额度时直接拦截。"
+    "quotaEnabledDesc": "开启后，使用该提供商的请求会检查对应 API 令牌的额度；令牌无额度时直接拦截。",
+    "consecutiveErrorFreeze": "连续错误后临时冻结",
+    "consecutiveErrorFreezeDesc": "开启后，当该提供商连续发生可归因于上游的错误达到阈值时，会按全局冷却时间临时冻结，并切到后续提供商。",
+    "consecutiveErrorFreezeThreshold": "连续错误阈值",
+    "consecutiveErrorFreezeHint": "只统计 5xx、429、连接失败、超时和流式中断等上游错误；400/401/403、模型不存在和参数错误不会触发冻结。冻结时长复用设置里的默认冷却时间。"
   },
   "cooldown": {
     "title": "冷却保护中",

--- a/web/src/pages/providers/components/consecutive-error-freeze-settings.tsx
+++ b/web/src/pages/providers/components/consecutive-error-freeze-settings.tsx
@@ -27,6 +27,7 @@ export function ConsecutiveErrorFreezeSettings({
   onThresholdChange,
 }: ConsecutiveErrorFreezeSettingsProps) {
   const { t } = useTranslation();
+  const thresholdInputId = 'consecutive-error-freeze-threshold';
 
   if (!disableErrorCooldown) return null;
 
@@ -47,10 +48,11 @@ export function ConsecutiveErrorFreezeSettings({
 
       {enabled && (
         <div className="grid gap-2 sm:grid-cols-[180px_1fr] sm:items-center">
-          <label className="text-xs font-medium text-foreground">
+          <label htmlFor={thresholdInputId} className="text-xs font-medium text-foreground">
             {t('provider.consecutiveErrorFreezeThreshold')}
           </label>
           <Input
+            id={thresholdInputId}
             type="number"
             min={1}
             max={100}

--- a/web/src/pages/providers/components/consecutive-error-freeze-settings.tsx
+++ b/web/src/pages/providers/components/consecutive-error-freeze-settings.tsx
@@ -1,0 +1,72 @@
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui';
+
+interface ConsecutiveErrorFreezeSettingsProps {
+  disableErrorCooldown: boolean;
+  enabled: boolean;
+  threshold: number;
+  onEnabledChange: (enabled: boolean) => void;
+  onThresholdChange: (threshold: number) => void;
+}
+
+export function normalizeConsecutiveErrorFreezeThreshold(value: number | undefined | null): number {
+  if (!Number.isFinite(value || 0)) return 3;
+  const integer = Math.trunc(Number(value));
+  if (integer <= 0) return 3;
+  if (integer > 100) return 100;
+  return integer;
+}
+
+export function ConsecutiveErrorFreezeSettings({
+  disableErrorCooldown,
+  enabled,
+  threshold,
+  onEnabledChange,
+  onThresholdChange,
+}: ConsecutiveErrorFreezeSettingsProps) {
+  const { t } = useTranslation();
+
+  if (!disableErrorCooldown) return null;
+
+  return (
+    <div className="space-y-3 rounded-xl border border-warning/30 bg-warning/5 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="pr-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+            <AlertTriangle className="h-4 w-4 text-warning" />
+            {t('provider.consecutiveErrorFreeze')}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('provider.consecutiveErrorFreezeDesc')}
+          </p>
+        </div>
+        <Switch checked={enabled} onCheckedChange={onEnabledChange} />
+      </div>
+
+      {enabled && (
+        <div className="grid gap-2 sm:grid-cols-[180px_1fr] sm:items-center">
+          <label className="text-xs font-medium text-foreground">
+            {t('provider.consecutiveErrorFreezeThreshold')}
+          </label>
+          <Input
+            type="number"
+            min={1}
+            max={100}
+            value={threshold}
+            onChange={(event) =>
+              onThresholdChange(
+                normalizeConsecutiveErrorFreezeThreshold(Number(event.target.value)),
+              )
+            }
+            className="h-9 max-w-32"
+          />
+          <div className="sm:col-span-2 text-xs text-muted-foreground">
+            {t('provider.consecutiveErrorFreezeHint')}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/providers/components/grok-provider-view.tsx
+++ b/web/src/pages/providers/components/grok-provider-view.tsx
@@ -13,6 +13,10 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import {
+  ConsecutiveErrorFreezeSettings,
+  normalizeConsecutiveErrorFreezeThreshold,
+} from './consecutive-error-freeze-settings';
 
 interface GrokProviderViewProps {
   provider: Provider;
@@ -32,6 +36,12 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
   const [baseURL, setBaseURL] = useState(grok?.baseURL || '');
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
+  );
+  const [consecutiveErrorFreezeEnabled, setConsecutiveErrorFreezeEnabled] = useState(
+    !!provider.config?.consecutiveErrorFreezeEnabled,
+  );
+  const [consecutiveErrorFreezeThreshold, setConsecutiveErrorFreezeThreshold] = useState(
+    normalizeConsecutiveErrorFreezeThreshold(provider.config?.consecutiveErrorFreezeThreshold),
   );
   const [maxConcurrency, setMaxConcurrency] = useState(
     normalizeMaxConcurrency(provider.maxConcurrency),
@@ -53,6 +63,8 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
         maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
+          consecutiveErrorFreezeEnabled: disableErrorCooldown && consecutiveErrorFreezeEnabled,
+          consecutiveErrorFreezeThreshold,
           grok: {
             type: 'xai',
             authKind: 'oauth',
@@ -130,10 +142,7 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
                 </label>
                 <Input value={name} onChange={(event) => setName(event.target.value)} />
               </div>
-              <ProviderMaxConcurrencyField
-                value={maxConcurrency}
-                onChange={setMaxConcurrency}
-              />
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
               <div>
                 <label className="mb-2 block text-sm font-medium text-foreground">
                   {t('addProvider.grok.email')}
@@ -188,6 +197,13 @@ export function GrokProviderView({ provider, onDelete, onClose }: GrokProviderVi
               </div>
               <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
             </div>
+            <ConsecutiveErrorFreezeSettings
+              disableErrorCooldown={disableErrorCooldown}
+              enabled={consecutiveErrorFreezeEnabled}
+              threshold={consecutiveErrorFreezeThreshold}
+              onEnabledChange={setConsecutiveErrorFreezeEnabled}
+              onThresholdChange={setConsecutiveErrorFreezeThreshold}
+            />
           </div>
 
           <div className="space-y-6">

--- a/web/src/pages/providers/components/newapi-provider-view.tsx
+++ b/web/src/pages/providers/components/newapi-provider-view.tsx
@@ -13,6 +13,10 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import {
+  ConsecutiveErrorFreezeSettings,
+  normalizeConsecutiveErrorFreezeThreshold,
+} from './consecutive-error-freeze-settings';
 
 const NEWAPI_CLIENT_TYPES = ['openai', 'claude', 'gemini'] as const;
 
@@ -48,6 +52,12 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [consecutiveErrorFreezeEnabled, setConsecutiveErrorFreezeEnabled] = useState(
+    !!provider.config?.consecutiveErrorFreezeEnabled,
+  );
+  const [consecutiveErrorFreezeThreshold, setConsecutiveErrorFreezeThreshold] = useState(
+    normalizeConsecutiveErrorFreezeThreshold(provider.config?.consecutiveErrorFreezeThreshold),
+  );
   const [maxConcurrency, setMaxConcurrency] = useState(
     normalizeMaxConcurrency(provider.maxConcurrency),
   );
@@ -73,6 +83,8 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
         maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
+          consecutiveErrorFreezeEnabled: disableErrorCooldown && consecutiveErrorFreezeEnabled,
+          consecutiveErrorFreezeThreshold,
           custom: {
             // Blank preserves the stored values for export-excluded providers.
             baseURL: baseURL.trim(),
@@ -143,10 +155,7 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
                 />
               </div>
 
-              <ProviderMaxConcurrencyField
-                value={maxConcurrency}
-                onChange={setMaxConcurrency}
-              />
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
 
               {!secretsAreWriteOnly && (
                 <div>
@@ -244,6 +253,13 @@ export function NewApiProviderView({ provider, onDelete, onClose }: NewApiProvid
               </div>
               <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
             </div>
+            <ConsecutiveErrorFreezeSettings
+              disableErrorCooldown={disableErrorCooldown}
+              enabled={consecutiveErrorFreezeEnabled}
+              threshold={consecutiveErrorFreezeThreshold}
+              onEnabledChange={setConsecutiveErrorFreezeEnabled}
+              onThresholdChange={setConsecutiveErrorFreezeThreshold}
+            />
           </div>
 
           {saveStatus === 'error' && (

--- a/web/src/pages/providers/components/ollama-provider-view.tsx
+++ b/web/src/pages/providers/components/ollama-provider-view.tsx
@@ -13,6 +13,10 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import {
+  ConsecutiveErrorFreezeSettings,
+  normalizeConsecutiveErrorFreezeThreshold,
+} from './consecutive-error-freeze-settings';
 
 interface OllamaProviderViewProps {
   provider: Provider;
@@ -35,6 +39,12 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [consecutiveErrorFreezeEnabled, setConsecutiveErrorFreezeEnabled] = useState(
+    !!provider.config?.consecutiveErrorFreezeEnabled,
+  );
+  const [consecutiveErrorFreezeThreshold, setConsecutiveErrorFreezeThreshold] = useState(
+    normalizeConsecutiveErrorFreezeThreshold(provider.config?.consecutiveErrorFreezeThreshold),
+  );
   const [maxConcurrency, setMaxConcurrency] = useState(
     normalizeMaxConcurrency(provider.maxConcurrency),
   );
@@ -56,6 +66,8 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
         maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
+          consecutiveErrorFreezeEnabled: disableErrorCooldown && consecutiveErrorFreezeEnabled,
+          consecutiveErrorFreezeThreshold,
           custom: {
             baseURL: baseURL.trim(),
             apiKey: apiKey.trim(),
@@ -125,10 +137,7 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
                 />
               </div>
 
-              <ProviderMaxConcurrencyField
-                value={maxConcurrency}
-                onChange={setMaxConcurrency}
-              />
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
 
               {!secretsAreWriteOnly && (
                 <div>
@@ -206,6 +215,13 @@ export function OllamaProviderView({ provider, onDelete, onClose }: OllamaProvid
               </div>
               <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
             </div>
+            <ConsecutiveErrorFreezeSettings
+              disableErrorCooldown={disableErrorCooldown}
+              enabled={consecutiveErrorFreezeEnabled}
+              threshold={consecutiveErrorFreezeThreshold}
+              onEnabledChange={setConsecutiveErrorFreezeEnabled}
+              onThresholdChange={setConsecutiveErrorFreezeThreshold}
+            />
           </div>
 
           {saveStatus === 'error' && (

--- a/web/src/pages/providers/components/openrouter-provider-view.tsx
+++ b/web/src/pages/providers/components/openrouter-provider-view.tsx
@@ -14,6 +14,10 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import {
+  ConsecutiveErrorFreezeSettings,
+  normalizeConsecutiveErrorFreezeThreshold,
+} from './consecutive-error-freeze-settings';
 
 interface OpenRouterProviderViewProps {
   provider: Provider;
@@ -49,6 +53,12 @@ export function OpenRouterProviderView({
   const [disableErrorCooldown, setDisableErrorCooldown] = useState(
     !!provider.config?.disableErrorCooldown,
   );
+  const [consecutiveErrorFreezeEnabled, setConsecutiveErrorFreezeEnabled] = useState(
+    !!provider.config?.consecutiveErrorFreezeEnabled,
+  );
+  const [consecutiveErrorFreezeThreshold, setConsecutiveErrorFreezeThreshold] = useState(
+    normalizeConsecutiveErrorFreezeThreshold(provider.config?.consecutiveErrorFreezeThreshold),
+  );
   const [maxConcurrency, setMaxConcurrency] = useState(
     normalizeMaxConcurrency(provider.maxConcurrency),
   );
@@ -74,6 +84,8 @@ export function OpenRouterProviderView({
         maxConcurrency: normalizeMaxConcurrency(maxConcurrency),
         config: {
           disableErrorCooldown,
+          consecutiveErrorFreezeEnabled: disableErrorCooldown && consecutiveErrorFreezeEnabled,
+          consecutiveErrorFreezeThreshold,
           openrouter: {
             // Blank preserves the stored key (backend keeps existing secret).
             apiKey: apiKey.trim(),
@@ -143,10 +155,7 @@ export function OpenRouterProviderView({
                 />
               </div>
 
-              <ProviderMaxConcurrencyField
-                value={maxConcurrency}
-                onChange={setMaxConcurrency}
-              />
+              <ProviderMaxConcurrencyField value={maxConcurrency} onChange={setMaxConcurrency} />
 
               <div>
                 <label className="text-sm font-medium text-foreground block mb-2">
@@ -231,6 +240,13 @@ export function OpenRouterProviderView({
               </div>
               <Switch checked={disableErrorCooldown} onCheckedChange={setDisableErrorCooldown} />
             </div>
+            <ConsecutiveErrorFreezeSettings
+              disableErrorCooldown={disableErrorCooldown}
+              enabled={consecutiveErrorFreezeEnabled}
+              threshold={consecutiveErrorFreezeThreshold}
+              onEnabledChange={setConsecutiveErrorFreezeEnabled}
+              onThresholdChange={setConsecutiveErrorFreezeThreshold}
+            />
           </div>
 
           {saveStatus === 'error' && (


### PR DESCRIPTION
## Summary
- make exception-switch freeze trigger only on explicit 429 upstream responses when disableErrorCooldown is enabled
- keep empty exception config as no-freeze/no-failover behavior and preserve existing disableErrorCooldown retry semantics for non-429 errors
- fix scoped cooldown recording, noctx/staticcheck review findings, and threshold input label/id wiring

## Test
- go test ./internal/executor -run 'TestDispatchDisableErrorCooldownRetriesHTTPErrorBeyondRetryBudget|TestDispatchDisableErrorCooldownDoesNotFreezeOn500WhenConsecutiveFreezeEnabled|TestDispatchDisableErrorCooldownFreezesAfterConsecutive429AndFailsOver|TestConsecutiveErrorFreezeIgnoresRequestScopedClientErrors|TestConsecutiveErrorFreezeIgnoresProvider500Errors' -v
- go test ./internal/executor/... ./internal/cooldown/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“连续错误冻结”设置，可配置启用开关及错误阈值（默认 3 次，支持 1–100 次）。
  - 提供商连续出现特定上游错误时会临时冻结，并自动切换至后备提供商。
  - 请求成功后自动重置连续失败计数。
  - 设置页面新增相关说明，明确会触发冻结的错误类型。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->