### PR TITLE
fix(proxy): isolate API token concurrency rejections

### DIFF
--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -122,12 +122,18 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var apiToken *domain.APIToken
 		if h.tokenAuth != nil {
 			var err error
-			apiToken, err = h.tokenAuth.ValidateRequest(r, domain.ClientTypeCodex)
+			apiToken, err = h.tokenAuth.ResolveToken(r)
 			if err != nil {
 				writeError(w, http.StatusUnauthorized, err.Error())
 				return
 			}
 			if apiToken != nil {
+				if err := h.tokenAuth.AcquireConcurrency(apiToken); err != nil {
+					writeRateLimitError(w, err.Error(), 1)
+					return
+				}
+				defer h.tokenAuth.ReleaseConcurrency(apiToken)
+				h.tokenAuth.UpdateLastSeen(r, apiToken)
 				if apiToken.TenantID > 0 {
 					tenantID = apiToken.TenantID
 				}
@@ -218,12 +224,42 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/v1")
 	}
 
+	var apiToken *domain.APIToken
+	var apiTokenID uint64
+	if h.tokenAuth != nil {
+		var err error
+		apiToken, err = h.tokenAuth.ResolveToken(r)
+		if err != nil {
+			log.Printf("[Proxy] Token auth failed: %v", err)
+			writeError(w, http.StatusUnauthorized, err.Error())
+			c.Abort()
+			return
+		}
+		if apiToken != nil {
+			apiTokenID = apiToken.ID
+			log.Printf("[Proxy] Token authenticated: id=%d, name=%s, projectID=%d", apiToken.ID, apiToken.Name, apiToken.ProjectID)
+			c.Set(flow.KeyAPITokenID, apiTokenID)
+			c.Set(flow.KeyAPITokenDevMode, apiToken.DevMode)
+
+			if err := h.tokenAuth.AcquireConcurrency(apiToken); err != nil {
+				log.Printf("[Proxy] Token concurrency limit hit: tokenID=%d err=%v", apiToken.ID, err)
+				c.Set(flow.KeyRequestHeaders, r.Header)
+				c.Set(flow.KeyRequestURI, r.URL.RequestURI())
+				h.executor.RecordRejectedProxyRequest(c, apiToken, http.StatusTooManyRequests, err.Error())
+				writeRateLimitError(w, err.Error(), 1)
+				c.Abort()
+				return
+			}
+			defer h.tokenAuth.ReleaseConcurrency(apiToken)
+			h.tokenAuth.UpdateLastSeen(r, apiToken)
+		}
+	}
+
 	// 大上传准入控制:在把 body 读进内存之前先门控,避免大量并发大上传同时挤爆堆。
 	// 名额持有到本函数返回(c.Next 同步跑完整个请求链路后),覆盖 body 在内存的整个生命周期。
 	//
-	// 刻意放在 stream 检测/鉴权之前:目的就是在做任何工作、读任何 body 之前廉价地泄洪。
-	// 代价是被泄洪的请求即使本是 SSE,拿到的也是 HTTP 层 413/429 而非 SSE 错误事件——
-	// 此时 body 还没读、client type 还不知道,无法构造对应协议的错误,可接受。
+	// API token 并发门控已在上方抢先完成:同一 token 超额请求会在读 body /
+	// 占用大上传槽位之前直接 429,避免它们拖累其他正常请求。
 	if h.uploadLimiter != nil {
 		if h.uploadLimiter.tooLarge(r.ContentLength) {
 			log.Printf("[Proxy] rejecting over-limit upload: %s %s (len=%d > %d)", r.Method, r.URL.Path, r.ContentLength, h.uploadLimiter.maxBytes)
@@ -288,24 +324,6 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		return
 	}
 
-	var err error
-	var apiToken *domain.APIToken
-	var apiTokenID uint64
-	if h.tokenAuth != nil {
-		apiToken, err = h.tokenAuth.ValidateRequest(r, clientType)
-		if err != nil {
-			log.Printf("[Proxy] Token auth failed: %v", err)
-			writeError(w, http.StatusUnauthorized, err.Error())
-			c.Abort()
-			return
-		}
-		if apiToken != nil {
-			apiTokenID = apiToken.ID
-			log.Printf("[Proxy] Token authenticated: id=%d, name=%s, projectID=%d", apiToken.ID, apiToken.Name, apiToken.ProjectID)
-			c.Set(flow.KeyAPITokenDevMode, apiToken.DevMode)
-		}
-	}
-
 	if isClaudeCountTokensRequest(r, clientType) {
 		log.Printf("[Proxy] Handling Claude count_tokens locally")
 		writeClaudeCountTokensResponse(w, body)
@@ -349,17 +367,6 @@ func (h *ProxyHandler) ingress(c *flow.Ctx) {
 		log.Printf("[Proxy] Using initial project ID: %d", projectID)
 	}
 	c.Set(flow.KeyProjectID, projectID)
-
-	if apiToken != nil {
-		if err := h.tokenAuth.AcquireConcurrency(apiToken); err != nil {
-			log.Printf("[Proxy] Token concurrency limit hit: tokenID=%d err=%v", apiToken.ID, err)
-			h.executor.RecordRejectedProxyRequest(c, apiToken, http.StatusTooManyRequests, err.Error())
-			writeRateLimitError(w, err.Error(), 1)
-			c.Abort()
-			return
-		}
-		defer h.tokenAuth.ReleaseConcurrency(apiToken)
-	}
 
 	// Determine tenantID from API token or use default
 	var tenantID uint64

--- a/internal/handler/token_auth.go
+++ b/internal/handler/token_auth.go
@@ -180,7 +180,17 @@ func (m *TokenAuthMiddleware) ValidateRequest(req *http.Request, clientType doma
 		return nil, err
 	}
 
-	// Update usage (async to not block request)
+	m.UpdateLastSeen(req, apiToken)
+
+	return apiToken, nil
+}
+
+// UpdateLastSeen records successful token use asynchronously so request handling
+// is not blocked by bookkeeping writes.
+func (m *TokenAuthMiddleware) UpdateLastSeen(req *http.Request, apiToken *domain.APIToken) {
+	if m == nil || apiToken == nil || apiToken.ID == 0 {
+		return
+	}
 	lastSeenAt := time.Now()
 	clientIP := strings.TrimSpace(getClientIP(req))
 	go func(tenantID uint64, tokenID uint64, lastIP string, seenAt time.Time) {
@@ -188,8 +198,6 @@ func (m *TokenAuthMiddleware) ValidateRequest(req *http.Request, clientType doma
 			log.Printf("[TokenAuth] Failed to update token last seen for ID %d: %v", tokenID, err)
 		}
 	}(apiToken.TenantID, apiToken.ID, clientIP, lastSeenAt)
-
-	return apiToken, nil
 }
 
 // WrapModelList protects GET model-list endpoints with the same API-token gate

--- a/tests/e2e/proxy_integration_test.go
+++ b/tests/e2e/proxy_integration_test.go
@@ -1862,6 +1862,105 @@ func TestProxyAllProtocolsCoexist(t *testing.T) {
 // Cooldown Integration Tests (using mock server)
 // ============================================================
 
+func TestTokenConcurrencyLimitOnlyRejectsExcessRequestsForThatToken(t *testing.T) {
+	firstTokenEntered := make(chan struct{}, 1)
+	firstTokenRelease := make(chan struct{})
+	firstTokenBlocking := true
+	var mu sync.Mutex
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		blockThisRequest := firstTokenBlocking
+		if firstTokenBlocking {
+			firstTokenBlocking = false
+		}
+		mu.Unlock()
+
+		if blockThisRequest {
+			firstTokenEntered <- struct{}{}
+			<-firstTokenRelease
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-mock-001",
+			"object":  "chat.completion",
+			"model":   "gpt-4o",
+			"created": 1700000000,
+			"choices": []map[string]any{{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": "ok",
+				},
+				"finish_reason": "stop",
+			}},
+		})
+	}))
+	defer mock.Close()
+
+	env := NewProxyTestEnv(t)
+	providerID := createProvider(t, env, "mock-openai-token-isolation", mock.URL, []string{"openai"})
+	createRoute(t, env, "openai", providerID)
+
+	resp := env.AdminPut("/api/admin/settings/api_token_auth_enabled", map[string]any{"value": "true"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	resp = env.AdminPut("/api/admin/settings/api_token_concurrent_limit", map[string]any{"value": "1"})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	createToken := func(name string) string {
+		t.Helper()
+		resp := env.AdminPost("/api/admin/api-tokens", map[string]any{"name": name})
+		AssertStatus(t, resp, http.StatusCreated)
+		var created map[string]any
+		DecodeJSON(t, resp, &created)
+		tokenStr, ok := created["token"].(string)
+		if !ok || tokenStr == "" {
+			t.Fatalf("Expected token string, got %v", created["token"])
+		}
+		return tokenStr
+	}
+	tokenA := createToken("isolated-concurrency-a")
+	tokenB := createToken("isolated-concurrency-b")
+
+	firstDone := make(chan error, 1)
+	go func() {
+		resp := env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), map[string]string{
+			"Authorization": "Bearer " + tokenA,
+		})
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			firstDone <- fmt.Errorf("first request status=%d body=%s", resp.StatusCode, body)
+			return
+		}
+		firstDone <- nil
+	}()
+
+	select {
+	case <-firstTokenEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first token request to reach upstream")
+	}
+
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), map[string]string{
+		"Authorization": "Bearer " + tokenA,
+	})
+	AssertStatus(t, resp, http.StatusTooManyRequests)
+	resp.Body.Close()
+
+	resp = env.ProxyPost("/v1/chat/completions", openaiRequest("gpt-4o"), map[string]string{
+		"Authorization": "Bearer " + tokenB,
+	})
+	AssertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	close(firstTokenRelease)
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTokenConcurrencyLimitRecordsRejectedRequest(t *testing.T) {
 	cases := []struct {
 		name               string


### PR DESCRIPTION
## Summary
- move API token concurrency acquisition ahead of body reads and large-upload admission
- reject only the excess request for the saturated token with 429 before it can consume upload/body resources
- keep WebSocket token concurrency under the same isolated gate
- add E2E coverage that a saturated token does not block another token

## Validation
- `go test ./internal/handler ./internal/executor ./tests/e2e -count=1`
- `go test ./...` *(expected setup failure at root: `main.go:26:12: pattern all:web/dist: no matching files found`; packages under internal/tests pass before that root embed setup failure)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * API Token 的并发限制现按令牌分别计算，单个令牌达到上限时不会影响其他令牌的请求。
  * WebSocket 和代理请求会更早完成令牌验证及并发控制。

* **问题修复**
  * 并发请求被拒绝时返回 429，并补充相关请求上下文信息。
  * 优化令牌最近使用时间的更新流程，提升异常场景下的稳定性。

* **测试**
  * 新增端到端测试，验证不同 API Token 之间的并发限制相互隔离。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->