### PR TITLE
fix(cliproxyapi): stop retry amplification on rate-limited and usage-capped accounts

### DIFF
--- a/internal/adapter/provider/cliproxyapi_antigravity/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_antigravity/adapter.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/cliproxyerr"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/exec"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
-	"github.com/awsl-project/maxx/internal/adapter/provider"
-	"github.com/awsl-project/maxx/internal/domain"
-	"github.com/awsl-project/maxx/internal/flow"
-	"github.com/awsl-project/maxx/internal/usage"
 )
 
 type CLIProxyAPIAntigravityAdapter struct {
@@ -135,10 +136,8 @@ func (a *CLIProxyAPIAntigravityAdapter) executeNonStream(c *flow.Ctx, w http.Res
 	resp, err := a.executor.Execute(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
 		log.Printf("[CLIProxyAPI-Antigravity] executeNonStream error: model=%s, err=%v", execReq.Model, err)
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
@@ -187,10 +186,8 @@ func (a *CLIProxyAPIAntigravityAdapter) executeStream(c *flow.Ctx, w http.Respon
 	stream, err := a.executor.ExecuteStream(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
 		log.Printf("[CLIProxyAPI-Antigravity] executeStream error: model=%s, err=%v", execReq.Model, err)
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor stream request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor stream request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 
 	// 设置 SSE 响应头
@@ -254,10 +251,8 @@ func (a *CLIProxyAPIAntigravityAdapter) executeStream(c *flow.Ctx, w http.Respon
 
 	// If error occurred before any data was sent, return error to caller
 	if streamErr != nil && sseBuffer.Len() == 0 {
-		proxyErr := domain.NewProxyErrorWithMessage(streamErr, true, fmt.Sprintf("stream chunk error: %v", streamErr))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonNetworkError
-		return proxyErr
+		return cliproxyerr.Classify(streamErr, execReq.Model, fmt.Sprintf("stream chunk error: %v", streamErr),
+			domain.ScopeProvider, domain.CooldownReasonNetworkError)
 	}
 
 	return nil

--- a/internal/adapter/provider/cliproxyapi_codex/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_codex/adapter.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/cliproxyerr"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -325,10 +326,8 @@ func (a *CLIProxyAPICodexAdapter) executeNonStream(c *flow.Ctx, w http.ResponseW
 
 	resp, err := a.executor.Execute(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
@@ -371,10 +370,8 @@ func (a *CLIProxyAPICodexAdapter) executeStream(c *flow.Ctx, w http.ResponseWrit
 
 	stream, err := a.executor.ExecuteStream(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor stream request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor stream request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 
 	// 设置 SSE 响应头
@@ -436,10 +433,8 @@ func (a *CLIProxyAPICodexAdapter) executeStream(c *flow.Ctx, w http.ResponseWrit
 
 	// If error occurred before any data was sent, return error to caller
 	if streamErr != nil && sseBuffer.Len() == 0 {
-		proxyErr := domain.NewProxyErrorWithMessage(streamErr, true, fmt.Sprintf("stream chunk error: %v", streamErr))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonNetworkError
-		return proxyErr
+		return cliproxyerr.Classify(streamErr, execReq.Model, fmt.Sprintf("stream chunk error: %v", streamErr),
+			domain.ScopeProvider, domain.CooldownReasonNetworkError)
 	}
 
 	return nil

--- a/internal/adapter/provider/cliproxyapi_grok/adapter.go
+++ b/internal/adapter/provider/cliproxyapi_grok/adapter.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/awsl-project/maxx/internal/adapter/provider"
+	"github.com/awsl-project/maxx/internal/adapter/provider/cliproxyerr"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/usage"
@@ -204,10 +205,8 @@ func (a *CLIProxyAPIGrokAdapter) executeNonStream(c *flow.Ctx, w http.ResponseWr
 	resp, err := a.executor.Execute(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
 		log.Printf("[CLIProxyAPI-Grok] executeNonStream error: model=%s, err=%v", execReq.Model, err)
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 	if eventChan := flow.GetEventChan(c); eventChan != nil {
 		eventChan.SendResponseInfo(&domain.ResponseInfo{Status: http.StatusOK, Body: string(resp.Payload)})
@@ -236,10 +235,8 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 	stream, err := a.executor.ExecuteStream(ctx, a.authObj, execReq, execOpts)
 	if err != nil {
 		log.Printf("[CLIProxyAPI-Grok] executeStream error: model=%s, err=%v", execReq.Model, err)
-		proxyErr := domain.NewProxyErrorWithMessage(err, true, fmt.Sprintf("executor stream request failed: %v", err))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(err, execReq.Model, fmt.Sprintf("executor stream request failed: %v", err),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -304,10 +301,8 @@ func (a *CLIProxyAPIGrokAdapter) executeStream(c *flow.Ctx, w http.ResponseWrite
 		}
 	}
 	if streamErr != nil {
-		proxyErr := domain.NewProxyErrorWithMessage(streamErr, true, fmt.Sprintf("stream error: %v", streamErr))
-		proxyErr.Scope = domain.ScopeProvider
-		proxyErr.Reason = domain.CooldownReasonServerError
-		return proxyErr
+		return cliproxyerr.Classify(streamErr, execReq.Model, fmt.Sprintf("stream error: %v", streamErr),
+			domain.ScopeProvider, domain.CooldownReasonServerError)
 	}
 	return nil
 }

--- a/internal/adapter/provider/cliproxyerr/classify.go
+++ b/internal/adapter/provider/cliproxyerr/classify.go
@@ -1,0 +1,272 @@
+// Package cliproxyerr classifies errors returned by the CLIProxyAPI SDK
+// executors into maxx's ProxyError scope/reason/retryable model.
+//
+// The SDK surfaces upstream failures as opaque errors whose message is the raw
+// upstream response body, and optionally exposes the HTTP status and a retry
+// hint through the StatusCode()/RetryAfter() interfaces. The cliproxyapi_*
+// adapters used to ignore all of that and label every failure a retryable
+// provider-side server error, so a rate-limited or usage-capped account was
+// retried until the executor's global attempt ceiling cut the request off —
+// proxy_request 75010 burned 200 upstream calls in 99 seconds that way, 100 of
+// them after the upstream had already said the quota resets in 2.6 days.
+package cliproxyerr
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	// maxRetryAfterHint caps how long an upstream retry hint may stall the
+	// inbound request inside the dispatch retry wait. A usage-limit reset is
+	// hours or days out; parking the client connection that long is never
+	// right, so longer hints are recorded as cooldown state only and the
+	// request fails over to another provider instead.
+	maxRetryAfterHint = 30 * time.Second
+
+	// defaultRateLimitCooldown matches the native codex adapter's fallback for
+	// a 429 that carries no explicit reset hint.
+	defaultRateLimitCooldown = time.Minute
+
+	// maxCooldownHorizon bounds how far out an upstream-reported reset may push
+	// a cooldown, so one bogus timestamp cannot park a key indefinitely.
+	maxCooldownHorizon = 7 * 24 * time.Hour
+)
+
+// Classify wraps err as a ProxyError carrying msg, refining scope, reason and
+// retryability from the HTTP status and error body the SDK reports. model names
+// the mapped model that produced the error, used as the cooldown key when the
+// failure turns out to be model-scoped. fallbackScope and fallbackReason apply
+// when the error carries no signal we can read confidently.
+func Classify(err error, model, msg string, fallbackScope domain.ErrorScope, fallbackReason domain.CooldownReason) *domain.ProxyError {
+	proxyErr := domain.NewProxyErrorWithMessage(err, true, msg)
+	proxyErr.Scope = fallbackScope
+	proxyErr.Reason = fallbackReason
+	proxyErr.Model = model
+	if err == nil {
+		return proxyErr
+	}
+
+	body := err.Error()
+	proxyErr.HTTPStatusCode = statusCodeOf(err)
+	applyRetryHint(proxyErr, err)
+
+	// The body is the more specific signal and wins: the SDK rewrites a
+	// usage-limit rejection to HTTP 429, which the status rules alone would
+	// mistake for a transient rate limit worth hammering.
+	if classifyBody(proxyErr, body) {
+		return proxyErr
+	}
+	classifyStatus(proxyErr, body)
+	return proxyErr
+}
+
+// statusCodeOf reads the HTTP status the SDK attached to err, if any.
+func statusCodeOf(err error) int {
+	var statusErr interface{ StatusCode() int }
+	if errors.As(err, &statusErr) {
+		return statusErr.StatusCode()
+	}
+	return 0
+}
+
+// applyRetryHint transfers the SDK's Retry-After hint onto proxyErr. The hint
+// always becomes cooldown state; it only becomes an in-request retry delay when
+// it is short enough to be worth waiting out.
+func applyRetryHint(proxyErr *domain.ProxyError, err error) {
+	var retryAfterErr interface{ RetryAfter() *time.Duration }
+	if !errors.As(err, &retryAfterErr) {
+		return
+	}
+	hint := retryAfterErr.RetryAfter()
+	if hint == nil || *hint <= 0 {
+		return
+	}
+	setCooldownUntil(proxyErr, time.Now().Add(*hint))
+	if *hint <= maxRetryAfterHint {
+		proxyErr.RetryAfter = *hint
+	}
+}
+
+// classifyBody refines proxyErr from the upstream JSON error body. It reports
+// false when the body carries no unambiguous signal, leaving the decision to
+// the status code. Patterns are kept narrow on purpose — anything we cannot
+// read confidently stays at the caller's fallback so genuine outages still trip
+// the wider provider cooldown.
+func classifyBody(proxyErr *domain.ProxyError, body string) bool {
+	if !gjson.Valid(body) {
+		return false
+	}
+	code := firstString(body, "error.code", "code")
+	errType := firstString(body, "error.type", "type")
+	msg := firstString(body, "error.message", "message", "detail", "error")
+
+	// Usage/quota exhaustion: the upstream told us when it resets, hours or
+	// days out. Retrying the same key before then cannot succeed.
+	if code == "usage_limit_reached" || errType == "usage_limit_reached" ||
+		code == "insufficient_quota" || code == "billing_hard_limit_reached" ||
+		containsAny(msg, "usage limit has been reached", "usage limit reached",
+			"insufficient quota", "quota exceeded", "exceeded your current quota",
+			"exceeded your quota", "out of quota", "exhausted your quota") {
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+		applyQuotaReset(proxyErr, body)
+		return true
+	}
+
+	// Model-level: do not fail the whole provider over one unavailable model.
+	if code == "model_not_found" || code == "model_not_supported" ||
+		containsAny(msg, "model is not supported", "model not supported",
+			"model is not available", "model not available", "no access to the model",
+			"does not have access to model", "does not exist or you do not have access") {
+		proxyErr.Scope = domain.ScopeModel
+		proxyErr.Reason = domain.CooldownReasonModelUnavailable
+		proxyErr.Retryable = false
+		return true
+	}
+
+	// Key-level auth: the credential is wrong, not the upstream.
+	if code == "invalid_api_key" || code == "unauthorized" || code == "permission_denied" ||
+		containsAny(msg, "invalid api key", "unauthorized", "authentication failed") {
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonAuthFailure
+		proxyErr.Retryable = false
+		return true
+	}
+
+	// Rate limiting is genuinely transient: keep it retryable, but scope the
+	// cooldown to the key so other providers stay usable.
+	if code == "rate_limit_exceeded" || errType == "rate_limit_exceeded" ||
+		strings.Contains(msg, "rate limit") {
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonRateLimitExceeded
+		proxyErr.Retryable = true
+		ensureRateLimitCooldown(proxyErr)
+		return true
+	}
+
+	return false
+}
+
+// classifyStatus maps the upstream HTTP status onto scope/reason/retryable,
+// mirroring the native codex adapter's classifyCodexHTTPError. A zero status
+// means the SDK gave us nothing to go on, so the caller's fallback stands.
+func classifyStatus(proxyErr *domain.ProxyError, body string) {
+	switch status := proxyErr.HTTPStatusCode; {
+	case status == 0:
+		return
+
+	case status == http.StatusBadRequest,
+		status == http.StatusRequestEntityTooLarge,
+		status == http.StatusUnsupportedMediaType,
+		status == http.StatusUnprocessableEntity:
+		// The request itself is the problem — no provider will accept it.
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Retryable = false
+
+	case status == http.StatusUnauthorized, status == http.StatusForbidden:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonAuthFailure
+		proxyErr.Retryable = false
+
+	case status == http.StatusPaymentRequired:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonQuotaExhausted
+		proxyErr.Retryable = false
+
+	case status == http.StatusNotFound:
+		if proxyErr.Model != "" && strings.Contains(strings.ToLower(body), "model") {
+			proxyErr.Scope = domain.ScopeModel
+			proxyErr.Reason = domain.CooldownReasonModelUnavailable
+		} else {
+			proxyErr.Scope = domain.ScopeEndpoint
+			proxyErr.Reason = domain.CooldownReasonServerError
+		}
+		proxyErr.Retryable = false
+
+	case status == http.StatusTooManyRequests:
+		proxyErr.Scope = domain.ScopeKey
+		proxyErr.Reason = domain.CooldownReasonRateLimitExceeded
+		proxyErr.Retryable = true
+		ensureRateLimitCooldown(proxyErr)
+
+	case status == http.StatusRequestTimeout:
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonNetworkError
+		proxyErr.Retryable = true
+
+	case status >= 500:
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonServerError
+		proxyErr.Retryable = true
+
+	case status >= 400:
+		// Any other 4xx is a client-side reject; retrying only amplifies load.
+		proxyErr.Scope = domain.ScopeRequest
+		proxyErr.Retryable = false
+	}
+}
+
+// applyQuotaReset records the upstream's own reset time as the cooldown
+// deadline, so the key is skipped until it can actually serve again.
+func applyQuotaReset(proxyErr *domain.ProxyError, body string) {
+	for _, path := range []string{"error.resets_at", "resets_at"} {
+		if v := gjson.Get(body, path); v.Exists() && v.Int() > 0 {
+			setCooldownUntil(proxyErr, time.Unix(v.Int(), 0))
+			return
+		}
+	}
+	for _, path := range []string{"error.resets_in_seconds", "resets_in_seconds"} {
+		if v := gjson.Get(body, path); v.Exists() && v.Int() > 0 {
+			setCooldownUntil(proxyErr, time.Now().Add(time.Duration(v.Int())*time.Second))
+			return
+		}
+	}
+}
+
+// ensureRateLimitCooldown gives a rate limit without an explicit reset hint a
+// short default cooldown rather than none at all.
+func ensureRateLimitCooldown(proxyErr *domain.ProxyError) {
+	if proxyErr.CooldownUntil == nil && proxyErr.RetryAfter <= 0 {
+		setCooldownUntil(proxyErr, time.Now().Add(defaultRateLimitCooldown))
+	}
+}
+
+// setCooldownUntil stores until as the cooldown deadline, ignoring times that
+// are already past and clamping ones absurdly far out.
+func setCooldownUntil(proxyErr *domain.ProxyError, until time.Time) {
+	now := time.Now()
+	if !until.After(now) {
+		return
+	}
+	if horizon := now.Add(maxCooldownHorizon); until.After(horizon) {
+		until = horizon
+	}
+	proxyErr.CooldownUntil = &until
+}
+
+// firstString returns the first non-empty string among the given JSON paths,
+// lowercased for comparison against the pattern tables above.
+func firstString(body string, paths ...string) string {
+	for _, path := range paths {
+		if v := gjson.Get(body, path); v.Type == gjson.String && v.String() != "" {
+			return strings.ToLower(v.String())
+		}
+	}
+	return ""
+}
+
+func containsAny(s string, patterns ...string) bool {
+	for _, p := range patterns {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/adapter/provider/cliproxyerr/classify_test.go
+++ b/internal/adapter/provider/cliproxyerr/classify_test.go
@@ -1,0 +1,204 @@
+package cliproxyerr
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// sdkErr mimics the CLIProxyAPI SDK's statusErr: its message is the raw
+// upstream body, and it optionally exposes the HTTP status and a retry hint.
+type sdkErr struct {
+	body       string
+	code       int
+	retryAfter *time.Duration
+}
+
+func (e sdkErr) Error() string              { return e.body }
+func (e sdkErr) StatusCode() int            { return e.code }
+func (e sdkErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+// usageLimitBody is the exact payload proxy_request 75010 received 9 times and
+// then retried 100 more times, and resetsAt is its reported reset instant.
+const usageLimitBody = `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"prolite","resets_at":1788747900,"eligible_promo":null,"resets_in_seconds":227596}}`
+
+const resetsAt = 1788747900
+
+func TestClassifyUsageLimitReachedIsNotRetryable(t *testing.T) {
+	// The SDK rewrites usage_limit_reached to HTTP 429, so status alone would
+	// call this a transient throttle worth retrying.
+	proxyErr := Classify(sdkErr{body: usageLimitBody, code: 429}, "gpt-5.6-sol", "executor stream request failed",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Retryable {
+		t.Error("usage_limit_reached must not be retryable")
+	}
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Errorf("scope = %q, want %q", proxyErr.Scope, domain.ScopeKey)
+	}
+	if proxyErr.Reason != domain.CooldownReasonQuotaExhausted {
+		t.Errorf("reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonQuotaExhausted)
+	}
+	if proxyErr.CooldownUntil == nil {
+		t.Fatal("expected a cooldown deadline from resets_at")
+	}
+	if got := proxyErr.CooldownUntil.Unix(); got != resetsAt {
+		t.Errorf("cooldown until = %d, want %d (resets_at)", got, resetsAt)
+	}
+	// A 2.6-day reset must never become an in-request retry wait.
+	if proxyErr.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %v, want 0 (must fail over, not park the client)", proxyErr.RetryAfter)
+	}
+}
+
+func TestClassifyUsageLimitFromResetsInSecondsOnly(t *testing.T) {
+	body := `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_in_seconds":600}}`
+	proxyErr := Classify(sdkErr{body: body, code: 429}, "gpt-5.6-sol", "msg", domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.CooldownUntil == nil {
+		t.Fatal("expected a cooldown deadline from resets_in_seconds")
+	}
+	if d := time.Until(*proxyErr.CooldownUntil); d < 9*time.Minute || d > 11*time.Minute {
+		t.Errorf("cooldown in %v, want ~10m", d)
+	}
+}
+
+func TestClassifyRateLimitStaysRetryable(t *testing.T) {
+	// The other 191 attempts on proxy_request 75010.
+	proxyErr := Classify(sdkErr{body: `{"detail":"Rate limit exceeded"}`, code: 429}, "gpt-5.6-sol", "msg",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if !proxyErr.Retryable {
+		t.Error("a plain rate limit should stay retryable")
+	}
+	if proxyErr.Scope != domain.ScopeKey {
+		t.Errorf("scope = %q, want %q (cooldown the key, not the provider)", proxyErr.Scope, domain.ScopeKey)
+	}
+	if proxyErr.Reason != domain.CooldownReasonRateLimitExceeded {
+		t.Errorf("reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonRateLimitExceeded)
+	}
+	if proxyErr.CooldownUntil == nil {
+		t.Error("expected a default rate-limit cooldown")
+	}
+}
+
+func TestClassifyRateLimitBodyWithoutStatus(t *testing.T) {
+	// CLIProxyAPI does not always attach a status; the body alone must suffice.
+	proxyErr := Classify(errors.New(`{"detail":"Rate limit exceeded"}`), "gpt-5.6-sol", "msg",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Scope != domain.ScopeKey || proxyErr.Reason != domain.CooldownReasonRateLimitExceeded {
+		t.Errorf("scope/reason = %q/%q, want key/rate_limit_exceeded", proxyErr.Scope, proxyErr.Reason)
+	}
+}
+
+func TestClassifyStatusCodes(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		scope     domain.ErrorScope
+		reason    domain.CooldownReason
+		retryable bool
+	}{
+		{"bad request", 400, `{"error":{"message":"bad payload"}}`, domain.ScopeRequest, domain.CooldownReasonServerError, false},
+		{"payload too large", 413, `{}`, domain.ScopeRequest, domain.CooldownReasonServerError, false},
+		{"unauthorized", 401, `{}`, domain.ScopeKey, domain.CooldownReasonAuthFailure, false},
+		{"forbidden", 403, `{}`, domain.ScopeKey, domain.CooldownReasonAuthFailure, false},
+		{"payment required", 402, `{}`, domain.ScopeKey, domain.CooldownReasonQuotaExhausted, false},
+		{"not found", 404, `{"error":{"message":"no such endpoint"}}`, domain.ScopeEndpoint, domain.CooldownReasonServerError, false},
+		{"request timeout", 408, `{}`, domain.ScopeProvider, domain.CooldownReasonNetworkError, true},
+		{"server error", 500, `{}`, domain.ScopeProvider, domain.CooldownReasonServerError, true},
+		{"bad gateway", 502, `{}`, domain.ScopeProvider, domain.CooldownReasonServerError, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyErr := Classify(sdkErr{body: tt.body, code: tt.status}, "gpt-5.6-sol", "msg",
+				domain.ScopeProvider, domain.CooldownReasonServerError)
+			if proxyErr.HTTPStatusCode != tt.status {
+				t.Errorf("status = %d, want %d", proxyErr.HTTPStatusCode, tt.status)
+			}
+			if proxyErr.Scope != tt.scope {
+				t.Errorf("scope = %q, want %q", proxyErr.Scope, tt.scope)
+			}
+			if proxyErr.Retryable != tt.retryable {
+				t.Errorf("retryable = %v, want %v", proxyErr.Retryable, tt.retryable)
+			}
+			// ScopeRequest carries no cooldown reason; it never reaches a cooldown.
+			if tt.scope != domain.ScopeRequest && proxyErr.Reason != tt.reason {
+				t.Errorf("reason = %q, want %q", proxyErr.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestClassifyModelNotSupportedIsModelScoped(t *testing.T) {
+	body := `{"detail":"The model is not supported when using Codex with a ChatGPT account"}`
+	proxyErr := Classify(sdkErr{body: body, code: 400}, "gpt-5.6-sol", "msg",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Scope != domain.ScopeModel {
+		t.Errorf("scope = %q, want %q (must not freeze the whole provider)", proxyErr.Scope, domain.ScopeModel)
+	}
+	if proxyErr.Reason != domain.CooldownReasonModelUnavailable {
+		t.Errorf("reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonModelUnavailable)
+	}
+	if proxyErr.Model != "gpt-5.6-sol" {
+		t.Errorf("model = %q, want the mapped model as the cooldown key", proxyErr.Model)
+	}
+	if proxyErr.Retryable {
+		t.Error("an unsupported model must not be retried on the same provider")
+	}
+}
+
+func TestClassifyKeepsFallbackForUnreadableErrors(t *testing.T) {
+	// A bare transport error: no status, no JSON body. The caller's fallback
+	// classification must survive so genuine outages still trip the cooldown.
+	proxyErr := Classify(errors.New("connection reset by peer"), "gpt-5.6-sol", "stream chunk error",
+		domain.ScopeProvider, domain.CooldownReasonNetworkError)
+
+	if proxyErr.Scope != domain.ScopeProvider || proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Errorf("scope/reason = %q/%q, want the fallback provider/network_error", proxyErr.Scope, proxyErr.Reason)
+	}
+	if !proxyErr.Retryable {
+		t.Error("an unclassified transport error should stay retryable")
+	}
+	if proxyErr.HTTPStatusCode != 0 {
+		t.Errorf("status = %d, want 0", proxyErr.HTTPStatusCode)
+	}
+}
+
+func TestClassifyRetryHintBounds(t *testing.T) {
+	short := 5 * time.Second
+	long := 48 * time.Hour
+
+	shortErr := Classify(sdkErr{body: `{"detail":"Rate limit exceeded"}`, code: 429, retryAfter: &short},
+		"gpt-5.6-sol", "msg", domain.ScopeProvider, domain.CooldownReasonServerError)
+	if shortErr.RetryAfter != short {
+		t.Errorf("RetryAfter = %v, want %v (short hints are worth waiting out)", shortErr.RetryAfter, short)
+	}
+
+	longErr := Classify(sdkErr{body: `{"detail":"Rate limit exceeded"}`, code: 429, retryAfter: &long},
+		"gpt-5.6-sol", "msg", domain.ScopeProvider, domain.CooldownReasonServerError)
+	if longErr.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %v, want 0 (a 48h hint must fail over, not block the client)", longErr.RetryAfter)
+	}
+	if longErr.CooldownUntil == nil {
+		t.Fatal("a long hint should still become cooldown state")
+	}
+	if d := time.Until(*longErr.CooldownUntil); d > maxCooldownHorizon {
+		t.Errorf("cooldown in %v, want clamped to %v", d, maxCooldownHorizon)
+	}
+}
+
+func TestClassifyNilError(t *testing.T) {
+	proxyErr := Classify(nil, "gpt-5.6-sol", "msg", domain.ScopeProvider, domain.CooldownReasonServerError)
+	if proxyErr == nil {
+		t.Fatal("Classify(nil) must still return a ProxyError")
+	}
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Errorf("scope = %q, want the fallback", proxyErr.Scope)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -217,6 +217,13 @@ func (e *Executor) recordSmartMappingSuccess(key string, mappedModel string) {
 	e.smartMappingMu.Unlock()
 }
 
+// fallbackRetryInitialInterval and fallbackRetryMaxInterval back the retry
+// config used when a tenant has no default configured.
+const (
+	fallbackRetryInitialInterval = time.Second
+	fallbackRetryMaxInterval     = 30 * time.Second
+)
+
 func (e *Executor) getRetryConfig(tenantID uint64, config *domain.RetryConfig) *domain.RetryConfig {
 	if config != nil {
 		return config
@@ -228,21 +235,34 @@ func (e *Executor) getRetryConfig(tenantID uint64, config *domain.RetryConfig) *
 		return defaultConfig
 	}
 
-	// No default config means no retry
+	// No default config means no retry. The intervals still matter: providers
+	// with disableErrorCooldown retry past MaxRetries, and a zero interval made
+	// that a busy loop (proxy_request 75010 fired ~90 upstream calls per second
+	// because the tenant had no default retry config yet).
 	return &domain.RetryConfig{
 		MaxRetries:      0,
-		InitialInterval: 0,
-		BackoffRate:     1.0,
-		MaxInterval:     0,
+		InitialInterval: fallbackRetryInitialInterval,
+		BackoffRate:     2.0,
+		MaxInterval:     fallbackRetryMaxInterval,
 	}
 }
 
 func (e *Executor) calculateBackoff(config *domain.RetryConfig, attempt int) time.Duration {
-	wait := float64(config.InitialInterval)
-	for i := 0; i < attempt; i++ {
-		wait *= config.BackoffRate
+	if config == nil {
+		return fallbackRetryInitialInterval
 	}
-	if time.Duration(wait) > config.MaxInterval {
+	wait := float64(config.InitialInterval)
+	// A rate below 1 would shrink the wait on every retry; treat it as flat.
+	rate := config.BackoffRate
+	if rate < 1 {
+		rate = 1
+	}
+	for i := 0; i < attempt; i++ {
+		wait *= rate
+	}
+	// MaxInterval <= 0 means no ceiling was configured. Clamping to it would
+	// silently collapse every backoff to zero.
+	if config.MaxInterval > 0 && time.Duration(wait) > config.MaxInterval {
 		return config.MaxInterval
 	}
 	return time.Duration(wait)
@@ -464,6 +484,15 @@ func isDisabledErrorCooldownRetryableError(proxyErr *domain.ProxyError) bool {
 		return false
 	}
 	if isBedrockAdaptiveThinkingSchemaError(proxyErr) {
+		return false
+	}
+	// A quota / usage-limit / balance rejection is not transient: the upstream
+	// reports a reset that is hours or days out (Codex "usage_limit_reached"
+	// carries resets_in_seconds, observed at 2.6 days). Retrying the same key
+	// before then can only fail, so the escape hatch does not apply — the SDK
+	// reports these as 429, which would otherwise read as a retryable throttle.
+	switch proxyErr.Reason {
+	case domain.CooldownReasonQuotaExhausted, domain.CooldownReasonInsufficientBalance:
 		return false
 	}
 	// Non-retryable client errors (4xx) must NOT be force-retried, even under

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -31,6 +31,18 @@ import (
 // route×retry fan-out yet orders of magnitude below the observed blowups.
 const maxUpstreamAttemptsPerRequest = 200
 
+// maxAttemptsPerProviderWithoutErrorCooldown bounds how many upstream calls a
+// single provider may absorb for one request while disableErrorCooldown is on.
+//
+// disableErrorCooldown is an operator escape hatch meaning "do not build
+// cooldown state from this provider's failures". It used to also mean "retry
+// this provider forever", which turned any persistent retryable failure into a
+// tight loop that only the global ceiling could stop — proxy_request 75010 hit
+// a rate-limited Codex account 200 times in 99 seconds that way. Bounding the
+// per-provider budget keeps the escape hatch (far more retries than the
+// configured RetryConfig allows) while still failing over to the next route.
+const maxAttemptsPerProviderWithoutErrorCooldown = 10
+
 func (e *Executor) dispatch(c *flow.Ctx) {
 	state, ok := getExecState(c)
 	if !ok {
@@ -94,8 +106,18 @@ routeLoop:
 		}
 		retryConfig := e.getRetryConfig(state.tenantID, matchedRoute.RetryConfig)
 
+		// providerAttempts counts every upstream call made against this route.
+		// Unlike attempt it is never reset by smart-mapping model switches, so
+		// it bounds the whole provider visit rather than one candidate model.
+		providerAttempts := 0
+
 		for attempt := 0; ; {
 			if attempt > retryConfig.MaxRetries && !shouldSkipErrorCooldown(matchedRoute.Provider) {
+				break
+			}
+			if shouldSkipErrorCooldown(matchedRoute.Provider) && providerAttempts >= maxAttemptsPerProviderWithoutErrorCooldown {
+				log.Printf("[Executor] Provider %d reached the disableErrorCooldown attempt cap (%d) for this request; failing over. lastErr=%v",
+					matchedRoute.Provider.ID, maxAttemptsPerProviderWithoutErrorCooldown, state.lastErr)
 				break
 			}
 			if ctx.Err() != nil {
@@ -239,6 +261,7 @@ routeLoop:
 
 			proxyReq.ProxyUpstreamAttemptCount++
 			totalUpstreamAttempts++
+			providerAttempts++
 			if e.broadcaster != nil {
 				e.broadcaster.BroadcastProxyRequest(proxyReq)
 				e.broadcaster.BroadcastProxyUpstreamAttempt(attemptRecord)

--- a/internal/executor/retry_amplification_test.go
+++ b/internal/executor/retry_amplification_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/awsl-project/maxx/internal/adapter/provider/cliproxyerr"
 	"github.com/awsl-project/maxx/internal/domain"
 	"github.com/awsl-project/maxx/internal/flow"
 	"github.com/awsl-project/maxx/internal/router"
@@ -38,6 +39,13 @@ func (a *classifiedErrorAdapter) Execute(_ *flow.Ctx, _ *domain.Provider) error 
 }
 
 func newAmplificationDispatchCtx(disableErrorCooldown bool, adapter *classifiedErrorAdapter) (*flow.Ctx, *recordingProxyRequestRepo) {
+	return newMultiRouteAmplificationDispatchCtx(1, disableErrorCooldown, adapter)
+}
+
+// newMultiRouteAmplificationDispatchCtx builds a dispatch context fronted by
+// routeCount routes that all share the same failing adapter, so a test can
+// exercise failover fan-out as well as single-provider retry behaviour.
+func newMultiRouteAmplificationDispatchCtx(routeCount int, disableErrorCooldown bool, adapter *classifiedErrorAdapter) (*flow.Ctx, *recordingProxyRequestRepo) {
 	proxyRepo := &recordingProxyRequestRepo{}
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(context.Background())
@@ -49,28 +57,30 @@ func newAmplificationDispatchCtx(disableErrorCooldown bool, adapter *classifiedE
 		Status:     "IN_PROGRESS",
 		StartTime:  time.Now(),
 	}
+	routes := make([]*router.MatchedRoute, 0, routeCount)
+	for i := range routeCount {
+		routes = append(routes, &router.MatchedRoute{
+			Route: &domain.Route{ID: uint64(10 + i), TenantID: domain.DefaultTenantID, ProviderID: uint64(20 + i), ClientType: domain.ClientTypeOpenAI},
+			Provider: &domain.Provider{
+				ID:       uint64(20 + i),
+				TenantID: domain.DefaultTenantID,
+				Type:     "custom",
+				Name:     "custom-disabled-cooldown-amplification",
+				Config:   &domain.ProviderConfig{DisableErrorCooldown: disableErrorCooldown},
+			},
+			ProviderAdapter: adapter,
+			// InitialInterval 0 reproduces the production config (empty
+			// retry_configs → 0 backoff) that let the loop spin at ~10/sec.
+			RetryConfig: &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+		})
+	}
 	state := &execState{
 		ctx:          context.Background(),
 		proxyReq:     proxyReq,
 		tenantID:     domain.DefaultTenantID,
 		clientType:   domain.ClientTypeOpenAI,
 		requestModel: "gpt-image-model",
-		routes: []*router.MatchedRoute{
-			{
-				Route: &domain.Route{ID: 10, TenantID: domain.DefaultTenantID, ProviderID: 20, ClientType: domain.ClientTypeOpenAI},
-				Provider: &domain.Provider{
-					ID:       20,
-					TenantID: domain.DefaultTenantID,
-					Type:     "custom",
-					Name:     "custom-disabled-cooldown-amplification",
-					Config:   &domain.ProviderConfig{DisableErrorCooldown: disableErrorCooldown},
-				},
-				ProviderAdapter: adapter,
-				// InitialInterval 0 reproduces the production config (empty
-				// retry_configs → 0 backoff) that let the loop spin at ~10/sec.
-				RetryConfig: &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
-			},
-		},
+		routes:       routes,
 	}
 	c.Set(flow.KeyExecutorState, state)
 	return c, proxyRepo
@@ -140,14 +150,11 @@ func TestDispatchDoesNotAmplifyInvalidImageError(t *testing.T) {
 	}
 }
 
-// TestDispatchHardCapsRunawayRetryableErrors is the backstop test: even a
-// genuinely-retryable error that (via a classification bug or misconfiguration)
-// never stops retrying must be bounded by the hard per-request ceiling, instead
-// of running for hours.
-func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
-	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
-		// A 5xx under disableErrorCooldown retries forever-until-success by
-		// design; here it never succeeds, so only the hard cap can stop it.
+// newAlways500Adapter returns an adapter whose every call fails with a
+// retryable 5xx — under disableErrorCooldown this is the shape that used to
+// retry until the global ceiling stopped it.
+func newAlways500Adapter() *classifiedErrorAdapter {
+	return &classifiedErrorAdapter{build: func() *domain.ProxyError {
 		pe := domain.NewProxyErrorWithMessage(
 			errors.New("upstream returned 500"),
 			true,
@@ -158,7 +165,38 @@ func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
 		pe.HTTPStatusCode = http.StatusInternalServerError
 		return pe
 	}}
+}
+
+// TestDispatchCapsRetriesWhenErrorCooldownDisabled pins the per-provider budget:
+// disableErrorCooldown still buys far more retries than the RetryConfig allows,
+// but no longer an unbounded loop against one provider.
+func TestDispatchCapsRetriesWhenErrorCooldownDisabled(t *testing.T) {
+	adapter := newAlways500Adapter()
 	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail once the per-provider cap is hit")
+	}
+	if adapter.calls != maxAttemptsPerProviderWithoutErrorCooldown {
+		t.Fatalf("adapter calls = %d, want %d (per-provider cap)", adapter.calls, maxAttemptsPerProviderWithoutErrorCooldown)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// TestDispatchHardCapsRunawayRetryableErrors is the backstop test: even a
+// genuinely-retryable error that (via a classification bug or misconfiguration)
+// never stops retrying must be bounded by the hard per-request ceiling, instead
+// of running for hours. Enough routes are matched that the per-provider cap
+// alone would allow more calls than the ceiling permits.
+func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
+	routeCount := maxUpstreamAttemptsPerRequest/maxAttemptsPerProviderWithoutErrorCooldown + 1
+	adapter := newAlways500Adapter()
+	c, proxyRepo := newMultiRouteAmplificationDispatchCtx(routeCount, true, adapter)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
 
 	e.dispatch(c)
@@ -168,6 +206,76 @@ func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
 	}
 	if adapter.calls != maxUpstreamAttemptsPerRequest {
 		t.Fatalf("adapter calls = %d, want %d (hard ceiling)", adapter.calls, maxUpstreamAttemptsPerRequest)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// cliProxySDKErr mimics the CLIProxyAPI SDK's status-carrying error: the
+// message is the raw upstream body and StatusCode reports the HTTP status.
+type cliProxySDKErr struct {
+	body string
+	code int
+}
+
+func (e cliProxySDKErr) Error() string   { return e.body }
+func (e cliProxySDKErr) StatusCode() int { return e.code }
+
+// TestDispatchDoesNotRetryUsageLimitUnderDisabledCooldown reproduces
+// proxy_request 75010 end to end, through the real adapter-side classifier: a
+// Codex account whose quota resets in 2.6 days answered "usage_limit_reached",
+// which the SDK reports as HTTP 429. Treating that as a transient throttle got
+// it retried 100 more times. It must now cost exactly one upstream call.
+func TestDispatchDoesNotRetryUsageLimitUnderDisabledCooldown(t *testing.T) {
+	const usageLimitBody = `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"prolite","resets_at":1788747900,"resets_in_seconds":227596}}`
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		return cliproxyerr.Classify(
+			cliProxySDKErr{body: usageLimitBody, code: http.StatusTooManyRequests},
+			"gpt-5.6-sol",
+			"executor stream request failed",
+			domain.ScopeProvider, domain.CooldownReasonServerError,
+		)
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail on an exhausted usage limit")
+	}
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1 (a multi-day usage limit must not be retried)", adapter.calls)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
+		t.Fatalf("final proxy status = %q, want FAILED", last)
+	}
+}
+
+// TestDispatchCapsRateLimitRetriesUnderDisabledCooldown covers the other 191
+// attempts on proxy_request 75010: a plain 429 stays retryable, but under
+// disableErrorCooldown it must exhaust the per-provider budget rather than loop
+// until the global ceiling.
+func TestDispatchCapsRateLimitRetriesUnderDisabledCooldown(t *testing.T) {
+	adapter := &classifiedErrorAdapter{build: func() *domain.ProxyError {
+		return cliproxyerr.Classify(
+			cliProxySDKErr{body: `{"detail":"Rate limit exceeded"}`, code: http.StatusTooManyRequests},
+			"gpt-5.6-sol",
+			"executor stream request failed",
+			domain.ScopeProvider, domain.CooldownReasonServerError,
+		)
+	}}
+	c, proxyRepo := newAmplificationDispatchCtx(true, adapter)
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail once the rate limit persisted")
+	}
+	if adapter.calls != maxAttemptsPerProviderWithoutErrorCooldown {
+		t.Fatalf("adapter calls = %d, want %d (per-provider cap)", adapter.calls, maxAttemptsPerProviderWithoutErrorCooldown)
 	}
 	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
 		t.Fatalf("final proxy status = %q, want FAILED", last)

--- a/internal/executor/retry_backoff_test.go
+++ b/internal/executor/retry_backoff_test.go
@@ -1,0 +1,96 @@
+package executor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+// TestGetRetryConfigFallbackKeepsBackoff covers the state proxy_request 75010
+// ran into: the tenant had no default retry config yet, so the fallback's zero
+// intervals turned a disableErrorCooldown provider's retries into a busy loop
+// firing ~90 upstream calls per second.
+func TestGetRetryConfigFallbackKeepsBackoff(t *testing.T) {
+	e := &Executor{retryConfigRepo: &staticRetryConfigRepo{}}
+
+	config := e.getRetryConfig(domain.DefaultTenantID, nil)
+
+	if config.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0 (no default config still means no configured retry)", config.MaxRetries)
+	}
+	if config.InitialInterval <= 0 {
+		t.Errorf("InitialInterval = %v, want a non-zero fallback", config.InitialInterval)
+	}
+	if config.MaxInterval <= 0 {
+		t.Errorf("MaxInterval = %v, want a non-zero fallback", config.MaxInterval)
+	}
+	if got := e.calculateBackoff(config, 0); got <= 0 {
+		t.Errorf("first backoff = %v, want > 0", got)
+	}
+}
+
+func TestGetRetryConfigPrefersRouteConfig(t *testing.T) {
+	e := &Executor{retryConfigRepo: &staticRetryConfigRepo{
+		defaultConfig: &domain.RetryConfig{MaxRetries: 9},
+	}}
+	routeConfig := &domain.RetryConfig{MaxRetries: 2}
+
+	if got := e.getRetryConfig(domain.DefaultTenantID, routeConfig); got != routeConfig {
+		t.Errorf("getRetryConfig = %+v, want the route's own config", got)
+	}
+	if got := e.getRetryConfig(domain.DefaultTenantID, nil); got.MaxRetries != 9 {
+		t.Errorf("MaxRetries = %d, want the tenant default (9)", got.MaxRetries)
+	}
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	e := &Executor{}
+	tests := []struct {
+		name    string
+		config  *domain.RetryConfig
+		attempt int
+		want    time.Duration
+	}{
+		{
+			name:    "grows exponentially",
+			config:  &domain.RetryConfig{InitialInterval: time.Second, BackoffRate: 2, MaxInterval: 30 * time.Second},
+			attempt: 3,
+			want:    8 * time.Second,
+		},
+		{
+			name:    "caps at MaxInterval",
+			config:  &domain.RetryConfig{InitialInterval: time.Second, BackoffRate: 2, MaxInterval: 30 * time.Second},
+			attempt: 10,
+			want:    30 * time.Second,
+		},
+		{
+			// MaxInterval 0 used to mean "clamp everything to zero", silently
+			// disabling backoff for any config that left the ceiling unset.
+			name:    "unset MaxInterval means no ceiling",
+			config:  &domain.RetryConfig{InitialInterval: time.Second, BackoffRate: 2, MaxInterval: 0},
+			attempt: 2,
+			want:    4 * time.Second,
+		},
+		{
+			// A rate below 1 would shrink the wait on every retry.
+			name:    "shrinking rate is treated as flat",
+			config:  &domain.RetryConfig{InitialInterval: time.Second, BackoffRate: 0, MaxInterval: 30 * time.Second},
+			attempt: 4,
+			want:    time.Second,
+		},
+		{
+			name:    "explicit zero interval stays zero",
+			config:  &domain.RetryConfig{InitialInterval: 0, BackoffRate: 2, MaxInterval: 30 * time.Second},
+			attempt: 3,
+			want:    0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := e.calculateBackoff(tt.config, tt.attempt); got != tt.want {
+				t.Errorf("calculateBackoff(attempt=%d) = %v, want %v", tt.attempt, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景

线上 [proxy_request 75010](https://maxx.hubitos.ai/requests/75010) 在 **99.5 秒内向同一个 Codex 账号发起了 200 次上游调用**（相邻两次间隔中位数 11ms），最后是被全局硬顶 `maxUpstreamAttemptsPerRequest = 200` 掐掉的，不是自己停的。

200 次 attempt 全部落在 provider 13 / route 32 / `gpt-5.6-sol`：

- 191 次 `{"detail":"Rate limit exceeded"}`
- 第 91–99 次是 `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"prolite","resets_at":1788747900,"resets_in_seconds":227596}}`

也就是说上游在第 91 次就明确说了"额度用完，2.6 天后恢复"，后面还接着打了 100 次。

## 根因（四个条件叠加）

1. **`cliproxyapi_*` 适配器完全不看错误内容**。`NewProxyErrorWithMessage(err, true, ...)` 把 `Retryable` 硬编码成 `true`、`Reason` 硬编码成 `server_error`。原生 codex 适配器有 `classify.go`，但走 CLIProxyAPI 这条路（`useCLIProxyAPI: true`）绕过了它。SDK 的 `statusErr` 本来就实现了 `StatusCode()` / `RetryAfter()`，之前完全没人读。
2. **`disableErrorCooldown: true` 等于无限重试**。它跳过了 `attempt > retryConfig.MaxRetries` 的退出条件，单 provider 内重试次数无上限。该 provider 又没开 `consecutiveErrorFreezeEnabled`，唯一逃生口也关着。
3. **退避是 0 秒**。租户当时还没有默认 retry config（现存的 `Default Config` 创建于 11:16:05，比这个请求晚 5 分钟），走兜底 `{MaxRetries:0, InitialInterval:0, MaxInterval:0}`，`calculateBackoff` 直接返回 0。
4. 只匹配到一条路由，没有别的 provider 可以 failover。

## 改动

### 1. 补错误分类（`a323043`）

新增 `internal/adapter/provider/cliproxyerr`，`cliproxyapi_codex` / `_grok` / `_antigravity` 三个适配器的 9 个错误构造点全部改走它。读 SDK 的 `StatusCode()` / `RetryAfter()` 接口 + 解析错误体 JSON：

| 上游信号 | Scope | Reason | Retryable |
|---|---|---|---|
| `usage_limit_reached` / quota 耗尽 | Key | `quota_exhausted` | **false**，cooldown 到上游给的 `resets_at` |
| rate limit | Key | `rate_limit_exceeded` | true（确实瞬时） |
| auth / model 不可用 / 其它 4xx | Key / Model / Request | 对应 | false |
| 5xx / 408 / 读不懂的传输错误 | Provider | 保持调用方 fallback | true |

超过 30 秒的 retry 提示只写 cooldown、不写 `RetryAfter`——否则 2.6 天的 reset 会让客户端连接直接挂在那里等。

### 2. 给 `disableErrorCooldown` 加上限（`a5e0d62`）

`maxAttemptsPerProviderWithoutErrorCooldown = 10`。这个开关的语义收窄成"不写 cooldown 状态"，而不是"无限重试"——仍然远多于 `RetryConfig` 配置的次数，但现在会 failover 到下一条路由。计数器挂在 route 上而非 attempt 上，所以 smart-mapping 切换候选模型时那个 `modelCandidateIndex = 0` 回绕也重置不掉它。全局 200 兜底保留。

同时 `isDisabledErrorCooldownRetryableError` 对 `quota_exhausted` / `insufficient_balance` 直接返回 false——SDK 把这类报成 429，不特判的话会被当成可重试限流重新放行。

### 3. 退避不再是 0（`a5e0d62`）

- 没有默认 retry config 时的兜底从 `{0, 1.0, 0}` 改成 `{1s, 2.0, 30s}`
- `calculateBackoff` 里 `MaxInterval <= 0` 现在表示"不设上限"。原来的 `if wait > MaxInterval { return MaxInterval }` 在 `MaxInterval=0` 时会把**任何**退避压成 0 —— 这是个独立的隐藏 bug：配了 `InitialInterval` 但没配 `MaxInterval` 的策略等于没有退避
- `BackoffRate < 1` 按 1 处理，避免越退越短

## 测试

- `cliproxyerr/classify_test.go`：14 个用例，直接用 75010 的原始 error body
- `retry_amplification_test.go`：新增两个端到端回归——`usage_limit_reached` 现在恰好 1 次调用，`Rate limit exceeded` 恰好 10 次；原有的 `TestDispatchHardCapsRunawayRetryableErrors` 改用 21 条路由，验证全局 200 兜底仍然有效
- `retry_backoff_test.go`：覆盖兜底 retry config 和退避计算

`go test ./...` 全绿。

放到 75010 的场景上：**200 次 → 1 次**。

## 后续（本 PR 未含）

线上 provider 13 目前仍是 `disableErrorCooldown: true` 且未开 `consecutiveErrorFreezeEnabled`，route 32 事发后被手动禁用。配置侧是否调整需要单独确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误处理**
  * 统一识别配额不足、限流、认证失败、模型不可用及网络错误，并提供更准确的重试与冷却状态。
  * 根据上游提示优化冷却截止时间和请求内重试延迟。

* **稳定性改进**
  * 为未配置重试策略的请求提供合理的指数退避，避免高频重试。
  * 限制单个服务提供方的连续重试次数，减少异常情况下的请求放大。
  * 配额不足和余额不足时不再强制重复重试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->