### PR TITLE
fix(router): skip bad provider instead of freezing all adapter reconcile

### DIFF
--- a/internal/router/reconcile_bad_provider_test.go
+++ b/internal/router/reconcile_bad_provider_test.go
@@ -1,0 +1,142 @@
+package router
+
+import (
+	"errors"
+
+	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+
+	"testing"
+)
+
+// wsRouterBadType simulates a provider whose adapter factory always fails,
+// e.g. the real-world fal provider created with an empty config where
+// NewAdapter returns an error when Config.Fal == nil.
+const wsRouterBadType = "responses-ws-router-bad-config-test"
+
+func init() {
+	provideradapter.RegisterAdapterFactory(wsRouterBadType, func(*domain.Provider) (provideradapter.ProviderAdapter, error) {
+		return nil, errors.New("bad provider: nil config")
+	})
+}
+
+// TestInitAdaptersSkipsBadProvider proves a single provider whose factory
+// errors does not abort adapter building for the rest.
+func TestInitAdaptersSkipsBadProvider(t *testing.T) {
+	providers := &wsRouterProviderRepo{providers: []*domain.Provider{
+		{
+			ID:                   901,
+			TenantID:             1,
+			Type:                 wsRouterBadType,
+			Name:                 "broken-config",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+		{
+			ID:                   902,
+			TenantID:             1,
+			Type:                 wsRouterNativeType,
+			Name:                 "healthy",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+	}}
+
+	providerRepo := cached.NewProviderRepository(providers)
+	if err := providerRepo.Load(); err != nil {
+		t.Fatalf("load providers: %v", err)
+	}
+	r := NewRouter(
+		cached.NewRouteRepository(&wsRouterRouteRepo{}),
+		providerRepo,
+		cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{}),
+		cached.NewRetryConfigRepository(wsRouterRetryRepo{}),
+		cached.NewProjectRepository(&wsRouterProjectRepo{}),
+	)
+
+	// The broken provider must not abort InitAdapters.
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters returned error for one bad provider: %v", err)
+	}
+	if _, ok := r.GetAdapter(901); ok {
+		t.Fatal("bad provider unexpectedly got a live adapter")
+	}
+	if _, ok := r.GetAdapter(902); !ok {
+		t.Fatal("healthy provider was poisoned by the bad provider (no live adapter)")
+	}
+}
+
+// TestReconcileAdaptersSkipsBadProvider proves that when a bad provider is
+// added on a provider-invalidation reconcile, a newly added good provider
+// still gets a live adapter (the poison bug from the hubitos incident).
+func TestReconcileAdaptersSkipsBadProvider(t *testing.T) {
+	providers := &wsRouterProviderRepo{providers: []*domain.Provider{
+		{
+			ID:                   911,
+			TenantID:             1,
+			Type:                 wsRouterNativeType,
+			Name:                 "existing-healthy",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+	}}
+
+	providerRepo := cached.NewProviderRepository(providers)
+	if err := providerRepo.Load(); err != nil {
+		t.Fatalf("load providers: %v", err)
+	}
+	r := NewRouter(
+		cached.NewRouteRepository(&wsRouterRouteRepo{}),
+		providerRepo,
+		cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{}),
+		cached.NewRetryConfigRepository(wsRouterRetryRepo{}),
+		cached.NewProjectRepository(&wsRouterProjectRepo{}),
+	)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+	if _, ok := r.GetAdapter(911); !ok {
+		t.Fatal("missing initial healthy adapter")
+	}
+
+	// Add a bad provider (empty-config fal) AND a new good provider, mimicking
+	// a cross-instance provider-invalidation broadcast.
+	providers.providers = []*domain.Provider{
+		{
+			ID:                   911,
+			TenantID:             1,
+			Type:                 wsRouterNativeType,
+			Name:                 "existing-healthy",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+		{
+			ID:                   912,
+			TenantID:             1,
+			Type:                 wsRouterBadType,
+			Name:                 "broken-config",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+		{
+			ID:                   913,
+			TenantID:             1,
+			Type:                 wsRouterNativeType,
+			Name:                 "newly-added-healthy",
+			SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex},
+		},
+	}
+	if err := providerRepo.Load(); err != nil {
+		t.Fatalf("reload providers: %v", err)
+	}
+
+	if err := r.ReconcileAdapters(); err != nil {
+		t.Fatalf("ReconcileAdapters aborted wholesale on one bad provider: %v", err)
+	}
+
+	if _, ok := r.GetAdapter(911); !ok {
+		t.Fatal("existing healthy provider lost its adapter after reconcile")
+	}
+	if _, ok := r.GetAdapter(912); ok {
+		t.Fatal("bad provider unexpectedly got a live adapter")
+	}
+	if _, ok := r.GetAdapter(913); !ok {
+		t.Fatal("newly added healthy provider never got a live adapter (poison bug)")
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -137,7 +137,11 @@ func (r *Router) InitAdapters() error {
 		}
 		a, err := factory(p)
 		if err != nil {
-			return err
+			// A single mis-configured provider (e.g. empty config) must not
+			// abort building adapters for every other provider. Log and skip
+			// it so the rest still get live adapters.
+			log.Printf("[Router] InitAdapters: skipping provider %d (%s): factory error: %v", p.ID, p.Type, err)
+			continue
 		}
 		r.injectProviderUpdate(a, p)
 		next[p.ID] = a
@@ -186,7 +190,11 @@ func (r *Router) ReconcileAdapters() error {
 		}
 		a, err := factory(p)
 		if err != nil {
-			return err
+			// A single mis-configured provider must not abort reconciliation
+			// for every other provider (which would freeze hot-reload until a
+			// full restart). Log and skip it so the rest still reconcile.
+			log.Printf("[Router] ReconcileAdapters: skipping provider %d (%s): factory error: %v", p.ID, p.Type, err)
+			continue
 		}
 		r.injectProviderUpdate(a, p)
 		next[p.ID] = a


### PR DESCRIPTION
## Incident

On hubitos, a `fal` provider was created with an **empty config** (an old CLI dropped the key). `NewAdapter` for `fal` returns an error when `Config.Fal == nil`.

That single broken provider **poisoned the entire adapter map** and froze hot-reload for **all** providers until a full process restart. A newly added, correctly-configured provider never got a live adapter.

## Root cause (wholesale `return err`)

In `internal/router/router.go`, both adapter-building loops bailed out entirely the moment any one provider's `factory(p)` errored:

- `InitAdapters()` — on error did `return err`, aborting building the **whole** adapter map at boot.
- `ReconcileAdapters()` — on error did `return err`. This runs on the cross-instance provider-invalidation broadcast (`internal/core/coordinator_setup.go`). `CachedProviderRepo.Load()` succeeds — so provider metadata / `/v1/models` update — but `ReconcileAdapters()` returns err, so the adapter map is **never swapped** under `mu.Lock`. Any newly added good provider stays without a live adapter. Only a restart fixes it.

## Fix (log + continue)

Make both functions resilient to a single provider whose `factory(p)` errors: instead of `return err`, log a `[Router]` message and `continue` to the next provider. One broken provider can no longer freeze adapter building/reconciliation for everyone else.

All other behavior is preserved: fingerprints, `changedProviderIDs` bookkeeping, the `mu.Lock` swap, and `ClearResponsesWebSocketTransportCooldown` calls are unchanged. Factory signatures and `NewAdapter` are untouched.

## Test

Adds `internal/router/reconcile_bad_provider_test.go` with a fake provider type whose factory always errors (mimicking empty-config fal):

- `TestInitAdaptersSkipsBadProvider` — one bad provider does not abort init; the healthy provider still gets a live adapter.
- `TestReconcileAdaptersSkipsBadProvider` — adding a bad provider alongside a new good provider on reconcile no longer aborts wholesale; the existing and the newly added healthy providers both keep/get live adapters, while the bad one gets none.

### Verification
- `go build ./...` — clean
- `go test ./internal/router/... ./internal/core/...` — pass
- `gofmt -l internal/router/` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进路由器适配器初始化与更新流程：单个服务提供方发生错误时，系统会记录问题并继续处理其他提供方。
  * 健康的服务提供方仍可正常创建或更新适配器，故障提供方不会影响整体运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->