### PR TITLE
fix(cliproxyerr): stop a stale resets_at from dropping the quota cooldown

### DIFF
--- a/internal/adapter/provider/cliproxyerr/classify.go
+++ b/internal/adapter/provider/cliproxyerr/classify.go
@@ -87,7 +87,7 @@ func applyRetryHint(proxyErr *domain.ProxyError, err error) {
 	if hint == nil || *hint <= 0 {
 		return
 	}
-	setCooldownUntil(proxyErr, time.Now().Add(*hint))
+	_ = setCooldownUntil(proxyErr, time.Now().Add(*hint))
 	if *hint <= maxRetryAfterHint {
 		proxyErr.RetryAfter = *hint
 	}
@@ -214,18 +214,23 @@ func classifyStatus(proxyErr *domain.ProxyError, body string) {
 }
 
 // applyQuotaReset records the upstream's own reset time as the cooldown
-// deadline, so the key is skipped until it can actually serve again.
+// deadline, so the key is skipped until it can actually serve again. Each
+// source is tried until one yields a deadline that is actually in the future:
+// resets_at is an absolute instant and goes stale under clock skew, in which
+// case the relative resets_in_seconds still gives us a usable horizon.
 func applyQuotaReset(proxyErr *domain.ProxyError, body string) {
 	for _, path := range []string{"error.resets_at", "resets_at"} {
 		if v := gjson.Get(body, path); v.Exists() && v.Int() > 0 {
-			setCooldownUntil(proxyErr, time.Unix(v.Int(), 0))
-			return
+			if setCooldownUntil(proxyErr, time.Unix(v.Int(), 0)) {
+				return
+			}
 		}
 	}
 	for _, path := range []string{"error.resets_in_seconds", "resets_in_seconds"} {
 		if v := gjson.Get(body, path); v.Exists() && v.Int() > 0 {
-			setCooldownUntil(proxyErr, time.Now().Add(time.Duration(v.Int())*time.Second))
-			return
+			if setCooldownUntil(proxyErr, time.Now().Add(time.Duration(v.Int())*time.Second)) {
+				return
+			}
 		}
 	}
 }
@@ -234,21 +239,23 @@ func applyQuotaReset(proxyErr *domain.ProxyError, body string) {
 // short default cooldown rather than none at all.
 func ensureRateLimitCooldown(proxyErr *domain.ProxyError) {
 	if proxyErr.CooldownUntil == nil && proxyErr.RetryAfter <= 0 {
-		setCooldownUntil(proxyErr, time.Now().Add(defaultRateLimitCooldown))
+		_ = setCooldownUntil(proxyErr, time.Now().Add(defaultRateLimitCooldown))
 	}
 }
 
 // setCooldownUntil stores until as the cooldown deadline, ignoring times that
-// are already past and clamping ones absurdly far out.
-func setCooldownUntil(proxyErr *domain.ProxyError, until time.Time) {
+// are already past and clamping ones absurdly far out. It reports whether a
+// deadline was recorded, so callers can fall through to another source.
+func setCooldownUntil(proxyErr *domain.ProxyError, until time.Time) bool {
 	now := time.Now()
 	if !until.After(now) {
-		return
+		return false
 	}
 	if horizon := now.Add(maxCooldownHorizon); until.After(horizon) {
 		until = horizon
 	}
 	proxyErr.CooldownUntil = &until
+	return true
 }
 
 // firstString returns the first non-empty string among the given JSON paths,

--- a/internal/adapter/provider/cliproxyerr/classify.go
+++ b/internal/adapter/provider/cliproxyerr/classify.go
@@ -228,11 +228,23 @@ func applyQuotaReset(proxyErr *domain.ProxyError, body string) {
 	}
 	for _, path := range []string{"error.resets_in_seconds", "resets_in_seconds"} {
 		if v := gjson.Get(body, path); v.Exists() && v.Int() > 0 {
-			if setCooldownUntil(proxyErr, time.Now().Add(time.Duration(v.Int())*time.Second)) {
+			if setCooldownUntil(proxyErr, time.Now().Add(cooldownFromSeconds(v.Int()))) {
 				return
 			}
 		}
 	}
+}
+
+// cooldownFromSeconds converts an upstream-reported second count into a
+// duration, saturating at maxCooldownHorizon. The clamp has to happen before
+// the multiplication: time.Duration is int64 nanoseconds, so anything past
+// ~292 years wraps to a negative duration, which setCooldownUntil then drops as
+// a past deadline instead of clamping it to the horizon.
+func cooldownFromSeconds(seconds int64) time.Duration {
+	if seconds > int64(maxCooldownHorizon/time.Second) {
+		return maxCooldownHorizon
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // ensureRateLimitCooldown gives a rate limit without an explicit reset hint a

--- a/internal/adapter/provider/cliproxyerr/classify_test.go
+++ b/internal/adapter/provider/cliproxyerr/classify_test.go
@@ -2,6 +2,7 @@ package cliproxyerr
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,16 +21,24 @@ func (e sdkErr) Error() string              { return e.body }
 func (e sdkErr) StatusCode() int            { return e.code }
 func (e sdkErr) RetryAfter() *time.Duration { return e.retryAfter }
 
-// usageLimitBody is the exact payload proxy_request 75010 received 9 times and
-// then retried 100 more times, and resetsAt is its reported reset instant.
-const usageLimitBody = `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"prolite","resets_at":1788747900,"eligible_promo":null,"resets_in_seconds":227596}}`
+// usageLimitReset is the reset horizon proxy_request 75010 was given, 2.6 days
+// out. The upstream reports it as an absolute instant, so the fixture builds it
+// relative to now: a hard-coded timestamp would go stale and silently stop
+// exercising the cooldown path it is meant to pin.
+const usageLimitReset = 227596 * time.Second
 
-const resetsAt = 1788747900
+// usageLimitBody renders the payload proxy_request 75010 received 9 times and
+// then retried 100 more times, with its reset pointed at resetsAt.
+func usageLimitBody(resetsAt time.Time) string {
+	return fmt.Sprintf(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"prolite","resets_at":%d,"eligible_promo":null,"resets_in_seconds":%d}}`,
+		resetsAt.Unix(), int(time.Until(resetsAt).Seconds()))
+}
 
 func TestClassifyUsageLimitReachedIsNotRetryable(t *testing.T) {
+	resetsAt := time.Now().Add(usageLimitReset)
 	// The SDK rewrites usage_limit_reached to HTTP 429, so status alone would
 	// call this a transient throttle worth retrying.
-	proxyErr := Classify(sdkErr{body: usageLimitBody, code: 429}, "gpt-5.6-sol", "executor stream request failed",
+	proxyErr := Classify(sdkErr{body: usageLimitBody(resetsAt), code: 429}, "gpt-5.6-sol", "executor stream request failed",
 		domain.ScopeProvider, domain.CooldownReasonServerError)
 
 	if proxyErr.Retryable {
@@ -44,8 +53,8 @@ func TestClassifyUsageLimitReachedIsNotRetryable(t *testing.T) {
 	if proxyErr.CooldownUntil == nil {
 		t.Fatal("expected a cooldown deadline from resets_at")
 	}
-	if got := proxyErr.CooldownUntil.Unix(); got != resetsAt {
-		t.Errorf("cooldown until = %d, want %d (resets_at)", got, resetsAt)
+	if got := proxyErr.CooldownUntil.Unix(); got != resetsAt.Unix() {
+		t.Errorf("cooldown until = %d, want %d (resets_at)", got, resetsAt.Unix())
 	}
 	// A 2.6-day reset must never become an in-request retry wait.
 	if proxyErr.RetryAfter != 0 {
@@ -59,6 +68,20 @@ func TestClassifyUsageLimitFromResetsInSecondsOnly(t *testing.T) {
 
 	if proxyErr.CooldownUntil == nil {
 		t.Fatal("expected a cooldown deadline from resets_in_seconds")
+	}
+	if d := time.Until(*proxyErr.CooldownUntil); d < 9*time.Minute || d > 11*time.Minute {
+		t.Errorf("cooldown in %v, want ~10m", d)
+	}
+}
+
+func TestClassifyUsageLimitFallsBackWhenResetsAtIsStale(t *testing.T) {
+	// resets_at is absolute and goes stale under clock skew between us and the
+	// upstream; the relative resets_in_seconds must still park the key.
+	body := `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_at":1,"resets_in_seconds":600}}`
+	proxyErr := Classify(sdkErr{body: body, code: 429}, "gpt-5.6-sol", "msg", domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.CooldownUntil == nil {
+		t.Fatal("a stale resets_at must not swallow the resets_in_seconds fallback")
 	}
 	if d := time.Until(*proxyErr.CooldownUntil); d < 9*time.Minute || d > 11*time.Minute {
 		t.Errorf("cooldown in %v, want ~10m", d)

--- a/internal/adapter/provider/cliproxyerr/classify_test.go
+++ b/internal/adapter/provider/cliproxyerr/classify_test.go
@@ -176,6 +176,39 @@ func TestClassifyModelNotSupportedIsModelScoped(t *testing.T) {
 	}
 }
 
+// TestClassifyBareStatusError covers the shape 30 of the amplified production
+// requests carried: the SDK's statusErr with no body at all, whose Error() is
+// just "status 404". The status must still be read off the error.
+func TestClassifyBareStatusError(t *testing.T) {
+	proxyErr := Classify(sdkErr{body: "status 404", code: 404}, "gpt-5.6-sol", "executor stream request failed",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Retryable {
+		t.Error("a 404 must not be retried on the same provider")
+	}
+	if proxyErr.Scope != domain.ScopeEndpoint {
+		t.Errorf("scope = %q, want %q", proxyErr.Scope, domain.ScopeEndpoint)
+	}
+	if proxyErr.HTTPStatusCode != 404 {
+		t.Errorf("status = %d, want 404 (read from the SDK error, not the body)", proxyErr.HTTPStatusCode)
+	}
+}
+
+// TestClassifyTransportErrorKeepsFallback covers the client-disconnect shape
+// seen in production: a net/http error with no status and no JSON body.
+func TestClassifyTransportErrorKeepsFallback(t *testing.T) {
+	err := errors.New(`Post "https://chatgpt.com/backend-api/codex/responses": context canceled`)
+	proxyErr := Classify(err, "gpt-5.6-luna", "executor stream request failed",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Scope != domain.ScopeProvider || proxyErr.Reason != domain.CooldownReasonServerError {
+		t.Errorf("scope/reason = %q/%q, want the caller's fallback", proxyErr.Scope, proxyErr.Reason)
+	}
+	if !proxyErr.Retryable {
+		t.Error("a transport error stays retryable; the dispatch loop bounds it")
+	}
+}
+
 func TestClassifyKeepsFallbackForUnreadableErrors(t *testing.T) {
 	// A bare transport error: no status, no JSON body. The caller's fallback
 	// classification must survive so genuine outages still trip the cooldown.

--- a/internal/adapter/provider/cliproxyerr/classify_test.go
+++ b/internal/adapter/provider/cliproxyerr/classify_test.go
@@ -88,6 +88,41 @@ func TestClassifyUsageLimitFallsBackWhenResetsAtIsStale(t *testing.T) {
 	}
 }
 
+func TestClassifyUsageLimitClampsOversizedResets(t *testing.T) {
+	// time.Duration is int64 nanoseconds, so a second count beyond ~292 years
+	// overflows the conversion and lands in the past — setCooldownUntil would
+	// then drop the deadline entirely instead of clamping it to the horizon.
+	tests := []struct {
+		name string
+		body string
+	}{
+		// 1e10 seconds (~317 years) is past the ~292-year int64-nanosecond
+		// ceiling and wraps to a negative duration, i.e. a deadline in the past.
+		{"oversized resets_in_seconds", `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_in_seconds":10000000000}}`},
+		{"oversized resets_at", `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_at":99999999999999}}`},
+		// A stale absolute reset must still fall through to the relative one
+		// even when that one is oversized.
+		{"stale resets_at with oversized resets_in_seconds", `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_at":1,"resets_in_seconds":10000000000}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyErr := Classify(sdkErr{body: tt.body, code: 429}, "gpt-5.6-sol", "msg",
+				domain.ScopeProvider, domain.CooldownReasonServerError)
+
+			if proxyErr.CooldownUntil == nil {
+				t.Fatal("an oversized reset must still record a cooldown")
+			}
+			d := time.Until(*proxyErr.CooldownUntil)
+			if d <= 0 {
+				t.Fatalf("cooldown in %v, want a future deadline (overflowed into the past)", d)
+			}
+			if d > maxCooldownHorizon || d < maxCooldownHorizon-time.Minute {
+				t.Errorf("cooldown in %v, want it clamped near %v", d, maxCooldownHorizon)
+			}
+		})
+	}
+}
+
 func TestClassifyRateLimitStaysRetryable(t *testing.T) {
 	// The other 191 attempts on proxy_request 75010.
 	proxyErr := Classify(sdkErr{body: `{"detail":"Rate limit exceeded"}`, code: 429}, "gpt-5.6-sol", "msg",


### PR DESCRIPTION
#852 的跟进。处理它遗留的 review 意见，外加一个由此暴露出来的真 bug，以及全量生产数据审计后补的两个回归测试。

## 1. 测试里的定时炸弹（**09-07 会让 CI 变红**）

CodeRabbit 在 #852 上提过这条，没人处理就合了。我在 `classify_test.go` 里把 75010 的原始 `resets_at: 1788747900` 写死了——那是 **2026-09-07T02:25:00Z**。过了那个点 `setCooldownUntil` 会因为时间已过而拒绝写入，`CooldownUntil` 变成 `nil`，断言直接失败。

改成用 `time.Now().Add(...)` 在运行时生成，`resets_at` 和 `resets_in_seconds` 两个字段都跟着走。

## 2. 由此暴露的真 bug：过期的 `resets_at` 会吞掉兜底

把测试改成时间相关的过程中发现，`applyQuotaReset` 只要 `resets_at` 字段存在且 `> 0` 就直接 `return`——哪怕 `setCooldownUntil` 因为时间已过而拒绝了它。于是 `resets_in_seconds` 这条兜底路径整个被跳过，`CooldownUntil` 保持 `nil`，key 不会被 park。

两个字段的可靠性并不对等：

- `resets_at` 是**绝对时刻**，依赖我们和上游的时钟一致
- `resets_in_seconds` 是**相对值**，不受时钟偏差影响

时钟偏差下前者会失效而后者仍然有效，这正是需要兜底的场景，却恰好被吞掉了。

现在 `setCooldownUntil` 返回是否真的写入了 deadline，`applyQuotaReset` 逐个来源尝试直到有一个落在未来。

## 3. 补两个生产形态的回归测试

顺手把 7 天 retention 全量扫了一遍（18,021 条请求 / 2,230 条错误）。命中 200 次上限的不是 #852 里看到的 2 条，而是 **70 条**，全部在 provider 13，时间跨度 09-03 14:58 → 09-04 11:12（route 32 被禁用时终止）。

它们的 attempt 里有两种 #852 没覆盖到的错误形态：

| 形态 | 出现 | 说明 |
|---|---|---|
| `status 404` | 30 条请求 | SDK `statusErr` 的**空 body** 形态，`Error()` 只返回字面量 `"status 404"`。峰值 proxy_request 72797：**200 次 / 21.8 秒 = 9.2 次每秒** |
| `Post "https://chatgpt.com/...": context canceled` | 5 条请求 | 裸传输层错误，既无状态码也无 JSON |

两者行为已经是对的——`status 404` 因为分类器从 `StatusCode()` 接口读状态而非解析 body，所以能拿到 404 并判定不可重试；传输层错误则保持调用方 fallback 的 retryable，由 dispatch 的 per-provider 上限兜住。本 PR 只是把它们钉住。

（另外确认了一件事：那条 `context canceled` 是虚惊。查 proxy_request 74962 的完整 attempt 时间线，它只是**最后一次** attempt——客户端等了 29 秒断开——前 62 次仍是同一批限流放大。循环退出逻辑本身没问题。）

## 验证

`go test ./...` 全绿。

另外做了一次 adapter 横扫：现在没有"拿到上游响应却不分类"的 adapter 了。`grok` 委托 `cliproxyapi_grok`，`newapi`/`ollama`/`openrouter`/`zai` 委托 `custom`，`fal` 自带分类。其余硬编码 `Retryable: true` 的调用点都是 stream read / websocket upgrade / 格式转换这类传输层错误，`true` 是正确的默认值。

## 附：一个未处理的运维项

当前有 3 个 provider 开着 `disableErrorCooldown` 且都**没开** `consecutiveErrorFreezeEnabled`：

- `13` codex（路由已禁用）
- `1` OpenRouter ← 当前主力流量
- `12` fal

也就是说这三个的防线只剩 #852 加的 per-provider 10 次上限。是否打开熔断属于配置决策，本 PR 不含。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化配额重置时间的识别：当某个重置时间已过期时，会继续尝试其他可用信息，减少冷却时间判断错误。
  - 改进限流与配额异常处理，提升对缺少详细状态信息或网络传输异常的兼容性。
  - 更准确地设置未来冷却截止时间，并避免使用已失效的时间信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->