### PR TITLE
fix(security): redact fal provider apiKey in admin provider API

### DIFF
--- a/internal/handler/sanitize_provider_fal_test.go
+++ b/internal/handler/sanitize_provider_fal_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// TestSanitizeProviderRedactsFalAPIKey guards against leaking the fal provider's
+// full "id:secret" API key through the admin provider API. Before the fal branch
+// existed in sanitizeProvider, GET /api/admin/providers/{id} returned
+// config.fal.apiKey in cleartext.
+func TestSanitizeProviderRedactsFalAPIKey(t *testing.T) {
+	provider := &domain.Provider{
+		Type:                 "fal",
+		SupportModels:        []string{"fal-ai/flux/dev"},
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeVideo},
+		Config: &domain.ProviderConfig{
+			Fal: &domain.ProviderConfigFal{APIKey: "id:secret"},
+		},
+	}
+
+	sanitized := sanitizeProvider(provider)
+	if sanitized == nil {
+		t.Fatal("sanitizeProvider returned nil")
+	}
+	if sanitized.Config == nil || sanitized.Config.Fal == nil {
+		t.Fatal("sanitized fal config missing")
+	}
+	if got := sanitized.Config.Fal.APIKey; got != "" {
+		t.Fatalf("expected fal APIKey to be redacted, got %q", got)
+	}
+
+	// Non-secret fields must survive sanitization.
+	if sanitized.Type != "fal" {
+		t.Fatalf("expected type %q, got %q", "fal", sanitized.Type)
+	}
+	if len(sanitized.SupportModels) != 1 || sanitized.SupportModels[0] != "fal-ai/flux/dev" {
+		t.Fatalf("supportModels not preserved: %v", sanitized.SupportModels)
+	}
+	if len(sanitized.SupportedClientTypes) != 1 || sanitized.SupportedClientTypes[0] != domain.ClientTypeVideo {
+		t.Fatalf("supportedClientTypes not preserved: %v", sanitized.SupportedClientTypes)
+	}
+
+	// Original provider must not be mutated.
+	if provider.Config.Fal.APIKey != "id:secret" {
+		t.Fatalf("original provider APIKey mutated: %q", provider.Config.Fal.APIKey)
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1792,6 +1792,11 @@ func sanitizeProvider(provider *domain.Provider) *domain.Provider {
 		grok.IDToken = ""
 		config.Grok = &grok
 	}
+	if config.Fal != nil {
+		fal := *config.Fal
+		fal.APIKey = ""
+		config.Fal = &fal
+	}
 	sanitized.Config = &config
 	return &sanitized
 }


### PR DESCRIPTION
## The leak

`GET /api/admin/providers/{id}` for a **fal** provider returned the provider's full `config.fal.apiKey` — the complete `id:secret` string — in **cleartext**.

`sanitizeProvider` (`internal/handler/self_service.go`) is responsible for blanking each provider type's secret field before the config is returned to API clients: `config.Custom.APIKey`, `config.Antigravity.RefreshToken`, `config.Bedrock.SecretAccessKey`, `config.Kiro.*`, `config.Codex.*`, `config.Claude.*`, `config.OpenRouter.APIKey`, `config.Zai.APIKey`, `config.Grok.*`. But it had **no branch for `config.Fal`**, so the fal key was never redacted. Confirmed live.

`domain.ProviderConfigFal` has a single secret field, `APIKey string` (the `id:secret` credential injected as `Authorization: Key <apiKey>`).

## The fix

Add a fal branch to `sanitizeProvider`, mirroring the existing OpenRouter / Zai / Grok blocks: when `config.Fal != nil`, copy it and clear `.APIKey` before reassigning. This is analogous to the recently merged auth-header redaction hardening (#832) — same class of "secret must be redacted before leaving the server" fix.

```go
if config.Fal != nil {
	fal := *config.Fal
	fal.APIKey = ""
	config.Fal = &fal
}
```

## The test

Adds `TestSanitizeProviderRedactsFalAPIKey` (`internal/handler/sanitize_provider_fal_test.go`): constructs a `fal` provider with `Config.Fal.APIKey = "id:secret"`, calls `sanitizeProvider`, and asserts:
- the returned `config.fal.apiKey` is emptied,
- non-secret fields survive (`type`, `supportModels`, `supportedClientTypes`),
- the original provider is not mutated (copy-on-sanitize).

## Verification
- `go build ./...` — passes
- `go test ./internal/handler/...` — passes (new test PASS)
- `gofmt -l` on the changed files — clean

No real credentials appear anywhere; the test uses a fake `id:secret`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)