### PR TITLE
fix(fal): accept /videos/{id} poll paths in pollTaskID

### DIFF
--- a/internal/adapter/provider/fal/adapter_test.go
+++ b/internal/adapter/provider/fal/adapter_test.go
@@ -745,3 +745,30 @@ func TestIsFalBalanceLocked(t *testing.T) {
 		}
 	}
 }
+
+func TestPollTaskID(t *testing.T) {
+	const id = "aHR0cHM6Ly9xdWV1ZS5mYWwucnVu" // opaque base64url task id
+	cases := []struct {
+		uri  string
+		want string
+	}{
+		// legacy /video/generations forms
+		{"/v1/video/generations/" + id, id},
+		{"/video/generations/" + id, id},
+		// /videos forms added in #839 — regression this test guards
+		{"/v1/videos/" + id, id},
+		{"/videos/" + id, id},
+		// trailing segment / query string are trimmed
+		{"/videos/" + id + "?foo=bar", id},
+		{"/v1/video/generations/" + id + "/status", id},
+		// non-poll paths yield empty
+		{"/v1/images/generations", ""},
+		{"/videos", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := pollTaskID(tc.uri); got != tc.want {
+			t.Fatalf("pollTaskID(%q) = %q, want %q", tc.uri, got, tc.want)
+		}
+	}
+}

--- a/internal/adapter/provider/fal/video.go
+++ b/internal/adapter/provider/fal/video.go
@@ -175,10 +175,19 @@ func extractVideoURL(body []byte) string {
 	return found
 }
 
-// pollTaskID extracts the {task_id} segment from a video poll path
-// (/v1/video/generations/{task_id} or /video/generations/{task_id}).
+// pollTaskID extracts the {task_id} segment from a video poll path. It must
+// accept every prefix client.IsVideoPollPath routes here — the legacy
+// /v1/video/generations/{task_id} and /video/generations/{task_id} forms as
+// well as the /v1/videos/{task_id} and /videos/{task_id} forms added in #839.
+// Missing the /videos variants made GET /videos/{id} return "invalid fal video
+// task id" even though the gateway had already routed it to executeVideoPoll.
 func pollTaskID(uri string) string {
-	for _, base := range []string{"/v1/video/generations/", "/video/generations/"} {
+	for _, base := range []string{
+		"/v1/video/generations/",
+		"/video/generations/",
+		"/v1/videos/",
+		"/videos/",
+	} {
 		if strings.HasPrefix(uri, base) {
 			id := strings.TrimPrefix(uri, base)
 			if i := strings.IndexAny(id, "/?"); i >= 0 {


### PR DESCRIPTION
## Problem

`client.IsVideoPollPath` routes **four** prefixes to the fal video poll handler:

`/v1/video/generations/`, `/video/generations/`, `/v1/videos/`, `/videos/` — the last two added in #839.

But `pollTaskID` (internal/adapter/provider/fal/video.go) only stripped the two `/video/generations/` forms. So a `GET /videos/{id}` was accepted by the gateway, routed to `executeVideoPoll`, then failed to extract a task id and returned **`invalid fal video task id`** — even though the id was perfectly valid. Observed live on hubitos when polling a fal video via the `/videos/{id}` surface.

## Fix

Align `pollTaskID` with `IsVideoPollPath`: strip all four prefixes. One-liner behavior change, no envelope/format change.

## Scope

fal-adapter-only. The custom/newapi adapter (seedance) already path-forwards `/videos/` (custom/adapter.go), and openrouter delegates to that same custom path — neither shares fal's base64 `pollTaskID`, so neither has this gap.

## Test

Adds `TestPollTaskID` covering all four prefixes + trailing-segment/query trimming + non-poll paths. `go test ./internal/adapter/provider/fal/ ./internal/adapter/client/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进视频任务状态轮询，现支持从更多视频任务地址中正确识别任务 ID。
  * 兼容新版及历史任务路径格式，并能忽略路径末尾片段和查询参数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->