### PR TITLE
fix(codex): normalize bridged OpenAI requests

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -358,8 +358,42 @@ func applyCustomProtocolIdentity(c *flow.Ctx, clientType domain.ClientType, targ
 	if targetUserAgent != "" {
 		headers["User-Agent"] = []string{flow.ResolveUpstreamUserAgent(c, targetUserAgent)}
 	}
-	if clientType == domain.ClientTypeCodex && flow.IsProtocolConversion(c) {
+	if !flow.IsProtocolConversion(c) {
+		return
+	}
+
+	if clientType == domain.ClientTypeCodex {
 		headers.Del("Version")
+		return
+	}
+	if clientType != domain.ClientTypeOpenAI {
+		return
+	}
+
+	// Codex→OpenAI Chat bridge requests are sent to /v1/chat/completions, so they
+	// must look like ordinary OpenAI Chat requests. Previously they could still
+	// carry Codex CLI fingerprints (OpenAI-Beta: responses=experimental,
+	// Originator, Version, Session_id, and codex_cli_rs User-Agent). NewAPI/OneAPI
+	// style upstreams can include those in channel selection / load-balancing
+	// policy, so the same provider and mapped model may succeed on the native
+	// OpenAI route while the bridged Codex route receives a different filtered
+	// candidate set and 422s with api_format=openai/chat_completions.
+	stripSourceProtocolHeaders(headers)
+}
+
+func stripSourceProtocolHeaders(headers http.Header) {
+	for _, h := range []string{
+		"OpenAI-Beta",
+		"Openai-Beta",
+		"Originator",
+		"Version",
+		"Session_id",
+		"Session-Id",
+	} {
+		headers.Del(h)
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(headers.Get("User-Agent"))), "codex_cli_rs/") {
+		headers.Del("User-Agent")
 	}
 }
 

--- a/internal/adapter/provider/custom/adapter_user_agent_test.go
+++ b/internal/adapter/provider/custom/adapter_user_agent_test.go
@@ -73,6 +73,28 @@ func TestApplyCustomProtocolIdentityDropsSourceVersionForCodexConversion(t *test
 	}
 }
 
+func TestApplyCustomProtocolIdentityStripsCodexHeadersForOpenAIConversion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/chat/completions", nil)
+	ctx := flow.NewCtx(httptest.NewRecorder(), req)
+	ctx.Set(flow.KeyOriginalClientType, domain.ClientTypeCodex)
+	ctx.Set(flow.KeyClientType, domain.ClientTypeOpenAI)
+
+	headers := make(http.Header)
+	headers.Set("User-Agent", "codex_cli_rs/0.144.1 (Mac OS 26.0.1; arm64) Apple_Terminal/464")
+	headers.Set("OpenAI-Beta", "responses=experimental")
+	headers.Set("Originator", "codex_cli_rs")
+	headers.Set("Version", "0.144.1")
+	headers.Set("Session_id", "sess_123")
+
+	applyCustomProtocolIdentity(ctx, domain.ClientTypeOpenAI, "", headers)
+
+	for _, h := range []string{"User-Agent", "OpenAI-Beta", "Originator", "Version", "Session_id"} {
+		if got := headers.Get(h); got != "" {
+			t.Fatalf("%s = %q, want stripped after Codex->OpenAI conversion", h, got)
+		}
+	}
+}
+
 func assertCustomAdapterExecuteUserAgent(t *testing.T, originalClientType, targetClientType domain.ClientType, requestURI string, clientUA string, expectedUA string) {
 	t.Helper()
 

--- a/internal/converter/coverage_openai_request_test.go
+++ b/internal/converter/coverage_openai_request_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/tidwall/gjson"
 )
 
 func TestOpenAIToGeminiRequestToolChoice(t *testing.T) {
@@ -1095,5 +1097,44 @@ func TestCodexToOpenAIRequestNormalizesFilesImagesAndBareTextParts(t *testing.T)
 		if !strings.Contains(outStr, expected) {
 			t.Fatalf("expected %s in converted request: %s", expected, outStr)
 		}
+	}
+}
+
+func TestOpenAIToCodexSkipsEmptyAssistantToolCallMessage(t *testing.T) {
+	req := OpenAIRequest{
+		Model: "gpt-5.5",
+		Messages: []OpenAIMessage{
+			{Role: "user", Content: "hi"},
+			{
+				Role:    "assistant",
+				Content: nil,
+				ToolCalls: []OpenAIToolCall{{
+					ID:   "call_1",
+					Type: "function",
+					Function: OpenAIFunctionCall{
+						Name:      "lookup",
+						Arguments: `{"q":"x"}`,
+					},
+				}},
+			},
+			{Role: "tool", ToolCallID: "call_1", Content: "ok"},
+		},
+	}
+	body, _ := json.Marshal(req)
+	out, err := (&openaiToCodexRequest{}).Transform(body, "moonshotai/kimi-k3", true)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	input := gjson.GetBytes(out, "input").Array()
+	for i, item := range input {
+		if item.Get("type").String() == "message" && item.Get("role").String() == "assistant" && item.Get("content.#").Int() == 0 {
+			t.Fatalf("input[%d] is an empty assistant message: %s", i, string(out))
+		}
+	}
+	if got := gjson.GetBytes(out, `input.#(type="function_call").call_id`).String(); got != "call_1" {
+		t.Fatalf("function_call missing, got %q in %s", got, string(out))
+	}
+	if got := gjson.GetBytes(out, `input.#(type="function_call_output").call_id`).String(); got != "call_1" {
+		t.Fatalf("function_call_output missing, got %q in %s", got, string(out))
 	}
 }

--- a/internal/converter/openai_to_codex.go
+++ b/internal/converter/openai_to_codex.go
@@ -117,7 +117,9 @@ func (c *openaiToCodexRequest) Transform(body []byte, model string, stream bool)
 					}
 				}
 
-				out, _ = sjson.SetRaw(out, "input.-1", msg)
+				if gjson.Get(msg, "content.#").Int() > 0 {
+					out, _ = sjson.SetRaw(out, "input.-1", msg)
+				}
 
 				if role == "assistant" {
 					if toolCalls := m.Get("tool_calls"); toolCalls.Exists() && toolCalls.IsArray() {


### PR DESCRIPTION
## Summary
- strip Codex-specific headers/User-Agent when Codex requests are bridged to OpenAI Chat Completions through custom providers
- avoid emitting empty Codex assistant message items for OpenAI assistant tool-call messages with `content: null`
- add regression coverage for both Codex bridge headers and tool-call transcript conversion

## Tests
- `go test ./internal/converter ./internal/adapter/provider/custom ./internal/adapter/provider/codex ./internal/executor`
- `go test ./...` *(fails only at root setup: `main.go:26:12: pattern all:web/dist: no matching files found`; all listed packages including e2e pass)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **漏洞修复**
  * 优化 Codex 与 OpenAI 协议转换时的请求头处理，避免传递不必要的客户端标识信息。
  * 修复消息转换问题，避免生成空的助手消息，同时保持工具调用关联信息正确。

* **测试**
  * 新增协议转换请求头清理及空消息处理的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->