### PR TITLE
fix(router): match mapped model support candidates

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -132,6 +132,9 @@ func (e *Executor) mapModel(tenantID uint64, requestModel string, route *domain.
 }
 
 func (e *Executor) mapModelCandidates(tenantID uint64, requestModel string, route *domain.Route, provider *domain.Provider, clientType domain.ClientType, projectID uint64, apiTokenID uint64) []string {
+	if e == nil || e.modelMappingRepo == nil || route == nil || provider == nil {
+		return []string{requestModel}
+	}
 	query := &domain.ModelMappingQuery{
 		ClientType:   clientType,
 		ProviderType: provider.Type,

--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -27,11 +27,14 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 		requiredProviderID = state.wsExchange.PinnedProviderID
 	}
 	result, err := e.router.Match(&router.MatchContext{
-		Ctx:                       state.ctx,
-		TenantID:                  state.tenantID,
-		ClientType:                state.clientType,
-		ProjectID:                 state.projectID,
-		RequestModel:              state.requestModel,
+		Ctx:          state.ctx,
+		TenantID:     state.tenantID,
+		ClientType:   state.clientType,
+		ProjectID:    state.projectID,
+		RequestModel: state.requestModel,
+		ModelCandidates: func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string {
+			return e.mapModelCandidates(state.tenantID, requestModel, route, provider, clientType, state.projectID, state.apiTokenID)
+		},
 		APITokenID:                state.apiTokenID,
 		SessionID:                 state.sessionID,
 		RequireResponsesWebSocket: requireWS,

--- a/internal/executor/provider_proxy.go
+++ b/internal/executor/provider_proxy.go
@@ -39,8 +39,11 @@ func (e *Executor) MatchProviderProxyRoute(ctx context.Context, tenantID uint64,
 		ClientType:   clientType,
 		ProjectID:    projectID,
 		RequestModel: requestModel,
-		APITokenID:   apiTokenID,
-		SessionID:    sessionID,
+		ModelCandidates: func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string {
+			return e.mapModelCandidates(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
+		},
+		APITokenID: apiTokenID,
+		SessionID:  sessionID,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/executor/provider_proxy_match_test.go
+++ b/internal/executor/provider_proxy_match_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	provideradapter "github.com/awsl-project/maxx/internal/adapter/provider"
@@ -199,5 +200,58 @@ func TestMatchProviderProxyRouteUsesProjectRouteRetryPolicy(t *testing.T) {
 	}
 	if matched.RetryConfig == nil || matched.RetryConfig.MaxRetries != 2 {
 		t.Fatalf("matched retry config = %+v, want project MaxRetries=2", matched.RetryConfig)
+	}
+}
+
+func TestMatchProviderProxyRouteUsesMappedModelCandidatesForSupportModels(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(&providerProxyMatchRouteRepo{routes: []*domain.Route{
+		{ID: 10, TenantID: 1, ProviderID: 79007, ClientType: domain.ClientTypeOpenAI, IsEnabled: true, Position: 1},
+		{ID: 11, TenantID: 1, ProviderID: 79008, ClientType: domain.ClientTypeOpenAI, IsEnabled: true, Position: 2},
+	}})
+	providerRepo := cached.NewProviderRepository(&providerProxyMatchProviderRepo{providers: []*domain.Provider{
+		{ID: 79007, TenantID: 1, Type: providerProxyMatchTestType, Name: "pre-mapped-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}, SupportModels: []string{"gpt-5"}},
+		{ID: 79008, TenantID: 1, Type: providerProxyMatchTestType, Name: "mapped-target", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}, SupportModels: []string{"moonshotai/kimi-k3"}},
+	}})
+	retryRepo := cached.NewRetryConfigRepository(&providerProxyMatchRetryRepo{configs: []*domain.RetryConfig{
+		{ID: 1, TenantID: 1, IsDefault: true, MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	}})
+	strategyRepo := cached.NewRoutingStrategyRepository(providerProxyMatchStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(providerProxyMatchProjectRepo{})
+
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := router.NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo, &stubExecutorSettingsRepo{values: map[string]string{
+		domain.SettingKeyStrictSupportModelsRoutingEnabled: "true",
+	}})
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("init adapters: %v", err)
+	}
+	e := &Executor{
+		router: r,
+		modelMappingRepo: &staticModelMappingRepo{mappings: []*domain.ModelMapping{
+			{Pattern: "gpt-5", Target: "moonshotai/kimi-k3", IsEnabled: true},
+		}},
+	}
+
+	matched, err := e.MatchProviderProxyRoute(context.Background(), 1, 79008, domain.ClientTypeOpenAI, 0, "gpt-5", 46, "session-1")
+	if err != nil {
+		t.Fatalf("MatchProviderProxyRoute returned error: %v", err)
+	}
+	if matched.Provider.ID != 79008 {
+		t.Fatalf("matched provider ID = %d, want 79008", matched.Provider.ID)
+	}
+
+	_, err = e.MatchProviderProxyRoute(context.Background(), 1, 79007, domain.ClientTypeOpenAI, 0, "gpt-5", 46, "session-1")
+	if !errors.Is(err, domain.ErrNoAvailableProviders) {
+		t.Fatalf("MatchProviderProxyRoute error = %v, want ErrNoAvailableProviders", err)
 	}
 }

--- a/internal/executor/route_match_test.go
+++ b/internal/executor/route_match_test.go
@@ -72,3 +72,75 @@ func TestExecutorRouteMatchFailureCreatesRejectedProxyRequest(t *testing.T) {
 		t.Fatalf("c.Err is nil, want proxy error")
 	}
 }
+
+func TestExecutorRouteMatchUsesMappedModelCandidatesForSupportModels(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(&providerProxyMatchRouteRepo{routes: []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeOpenAI, IsEnabled: true, Position: 1},
+		{ID: 2, TenantID: 1, ProviderID: 102, ClientType: domain.ClientTypeOpenAI, IsEnabled: true, Position: 2},
+	}})
+	providerRepo := cached.NewProviderRepository(&providerProxyMatchProviderRepo{providers: []*domain.Provider{
+		{ID: 101, TenantID: 1, Type: providerProxyMatchTestType, Name: "pre-mapped-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}, SupportModels: []string{"gpt-5"}},
+		{ID: 102, TenantID: 1, Type: providerProxyMatchTestType, Name: "mapped-target", SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI}, SupportModels: []string{"moonshotai/kimi-k3"}},
+	}})
+	retryRepo := cached.NewRetryConfigRepository(&providerProxyMatchRetryRepo{configs: []*domain.RetryConfig{
+		{ID: 1, TenantID: 1, IsDefault: true, MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	}})
+	strategyRepo := cached.NewRoutingStrategyRepository(providerProxyMatchStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(providerProxyMatchProjectRepo{})
+
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := router.NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo, &stubExecutorSettingsRepo{values: map[string]string{
+		domain.SettingKeyStrictSupportModelsRoutingEnabled: "true",
+	}})
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("init adapters: %v", err)
+	}
+
+	proxyRepo := &recordingProxyRequestRepo{}
+	exec := &Executor{
+		router:           r,
+		proxyRequestRepo: proxyRepo,
+		modelMappingRepo: &staticModelMappingRepo{mappings: []*domain.ModelMapping{
+			{Pattern: "gpt-5", Target: "moonshotai/kimi-k3", IsEnabled: true},
+		}},
+		instanceID: "test-instance",
+	}
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"gpt-5"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := flow.NewCtx(rec, req)
+	state := &execState{
+		ctx:            req.Context(),
+		tenantID:       1,
+		clientType:     domain.ClientTypeOpenAI,
+		requestModel:   "gpt-5",
+		apiTokenID:     46,
+		requestBody:    []byte(`{"model":"gpt-5"}`),
+		requestURI:     req.URL.RequestURI(),
+		requestHeaders: req.Header,
+	}
+	c.Set(flow.KeyExecutorState, state)
+
+	exec.routeMatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("routeMatch error = %v", c.Err)
+	}
+	if len(state.routes) != 1 || state.routes[0].Provider.ID != 102 {
+		t.Fatalf("matched routes = %+v, want only mapped-target provider 102", state.routes)
+	}
+	if len(proxyRepo.created) != 1 || proxyRepo.created[0].ProviderID != 0 || proxyRepo.created[0].RequestModel != "gpt-5" {
+		t.Fatalf("created proxy request = %+v, want pre-dispatch request preserved", proxyRepo.created)
+	}
+}

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -168,10 +168,13 @@ func (h *ModelsHandler) isModelAvailable(tenantID uint64, clientType domain.Clie
 		return false
 	}
 	result, err := h.router.Match(&router.MatchContext{
-		TenantID:            tenantID,
-		ClientType:          clientType,
-		ProjectID:           projectID,
-		RequestModel:        model,
+		TenantID:     tenantID,
+		ClientType:   clientType,
+		ProjectID:    projectID,
+		RequestModel: model,
+		ModelCandidates: func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string {
+			return h.modelCandidatesForRoute(tenantID, requestModel, route, provider, clientType, projectID, apiTokenID)
+		},
 		APITokenID:          apiTokenID,
 		StrictSupportModels: true,
 	})
@@ -185,7 +188,53 @@ func (h *ModelsHandler) isModelAvailable(tenantID uint64, clientType domain.Clie
 		if providerID != 0 && matched.Provider.ID != providerID {
 			continue
 		}
-		if isProviderModelExposed(matched.Provider, model) {
+		candidates := h.modelCandidatesForRoute(tenantID, model, matched.Route, matched.Provider, clientType, projectID, apiTokenID)
+		if isProviderAnyModelExposed(matched.Provider, append([]string{model}, candidates...)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (h *ModelsHandler) modelCandidatesForRoute(tenantID uint64, requestModel string, route *domain.Route, provider *domain.Provider, clientType domain.ClientType, projectID, apiTokenID uint64) []string {
+	if h == nil || h.modelMappingRepo == nil || route == nil || provider == nil {
+		return []string{requestModel}
+	}
+	mappings, err := h.modelMappingRepo.ListByQuery(tenantID, &domain.ModelMappingQuery{
+		ClientType:   clientType,
+		ProviderType: provider.Type,
+		ProviderID:   provider.ID,
+		ProjectID:    projectID,
+		RouteID:      route.ID,
+		APITokenID:   apiTokenID,
+	})
+	if err != nil {
+		return []string{requestModel}
+	}
+	candidates := make([]string, 0, len(mappings))
+	seen := make(map[string]struct{}, len(mappings))
+	for _, mapping := range mappings {
+		if mapping == nil || !domain.MatchWildcard(mapping.Pattern, requestModel) {
+			continue
+		}
+		if _, exists := seen[mapping.Target]; exists {
+			continue
+		}
+		seen[mapping.Target] = struct{}{}
+		candidates = append(candidates, mapping.Target)
+	}
+	if len(candidates) == 0 {
+		return []string{requestModel}
+	}
+	return candidates
+}
+
+func isProviderAnyModelExposed(provider *domain.Provider, models []string) bool {
+	if provider == nil || !provider.ExposedModelsEnabled {
+		return true
+	}
+	for _, model := range models {
+		if isProviderModelExposed(provider, model) {
 			return true
 		}
 	}

--- a/internal/handler/models_availability_test.go
+++ b/internal/handler/models_availability_test.go
@@ -327,3 +327,44 @@ func TestUserPanelAvailableModelsIncludesCodexOnlyVisibleRoute(t *testing.T) {
 		t.Fatalf("names = %v, want Codex-only model", names)
 	}
 }
+
+func TestModelsHandlerAvailabilityUsesMappedModelCandidates(t *testing.T) {
+	providers := []*domain.Provider{
+		testCustomProvider(10, "pre-mapped-only", []string{"gpt-5"}),
+		testCustomProvider(20, "mapped-target", []string{"moonshotai/kimi-k3"}),
+	}
+	providers[1].ExposedModelsEnabled = true
+	providers[1].ExposedModels = []string{"moonshotai/kimi-k3"}
+	routes := []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 10, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 1, Weight: 1},
+		{ID: 2, TenantID: 1, ProviderID: 20, ClientType: domain.ClientTypeOpenAI, ProjectID: 0, IsEnabled: true, Position: 2, Weight: 1},
+	}
+	r, providerRepo := newModelAvailabilityRouter(t, providers, routes, nil)
+	mappingRepo := &fakeModelMappingRepo{mappings: []*domain.ModelMapping{
+		{Pattern: "gpt-5", Target: "moonshotai/kimi-k3", IsEnabled: true},
+	}}
+	handler := NewModelsHandler(&fakeResponseModelRepo{names: []string{"gpt-5", "moonshotai/kimi-k3"}}, providerRepo, mappingRepo, r)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	ids := decodeOpenAIModelIDs(t, rec.Body.Bytes())
+	if !containsModel(ids, "gpt-5") || !containsModel(ids, "moonshotai/kimi-k3") {
+		t.Fatalf("ids = %v, want both gpt-5 and moonshotai/kimi-k3 available through mapped-target", ids)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("X-Maxx-Provider-ID", "10")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	ids = decodeOpenAIModelIDs(t, rec.Body.Bytes())
+	if containsModel(ids, "gpt-5") || containsModel(ids, "moonshotai/kimi-k3") {
+		t.Fatalf("provider 10 ids = %v, want mapped request unavailable for pre-mapped-only provider", ids)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -59,6 +59,7 @@ type MatchContext struct {
 	ClientType                domain.ClientType
 	ProjectID                 uint64
 	RequestModel              string
+	ModelCandidates           func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string
 	APITokenID                uint64
 	SessionID                 string
 	RequireResponsesWebSocket bool
@@ -374,8 +375,10 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 			continue
 		}
 
-		// Skip providers in cooldown (checks provider, key, and model-level cooldowns)
-		if r.cooldownManager.IsInCooldown(route.ProviderID, string(clientType), requestModel) {
+		modelCandidates := r.modelCandidatesForMatch(route, prov, clientType, requestModel, ctx.ModelCandidates)
+
+		// Skip providers in cooldown (checks provider, key, and outbound model-level cooldowns)
+		if r.isAnyModelCandidateInCooldown(route.ProviderID, clientType, modelCandidates) {
 			sawTransientSkip = true
 			continue
 		}
@@ -406,13 +409,15 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 			}
 		}
 
-		// Check if provider supports the request model only when the adapter
-		// natively speaks the request protocol. Converted routes (for example an
-		// OpenAI chat route targeting a Claude provider) map the model later in
-		// dispatch, so applying provider-native SupportModels to the pre-mapped
-		// request model here would incorrectly drop valid cross-protocol routes.
+		// Check if provider supports the outbound model only when the adapter
+		// natively speaks the request protocol. Model mappings are route/provider
+		// scoped and dispatch applies them after route matching, so route matching
+		// must evaluate the same candidate list here; otherwise a request such as
+		// gpt-5 -> moonshotai/kimi-k3 can be routed by the pre-mapped gpt-5 allowlist
+		// to a provider/key that cannot serve the mapped model, while a direct
+		// moonshotai/kimi-k3 request would choose a different working route.
 		if (r.strictSupportModelsRoutingEnabled() || ctx.StrictSupportModels) && adapterSupportsClientType(adp, clientType) && len(prov.SupportModels) > 0 && requestModel != "" {
-			if !r.isModelSupported(requestModel, prov.SupportModels) {
+			if !r.isAnyModelCandidateSupported(prov, modelCandidates) {
 				sawModelReject = true
 				continue
 			}
@@ -625,6 +630,37 @@ func (r *Router) CloseResponsesWebSocketConnection(connectionID string) {
 
 func (r *Router) strictSupportModelsRoutingEnabled() bool {
 	return systemsettingcache.GetBooleanDefault(r.settingRepo, domain.SettingKeyStrictSupportModelsRoutingEnabled, false)
+}
+
+func (r *Router) modelCandidatesForMatch(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string, candidatesFn func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string) []string {
+	candidates := []string{requestModel}
+	if candidatesFn != nil {
+		if mapped := candidatesFn(route, provider, clientType, requestModel); len(mapped) > 0 {
+			candidates = mapped
+		}
+	}
+	return candidates
+}
+
+func (r *Router) isAnyModelCandidateInCooldown(providerID uint64, clientType domain.ClientType, candidates []string) bool {
+	if len(candidates) == 0 {
+		return r.cooldownManager.IsInCooldown(providerID, string(clientType), "")
+	}
+	for _, model := range candidates {
+		if r.cooldownManager.IsInCooldown(providerID, string(clientType), model) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Router) isAnyModelCandidateSupported(provider *domain.Provider, candidates []string) bool {
+	for _, model := range candidates {
+		if model != "" && r.isModelSupported(model, provider.SupportModels) {
+			return true
+		}
+	}
+	return false
 }
 
 // isModelSupported checks if a model matches any pattern in the support list

--- a/internal/router/support_models_routing_test.go
+++ b/internal/router/support_models_routing_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/repository/cached"
@@ -127,5 +128,89 @@ func TestStrictSupportModelsRoutingReturnsModelUnsupportedWhenAllSkipped(t *test
 	_, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "codex-target"})
 	if !errors.Is(err, domain.ErrModelNotSupported) {
 		t.Fatalf("Match() error = %v, want ErrModelNotSupported", err)
+	}
+}
+
+func TestStrictSupportModelsRoutingUsesMappedModelCandidates(t *testing.T) {
+	r := newSupportModelRoutingTestRouter(t, true,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 2, TenantID: 1, ProviderID: 102, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "pre-mapped-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"gpt-5"}},
+			{ID: 102, TenantID: 1, Type: wsRouterNativeType, Name: "mapped-target", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"moonshotai/kimi-k3"}},
+		},
+	)
+
+	result, err := r.Match(&MatchContext{
+		TenantID:     1,
+		ClientType:   domain.ClientTypeCodex,
+		RequestModel: "gpt-5",
+		ModelCandidates: func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string {
+			if requestModel == "gpt-5" {
+				return []string{"moonshotai/kimi-k3"}
+			}
+			return []string{requestModel}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if got := matchedProviderIDs(result); len(got) != 1 || got[0] != 102 {
+		t.Fatalf("matched provider IDs = %v, want [102]", got)
+	}
+}
+
+func TestStrictSupportModelsRoutingFallsBackToRequestModelWithoutCandidates(t *testing.T) {
+	r := newSupportModelRoutingTestRouter(t, true,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+		},
+		[]*domain.Provider{
+			{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "direct", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"moonshotai/kimi-k3"}},
+		},
+	)
+
+	result, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "moonshotai/kimi-k3"})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if got := matchedProviderIDs(result); len(got) != 1 || got[0] != 101 {
+		t.Fatalf("matched provider IDs = %v, want [101]", got)
+	}
+}
+
+func TestRouteMatchChecksCooldownAgainstMappedModelCandidates(t *testing.T) {
+	r := newSupportModelRoutingTestRouter(t, true,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 2, TenantID: 1, ProviderID: 102, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "mapped-target-cooldown", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"moonshotai/kimi-k3"}},
+			{ID: 102, TenantID: 1, Type: wsRouterNativeType, Name: "mapped-target-live", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"moonshotai/kimi-k3"}},
+		},
+	)
+
+	r.cooldownManager.SetCooldownUntil(101, string(domain.ClientTypeCodex), "moonshotai/kimi-k3", time.Now().Add(time.Minute))
+	defer r.cooldownManager.ClearCooldown(101, string(domain.ClientTypeCodex), "moonshotai/kimi-k3")
+
+	result, err := r.Match(&MatchContext{
+		TenantID:     1,
+		ClientType:   domain.ClientTypeCodex,
+		RequestModel: "gpt-5",
+		ModelCandidates: func(route *domain.Route, provider *domain.Provider, clientType domain.ClientType, requestModel string) []string {
+			if requestModel == "gpt-5" {
+				return []string{"moonshotai/kimi-k3"}
+			}
+			return []string{requestModel}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Match() error = %v", err)
+	}
+	if got := matchedProviderIDs(result); len(got) != 1 || got[0] != 102 {
+		t.Fatalf("matched provider IDs = %v, want [102]", got)
 	}
 }


### PR DESCRIPTION
## Summary
- make route matching evaluate route/provider-scoped mapped model candidates when strict SupportModels routing is active
- wire the same model candidate lookup through normal executor route matching, provider proxy route matching, and model availability checks
- add regression coverage for mapped `gpt-5 -> moonshotai/kimi-k3` requests and direct `moonshotai/kimi-k3` fallback behavior

## Why
A mapped request was previously routed by the pre-mapped request model (`gpt-5`) and only later dispatched as the mapped outbound model (`moonshotai/kimi-k3`). That can select a route/provider/key that accepts `gpt-5` in `SupportModels` but cannot actually serve `moonshotai/kimi-k3` upstream, producing upstream `422` errors such as `no channel candidates remain`.

Direct `moonshotai/kimi-k3` requests can still appear intermittently healthy because route ordering is strategy-dependent (including `weighted_random`/session affinity/cooldown state) and direct requests are filtered by the target model from the start, so they may land on a different provider/channel set than the mapped `gpt-5` path. This PR aligns the mapped path with the direct outbound model support filter before provider selection.

## Tests
- `git diff --check`
- `go test ./cmd/... ./internal/... ./tests/e2e ./tests/multiinstance`

## Note
- `go test ./...` still fails at the root package setup when `web/dist` is absent: `main.go:26:12: pattern all:web/dist: no matching files found`. The targeted Go package suite above passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 模型映射现已应用于严格模型支持路由，可根据映射后的目标模型选择可用提供商。
  * 通过提供商直连请求进行模型匹配时，同样支持模型映射。

* **Bug 修复**
  * 优化模型可用性检查，使模型列表能正确反映映射模型在不同提供商上的可用状态。
  * 在缺少映射配置或相关信息时，系统将继续使用原始请求模型进行匹配。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->