### PR TITLE
fix(executor): surface real first-provider error on catch-all fallthrough

### DIFF
--- a/internal/executor/fallthrough_error.go
+++ b/internal/executor/fallthrough_error.go
@@ -1,0 +1,149 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxSurfacedErrorMessageLen bounds the upstream error snippet we fold into the
+// surfaced/logged summary so a large upstream error body can't bloat the client
+// response or a log line. Enough to keep the meaningful part (e.g. a status +
+// short JSON detail) while staying compact.
+const maxSurfacedErrorMessageLen = 300
+
+// attemptFailure is a compact, secret-free record of a single failed upstream
+// attempt. It is only ever built from provider ids and upstream status/message
+// text — never from request/response headers — so it is always safe to surface
+// to the client and to logs.
+type attemptFailure struct {
+	providerID uint64
+	status     int
+	message    string
+}
+
+// summary renders a single failed attempt as "provider N: <status> <message>".
+func (f attemptFailure) summary() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "provider %d", f.providerID)
+	if f.status > 0 {
+		fmt.Fprintf(&b, ": %d", f.status)
+	} else {
+		b.WriteString(":")
+	}
+	if f.message != "" {
+		b.WriteString(" ")
+		b.WriteString(f.message)
+	}
+	return b.String()
+}
+
+// newAttemptFailure builds a secret-free summary of a failed upstream attempt.
+// It reads only the provider id and the error's own message/status — the error
+// message is an upstream status/body snippet, which already excludes auth
+// headers (those are redacted before persistence elsewhere). The message is
+// truncated so no oversized upstream body leaks into the surfaced error or log.
+func newAttemptFailure(providerID uint64, err error) attemptFailure {
+	f := attemptFailure{providerID: providerID}
+	if err == nil {
+		return f
+	}
+	if proxyErr, ok := asProxyError(err); ok {
+		if proxyErr.HTTPStatusCode >= 400 && proxyErr.HTTPStatusCode < 600 {
+			f.status = proxyErr.HTTPStatusCode
+		}
+	}
+	f.message = truncateForSurface(strings.TrimSpace(err.Error()))
+	return f
+}
+
+func truncateForSurface(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= maxSurfacedErrorMessageLen {
+		return s
+	}
+	return s[:maxSurfacedErrorMessageLen] + "…"
+}
+
+// attemptTrailSummary renders the whole failed-attempt chain as a single
+// "provider A: ... -> provider B: ..." string for one-line WARN logging.
+func attemptTrailSummary(trail []attemptFailure) string {
+	parts := make([]string, 0, len(trail))
+	for _, f := range trail {
+		parts = append(parts, f.summary())
+	}
+	return strings.Join(parts, " -> ")
+}
+
+// firstInformativeFailure returns the earliest recorded attempt failure that
+// carries a distinctive upstream signal (an HTTP status or a non-empty
+// message). The first provider tried is usually the one with the real cause
+// (e.g. "fal returned status 403: User is locked"), which a later catch-all
+// provider's unrelated error (e.g. "404 no model found") would otherwise mask.
+func firstInformativeFailure(trail []attemptFailure) (attemptFailure, bool) {
+	for _, f := range trail {
+		if f.status > 0 || f.message != "" {
+			return f, true
+		}
+	}
+	return attemptFailure{}, false
+}
+
+// trailInvolvesMultipleProviders reports whether the recorded failures span
+// more than one distinct provider — i.e. an actual cross-provider fallthrough
+// happened, as opposed to same-provider retries. Only then is surfacing the
+// first provider's error useful (it would otherwise be identical to the final
+// error).
+func trailInvolvesMultipleProviders(trail []attemptFailure) bool {
+	var first uint64
+	seen := false
+	for _, f := range trail {
+		if !seen {
+			first = f.providerID
+			seen = true
+			continue
+		}
+		if f.providerID != first {
+			return true
+		}
+	}
+	return false
+}
+
+// augmentFallthroughError, when a request fails after failing over across more
+// than one provider, folds a short summary of the first informative upstream
+// error into the final error's message. This makes the true first-provider
+// cause observable to the client instead of only the last (often catch-all)
+// provider's unrelated error. Routing/failover behavior is unchanged — this
+// only enriches the surfaced message. It returns the (possibly mutated) error,
+// the first informative failure, and a bool indicating whether augmentation was
+// applied.
+func augmentFallthroughError(finalErr error, trail []attemptFailure) (error, attemptFailure, bool) {
+	if finalErr == nil {
+		return finalErr, attemptFailure{}, false
+	}
+	if !trailInvolvesMultipleProviders(trail) {
+		return finalErr, attemptFailure{}, false
+	}
+	first, ok := firstInformativeFailure(trail)
+	if !ok {
+		return finalErr, attemptFailure{}, false
+	}
+
+	proxyErr, ok := asProxyError(finalErr)
+	if !ok {
+		return finalErr, first, false
+	}
+	// Don't restate the same thing if the final error already carries the first
+	// provider's error (nothing was masked).
+	if first.message != "" && strings.Contains(proxyErr.Error(), first.message) {
+		return finalErr, attemptFailure{}, false
+	}
+
+	note := "first upstream " + first.summary()
+	if proxyErr.Message != "" {
+		proxyErr.Message = proxyErr.Message + " [" + note + "]"
+	} else {
+		proxyErr.Message = note
+	}
+	return proxyErr, first, true
+}

--- a/internal/executor/fallthrough_error_test.go
+++ b/internal/executor/fallthrough_error_test.go
@@ -1,0 +1,222 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/cooldown"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+// staticErrorAdapter is a provider adapter that always returns a fixed error,
+// modeling one hop of a cross-provider fallthrough.
+type staticErrorAdapter struct {
+	err   error
+	calls int
+}
+
+func (a *staticErrorAdapter) SupportedClientTypes() []domain.ClientType {
+	return []domain.ClientType{domain.ClientTypeOpenAI}
+}
+
+func (a *staticErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error {
+	a.calls++
+	return a.err
+}
+
+// TestDispatchSurfacesFirstUpstreamErrorAfterCatchAllFallthrough reproduces the
+// real incident: a request is routed to the fal provider first, which returns a
+// meaningful "403 User is locked / balance" error; maxx fails over to an
+// OpenAI-compatible catch-all (OpenRouter) which returns an unrelated "404 no
+// model found". Before the fix the client saw ONLY the 404, masking the real
+// cause. The surfaced final error must now reference the first provider's real
+// 403 balance error too.
+func TestDispatchSurfacesFirstUpstreamErrorAfterCatchAllFallthrough(t *testing.T) {
+	const falProviderID = uint64(12)
+	const catchAllProviderID = uint64(1)
+	cooldown.Default().ClearCooldown(falProviderID, "", "")
+	cooldown.Default().ClearCooldown(catchAllProviderID, "", "")
+	defer cooldown.Default().ClearCooldown(falProviderID, "", "")
+	defer cooldown.Default().ClearCooldown(catchAllProviderID, "", "")
+
+	// First provider (fal): meaningful, retryable key-scoped error → fails over.
+	falErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeKey, domain.CooldownReasonQuotaExhausted)
+	falErr.Message = `fal returned status 403: {"detail":"User is locked. Reason: TOP_UP."}`
+	falErr.HTTPStatusCode = http.StatusForbidden
+	falAdapter := &staticErrorAdapter{err: falErr}
+
+	// Catch-all provider (OpenRouter): unrelated 404, terminal.
+	catchAllErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeModel, domain.CooldownReasonModelUnavailable)
+	catchAllErr.Message = `404 {"error":{"message":"No model found for \"fal-ai/flux/schnell\"","code":404}}`
+	catchAllErr.HTTPStatusCode = http.StatusNotFound
+	catchAllErr.Retryable = false
+	catchAllAdapter := &staticErrorAdapter{err: catchAllErr}
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	attemptRepo := &recordingAttemptRepo{}
+	e := &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      attemptRepo,
+		modelMappingRepo: &stubModelMappingRepo{},
+		settingsRepo:     &stubExecutorSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	const uri = "/v1/chat/completions"
+	body := `{"model":"fal-ai/flux/schnell"}`
+	req := httptest.NewRequest(http.MethodPost, uri, strings.NewReader(body)).WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{
+		ID:           303,
+		TenantID:     domain.DefaultTenantID,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "fal-ai/flux/schnell",
+		Status:       "IN_PROGRESS",
+		StartTime:    time.Now(),
+	}
+	noRetry := &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0}
+	state := &execState{
+		ctx:                 context.Background(),
+		proxyReq:            proxyReq,
+		tenantID:            domain.DefaultTenantID,
+		clientType:          domain.ClientTypeOpenAI,
+		requestModel:        "fal-ai/flux/schnell",
+		requestBody:         []byte(body),
+		originalRequestBody: []byte(body),
+		requestHeaders:      http.Header{"Content-Type": []string{"application/json"}},
+		requestURI:          uri,
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 1, TenantID: domain.DefaultTenantID, ProviderID: falProviderID, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: falProviderID, TenantID: domain.DefaultTenantID, Type: "fal", Name: "fal"},
+				ProviderAdapter: falAdapter,
+				RetryConfig:     noRetry,
+			},
+			{
+				Route:           &domain.Route{ID: 2, TenantID: domain.DefaultTenantID, ProviderID: catchAllProviderID, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: catchAllProviderID, TenantID: domain.DefaultTenantID, Type: "openrouter", Name: "openrouter"},
+				ProviderAdapter: catchAllAdapter,
+				RetryConfig:     noRetry,
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail after both providers errored")
+	}
+	if falAdapter.calls != 1 {
+		t.Fatalf("fal adapter calls = %d, want 1", falAdapter.calls)
+	}
+	if catchAllAdapter.calls != 1 {
+		t.Fatalf("catch-all adapter calls = %d, want 1 (fallthrough must still occur)", catchAllAdapter.calls)
+	}
+
+	surfaced := c.Err.Error()
+	// The real first-provider cause must be observable in the surfaced error.
+	if !strings.Contains(surfaced, "provider 12") {
+		t.Fatalf("surfaced error does not reference first provider (12): %q", surfaced)
+	}
+	if !strings.Contains(surfaced, "User is locked") {
+		t.Fatalf("surfaced error masked the real 403 balance cause: %q", surfaced)
+	}
+	// The final catch-all 404 should still be present (we augment, not replace).
+	if !strings.Contains(surfaced, "No model found") {
+		t.Fatalf("surfaced error dropped the final catch-all error: %q", surfaced)
+	}
+
+	// The persisted proxy request error must carry the surfaced (augmented) text.
+	if len(proxyRepo.updated) == 0 {
+		t.Fatal("expected proxy request updates")
+	}
+	finalReq := proxyRepo.updated[len(proxyRepo.updated)-1]
+	if finalReq.Status != "FAILED" {
+		t.Fatalf("final proxy request status = %q, want FAILED", finalReq.Status)
+	}
+	if !strings.Contains(finalReq.Error, "User is locked") {
+		t.Fatalf("persisted request error masked the real cause: %q", finalReq.Error)
+	}
+
+	// No secrets: the summary is built only from provider ids + upstream
+	// status/message, never from headers/keys.
+	if strings.Contains(surfaced, "Authorization") || strings.Contains(surfaced, "Bearer ") {
+		t.Fatalf("surfaced error unexpectedly contains auth material: %q", surfaced)
+	}
+}
+
+// TestDispatchSingleProviderErrorNotAugmented ensures the surfacing logic only
+// fires on genuine cross-provider fallthrough — a single provider's error is
+// returned verbatim, with no "first upstream" note (nothing was masked).
+func TestDispatchSingleProviderErrorNotAugmented(t *testing.T) {
+	const providerID = uint64(77)
+	cooldown.Default().ClearCooldown(providerID, "", "")
+	defer cooldown.Default().ClearCooldown(providerID, "", "")
+
+	onlyErr := domain.NewScopedProxyError(domain.ErrUpstreamError, domain.ScopeModel, domain.CooldownReasonModelUnavailable)
+	onlyErr.Message = `404 {"error":{"message":"boom"}}`
+	onlyErr.HTTPStatusCode = http.StatusNotFound
+	onlyErr.Retryable = false
+	adapter := &staticErrorAdapter{err: onlyErr}
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	e := &Executor{
+		proxyRequestRepo: proxyRepo,
+		attemptRepo:      &recordingAttemptRepo{},
+		modelMappingRepo: &stubModelMappingRepo{},
+		settingsRepo:     &stubExecutorSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	const uri = "/v1/chat/completions"
+	body := `{"model":"m"}`
+	req := httptest.NewRequest(http.MethodPost, uri, strings.NewReader(body)).WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+
+	proxyReq := &domain.ProxyRequest{
+		ID:           304,
+		TenantID:     domain.DefaultTenantID,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "m",
+		Status:       "IN_PROGRESS",
+		StartTime:    time.Now(),
+	}
+	state := &execState{
+		ctx:                 context.Background(),
+		proxyReq:            proxyReq,
+		tenantID:            domain.DefaultTenantID,
+		clientType:          domain.ClientTypeOpenAI,
+		requestModel:        "m",
+		requestBody:         []byte(body),
+		originalRequestBody: []byte(body),
+		requestHeaders:      http.Header{"Content-Type": []string{"application/json"}},
+		requestURI:          uri,
+		routes: []*router.MatchedRoute{
+			{
+				Route:           &domain.Route{ID: 1, TenantID: domain.DefaultTenantID, ProviderID: providerID, ClientType: domain.ClientTypeOpenAI},
+				Provider:        &domain.Provider{ID: providerID, TenantID: domain.DefaultTenantID, Type: "custom", Name: "solo"},
+				ProviderAdapter: adapter,
+				RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+			},
+		},
+	}
+	c.Set(flow.KeyExecutorState, state)
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail")
+	}
+	if strings.Contains(c.Err.Error(), "first upstream") {
+		t.Fatalf("single-provider error should not be augmented with a first-upstream note: %q", c.Err.Error())
+	}
+}

--- a/internal/executor/flow_state.go
+++ b/internal/executor/flow_state.go
@@ -17,6 +17,16 @@ type execState struct {
 	currentAttempt *domain.ProxyUpstreamAttempt
 	lastErr        error
 
+	// attemptTrail records a one-line summary of every failed upstream attempt
+	// (provider id → status/message) across all routes for this request. When a
+	// request ends in failure after failing over between providers, the final
+	// error alone can be misleading — e.g. a meaningful "provider N: 403 balance"
+	// gets masked by a catch-all provider's unrelated "404 no model". The trail
+	// lets us surface the real first cause both in the returned error and in a
+	// single WARN log line. It never contains auth headers or keys — only
+	// provider ids and upstream status/message text.
+	attemptTrail []attemptFailure
+
 	tenantID            uint64
 	clientType          domain.ClientType
 	projectID           uint64

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -404,6 +404,10 @@ routeLoop:
 			attemptRecord.EndTime = time.Now()
 			attemptRecord.Duration = attemptRecord.EndTime.Sub(attemptRecord.StartTime)
 			state.lastErr = err
+			// Record a compact, secret-free summary of this failed attempt so a
+			// later catch-all provider's unrelated error can't mask the real
+			// first-provider cause when the request ultimately fails.
+			state.attemptTrail = append(state.attemptTrail, newAttemptFailure(matchedRoute.Provider.ID, err))
 
 			attemptRecord.Status = attemptFailureStatus(ctx, err)
 			attemptRecord.Error = err.Error()
@@ -614,6 +618,20 @@ routeLoop:
 			}
 			attempt++
 		}
+	}
+
+	// A request that ran out of routes after failing over across more than one
+	// provider currently surfaces ONLY the last provider's error. When the last
+	// provider is a catch-all (e.g. an OpenAI-compatible fallback), that error is
+	// often unrelated to the real cause on the first provider (e.g. the fal
+	// provider's "403 User is locked / balance" masked by the catch-all's "404 no
+	// model found"). Fold the first informative upstream error into the final
+	// error and emit one WARN line summarizing the whole attempt chain, so the
+	// true cause is observable. Routing/failover behavior is unchanged.
+	if augmented, firstFailure, ok := augmentFallthroughError(state.lastErr, state.attemptTrail); ok {
+		state.lastErr = augmented
+		log.Printf("[Executor] WARN request failed after fallthrough across %d attempts; surfacing first upstream cause. chain=[%s] firstInformative=%q finalError=%v",
+			len(state.attemptTrail), attemptTrailSummary(state.attemptTrail), firstFailure.summary(), state.lastErr)
 	}
 
 	proxyReq.Status = "FAILED"


### PR DESCRIPTION
## Incident

When a request fails over across multiple matched providers and the **last** provider is a **catch-all** (e.g. an OpenAI-compatible fallback like OpenRouter), the client previously received **only the last provider's error** — which is often unrelated to the real cause on the first provider, masking it. This sent debugging down the wrong path twice.

Concretely: a `fal` image request was routed to the fal provider first, which returned a meaningful error —

```
fal returned status 403: {"detail":"User is locked. Reason: TOP_UP."}
```

(the fal account was out of balance). maxx then failed over to the OpenAI catch-all (OpenRouter), which returned an unrelated —

```
404 {"error":{"message":"No model found for \"fal-ai/flux/schnell\"","code":404}}
```

The **client only saw the 404**, hiding the true balance cause. The video path had the same shape (fal 403 → seedance 503 shown).

## The fix (surfacing only)

As the dispatch loop fails over, it now records a compact, secret-free summary of every failed upstream attempt (`provider id → status/message`) in `execState.attemptTrail`. When a request ultimately fails **after a genuine cross-provider fallthrough** (more than one distinct provider tried), it:

- folds a short `first upstream provider N: <status> <message>` note into the returned `ProxyError` message, so the real first cause reaches the client instead of only the catch-all's error; and
- emits **one WARN log line** summarizing the whole attempt chain, e.g. `provider 12: 403 ... User is locked ... -> provider 1: 404 No model found ...`, so operators see the full picture in one place.

The summary is built only from provider ids and the upstream error's own status/message text (truncated to 300 chars) — **never** from request/response headers or keys, so no auth material can leak (existing header redaction already sanitizes persisted request info; this path never touches headers at all). Single-provider errors and same-provider retries are returned verbatim (nothing was masked, so nothing is appended).

## Tests

`internal/executor/fallthrough_error_test.go`:

- `TestDispatchSurfacesFirstUpstreamErrorAfterCatchAllFallthrough` — reproduces the incident: provider A (fal) returns a distinctive retryable `403 User is locked` and catch-all provider B (OpenRouter) returns a terminal `404 No model found`. Asserts both providers were actually tried (fallthrough unchanged) and that the surfaced error + persisted request error reference provider A's real `403 User is locked` cause **and** still contain B's final error, with no auth material.
- `TestDispatchSingleProviderErrorNotAugmented` — a single provider's error is returned verbatim, with no `first upstream` note (nothing was masked).

Verification:

- `go build ./internal/...` clean
- `go test ./internal/executor/... ./internal/handler/...` all pass
- `gofmt -l internal/executor/` empty; `go vet ./internal/executor/...` clean

## Note on scope

**Routing and failover behavior are unchanged** — which providers are tried, retry semantics, and cooldowns are all untouched. This PR only enriches what error information is surfaced to the client and logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)