### PR TITLE
fix(router): expose route rejection diagnostics

### DIFF
--- a/internal/executor/middleware_route_match.go
+++ b/internal/executor/middleware_route_match.go
@@ -68,7 +68,7 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 			proxyErr.Code = "model_not_supported"
 			proxyErr.Model = state.requestModel
 		} else if errors.Is(err, domain.ErrNoAvailableProviders) {
-			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
+			proxyErr = domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, message)
 			proxyErr.Code = "no_available_provider"
 		} else if errors.Is(err, domain.ErrNoRoutes) {
 			proxyErr.Code = "no_routes_available"
@@ -91,7 +91,7 @@ func (e *Executor) routeMatch(c *flow.Ctx) {
 	}
 
 	if len(result.Routes) == 0 {
-		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "no available provider for matched route")
+		proxyErr := domain.NewProxyErrorWithMessage(domain.ErrNoAvailableProviders, false, "route match failed: no available providers")
 		proxyErr.Scope = domain.ScopeRequest
 		proxyErr.Code = "no_available_provider"
 		proxyErr.HTTPStatusCode = http.StatusServiceUnavailable

--- a/internal/router/responses_websocket_test.go
+++ b/internal/router/responses_websocket_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -634,6 +635,9 @@ func TestMatch_ResponsesWebSocketRejectsWhenOnlyProviderIsAtConcurrencyLimit(t *
 	if !errors.Is(err, domain.ErrNoResponsesWebSocketProviders) {
 		t.Fatalf("Match error = %v, want ErrNoResponsesWebSocketProviders", err)
 	}
+	if !strings.Contains(err.Error(), "provider_concurrency_limit=1") {
+		t.Fatalf("Match error = %q, want provider_concurrency_limit diagnostic", err.Error())
+	}
 }
 
 // RequiredProviderID pins eligibility to one provider; a missing pin is a
@@ -678,6 +682,9 @@ func TestMatch_ResponsesWebSocketRequiredProviderIDPinsProvider(t *testing.T) {
 	})
 	if !errors.Is(err, domain.ErrResponsesWebSocketSessionUnavailable) {
 		t.Fatalf("missing pin error = %v, want %v", err, domain.ErrResponsesWebSocketSessionUnavailable)
+	}
+	if !strings.Contains(err.Error(), "required_provider_mismatch=2") {
+		t.Fatalf("missing pin error = %q, want required_provider_mismatch diagnostic", err.Error())
 	}
 }
 

--- a/internal/router/route_semantics_test.go
+++ b/internal/router/route_semantics_test.go
@@ -1,0 +1,85 @@
+package router
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/repository/cached"
+)
+
+func TestMatchTreatsRouteClientTypeAsInboundBucket(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(&wsRouterRouteRepo{routes: []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+	}})
+	providerRepo := cached.NewProviderRepository(&wsRouterProviderRepo{providers: []*domain.Provider{
+		{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "codex-only", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+	}})
+	retryRepo := cached.NewRetryConfigRepository(wsRouterRetryRepo{})
+	strategyRepo := cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(&wsRouterProjectRepo{})
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+
+	_, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeOpenAI, RequestModel: "gpt-5"})
+	if !errors.Is(err, domain.ErrNoRoutes) {
+		t.Fatalf("OpenAI request matched Codex route: err=%v, want ErrNoRoutes", err)
+	}
+
+	result, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "gpt-5"})
+	if err != nil {
+		t.Fatalf("Codex request did not match Codex route: %v", err)
+	}
+	if len(result.Routes) != 1 || result.Routes[0].Route.ID != 1 {
+		t.Fatalf("routes = %+v, want Codex route 1", result.Routes)
+	}
+}
+
+func TestMatchNoAvailableProvidersIncludesRejectionDiagnostics(t *testing.T) {
+	routeRepo := cached.NewRouteRepository(&wsRouterRouteRepo{routes: []*domain.Route{
+		{ID: 1, TenantID: 1, ProviderID: 901, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+	}})
+	providerRepo := cached.NewProviderRepository(&wsRouterProviderRepo{providers: []*domain.Provider{
+		{ID: 901, TenantID: 1, Type: wsRouterBadType, Name: "broken-config", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}},
+	}})
+	retryRepo := cached.NewRetryConfigRepository(wsRouterRetryRepo{})
+	strategyRepo := cached.NewRoutingStrategyRepository(wsRouterStrategyRepo{})
+	projectRepo := cached.NewProjectRepository(&wsRouterProjectRepo{})
+	for name, load := range map[string]func() error{
+		"routes":     routeRepo.Load,
+		"providers":  providerRepo.Load,
+		"retry":      retryRepo.Load,
+		"strategies": strategyRepo.Load,
+		"projects":   projectRepo.Load,
+	} {
+		if err := load(); err != nil {
+			t.Fatalf("load %s: %v", name, err)
+		}
+	}
+	r := NewRouter(routeRepo, providerRepo, strategyRepo, retryRepo, projectRepo)
+	if err := r.InitAdapters(); err != nil {
+		t.Fatalf("InitAdapters: %v", err)
+	}
+
+	_, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "gpt-5"})
+	if !errors.Is(err, domain.ErrNoAvailableProviders) {
+		t.Fatalf("Match() error = %v, want ErrNoAvailableProviders", err)
+	}
+	if !strings.Contains(err.Error(), "rejections: adapter_missing=1") {
+		t.Fatalf("error = %q, want adapter_missing diagnostic", err.Error())
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,10 +8,12 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"math/rand"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -364,14 +366,20 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	// generic ErrNoAvailableProviders rather than blaming the model.
 	sawModelReject := false
 	sawTransientSkip := false
+	rejects := make(map[string]int)
+	noteReject := func(reason string) {
+		rejects[reason]++
+	}
 
 	for _, route := range filtered {
 		prov, ok := providers[route.ProviderID]
 		if !ok {
+			noteReject("provider_missing")
 			continue
 		}
 		if r.isProviderAtConcurrencyLimit(prov) {
 			sawTransientSkip = true
+			noteReject("provider_concurrency_limit")
 			continue
 		}
 
@@ -380,14 +388,17 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		// Skip providers in cooldown (checks provider, key, and outbound model-level cooldowns)
 		if r.isAnyModelCandidateInCooldown(route.ProviderID, clientType, modelCandidates) {
 			sawTransientSkip = true
+			noteReject("cooldown")
 			continue
 		}
 
 		adp, ok := r.adapters[route.ProviderID]
 		if !ok {
+			noteReject("adapter_missing")
 			continue
 		}
 		if ctx.RequiredProviderID != 0 && prov.ID != ctx.RequiredProviderID {
+			noteReject("required_provider_mismatch")
 			continue
 		}
 		// Derive native capability from provider + client type; never trust
@@ -396,6 +407,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if ctx.RequireResponsesWebSocket {
 			if !provider.ResponsesWebSocketTransportAvailable(prov.ID) {
 				sawTransientSkip = true
+				noteReject("websocket_transport_unavailable")
 				continue
 			}
 			wsAdapter := adapterSupportsResponsesWebSocket(adp)
@@ -405,6 +417,14 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 					"[Router] skip codex websocket candidate provider=%d type=%s native=%v wsAdapter=%v wsEnabled=%v adapter=%T",
 					prov.ID, prov.Type, native, wsAdapter, wsEnabled, adp,
 				)
+				switch {
+				case !native:
+					noteReject("websocket_non_native_route")
+				case !wsAdapter:
+					noteReject("websocket_adapter_unsupported")
+				case !wsEnabled:
+					noteReject("websocket_provider_disabled")
+				}
 				continue
 			}
 		}
@@ -419,6 +439,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if (r.strictSupportModelsRoutingEnabled() || ctx.StrictSupportModels) && adapterSupportsClientType(adp, clientType) && len(prov.SupportModels) > 0 && requestModel != "" {
 			if !r.isAnyModelCandidateSupported(prov, modelCandidates) {
 				sawModelReject = true
+				noteReject("support_models_mismatch")
 				continue
 			}
 		}
@@ -453,7 +474,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		if sawModelReject && !sawTransientSkip {
 			return nil, domain.ErrModelNotSupported
 		}
-		return nil, domain.ErrNoAvailableProviders
+		return nil, noAvailableProvidersError(rejects)
 	}
 
 	// Sticky / session-affinity layer. Only meaningful when:
@@ -939,4 +960,20 @@ func (r *Router) injectProviderUpdate(a provider.ProviderAdapter, p *domain.Prov
 			return repo.GetByID(tenantID, id)
 		})
 	}
+}
+
+func noAvailableProvidersError(rejects map[string]int) error {
+	if len(rejects) == 0 {
+		return domain.ErrNoAvailableProviders
+	}
+	keys := make([]string, 0, len(rejects))
+	for key := range rejects {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, rejects[key]))
+	}
+	return fmt.Errorf("%w (rejections: %s)", domain.ErrNoAvailableProviders, strings.Join(parts, ", "))
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -359,13 +359,12 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	providers := r.providerRepo.GetAll()
 
 	// Track why candidates were dropped so an empty result can be reported
-	// precisely: sawModelReject means a route was skipped purely because the model
-	// is not in the provider's SupportModels allowlist (a client request error);
-	// sawTransientSkip means a route was skipped for a transient reason (cooldown)
-	// that might otherwise have served the model — in which case we stay with the
-	// generic ErrNoAvailableProviders rather than blaming the model.
+	// precisely: model rejections are a client request error only when every
+	// candidate failed solely on SupportModels. Provider/adapter/config/transport
+	// skips keep the generic no-available-provider path so we do not mislabel a
+	// broken or transient route set as an unsupported model.
 	sawModelReject := false
-	sawTransientSkip := false
+	sawNonModelReject := false
 	rejects := make(map[string]int)
 	noteReject := func(reason string) {
 		rejects[reason]++
@@ -374,11 +373,12 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	for _, route := range filtered {
 		prov, ok := providers[route.ProviderID]
 		if !ok {
+			sawNonModelReject = true
 			noteReject("provider_missing")
 			continue
 		}
 		if r.isProviderAtConcurrencyLimit(prov) {
-			sawTransientSkip = true
+			sawNonModelReject = true
 			noteReject("provider_concurrency_limit")
 			continue
 		}
@@ -387,17 +387,19 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 
 		// Skip providers in cooldown (checks provider, key, and outbound model-level cooldowns)
 		if r.isAnyModelCandidateInCooldown(route.ProviderID, clientType, modelCandidates) {
-			sawTransientSkip = true
+			sawNonModelReject = true
 			noteReject("cooldown")
 			continue
 		}
 
 		adp, ok := r.adapters[route.ProviderID]
 		if !ok {
+			sawNonModelReject = true
 			noteReject("adapter_missing")
 			continue
 		}
 		if ctx.RequiredProviderID != 0 && prov.ID != ctx.RequiredProviderID {
+			sawNonModelReject = true
 			noteReject("required_provider_mismatch")
 			continue
 		}
@@ -406,7 +408,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 		native := domain.RouteIsNative(prov, route)
 		if ctx.RequireResponsesWebSocket {
 			if !provider.ResponsesWebSocketTransportAvailable(prov.ID) {
-				sawTransientSkip = true
+				sawNonModelReject = true
 				noteReject("websocket_transport_unavailable")
 				continue
 			}
@@ -417,6 +419,7 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 					"[Router] skip codex websocket candidate provider=%d type=%s native=%v wsAdapter=%v wsEnabled=%v adapter=%T",
 					prov.ID, prov.Type, native, wsAdapter, wsEnabled, adp,
 				)
+				sawNonModelReject = true
 				switch {
 				case !native:
 					noteReject("websocket_non_native_route")
@@ -464,14 +467,14 @@ func (r *Router) Match(ctx *MatchContext) (*MatchResult, error) {
 	if len(matched) == 0 {
 		if ctx.RequireResponsesWebSocket {
 			if ctx.RequiredProviderID != 0 {
-				return nil, domain.ErrResponsesWebSocketSessionUnavailable
+				return nil, responsesWebSocketSessionUnavailableError(rejects)
 			}
-			return nil, domain.ErrNoResponsesWebSocketProviders
+			return nil, noResponsesWebSocketProvidersError(rejects)
 		}
 		// Only blame the model when the emptiness is entirely due to SupportModels
-		// rejections; a transient skip (cooldown) may hide a provider that does
-		// support it, so fall back to the generic error to avoid mislabeling.
-		if sawModelReject && !sawTransientSkip {
+		// rejections; any provider/adapter/config/transport rejection means the
+		// route set itself was unavailable and should keep diagnostic detail.
+		if sawModelReject && !sawNonModelReject {
 			return nil, domain.ErrModelNotSupported
 		}
 		return nil, noAvailableProvidersError(rejects)
@@ -963,8 +966,20 @@ func (r *Router) injectProviderUpdate(a provider.ProviderAdapter, p *domain.Prov
 }
 
 func noAvailableProvidersError(rejects map[string]int) error {
+	return withRejectionDiagnostics(domain.ErrNoAvailableProviders, rejects)
+}
+
+func noResponsesWebSocketProvidersError(rejects map[string]int) error {
+	return withRejectionDiagnostics(domain.ErrNoResponsesWebSocketProviders, rejects)
+}
+
+func responsesWebSocketSessionUnavailableError(rejects map[string]int) error {
+	return withRejectionDiagnostics(domain.ErrResponsesWebSocketSessionUnavailable, rejects)
+}
+
+func withRejectionDiagnostics(base error, rejects map[string]int) error {
 	if len(rejects) == 0 {
-		return domain.ErrNoAvailableProviders
+		return base
 	}
 	keys := make([]string, 0, len(rejects))
 	for key := range rejects {
@@ -975,5 +990,5 @@ func noAvailableProvidersError(rejects map[string]int) error {
 	for _, key := range keys {
 		parts = append(parts, fmt.Sprintf("%s=%d", key, rejects[key]))
 	}
-	return fmt.Errorf("%w (rejections: %s)", domain.ErrNoAvailableProviders, strings.Join(parts, ", "))
+	return fmt.Errorf("%w (rejections: %s)", base, strings.Join(parts, ", "))
 }

--- a/internal/router/support_models_routing_test.go
+++ b/internal/router/support_models_routing_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,5 +213,29 @@ func TestRouteMatchChecksCooldownAgainstMappedModelCandidates(t *testing.T) {
 	}
 	if got := matchedProviderIDs(result); len(got) != 1 || got[0] != 102 {
 		t.Fatalf("matched provider IDs = %v, want [102]", got)
+	}
+}
+
+func TestStrictSupportModelsRoutingKeepsNoAvailableProvidersWhenMixedWithMissingAdapter(t *testing.T) {
+	r := newSupportModelRoutingTestRouter(t, true,
+		[]*domain.Route{
+			{ID: 1, TenantID: 1, ProviderID: 101, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 1},
+			{ID: 2, TenantID: 1, ProviderID: 901, ClientType: domain.ClientTypeCodex, IsEnabled: true, Position: 2},
+		},
+		[]*domain.Provider{
+			{ID: 101, TenantID: 1, Type: wsRouterNativeType, Name: "unsupported", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"other-model"}},
+			{ID: 901, TenantID: 1, Type: wsRouterBadType, Name: "broken-config", SupportedClientTypes: []domain.ClientType{domain.ClientTypeCodex}, SupportModels: []string{"codex-target"}},
+		},
+	)
+
+	_, err := r.Match(&MatchContext{TenantID: 1, ClientType: domain.ClientTypeCodex, RequestModel: "codex-target"})
+	if !errors.Is(err, domain.ErrNoAvailableProviders) {
+		t.Fatalf("Match() error = %v, want ErrNoAvailableProviders", err)
+	}
+	if strings.Contains(err.Error(), domain.ErrModelNotSupported.Error()) {
+		t.Fatalf("error = %q, must not mislabel mixed route unavailability as model_not_supported", err.Error())
+	}
+	if !strings.Contains(err.Error(), "adapter_missing=1") || !strings.Contains(err.Error(), "support_models_mismatch=1") {
+		t.Fatalf("error = %q, want adapter_missing and support_models_mismatch diagnostics", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- clarify router route semantics with a regression test: `route.ClientType` is an inbound/client-facing bucket, not an outbound target protocol selector
- expose `ErrNoAvailableProviders` rejection diagnostics such as `adapter_missing`, `cooldown`, `provider_concurrency_limit`, `support_models_mismatch`, and Codex WebSocket-specific skips
- preserve the precise rejection message through `Executor.routeMatch` so request details show why candidates disappeared instead of the generic `no available provider for matched route`

## Verification
- `go test ./internal/router ./internal/executor ./internal/handler ./internal/adapter/provider/custom ./internal/converter`

## Notes
This does not change routing behavior. It makes the next failing Attempts Detail/log entry distinguish route/provider/config/cooldown causes instead of hiding them behind `route match failed: no available providers`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误提示改进**
  * 路由匹配失败时，错误信息会更准确地说明失败原因。
  * 无可用提供商时，提示将包含适配器缺失、并发限制、提供商不匹配及模型能力不匹配等诊断信息。
  * WebSocket 路由匹配失败时，也会显示更具体的拒绝原因，便于排查配置问题。

* **路由匹配改进**
  * 优化客户端类型与支持模型的路由匹配行为，减少错误分类。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->