### PR TITLE
fix(proxy): retry upstream connection errors with wrapped cause

### DIFF
--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -682,7 +683,7 @@ func normalizeUpstreamConnectionError(proxyErr *domain.ProxyError) {
 	if proxyErr == nil || !errors.Is(proxyErr.Err, domain.ErrUpstreamError) {
 		return
 	}
-	if proxyErr.Message != "failed to connect to upstream" && proxyErr.Message != "failed to connect to upstream after token refresh" {
+	if !strings.HasPrefix(proxyErr.Message, "failed to connect to upstream") {
 		return
 	}
 	proxyErr.Scope = domain.ScopeProvider

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -569,7 +569,7 @@ func TestExecuteProviderProxyNormalizesLegacyUpstreamConnectionError(t *testing.
 	cooldown.Default().ClearCooldown(providerID, "", "")
 	defer cooldown.Default().ClearCooldown(providerID, "", "")
 
-	legacyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to connect to upstream")
+	legacyErr := domain.NewProxyErrorWithMessage(domain.ErrUpstreamError, false, "failed to connect to upstream: upstream error")
 	adapter := &sequenceAdapter{errs: []error{legacyErr}}
 	e := &Executor{
 		proxyRequestRepo: &recordingProxyRequestRepo{},


### PR DESCRIPTION
## What Problem This Solves

`failed to connect to upstream: upstream error` was not normalized into the existing upstream connection retry path because the dispatcher only matched the exact message `failed to connect to upstream` or `failed to connect to upstream after token refresh`.

That meant a wrapped upstream connection error could bypass the expected retry strategy even though it represents the same provider/network-side transient failure.

## What Changed

- Treat `failed to connect to upstream` as a message prefix when normalizing upstream connection errors.
- Preserve the existing safety boundary: normalization still requires `ErrUpstreamError`; unrelated messages are not upgraded.
- Update the provider proxy regression test to use the real wrapped message: `failed to connect to upstream: upstream error`.

## Expected Behavior

`failed to connect to upstream: upstream error` is classified as `ScopeProvider + CooldownReasonNetworkError + Retryable=true`, then follows the configured retry path instead of failing as a non-retryable provider error.

## Evidence

- `go test ./internal/executor ./internal/domain` — passed.
- `go test ./internal/adapter/provider/custom ./internal/handler ./tests/e2e -run 'Retry|Proxy|Provider|Upstream|Error'` — passed.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 改进上游连接错误的识别，兼容包含额外说明的错误消息。
  * 相关错误现在可被正确归类为可重试的网络错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->