### PR TITLE
feat(providers): share custom providers as add commands

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -473,6 +473,9 @@
     "noProvidersHint": "Click \"Add Provider\" to create one",
     "importProviders": "Import Providers",
     "exportProviders": "Export Providers",
+    "shareProviderAddCommand": {
+      "copy": "Copy add command"
+    },
     "readOnlyHint": "Read-only for members. Admin access required to edit providers.",
     "importProvidersAdminOnly": "Only admins can import providers.",
     "addProviderAdminOnly": "Only admins can add providers.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -472,6 +472,9 @@
     "noProvidersHint": "点击「添加提供商」创建一个",
     "importProviders": "导入提供商",
     "exportProviders": "导出提供商",
+    "shareProviderAddCommand": {
+      "copy": "复制添加命令"
+    },
     "readOnlyHint": "成员仅可查看，编辑提供商需要管理员权限。",
     "importProvidersAdminOnly": "只有管理员可以导入提供商。",
     "addProviderAdminOnly": "只有管理员可以添加提供商。",

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -265,9 +265,14 @@ export function ProviderRow({
       return;
     }
 
-    await navigator.clipboard.writeText(shareCommand);
-    setShareCopied(true);
-    window.setTimeout(() => setShareCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(shareCommand);
+      setShareCopied(true);
+      window.setTimeout(() => setShareCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy provider add command:', error);
+      setShareCopied(false);
+    }
   };
 
   const handleShareCommandKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -1,5 +1,5 @@
-import { type KeyboardEvent } from 'react';
-import { Activity, Ban, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
+import { useState, type KeyboardEvent, type MouseEvent } from 'react';
+import { Activity, Ban, Copy, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import { useCooldowns } from '@/hooks/use-cooldowns';
 import { ClientIcon } from '@/components/icons/client-icons';
@@ -23,6 +23,7 @@ import {
   getAntigravityAvailabilityBadgeClass,
   getAntigravityAvailabilityInfo,
 } from '@/lib/antigravity-availability';
+import { buildProviderAddCommand, canBuildProviderAddCommand } from '../utils/provider-add-command';
 
 // 格式化 Token 数量
 function formatTokens(count: number): string {
@@ -253,9 +254,29 @@ export function ProviderRow({
   const worstCooldown = providerCooldowns[0];
   const modelCooldowns = providerCooldowns.filter((cd) => cd.model);
 
+  const [shareCopied, setShareCopied] = useState(false);
+  const shareCommand = canBuildProviderAddCommand(provider)
+    ? buildProviderAddCommand(provider)
+    : null;
   const isInteractive = !!onClick;
+  const handleCopyProviderAddCommand = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (!shareCommand || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(shareCommand);
+    setShareCopied(true);
+    window.setTimeout(() => setShareCopied(false), 2000);
+  };
+
+  const handleShareCommandKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (!onClick) return;
+    if ((event.target as HTMLElement | null)?.closest('button, input, textarea, select, a')) return;
 
     if (event.key === 'Enter') {
       onClick();
@@ -509,6 +530,22 @@ export function ProviderRow({
           )}
         </div>
       </div>
+      {shareCommand && (
+        <button
+          type="button"
+          onClick={handleCopyProviderAddCommand}
+          onKeyDown={handleShareCommandKeyDown}
+          className="relative z-10 inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background/70 px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          title={t('providers.shareProviderAddCommand.copy')}
+          aria-label={t('providers.shareProviderAddCommand.copy')}
+        >
+          <Copy className="h-3.5 w-3.5" />
+          <span className="hidden md:inline">
+            {shareCopied ? t('common.copied') : t('providers.shareProviderAddCommand.copy')}
+          </span>
+        </button>
+      )}
+
       {(provider.config?.disableErrorCooldown || provider.config?.smartMappingRetryEnabled) && (
         <div className="relative z-10 flex shrink-0 items-center self-stretch gap-1">
           {provider.config?.disableErrorCooldown && (
@@ -539,7 +576,6 @@ export function ProviderRow({
           )}
         </div>
       )}
-
 
       {/* Kiro Quota Area */}
       {isKiro && (

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.test.ts
@@ -36,6 +36,8 @@ describe('bulk custom provider import parser', () => {
       apiKey: 'sk-test',
       clients: ['claude', 'openai'],
       supportModels: ['claude-sonnet-4', 'gpt-5'],
+      exposedModelsEnabled: false,
+      exposedModels: [],
       modelMapping: {
         'claude-sonnet-4': 'upstream-sonnet',
         'gpt-5': 'upstream-gpt',
@@ -56,9 +58,9 @@ describe('bulk custom provider import parser', () => {
     expect(result.commands[0].modelMapping).toEqual({ '*': 'mimo-v2.5-pro' });
   });
 
-  it('builds provider config with persisted mappings', () => {
+  it('builds provider config with persisted mappings and exposed model allowlists', () => {
     const result = parseBulkCustomProviderCommands(
-      'provider add --name mimo --base-url https://api.example.com --api-key sk-test --clients claude --models claude-* --map "*=mimo-v2.5-pro" --response-map "mimo-v2.5-pro=claude-sonnet-4" --no-responses-passthrough',
+      'provider add --name mimo --base-url https://api.example.com --api-key sk-test --clients claude --models claude-* --exposed-models claude-sonnet-4 --map "*=mimo-v2.5-pro" --response-map "mimo-v2.5-pro=claude-sonnet-4" --no-responses-passthrough',
     );
 
     const data = toCreateProviderData(result.commands[0]);
@@ -68,6 +70,8 @@ describe('bulk custom provider import parser', () => {
       name: 'mimo',
       supportedClientTypes: ['claude'],
       supportModels: ['claude-*'],
+      exposedModelsEnabled: true,
+      exposedModels: ['claude-sonnet-4'],
       config: {
         custom: {
           baseURL: 'https://api.example.com',
@@ -77,6 +81,22 @@ describe('bulk custom provider import parser', () => {
           responsesPassthrough: false,
         },
       },
+    });
+  });
+
+  it('preserves an enabled empty exposed model allowlist', () => {
+    const result = parseBulkCustomProviderCommands(
+      'provider add --name mimo --base-url https://api.example.com --api-key sk-test --clients claude --enable-exposed-models',
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.commands[0]).toMatchObject({
+      exposedModelsEnabled: true,
+      exposedModels: [],
+    });
+    expect(toCreateProviderData(result.commands[0])).toMatchObject({
+      exposedModelsEnabled: true,
+      exposedModels: [],
     });
   });
 

--- a/web/src/pages/providers/utils/bulk-custom-provider-import.ts
+++ b/web/src/pages/providers/utils/bulk-custom-provider-import.ts
@@ -1,4 +1,9 @@
-import type { ClientType, CreateProviderData } from '@/lib/transport';
+import type {
+  ClientType,
+  CreateProviderData,
+  ProviderConfigCustomDisguise,
+  ReasoningPolicy,
+} from '@/lib/transport';
 
 export type BulkCustomProviderCommand = {
   lineNumber: number;
@@ -7,16 +12,26 @@ export type BulkCustomProviderCommand = {
   apiKey: string;
   clients: ClientType[];
   supportModels: string[];
+  exposedModelsEnabled: boolean;
+  exposedModels: string[];
   modelMapping: Record<string, string>;
   responseModelMapping: Record<string, string>;
   backend?: 'ollama';
   logo?: string;
+  clientBaseURL?: Partial<Record<ClientType, string>>;
+  clientMultiplier?: Partial<Record<ClientType, number>>;
+  disguise?: ProviderConfigCustomDisguise;
+  reasoning?: ReasoningPolicy;
+  quotaEnabled: boolean;
   disableErrorCooldown: boolean;
+  consecutiveErrorFreezeEnabled: boolean;
+  consecutiveErrorFreezeThreshold?: number;
   smartMappingRetryEnabled: boolean;
   smartMappingRetryLimit?: number;
   maxConcurrency: number;
   excludeFromExport: boolean;
   responsesPassthrough?: boolean;
+  responsesWebSocket: boolean;
 };
 
 export type BulkCustomProviderParseError = {
@@ -36,19 +51,29 @@ const VALUE_FLAGS = new Set([
   'api-key',
   'clients',
   'models',
+  'exposed-models',
   'map',
   'response-map',
   'backend',
   'logo',
+  'client-base-url',
+  'client-multiplier',
+  'disguise',
+  'reasoning',
+  'consecutive-error-freeze-threshold',
   'smart-mapping-retry-limit',
   'max-concurrency',
 ]);
 const BOOLEAN_FLAGS = new Set([
+  'quota-enabled',
   'disable-error-cooldown',
+  'consecutive-error-freeze',
   'smart-mapping-retry',
   'exclude-from-export',
+  'enable-exposed-models',
   'responses-passthrough',
   'no-responses-passthrough',
+  'responses-websocket',
 ]);
 
 function splitCommandLines(input: string): Array<{ lineNumber: number; text: string }> {
@@ -167,6 +192,74 @@ function setMapValues(target: Record<string, string>, source: Record<string, str
   }
 }
 
+function parseJSONFlag<T>(value: string, label: string): { value?: T; error?: string } {
+  try {
+    return { value: JSON.parse(value) as T };
+  } catch {
+    return { error: `${label} must be valid JSON` };
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseClientBaseURL(value: string): {
+  value?: Partial<Record<ClientType, string>>;
+  errors: string[];
+} {
+  const parsed = parseJSONFlag<Record<string, unknown>>(value, 'Client base URL');
+  if (parsed.error) return { errors: [parsed.error] };
+  if (!isPlainObject(parsed.value)) return { errors: ['Client base URL must be a JSON object'] };
+
+  const result: Partial<Record<ClientType, string>> = {};
+  const errors: string[] = [];
+  for (const [rawClient, rawURL] of Object.entries(parsed.value)) {
+    const client = rawClient.toLowerCase() as ClientType;
+    if (!CLIENT_TYPES.has(client)) {
+      errors.push(`Unsupported client "${rawClient}"`);
+      continue;
+    }
+    if (typeof rawURL !== 'string' || !rawURL.trim()) {
+      errors.push(`Client base URL for "${rawClient}" must be a non-empty string`);
+      continue;
+    }
+    result[client] = rawURL.trim();
+  }
+
+  return { value: result, errors };
+}
+
+function parseClientMultiplier(value: string): {
+  value?: Partial<Record<ClientType, number>>;
+  errors: string[];
+} {
+  const parsed = parseJSONFlag<Record<string, unknown>>(value, 'Client multiplier');
+  if (parsed.error) return { errors: [parsed.error] };
+  if (!isPlainObject(parsed.value)) return { errors: ['Client multiplier must be a JSON object'] };
+
+  const result: Partial<Record<ClientType, number>> = {};
+  const errors: string[] = [];
+  for (const [rawClient, rawMultiplier] of Object.entries(parsed.value)) {
+    const client = rawClient.toLowerCase() as ClientType;
+    if (!CLIENT_TYPES.has(client)) {
+      errors.push(`Unsupported client "${rawClient}"`);
+      continue;
+    }
+    if (
+      typeof rawMultiplier !== 'number' ||
+      !Number.isSafeInteger(rawMultiplier) ||
+      rawMultiplier < 0
+    ) {
+      errors.push(`Client multiplier for "${rawClient}" must be 0 or greater`);
+      continue;
+    }
+    result[client] = rawMultiplier;
+  }
+
+  return { value: result, errors };
+}
+
 function parseLine(lineNumber: number, text: string): BulkCustomProviderParseResult {
   const errors: BulkCustomProviderParseError[] = [];
   let tokens: string[];
@@ -194,16 +287,26 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
     apiKey: '',
     clients: [] as ClientType[],
     supportModels: [] as string[],
+    exposedModelsEnabled: false,
+    exposedModels: [] as string[],
     modelMapping: {} as Record<string, string>,
     responseModelMapping: {} as Record<string, string>,
     backend: undefined as 'ollama' | undefined,
     logo: undefined as string | undefined,
+    clientBaseURL: undefined as Partial<Record<ClientType, string>> | undefined,
+    clientMultiplier: undefined as Partial<Record<ClientType, number>> | undefined,
+    disguise: undefined as ProviderConfigCustomDisguise | undefined,
+    reasoning: undefined as ReasoningPolicy | undefined,
+    quotaEnabled: false,
     disableErrorCooldown: false,
+    consecutiveErrorFreezeEnabled: false,
+    consecutiveErrorFreezeThreshold: undefined as number | undefined,
     smartMappingRetryEnabled: false,
     smartMappingRetryLimit: undefined as number | undefined,
     maxConcurrency: 0,
     excludeFromExport: false,
     responsesPassthrough: undefined as boolean | undefined,
+    responsesWebSocket: false,
   };
 
   for (let index = 0; index < tokens.length; index += 1) {
@@ -221,11 +324,15 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
         errors.push({ lineNumber, message: `Flag --${flag} does not accept a value` });
         continue;
       }
+      if (flag === 'quota-enabled') parsed.quotaEnabled = true;
       if (flag === 'disable-error-cooldown') parsed.disableErrorCooldown = true;
+      if (flag === 'consecutive-error-freeze') parsed.consecutiveErrorFreezeEnabled = true;
       if (flag === 'smart-mapping-retry') parsed.smartMappingRetryEnabled = true;
       if (flag === 'exclude-from-export') parsed.excludeFromExport = true;
+      if (flag === 'enable-exposed-models') parsed.exposedModelsEnabled = true;
       if (flag === 'responses-passthrough') parsed.responsesPassthrough = true;
       if (flag === 'no-responses-passthrough') parsed.responsesPassthrough = false;
+      if (flag === 'responses-websocket') parsed.responsesWebSocket = true;
       continue;
     }
 
@@ -260,6 +367,10 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
       case 'models':
         parsed.supportModels = splitList(value);
         break;
+      case 'exposed-models':
+        parsed.exposedModels = splitList(value);
+        parsed.exposedModelsEnabled = true;
+        break;
       case 'map': {
         const result = parseMappingList(value);
         setMapValues(parsed.modelMapping, result.mapping);
@@ -281,6 +392,48 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
       case 'logo':
         parsed.logo = value.trim();
         break;
+      case 'client-base-url': {
+        const result = parseClientBaseURL(value);
+        parsed.clientBaseURL = result.value;
+        result.errors.forEach((message) => errors.push({ lineNumber, message }));
+        break;
+      }
+      case 'client-multiplier': {
+        const result = parseClientMultiplier(value);
+        parsed.clientMultiplier = result.value;
+        result.errors.forEach((message) => errors.push({ lineNumber, message }));
+        break;
+      }
+      case 'disguise': {
+        const result = parseJSONFlag<ProviderConfigCustomDisguise>(value, 'Disguise');
+        if (result.error) {
+          errors.push({ lineNumber, message: result.error });
+        } else {
+          parsed.disguise = result.value;
+        }
+        break;
+      }
+      case 'reasoning': {
+        const result = parseJSONFlag<ReasoningPolicy>(value, 'Reasoning');
+        if (result.error) {
+          errors.push({ lineNumber, message: result.error });
+        } else {
+          parsed.reasoning = result.value;
+        }
+        break;
+      }
+      case 'consecutive-error-freeze-threshold': {
+        const threshold = Number.parseInt(value, 10);
+        if (!Number.isFinite(threshold) || threshold < 1 || threshold > 100) {
+          errors.push({
+            lineNumber,
+            message: 'Consecutive error freeze threshold must be between 1 and 100',
+          });
+        } else {
+          parsed.consecutiveErrorFreezeThreshold = threshold;
+        }
+        break;
+      }
       case 'smart-mapping-retry-limit': {
         const parsedLimit = Number.parseInt(value, 10);
         if (!Number.isFinite(parsedLimit) || parsedLimit < 1 || parsedLimit > 20) {
@@ -319,6 +472,12 @@ function parseLine(lineNumber: number, text: string): BulkCustomProviderParseRes
       message: 'Smart mapping retry requires --disable-error-cooldown',
     });
   }
+  if (parsed.consecutiveErrorFreezeEnabled && !parsed.disableErrorCooldown) {
+    errors.push({
+      lineNumber,
+      message: 'Consecutive error freeze requires --disable-error-cooldown',
+    });
+  }
 
   if (errors.length > 0) {
     return { commands: [], errors };
@@ -350,13 +509,21 @@ export function toCreateProviderData(command: BulkCustomProviderCommand): Create
     logo: command.logo,
     maxConcurrency: command.maxConcurrency,
     config: {
+      quotaEnabled: command.quotaEnabled,
       disableErrorCooldown: command.disableErrorCooldown,
+      consecutiveErrorFreezeEnabled:
+        command.disableErrorCooldown && command.consecutiveErrorFreezeEnabled,
+      consecutiveErrorFreezeThreshold: command.consecutiveErrorFreezeThreshold,
       smartMappingRetryEnabled: command.disableErrorCooldown && command.smartMappingRetryEnabled,
       smartMappingRetryLimit: command.smartMappingRetryLimit ?? 1,
+      reasoning: command.reasoning,
       custom: {
         baseURL: command.baseURL,
         backend: command.backend,
         apiKey: command.apiKey,
+        clientBaseURL: command.clientBaseURL,
+        clientMultiplier: command.clientMultiplier,
+        disguise: command.disguise,
         modelMapping:
           Object.keys(command.modelMapping).length > 0 ? command.modelMapping : undefined,
         responseModelMapping:
@@ -364,10 +531,13 @@ export function toCreateProviderData(command: BulkCustomProviderCommand): Create
             ? command.responseModelMapping
             : undefined,
         responsesPassthrough: command.responsesPassthrough,
+        responsesWebSocket: command.responsesWebSocket,
       },
     },
     supportedClientTypes: command.clients,
     supportModels: command.supportModels,
+    exposedModelsEnabled: command.exposedModelsEnabled,
+    exposedModels: command.exposedModels,
     excludeFromExport: command.excludeFromExport,
   };
 }

--- a/web/src/pages/providers/utils/provider-add-command.test.ts
+++ b/web/src/pages/providers/utils/provider-add-command.test.ts
@@ -114,6 +114,24 @@ describe('provider-add-command', () => {
     expect(data.config?.custom?.responsesWebSocket).toBe(true);
   });
 
+  it('does not export stale exposed models when the allowlist is disabled', () => {
+    const provider: Provider = {
+      ...baseProvider,
+      exposedModelsEnabled: false,
+      exposedModels: ['claude-sonnet-4'],
+    };
+
+    const command = buildProviderAddCommand(provider);
+    expect(command).not.toContain('--exposed-models');
+    expect(command).not.toContain('--enable-exposed-models');
+
+    const parsed = parseBulkCustomProviderCommands(command ?? '');
+    expect(parsed.errors).toEqual([]);
+    const data = toCreateProviderData(parsed.commands[0]);
+    expect(data.exposedModelsEnabled).toBe(false);
+    expect(data.exposedModels).toEqual([]);
+  });
+
   it('preserves an enabled empty exposed model allowlist', () => {
     const provider: Provider = {
       ...baseProvider,

--- a/web/src/pages/providers/utils/provider-add-command.test.ts
+++ b/web/src/pages/providers/utils/provider-add-command.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import type { Provider } from '@/lib/transport';
+import { buildProviderAddCommand, canBuildProviderAddCommand } from './provider-add-command';
+import {
+  parseBulkCustomProviderCommands,
+  toCreateProviderData,
+} from './bulk-custom-provider-import';
+
+const baseProvider: Provider = {
+  id: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  type: 'custom',
+  name: "Mimo's Provider",
+  logo: 'https://example.com/logo.png',
+  supportedClientTypes: ['claude', 'openai', 'codex'],
+  supportModels: ['claude-*', 'gpt-5'],
+  exposedModelsEnabled: true,
+  exposedModels: ['claude-sonnet-4', 'gpt-5'],
+  maxConcurrency: 7,
+  excludeFromExport: false,
+  blackBox: false,
+  config: {
+    quotaEnabled: true,
+    disableErrorCooldown: true,
+    consecutiveErrorFreezeEnabled: true,
+    consecutiveErrorFreezeThreshold: 5,
+    smartMappingRetryEnabled: true,
+    smartMappingRetryLimit: 3,
+    reasoning: { defaultEffort: 'low', maxEffort: 'high' },
+    custom: {
+      baseURL: 'https://api.example.com/v1',
+      apiKey: "sk-test'quoted",
+      clientBaseURL: {
+        openai: 'https://openai.example.com/v1',
+        claude: 'https://claude.example.com',
+      },
+      clientMultiplier: {
+        openai: 12000,
+      },
+      disguise: {
+        type: 'claude-code',
+        claudeCode: {
+          mode: 'always',
+          strictMode: true,
+          sensitiveWords: ['secret'],
+        },
+      },
+      modelMapping: {
+        'claude-*': 'upstream-sonnet',
+        'gpt-5': 'upstream-gpt',
+      },
+      responseModelMapping: {
+        'upstream-sonnet': 'claude-sonnet-4',
+      },
+      responsesPassthrough: false,
+      responsesWebSocket: true,
+    },
+  },
+};
+
+describe('provider-add-command', () => {
+  it('builds a provider add command that round-trips through the bulk parser', () => {
+    const command = buildProviderAddCommand(baseProvider);
+
+    expect(command).toContain("--name 'Mimo'\"'\"'s Provider'");
+    expect(command).toContain("--api-key 'sk-test'\"'\"'quoted'");
+    expect(command).toContain('--disable-error-cooldown');
+    expect(command).toContain('--quota-enabled');
+    expect(command).toContain('--disable-error-cooldown');
+    expect(command).toContain('--consecutive-error-freeze');
+    expect(command).toContain('--consecutive-error-freeze-threshold 5');
+    expect(command).toContain('--smart-mapping-retry');
+    expect(command).toContain('--smart-mapping-retry-limit 3');
+    expect(command).toContain('--max-concurrency 7');
+    expect(command).toContain("--exposed-models 'claude-sonnet-4,gpt-5'");
+    expect(command).toContain('--client-base-url');
+    expect(command).toContain('--client-multiplier');
+    expect(command).toContain('--disguise');
+    expect(command).toContain('--reasoning');
+    expect(command).toContain('--no-responses-passthrough');
+    expect(command).toContain('--responses-websocket');
+
+    const parsed = parseBulkCustomProviderCommands(command ?? '');
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.commands).toHaveLength(1);
+
+    const data = toCreateProviderData(parsed.commands[0]);
+    expect(data.name).toBe(baseProvider.name);
+    expect(data.config?.custom?.baseURL).toBe(baseProvider.config?.custom?.baseURL);
+    expect(data.config?.custom?.apiKey).toBe(baseProvider.config?.custom?.apiKey);
+    expect(data.supportedClientTypes).toEqual(baseProvider.supportedClientTypes);
+    expect(data.supportModels).toEqual(baseProvider.supportModels);
+    expect(data.exposedModelsEnabled).toBe(true);
+    expect(data.exposedModels).toEqual(baseProvider.exposedModels);
+    expect(data.config?.custom?.modelMapping).toEqual(baseProvider.config?.custom?.modelMapping);
+    expect(data.config?.custom?.responseModelMapping).toEqual(
+      baseProvider.config?.custom?.responseModelMapping,
+    );
+    expect(data.config?.quotaEnabled).toBe(true);
+    expect(data.config?.disableErrorCooldown).toBe(true);
+    expect(data.config?.consecutiveErrorFreezeEnabled).toBe(true);
+    expect(data.config?.consecutiveErrorFreezeThreshold).toBe(5);
+    expect(data.config?.smartMappingRetryEnabled).toBe(true);
+    expect(data.config?.smartMappingRetryLimit).toBe(3);
+    expect(data.config?.reasoning).toEqual(baseProvider.config?.reasoning);
+    expect(data.maxConcurrency).toBe(7);
+    expect(data.config?.custom?.clientBaseURL).toEqual(baseProvider.config?.custom?.clientBaseURL);
+    expect(data.config?.custom?.clientMultiplier).toEqual(
+      baseProvider.config?.custom?.clientMultiplier,
+    );
+    expect(data.config?.custom?.disguise).toEqual(baseProvider.config?.custom?.disguise);
+    expect(data.config?.custom?.responsesPassthrough).toBe(false);
+    expect(data.config?.custom?.responsesWebSocket).toBe(true);
+  });
+
+  it('preserves an enabled empty exposed model allowlist', () => {
+    const provider: Provider = {
+      ...baseProvider,
+      exposedModelsEnabled: true,
+      exposedModels: [],
+    };
+
+    const command = buildProviderAddCommand(provider);
+    expect(command).toContain('--enable-exposed-models');
+    expect(command).not.toContain('--exposed-models');
+
+    const parsed = parseBulkCustomProviderCommands(command ?? '');
+    expect(parsed.errors).toEqual([]);
+    expect(toCreateProviderData(parsed.commands[0]).exposedModelsEnabled).toBe(true);
+    expect(toCreateProviderData(parsed.commands[0]).exposedModels).toEqual([]);
+  });
+
+  it('supports ollama providers without api keys', () => {
+    const provider: Provider = {
+      ...baseProvider,
+      config: {
+        custom: {
+          baseURL: 'http://localhost:11434/v1',
+          apiKey: '',
+          backend: 'ollama',
+        },
+      },
+      supportedClientTypes: ['openai'],
+      supportModels: ['llama3.1'],
+    };
+
+    expect(canBuildProviderAddCommand(provider)).toBe(true);
+    const command = buildProviderAddCommand(provider);
+    expect(command).toContain('--backend ollama');
+
+    const parsed = parseBulkCustomProviderCommands(command ?? '');
+    expect(parsed.errors).toEqual([]);
+  });
+
+  it('refuses providers that cannot be safely shared as provider add commands', () => {
+    expect(canBuildProviderAddCommand({ ...baseProvider, type: 'claude' })).toBe(false);
+    expect(canBuildProviderAddCommand({ ...baseProvider, blackBox: true })).toBe(false);
+    expect(canBuildProviderAddCommand({ ...baseProvider, excludeFromExport: true })).toBe(false);
+    expect(buildProviderAddCommand({ ...baseProvider, blackBox: true })).toBeNull();
+    expect(buildProviderAddCommand({ ...baseProvider, excludeFromExport: true })).toBeNull();
+    expect(
+      canBuildProviderAddCommand({
+        ...baseProvider,
+        config: { custom: { baseURL: '', apiKey: 'sk-test' } },
+      }),
+    ).toBe(false);
+    expect(
+      canBuildProviderAddCommand({
+        ...baseProvider,
+        config: { custom: { baseURL: 'https://api.example.com', apiKey: '' } },
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/src/pages/providers/utils/provider-add-command.ts
+++ b/web/src/pages/providers/utils/provider-add-command.ts
@@ -1,0 +1,109 @@
+import type { Provider, ProviderConfigCustomDisguise } from '@/lib/transport';
+
+function quoteShell(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function joinList(values: string[] | undefined): string {
+  return (values ?? []).filter(Boolean).join(',');
+}
+
+function joinMapping(mapping: Record<string, string> | undefined): string {
+  return Object.entries(mapping ?? {})
+    .filter(([source, target]) => source && target)
+    .map(([source, target]) => `${source}=${target}`)
+    .join(',');
+}
+
+function pushValueFlag(parts: string[], flag: string, value: string | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) return;
+  parts.push(flag, quoteShell(trimmed));
+}
+
+function pushJSONFlag(parts: string[], flag: string, value: unknown) {
+  if (value === undefined || value === null) return;
+  parts.push(flag, quoteShell(JSON.stringify(value)));
+}
+
+function nonDefaultRecord<T>(
+  value: Partial<Record<string, T>> | undefined,
+): typeof value | undefined {
+  return value && Object.keys(value).length > 0 ? value : undefined;
+}
+
+function providerDisguise(provider: Provider): ProviderConfigCustomDisguise | undefined {
+  const custom = provider.config?.custom;
+  if (custom?.disguise) return custom.disguise;
+
+  const legacyCloak = (custom as { cloak?: ProviderConfigCustomDisguise['claudeCode'] } | undefined)
+    ?.cloak;
+  return legacyCloak ? { type: 'claude-code', claudeCode: legacyCloak } : undefined;
+}
+
+export function canBuildProviderAddCommand(provider: Provider): boolean {
+  const custom = provider.config?.custom;
+  if (provider.blackBox || provider.excludeFromExport) return false;
+  if (provider.type !== 'custom' || !custom) return false;
+  if (!custom.baseURL?.trim()) return false;
+  if (custom.backend !== 'ollama' && !custom.apiKey?.trim()) return false;
+  return true;
+}
+
+export function buildProviderAddCommand(provider: Provider): string | null {
+  const custom = provider.config?.custom;
+  if (!canBuildProviderAddCommand(provider) || !custom) return null;
+
+  const parts = ['provider', 'add'];
+  pushValueFlag(parts, '--name', provider.name);
+  pushValueFlag(parts, '--base-url', custom.baseURL);
+  pushValueFlag(parts, '--api-key', custom.apiKey);
+
+  const clients = joinList(provider.supportedClientTypes);
+  if (clients) parts.push('--clients', quoteShell(clients));
+
+  const models = joinList(provider.supportModels);
+  if (models) parts.push('--models', quoteShell(models));
+
+  const exposedModels = joinList(provider.exposedModels);
+  if (exposedModels) {
+    parts.push('--exposed-models', quoteShell(exposedModels));
+  } else if (provider.exposedModelsEnabled) {
+    parts.push('--enable-exposed-models');
+  }
+
+  const modelMapping = joinMapping(custom.modelMapping);
+  if (modelMapping) parts.push('--map', quoteShell(modelMapping));
+
+  const responseModelMapping = joinMapping(custom.responseModelMapping);
+  if (responseModelMapping) parts.push('--response-map', quoteShell(responseModelMapping));
+
+  if (custom.backend === 'ollama') parts.push('--backend', 'ollama');
+  pushValueFlag(parts, '--logo', provider.logo);
+  pushJSONFlag(parts, '--client-base-url', nonDefaultRecord(custom.clientBaseURL));
+  pushJSONFlag(parts, '--client-multiplier', nonDefaultRecord(custom.clientMultiplier));
+  pushJSONFlag(parts, '--disguise', providerDisguise(provider));
+  pushJSONFlag(parts, '--reasoning', provider.config?.reasoning);
+
+  if (provider.config?.quotaEnabled) parts.push('--quota-enabled');
+  if (provider.config?.disableErrorCooldown) parts.push('--disable-error-cooldown');
+  if (provider.config?.consecutiveErrorFreezeEnabled) parts.push('--consecutive-error-freeze');
+  if (provider.config?.consecutiveErrorFreezeThreshold) {
+    parts.push(
+      '--consecutive-error-freeze-threshold',
+      String(provider.config.consecutiveErrorFreezeThreshold),
+    );
+  }
+  if (provider.config?.smartMappingRetryEnabled) parts.push('--smart-mapping-retry');
+  if (provider.config?.smartMappingRetryLimit && provider.config.smartMappingRetryLimit !== 1) {
+    parts.push('--smart-mapping-retry-limit', String(provider.config.smartMappingRetryLimit));
+  }
+  if (provider.maxConcurrency && provider.maxConcurrency > 0) {
+    parts.push('--max-concurrency', String(provider.maxConcurrency));
+  }
+  if (custom.responsesPassthrough === true) parts.push('--responses-passthrough');
+  if (custom.responsesPassthrough === false) parts.push('--no-responses-passthrough');
+  if (custom.responsesWebSocket === true) parts.push('--responses-websocket');
+
+  return parts.join(' ');
+}

--- a/web/src/pages/providers/utils/provider-add-command.ts
+++ b/web/src/pages/providers/utils/provider-add-command.ts
@@ -65,7 +65,7 @@ export function buildProviderAddCommand(provider: Provider): string | null {
   const models = joinList(provider.supportModels);
   if (models) parts.push('--models', quoteShell(models));
 
-  const exposedModels = joinList(provider.exposedModels);
+  const exposedModels = provider.exposedModelsEnabled ? joinList(provider.exposedModels) : '';
   if (exposedModels) {
     parts.push('--exposed-models', quoteShell(exposedModels));
   } else if (provider.exposedModelsEnabled) {


### PR DESCRIPTION
## Summary
- add a custom-provider share command builder that copies one `provider add ...` command from provider rows
- extend bulk custom provider command import with exposed model allowlist flags
- cover provider-add command round-trip and exposed-model import behavior with Vitest tests

## Validation
- `pnpm --dir web test src/pages/providers/utils/bulk-custom-provider-import.test.ts src/pages/providers/utils/provider-add-command.test.ts`
- `pnpm --dir web test src/pages/providers`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`

Note: local Node is v24.18.0 while web/package.json declares >=22.12.0 <23, so pnpm prints an engine warning before scripts. The scripts completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 提供商列表现支持一键复制可共享的提供商添加命令，并在复制成功后显示短暂提示。
  - 添加命令会保留提供商的模型、映射、并发限制及其他相关配置。
  - 批量导入提供商时支持配置暴露模型及其启用状态。

- **本地化**
  - 新增英文和中文的“复制添加命令”界面文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->