### PR TITLE
fix(executor): retry interrupted upstream streams

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -96,49 +96,52 @@ func (a *disabledCooldown429Adapter) Execute(_ *flow.Ctx, _ *domain.Provider) er
 	return proxyErr
 }
 
-func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
+func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownDisabled(t *testing.T) {
 	c, adapter, attemptRepo, proxyRepo := newDisabledCooldownStreamDispatchCtx(true)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, attemptRepo)
 
 	e.dispatch(c)
 
-	if c.Err == nil {
-		t.Fatal("expected committed stream read error")
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
 	}
-	if adapter.calls != 1 {
-		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
 	}
-	if len(attemptRepo.created) != 1 {
-		t.Fatalf("created attempts = %d, want 1", len(attemptRepo.created))
+	if len(attemptRepo.created) != 2 {
+		t.Fatalf("created attempts = %d, want 2", len(attemptRepo.created))
 	}
-	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "FAILED" {
-		t.Fatalf("attempt status = %q, want FAILED", got)
+	if got := attemptRepo.updated[0].Status; got != "FAILED" {
+		t.Fatalf("first attempt status = %q, want FAILED", got)
 	}
-	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\n" {
+	if got := attemptRepo.updated[len(attemptRepo.updated)-1].Status; got != "COMPLETED" {
+		t.Fatalf("final attempt status = %q, want COMPLETED", got)
+	}
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
 		t.Fatalf("client body = %q", got)
 	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
-		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
 	}
 }
 
-func TestDispatchDoesNotRetryCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
+func TestDispatchRetriesCommittedStreamReadErrorWhenErrorCooldownEnabled(t *testing.T) {
 	c, adapter, _, proxyRepo := newDisabledCooldownStreamDispatchCtx(false)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
 
 	e.dispatch(c)
 
-	if c.Err == nil {
-		t.Fatal("expected committed stream read error")
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
 	}
-	if adapter.calls != 1 {
-		t.Fatalf("adapter calls = %d, want 1", adapter.calls)
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
 	}
-	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\n" {
+	if got := c.Writer.(*httptest.ResponseRecorder).Body.String(); got != "data: partial\n\ndata: fallback\n\ndata: [DONE]\n\n" {
 		t.Fatalf("client body = %q", got)
 	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
-		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
+		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
 	}
 }
 
@@ -913,4 +916,64 @@ func newDisabledCooldownHTTPErrorDispatchCtx(disableErrorCooldown bool, maxRetri
 	}
 	c.Set(flow.KeyExecutorState, state)
 	return c, adapter, attemptRepo, proxyRepo
+}
+
+func TestCommittedStreamReadRetryClassifierMatchesRemoteResetVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		err  error
+	}{
+		{
+			name: "reported wsarecv reset after response started",
+			msg:  "upstream stream read error after response started",
+			err:  errors.New("read tcp 192.168.1.169:57843->upstream: wsarecv: An existing connection was forcibly closed by the remote host"),
+		},
+		{
+			name: "http2 stream reset",
+			msg:  "upstream stream read error after response started",
+			err:  errors.New("stream error: stream ID 1; INTERNAL_ERROR; received from peer"),
+		},
+		{
+			name: "unexpected eof after first chunk",
+			msg:  "upstream response stream was interrupted",
+			err:  errors.New("unexpected EOF"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxyErr := domain.NewProxyErrorWithMessage(tc.err, false, tc.msg)
+			proxyErr.Scope = domain.ScopeProvider
+			proxyErr.Reason = domain.CooldownReasonNetworkError
+
+			if !isCommittedStreamReadRetryableError(proxyErr) {
+				t.Fatalf("expected retryable committed stream read error: %v", proxyErr)
+			}
+			applyCommittedStreamReadRetryPolicy(proxyErr)
+			if !proxyErr.Retryable {
+				t.Fatal("expected policy to mark error retryable")
+			}
+			if !shouldRetryCommittedResponseError(proxyErr) {
+				t.Fatal("expected committed response guard to allow this retry")
+			}
+		})
+	}
+}
+
+func TestCommittedStreamReadRetryClassifierRejectsHTTPAndRequestErrors(t *testing.T) {
+	providerHTTPError := domain.NewProxyErrorWithMessage(errors.New("upstream returned 500"), true, "upstream returned 500")
+	providerHTTPError.Scope = domain.ScopeProvider
+	providerHTTPError.Reason = domain.CooldownReasonServerError
+	providerHTTPError.HTTPStatusCode = http.StatusInternalServerError
+	if isCommittedStreamReadRetryableError(providerHTTPError) || shouldRetryCommittedResponseError(providerHTTPError) {
+		t.Fatal("committed HTTP errors must not be replayed after downstream bytes were written")
+	}
+
+	requestError := domain.NewProxyErrorWithMessage(errors.New("client disconnected"), false, "client disconnected")
+	requestError.Scope = domain.ScopeRequest
+	requestError.Reason = domain.CooldownReasonNetworkError
+	if isCommittedStreamReadRetryableError(requestError) || shouldRetryCommittedResponseError(requestError) {
+		t.Fatal("request/client errors must not be retried as committed stream read failures")
+	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -516,16 +516,28 @@ func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
 	if proxyErr.Reason != domain.CooldownReasonNetworkError {
 		return false
 	}
+	if proxyErr.HTTPStatusCode != 0 {
+		return false
+	}
 	msg := proxyErr.Message
 	if proxyErr.Err != nil {
 		msg += " " + proxyErr.Err.Error()
 	}
 	msg = strings.ToLower(msg)
-	return false
+	return strings.Contains(msg, "upstream stream read error after response started") ||
+		strings.Contains(msg, "upstream response stream was interrupted") ||
+		strings.Contains(msg, "stream transport reset") ||
+		strings.Contains(msg, "wsarecv") ||
+		strings.Contains(msg, "forcibly closed by the remote host") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "stream id") ||
+		strings.Contains(msg, "internal_error") ||
+		strings.Contains(msg, "unexpected eof") ||
+		strings.Contains(msg, "premature eof")
 }
 
 func shouldRetryCommittedResponseError(proxyErr *domain.ProxyError) bool {
-	return false
+	return isCommittedStreamReadRetryableError(proxyErr)
 }
 
 func isBedrockAdaptiveThinkingSchemaError(proxyErr *domain.ProxyError) bool {


### PR DESCRIPTION
## Summary
- retry provider-scoped committed stream read interruptions such as `wsarecv: forcibly closed by the remote host`
- keep committed-response retry limited to network stream-read failures without HTTP status
- preserve guards for HTTP errors, request/client errors, canceled contexts, retry budget, and hard attempt ceiling

## Validation
- `go test ./internal/executor ./internal/adapter/provider/custom`
- `go test ./...`
- `cd web && pnpm typecheck && pnpm build`
- 200 focused retry regression iterations
- `go test -race ./internal/executor -run 'TestDispatchRetriesCommittedStreamReadError|TestDispatchDoesNotRetryCommittedStreamReadErrorWithoutRetryBudget|TestCommittedStreamReadRetryClassifier|TestDispatchDoesNotRetryAfterRequestContextCanceled|TestDispatchHardCapsRunawayRetryableErrors' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 改进流式响应读取失败的自动重试能力。
  - 对连接重置、流重置和意外结束等常见中断进行恢复，完成请求并合并已接收内容。
  - 避免将 HTTP 错误和请求级错误误判为可重试的流读取错误。
  - 在启用或禁用错误冷却机制时，均能正确处理可恢复的读取失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->