### PR TITLE
feat(user-panel): add model status tab

### DIFF
--- a/web/src/lib/user-panel-model-status.test.ts
+++ b/web/src/lib/user-panel-model-status.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import type { ProxyRequest } from '@/lib/transport';
+import { buildUserPanelModelStatuses } from './user-panel-model-status';
+
+function request(overrides: Partial<ProxyRequest>): ProxyRequest {
+  return {
+    id: 1,
+    createdAt: '2026-09-03T00:00:00Z',
+    updatedAt: '2026-09-03T00:00:00Z',
+    instanceID: '',
+    requestID: '',
+    sessionID: '',
+    clientType: 'openai',
+    requestModel: 'gpt-5',
+    mappedModel: '',
+    responseModel: '',
+    reasoningEffort: '',
+    startTime: '',
+    endTime: '',
+    duration: 0,
+    ttft: 0,
+    isStream: false,
+    status: 'COMPLETED',
+    statusCode: 200,
+    requestInfo: null,
+    responseInfo: null,
+    error: '',
+    proxyUpstreamAttemptCount: 0,
+    finalProxyUpstreamAttemptID: 0,
+    routeID: 0,
+    providerID: 0,
+    projectID: 0,
+    inputTokenCount: 0,
+    outputTokenCount: 0,
+    cacheReadCount: 0,
+    cacheWriteCount: 0,
+    cache5mWriteCount: 0,
+    cache1hWriteCount: 0,
+    modelPriceId: 0,
+    multiplier: 0,
+    cost: 0,
+    apiTokenID: 0,
+    ...overrides,
+  };
+}
+
+describe('buildUserPanelModelStatuses', () => {
+  it('marks available models without recent requests as no data', () => {
+    expect(
+      buildUserPanelModelStatuses({
+        availableModels: ['gemini-2.5-pro'],
+        requests: [],
+        now: Date.parse('2026-09-03T00:00:00Z'),
+      }),
+    ).toEqual([
+      {
+        model: 'gemini-2.5-pro',
+        health: 'no-data',
+        totalRequests: 0,
+        successfulRequests: 0,
+        failedRequests: 0,
+        consecutiveFailures: 0,
+      },
+    ]);
+  });
+
+  it('marks successful recent models as healthy', () => {
+    const statuses = buildUserPanelModelStatuses({
+      availableModels: ['gpt-5'],
+      requests: [request({ requestModel: 'gpt-5', status: 'COMPLETED', statusCode: 200 })],
+      now: Date.parse('2026-09-03T00:00:00Z'),
+    });
+
+    expect(statuses[0]).toMatchObject({
+      model: 'gpt-5',
+      health: 'healthy',
+      totalRequests: 1,
+      successfulRequests: 1,
+      failedRequests: 0,
+    });
+  });
+
+  it('marks models with some recent failures as degraded', () => {
+    const statuses = buildUserPanelModelStatuses({
+      availableModels: ['claude-sonnet-4'],
+      requests: [
+        request({
+          id: 2,
+          requestModel: 'claude-sonnet-4',
+          createdAt: '2026-09-03T00:00:00Z',
+          status: 'COMPLETED',
+          statusCode: 200,
+        }),
+        request({
+          id: 1,
+          requestModel: 'claude-sonnet-4',
+          createdAt: '2026-09-02T23:00:00Z',
+          status: 'FAILED',
+          statusCode: 502,
+          error: 'upstream timeout',
+        }),
+      ],
+      now: Date.parse('2026-09-03T00:00:00Z'),
+    });
+
+    expect(statuses[0]).toMatchObject({
+      model: 'claude-sonnet-4',
+      health: 'degraded',
+      totalRequests: 2,
+      successfulRequests: 1,
+      failedRequests: 1,
+      consecutiveFailures: 0,
+      lastError: 'upstream timeout',
+    });
+  });
+
+  it('marks models with three latest failures as unavailable', () => {
+    const statuses = buildUserPanelModelStatuses({
+      availableModels: ['bad-model'],
+      requests: [
+        request({
+          id: 3,
+          requestModel: 'bad-model',
+          createdAt: '2026-09-03T00:00:00Z',
+          status: 'FAILED',
+          statusCode: 502,
+          error: 'bad gateway',
+        }),
+        request({
+          id: 2,
+          requestModel: 'bad-model',
+          createdAt: '2026-09-02T23:59:00Z',
+          status: 'REJECTED',
+          statusCode: 429,
+          error: 'rate limited',
+        }),
+        request({
+          id: 1,
+          requestModel: 'bad-model',
+          createdAt: '2026-09-02T23:58:00Z',
+          status: 'COMPLETED',
+          statusCode: 500,
+          error: 'server error',
+        }),
+      ],
+      now: Date.parse('2026-09-03T00:00:00Z'),
+    });
+
+    expect(statuses[0]).toMatchObject({
+      model: 'bad-model',
+      health: 'unavailable',
+      failedRequests: 3,
+      consecutiveFailures: 3,
+      lastError: 'bad gateway',
+    });
+  });
+
+  it('ignores requests outside the last 24 hours', () => {
+    const statuses = buildUserPanelModelStatuses({
+      availableModels: ['gpt-5'],
+      requests: [
+        request({
+          requestModel: 'gpt-5',
+          createdAt: '2026-09-01T23:59:59Z',
+          status: 'FAILED',
+          statusCode: 502,
+        }),
+      ],
+      now: Date.parse('2026-09-03T00:00:00Z'),
+    });
+
+    expect(statuses[0]).toMatchObject({ health: 'no-data', totalRequests: 0 });
+  });
+});

--- a/web/src/lib/user-panel-model-status.ts
+++ b/web/src/lib/user-panel-model-status.ts
@@ -1,0 +1,124 @@
+import type { ProxyRequest } from '@/lib/transport';
+
+export type UserPanelModelHealth = 'healthy' | 'degraded' | 'no-data' | 'unavailable';
+
+export interface UserPanelModelStatusSummary {
+  model: string;
+  health: UserPanelModelHealth;
+  totalRequests: number;
+  successfulRequests: number;
+  failedRequests: number;
+  consecutiveFailures: number;
+  lastRequestedAt?: string;
+  lastError?: string;
+}
+
+const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function modelNameFromRequest(request: ProxyRequest): string {
+  return request.requestModel || request.responseModel || request.mappedModel || '';
+}
+
+function isRequestFailure(request: ProxyRequest): boolean {
+  return request.status === 'FAILED' || request.status === 'REJECTED' || request.statusCode >= 400;
+}
+
+function isRequestSuccess(request: ProxyRequest): boolean {
+  return request.status === 'COMPLETED' && request.statusCode > 0 && request.statusCode < 400;
+}
+
+function requestTime(request: ProxyRequest): number {
+  const value = new Date(request.createdAt).getTime();
+  return Number.isFinite(value) ? value : 0;
+}
+
+function trimError(value: string): string | undefined {
+  const error = value.trim();
+  if (!error) return undefined;
+  return error.length > 160 ? `${error.slice(0, 157)}...` : error;
+}
+
+function resolveHealth(params: {
+  totalRequests: number;
+  failedRequests: number;
+  consecutiveFailures: number;
+}): UserPanelModelHealth {
+  if (params.totalRequests === 0) return 'no-data';
+  if (params.consecutiveFailures >= 3) return 'unavailable';
+  if (params.failedRequests > 0) return 'degraded';
+  return 'healthy';
+}
+
+export function buildUserPanelModelStatuses(params: {
+  availableModels?: string[];
+  requests?: ProxyRequest[];
+  now?: number;
+}): UserPanelModelStatusSummary[] {
+  const now = params.now ?? Date.now();
+  const since = now - RECENT_WINDOW_MS;
+  const summaries = new Map<string, UserPanelModelStatusSummary>();
+
+  for (const model of params.availableModels ?? []) {
+    const name = model.trim();
+    if (!name) continue;
+    summaries.set(name, {
+      model: name,
+      health: 'no-data',
+      totalRequests: 0,
+      successfulRequests: 0,
+      failedRequests: 0,
+      consecutiveFailures: 0,
+    });
+  }
+
+  const recentRequests = (params.requests ?? [])
+    .filter((request) => requestTime(request) >= since)
+    .filter((request) => modelNameFromRequest(request).trim() !== '')
+    .sort((a, b) => requestTime(b) - requestTime(a));
+
+  for (const request of recentRequests) {
+    const model = modelNameFromRequest(request).trim();
+    const existing = summaries.get(model) ?? {
+      model,
+      health: 'no-data' as UserPanelModelHealth,
+      totalRequests: 0,
+      successfulRequests: 0,
+      failedRequests: 0,
+      consecutiveFailures: 0,
+    };
+
+    const failed = isRequestFailure(request);
+    const successful = isRequestSuccess(request);
+    existing.totalRequests += 1;
+    if (successful) existing.successfulRequests += 1;
+    if (failed) existing.failedRequests += 1;
+    if (!existing.lastRequestedAt) existing.lastRequestedAt = request.createdAt;
+    if (failed && !existing.lastError) existing.lastError = trimError(request.error);
+    summaries.set(model, existing);
+  }
+
+  for (const summary of summaries.values()) {
+    const modelRequests = recentRequests.filter(
+      (request) => modelNameFromRequest(request).trim() === summary.model,
+    );
+    let consecutiveFailures = 0;
+    for (const request of modelRequests) {
+      if (!isRequestFailure(request)) break;
+      consecutiveFailures += 1;
+    }
+    summary.consecutiveFailures = consecutiveFailures;
+    summary.health = resolveHealth(summary);
+  }
+
+  return [...summaries.values()].sort((a, b) => {
+    const order: Record<UserPanelModelHealth, number> = {
+      unavailable: 0,
+      degraded: 1,
+      healthy: 2,
+      'no-data': 3,
+    };
+    const byHealth = order[a.health] - order[b.health];
+    if (byHealth !== 0) return byHealth;
+    return a.model.localeCompare(b.model);
+  });
+}

--- a/web/src/lib/user-panel-tabs.test.ts
+++ b/web/src/lib/user-panel-tabs.test.ts
@@ -10,6 +10,7 @@ describe('user-panel-tabs', () => {
   it('validates only supported user panel tabs', () => {
     expect(isUserPanelTab('main')).toBe(true);
     expect(isUserPanelTab('requests')).toBe(true);
+    expect(isUserPanelTab('model-status')).toBe(true);
     expect(isUserPanelTab('usage')).toBe(false);
     expect(isUserPanelTab('')).toBe(false);
     expect(isUserPanelTab(null)).toBe(false);
@@ -23,6 +24,7 @@ describe('user-panel-tabs', () => {
 
   it('prefers a valid URL tab over a stored tab', () => {
     expect(resolveUserPanelTab({ urlTab: 'requests', storedTab: 'main' })).toBe('requests');
+    expect(resolveUserPanelTab({ urlTab: 'model-status', storedTab: 'main' })).toBe('model-status');
   });
 
   it('does not let an invalid URL tab fall back to stored state by default', () => {
@@ -36,12 +38,14 @@ describe('user-panel-tabs', () => {
   });
 
   it('falls back to main when URL and stored tab are invalid', () => {
-    expect(resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'other', allowStoredTab: true })).toBe(
-      'main',
-    );
+    expect(
+      resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'other', allowStoredTab: true }),
+    ).toBe('main');
   });
 
   it('updates tab in search while preserving unrelated query params', () => {
-    expect(updateUserPanelTabSearch('?foo=bar&tab=main', 'requests')).toBe('?foo=bar&tab=requests');
+    expect(updateUserPanelTabSearch('?foo=bar&tab=main', 'model-status')).toBe(
+      '?foo=bar&tab=model-status',
+    );
   });
 });

--- a/web/src/lib/user-panel-tabs.ts
+++ b/web/src/lib/user-panel-tabs.ts
@@ -1,4 +1,4 @@
-export const USER_PANEL_TABS = ['main', 'requests'] as const;
+export const USER_PANEL_TABS = ['main', 'model-status', 'requests'] as const;
 
 export type UserPanelTab = (typeof USER_PANEL_TABS)[number];
 
@@ -6,11 +6,12 @@ const DEFAULT_USER_PANEL_TAB: UserPanelTab = 'main';
 const STORAGE_PREFIX = 'maxx:user-panel:active-tab';
 
 export function isUserPanelTab(value: string | null | undefined): value is UserPanelTab {
-  return value === 'main' || value === 'requests';
+  return value === 'main' || value === 'model-status' || value === 'requests';
 }
 
 export function getUserPanelTabStorageKey(userId: number | string | null | undefined): string {
-  const scope = userId === null || userId === undefined || userId === '' ? 'anonymous' : String(userId);
+  const scope =
+    userId === null || userId === undefined || userId === '' ? 'anonymous' : String(userId);
   return `${STORAGE_PREFIX}:${scope}`;
 }
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -201,7 +201,27 @@
     "availableModelsLoadFailed": "Failed to load available models",
     "noAvailableModels": "No available models. Contact an administrator to configure routes or models.",
     "moreAvailableModels": "+{{count}} more",
-    "routeCodex": "Codex"
+    "routeCodex": "Codex",
+    "modelStatusTab": "Model Status",
+    "modelStatusSummary": "User-facing model availability",
+    "modelStatusSummaryDescription": "Summarized from currently available models and dedicated-key requests in the last 24 hours without exposing provider internals.",
+    "modelStatusLoadFailed": "Failed to load model status.",
+    "noModelStatus": "No model status yet",
+    "noModelStatusDescription": "No available models or recent request data yet. Generate a key and make requests to start tracking.",
+    "modelStatusNoRecentData": "Available now, but no requests in the last 24 hours.",
+    "modelStatusHealthyDetail": "{{count}} successful requests in the last 24 hours and no failures.",
+    "modelStatusDegradedDetail": "{{failed}} failures out of {{total}} requests in the last 24 hours.",
+    "modelStatusUnavailableDetail": "The latest {{count}} requests failed consecutively. Try another model for now.",
+    "modelStatusRecentRequests": "24h requests",
+    "modelStatusRecentFailures": "24h failures",
+    "modelStatusLastSeen": "Last seen",
+    "modelStatusLastError": "Latest error",
+    "modelHealth": {
+      "healthy": "Normal",
+      "degraded": "Degraded",
+      "no-data": "No data",
+      "unavailable": "Unavailable"
+    }
   },
   "testField": {
     "title": "Test Field",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -201,7 +201,27 @@
     "availableModelsLoadFailed": "可用模型加载失败",
     "noAvailableModels": "暂无可用模型，请联系管理员配置路由或模型。",
     "moreAvailableModels": "+{{count}} 个更多",
-    "routeCodex": "Codex"
+    "routeCodex": "Codex",
+    "modelStatusTab": "模型状态",
+    "modelStatusSummary": "用户视角的模型可用情况",
+    "modelStatusSummaryDescription": "基于当前可用模型和最近 24 小时专用 Key 请求自动汇总，不展示后台 provider 细节。",
+    "modelStatusLoadFailed": "模型状态加载失败。",
+    "noModelStatus": "暂无模型状态",
+    "noModelStatusDescription": "还没有可用模型或最近请求数据，请生成 Key 并开始调用后查看。",
+    "modelStatusNoRecentData": "当前可用，但最近 24 小时暂无请求数据。",
+    "modelStatusHealthyDetail": "最近 24 小时 {{count}} 次成功，未发现失败。",
+    "modelStatusDegradedDetail": "最近 24 小时 {{total}} 次请求中有 {{failed}} 次失败。",
+    "modelStatusUnavailableDetail": "最近连续 {{count}} 次失败，建议暂时换用其他模型。",
+    "modelStatusRecentRequests": "24h 请求",
+    "modelStatusRecentFailures": "24h 失败",
+    "modelStatusLastSeen": "最近出现",
+    "modelStatusLastError": "最近错误",
+    "modelHealth": {
+      "healthy": "正常",
+      "degraded": "波动",
+      "no-data": "暂无数据",
+      "unavailable": "不可用"
+    }
   },
   "testField": {
     "title": "测试场",

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -9,6 +9,7 @@ import {
   ListChecks,
   LogOut,
   Server,
+  Activity,
   UserRound,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -43,6 +44,10 @@ import {
 } from '@/hooks/queries';
 import type { APIToken, ProxyRequest } from '@/lib/transport';
 import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
+import {
+  buildUserPanelModelStatuses,
+  type UserPanelModelStatusSummary,
+} from '@/lib/user-panel-model-status';
 import {
   getUserPanelTabStorageKey,
   resolveUserPanelTab,
@@ -106,6 +111,130 @@ function getRequestStatusVariant(request: ProxyRequest) {
   }
   if (request.statusCode >= 400) return 'danger';
   return 'secondary';
+}
+
+function getModelHealthVariant(health: UserPanelModelStatusSummary['health']) {
+  if (health === 'healthy') return 'success';
+  if (health === 'degraded') return 'warning';
+  if (health === 'unavailable') return 'danger';
+  return 'secondary';
+}
+
+function formatModelStatusDetail(
+  summary: UserPanelModelStatusSummary,
+  t: ReturnType<typeof useTranslation>['t'],
+) {
+  if (summary.health === 'no-data') return t('userPanel.modelStatusNoRecentData');
+  if (summary.health === 'healthy') {
+    return t('userPanel.modelStatusHealthyDetail', { count: summary.successfulRequests });
+  }
+  if (summary.health === 'unavailable') {
+    return t('userPanel.modelStatusUnavailableDetail', { count: summary.consecutiveFailures });
+  }
+  return t('userPanel.modelStatusDegradedDetail', {
+    failed: summary.failedRequests,
+    total: summary.totalRequests,
+  });
+}
+
+function UserPanelModelStatusTab({
+  availableModels,
+  requests,
+  isLoading,
+  isError,
+}: {
+  availableModels?: string[];
+  requests: ProxyRequest[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const { t } = useTranslation();
+  const summaries = buildUserPanelModelStatuses({ availableModels, requests });
+
+  return (
+    <Card className="min-h-[820px] border-border bg-card shadow-sm">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="flex items-center gap-2 text-base font-medium">
+          <Activity className="size-4 text-muted-foreground" />
+          {t('userPanel.modelStatusTab')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex min-h-[744px] flex-col p-5">
+        {isLoading ? (
+          <div className="flex flex-1 items-center justify-center text-center text-sm text-muted-foreground">
+            {t('common.loading')}
+          </div>
+        ) : isError ? (
+          <div className="flex flex-1 items-center justify-center">
+            <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+              {t('userPanel.modelStatusLoadFailed')}
+            </div>
+          </div>
+        ) : summaries.length === 0 ? (
+          <div className="flex flex-1 flex-col items-center justify-center text-center">
+            <Activity className="size-9 text-muted-foreground" />
+            <p className="mt-3 font-medium">{t('userPanel.noModelStatus')}</p>
+            <p className="mt-2 max-w-md text-sm text-muted-foreground">
+              {t('userPanel.noModelStatusDescription')}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="rounded-xl border border-border bg-muted/25 p-4">
+              <p className="text-sm font-medium text-foreground">
+                {t('userPanel.modelStatusSummary')}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('userPanel.modelStatusSummaryDescription')}
+              </p>
+            </div>
+            <div className="divide-y divide-border rounded-xl border border-border">
+              {summaries.map((summary) => (
+                <div key={summary.model} className="space-y-3 p-4">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <p className="truncate font-mono text-sm font-medium">{summary.model}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatModelStatusDetail(summary, t)}
+                      </p>
+                    </div>
+                    <Badge variant={getModelHealthVariant(summary.health)}>
+                      {t(`userPanel.modelHealth.${summary.health}`)}
+                    </Badge>
+                  </div>
+                  <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+                    <div className="rounded-lg bg-muted/25 px-3 py-2">
+                      <span className="block">{t('userPanel.modelStatusRecentRequests')}</span>
+                      <span className="mt-1 block font-mono text-foreground">
+                        {formatNumber(summary.totalRequests)}
+                      </span>
+                    </div>
+                    <div className="rounded-lg bg-muted/25 px-3 py-2">
+                      <span className="block">{t('userPanel.modelStatusRecentFailures')}</span>
+                      <span className="mt-1 block font-mono text-foreground">
+                        {formatNumber(summary.failedRequests)}
+                      </span>
+                    </div>
+                    <div className="rounded-lg bg-muted/25 px-3 py-2">
+                      <span className="block">{t('userPanel.modelStatusLastSeen')}</span>
+                      <span className="mt-1 block font-mono text-foreground">
+                        {formatDateTime(summary.lastRequestedAt)}
+                      </span>
+                    </div>
+                  </div>
+                  {summary.lastError ? (
+                    <div className="rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                      {t('userPanel.modelStatusLastError')}: {summary.lastError}
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 function UserPanelRequestsTab() {
@@ -191,7 +320,11 @@ export function UserPanelPage() {
   const { t } = useTranslation();
   const { logout, user } = useAuth();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
-  const { data: userPanelRequests } = useProxyRequests({ limit: 25 });
+  const {
+    data: userPanelRequests,
+    isLoading: userPanelRequestsLoading,
+    isError: userPanelRequestsError,
+  } = useProxyRequests({ limit: 25 });
   const { data: publicSettings } = usePublicSettings();
   const {
     data: availableModels,
@@ -382,8 +515,9 @@ export function UserPanelPage() {
         </header>
 
         <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-5">
-          <TabsList className="grid w-full grid-cols-2 rounded-xl p-1">
+          <TabsList className="grid w-full grid-cols-3 rounded-xl p-1">
             <TabsTrigger value="main">{t('userPanel.mainTab')}</TabsTrigger>
+            <TabsTrigger value="model-status">{t('userPanel.modelStatusTab')}</TabsTrigger>
             <TabsTrigger value="requests" className="relative overflow-hidden">
               <MarqueeBackground
                 show={activeRequestCount > 0}
@@ -663,6 +797,15 @@ export function UserPanelPage() {
                 </div>
               </CardContent>
             </Card>
+          </TabsContent>
+
+          <TabsContent value="model-status">
+            <UserPanelModelStatusTab
+              availableModels={availableModels}
+              requests={userPanelRequests?.items ?? []}
+              isLoading={availableModelsLoading || userPanelRequestsLoading}
+              isError={availableModelsError || userPanelRequestsError}
+            />
           </TabsContent>
 
           <TabsContent value="requests">


### PR DESCRIPTION
## What Problem This Solves

Adds a user-facing model status tab to the user console so users can quickly see which models are available, whether recent usage is stable, and which models are currently erroring without inspecting raw request rows.

## Why This Change Was Made

The existing user console exposed available models and recent requests separately. Users had to infer model health manually from request history. This PR adds a dedicated summary that keeps the view scoped to the user's perspective and avoids provider internals.

## User Impact

- Adds a new Model Status tab in the user console.
- Shows each model as Normal, Degraded, No data, or Unavailable.
- Uses available models plus the user's dedicated-key requests from the last 24 hours.
- Surfaces recent request count, failure count, last seen time, and latest error summary.
- Keeps backend provider details hidden.

## Evidence

- `pnpm vitest run src/lib/user-panel-tabs.test.ts src/lib/user-panel-model-status.test.ts` — 12 tests passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm build` — passed.

Note: local validation ran under Node v24.18.0, while the web package declares `>=22.12.0 <23`; pnpm emitted an engine warning but all checks completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 用户面板新增“模型状态”标签页。
  - 展示各模型近 24 小时的健康状态：健康、降级、不可用或无数据。
  - 提供近期请求数、失败数、最近请求时间及最近错误信息等详情。
  - 新增中英文界面文案支持。

- **测试**
  - 新增模型状态统计逻辑测试，覆盖成功、失败、无数据及过期请求等场景。
  - 补充“模型状态”标签页的导航与回退行为测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->