### PR TITLE
fix(custom): fail over invalid model 422 errors

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -1439,7 +1439,19 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 		proxyErr.Reason = domain.CooldownReasonNetworkError
 		proxyErr.Retryable = true
 
-	// 400, 413, 422 — request-level errors
+	// 422 can also mean provider/channel model availability, not a malformed
+	// client request. NewAPI-style upstreams return invalid_model_error with
+	// "model not found" / "no channel candidates remain" when the selected
+	// provider key/channel cannot serve the mapped model. Treat that as a
+	// provider-model miss so the executor cools that model/provider and fails
+	// over to the next route instead of returning immediately.
+	case statusCode == http.StatusUnprocessableEntity && isModelUnavailableBody(bodyLower):
+		proxyErr.Scope = domain.ScopeModel
+		proxyErr.Reason = domain.CooldownReasonModelUnavailable
+		proxyErr.Model = model
+		proxyErr.Retryable = false
+
+	// 400, 413, other 422 — request-level errors
 	case statusCode == 400 || statusCode == 413 || statusCode == 422:
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.Retryable = false
@@ -1473,6 +1485,13 @@ func classifyHTTPError(statusCode int, body []byte, headers http.Header, clientT
 	}
 
 	return proxyErr
+}
+
+func isModelUnavailableBody(bodyLower string) bool {
+	if bodyLower == "" {
+		return false
+	}
+	return containsAny(bodyLower, "invalid_model_error", "invalid model", "model_not_found", "model not found", "no channel candidates remain") && containsAny(bodyLower, "model")
 }
 
 // classify429Error determines the scope and reason for 429 rate limit errors.

--- a/internal/adapter/provider/custom/rate_limit_test.go
+++ b/internal/adapter/provider/custom/rate_limit_test.go
@@ -182,3 +182,35 @@ func TestClassifyHTTPErrorRequestTimeoutIsRetryableNetworkError(t *testing.T) {
 		t.Fatal("408 upstream timeout should be retryable")
 	}
 }
+
+func TestClassifyHTTPError422InvalidModelIsModelScoped(t *testing.T) {
+	body := []byte(`{"error":{"message":"model not found: moonshotai/kimi-k3 (no channel candidates remain; applied filters: api_key.binding_mode=manual, api_key.channelIDs, api_format=openai/chat_completions, stream=true)","type":"invalid_model_error"}}`)
+
+	proxyErr := classifyHTTPError(http.StatusUnprocessableEntity, body, http.Header{}, domain.ClientTypeOpenAI, "moonshotai/kimi-k3")
+
+	if proxyErr.Scope != domain.ScopeModel {
+		t.Fatalf("Scope = %v, want ScopeModel", proxyErr.Scope)
+	}
+	if proxyErr.Reason != domain.CooldownReasonModelUnavailable {
+		t.Fatalf("Reason = %v, want CooldownReasonModelUnavailable", proxyErr.Reason)
+	}
+	if proxyErr.Model != "moonshotai/kimi-k3" {
+		t.Fatalf("Model = %q, want moonshotai/kimi-k3", proxyErr.Model)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("422 invalid_model_error should not retry the same provider")
+	}
+}
+
+func TestClassifyHTTPError422ValidationRemainsRequestScoped(t *testing.T) {
+	body := []byte(`{"error":{"message":"messages: field required","type":"invalid_request_error"}}`)
+
+	proxyErr := classifyHTTPError(http.StatusUnprocessableEntity, body, http.Header{}, domain.ClientTypeOpenAI, "moonshotai/kimi-k3")
+
+	if proxyErr.Scope != domain.ScopeRequest {
+		t.Fatalf("Scope = %v, want ScopeRequest", proxyErr.Scope)
+	}
+	if proxyErr.Retryable {
+		t.Fatal("422 validation error should not be retryable")
+	}
+}

--- a/internal/executor/force_retry_setting_test.go
+++ b/internal/executor/force_retry_setting_test.go
@@ -274,3 +274,47 @@ func newForceRetryDispatchHarnessWithContext(
 	}
 	return adapter, proxyReq, c, e
 }
+
+func TestDispatchModelScopedNonRetryableErrorFailsOverToNextRoute(t *testing.T) {
+	modelErr := domain.NewProxyErrorWithMessage(errors.New(`{"error":{"message":"model not found: moonshotai/kimi-k3"}}`), false, "upstream returned status 422")
+	modelErr.Scope = domain.ScopeModel
+	modelErr.Reason = domain.CooldownReasonModelUnavailable
+	modelErr.Model = "moonshotai/kimi-k3"
+	modelErr.HTTPStatusCode = http.StatusUnprocessableEntity
+
+	first := &forceRetrySequenceAdapter{errs: []error{modelErr}}
+	second := &forceRetrySequenceAdapter{}
+	_, proxyReq, c, e := newForceRetryDispatchHarness(
+		t,
+		false,
+		first,
+		&domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	)
+	storedState, ok := c.Get(flow.KeyExecutorState)
+	if !ok {
+		t.Fatal("executor state missing")
+	}
+	state := storedState.(*execState)
+	state.requestModel = "gpt-5"
+	state.routes = append(state.routes, &router.MatchedRoute{
+		Route:           &domain.Route{ID: 11, TenantID: domain.DefaultTenantID, ProviderID: 21, ClientType: domain.ClientTypeOpenAI},
+		Provider:        &domain.Provider{ID: 21, TenantID: domain.DefaultTenantID, Type: "custom", Name: "custom-success"},
+		ProviderAdapter: second,
+		RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+	})
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error = %v", c.Err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("adapter calls first=%d second=%d, want 1/1", first.calls, second.calls)
+	}
+	if proxyReq.Status != "COMPLETED" {
+		t.Fatalf("proxy request status = %q, want COMPLETED", proxyReq.Status)
+	}
+	if proxyReq.ProviderID != 21 {
+		t.Fatalf("final provider ID = %d, want 21", proxyReq.ProviderID)
+	}
+}


### PR DESCRIPTION
## Summary
- classify upstream 422 `invalid_model_error` / `model not found` / `no channel candidates remain` as provider-model availability failures instead of request validation errors
- preserve ordinary 422 validation errors as request-scoped and non-retryable
- add dispatch regression proving model-scoped non-retryable failures fail over to the next matched route

## Why
The observed upstream response is HTTP 422, but semantically it means the selected upstream provider/key/channel cannot serve the mapped model (`moonshotai/kimi-k3`). Treating every 422 as `ScopeRequest` makes the executor stop immediately, so it never cools that provider/model and never tries the next route.

## Validation
- `git diff --check`
- `go test ./cmd/... ./internal/... ./tests/e2e ./tests/multiinstance`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误处理**
  - 优化部分 HTTP 422 错误的识别：当上游明确表示模型不可用时，将自动标记相关模型并进入冷却，避免继续重复请求。
  - 模型不可用且不可重试时，系统会自动切换至下一可用路由。
  - 其他请求参数或验证类 422 错误仍按请求错误处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->