### PR TITLE
fix(executor): retry raw upstream EOF errors

### DIFF
--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -699,7 +700,31 @@ func asProxyError(err error) (*domain.ProxyError, bool) {
 	if errors.As(err, &proxyErr) {
 		return proxyErr, true
 	}
+	if proxyErr := newRawUpstreamNetworkProxyError(err); proxyErr != nil {
+		return proxyErr, true
+	}
 	return nil, false
+}
+
+func newRawUpstreamNetworkProxyError(err error) *domain.ProxyError {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	if !errors.Is(err, io.ErrUnexpectedEOF) &&
+		!strings.Contains(msg, "unexpected eof") &&
+		!strings.Contains(msg, "premature eof") &&
+		!strings.Contains(msg, "connection reset by peer") &&
+		!strings.Contains(msg, "forcibly closed by the remote host") &&
+		!strings.Contains(msg, "wsarecv") &&
+		!strings.Contains(msg, "stream id") &&
+		!strings.Contains(msg, "internal_error") {
+		return nil
+	}
+	proxyErr := domain.NewProxyErrorWithMessage(err, true, "upstream network error")
+	proxyErr.Scope = domain.ScopeProvider
+	proxyErr.Reason = domain.CooldownReasonNetworkError
+	return proxyErr
 }
 
 func normalizeUpstreamConnectionError(proxyErr *domain.ProxyError) {

--- a/internal/executor/single_attempt_test.go
+++ b/internal/executor/single_attempt_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -521,6 +522,55 @@ func TestExecuteProviderProxyRetriesWrappedUpstreamConnectionError(t *testing.T)
 
 	adapterErr := domain.NewUpstreamConnectionError("failed to connect to upstream")
 	adapter := &sequenceAdapter{errs: []error{fmt.Errorf("adapter wrapper: %w", adapterErr)}}
+	e := &Executor{
+		proxyRequestRepo: &recordingProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		retryConfigRepo: &staticRetryConfigRepo{defaultConfig: &domain.RetryConfig{
+			MaxRetries:      1,
+			InitialInterval: 0,
+			BackoffRate:     1,
+			MaxInterval:     0,
+		}},
+		modelMappingRepo: &staticModelMappingRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/provider/7/v1/chat/completions", nil).
+		WithContext(context.Background())
+	c := flow.NewCtx(httptest.NewRecorder(), req)
+	c.Set(flow.KeyRequestHeaders, http.Header{})
+	c.Set(flow.KeyRequestURI, "/provider/7/v1/chat/completions")
+
+	proxyReq := &domain.ProxyRequest{
+		TenantID:     1,
+		ID:           42,
+		ClientType:   domain.ClientTypeOpenAI,
+		RequestModel: "minimaxai/minimax-m3",
+		IsStream:     false,
+		Status:       "IN_PROGRESS",
+		RouteID:      11,
+		ProviderID:   providerID,
+	}
+	route := &domain.Route{ID: 11, ProviderID: providerID, ClientType: domain.ClientTypeOpenAI}
+	provider := &domain.Provider{ID: providerID, Type: "custom"}
+
+	if err := e.ExecuteProviderProxy(c, proxyReq, route, provider, adapter); err != nil {
+		t.Fatalf("ExecuteProviderProxy returned error: %v", err)
+	}
+	if adapter.calls != 2 {
+		t.Fatalf("adapter calls = %d, want 2", adapter.calls)
+	}
+	if proxyReq.ProxyUpstreamAttemptCount != 2 {
+		t.Fatalf("attempt count = %d, want 2", proxyReq.ProxyUpstreamAttemptCount)
+	}
+}
+
+func TestExecuteProviderProxyRetriesRawUnexpectedEOF(t *testing.T) {
+	providerID := uint64(99010)
+	cooldown.Default().ClearCooldown(providerID, "", "")
+	defer cooldown.Default().ClearCooldown(providerID, "", "")
+
+	adapter := &sequenceAdapter{errs: []error{io.ErrUnexpectedEOF}}
 	e := &Executor{
 		proxyRequestRepo: &recordingProxyRequestRepo{},
 		attemptRepo:      &recordingAttemptRepo{},


### PR DESCRIPTION
## Summary
- classify raw upstream transport resets (including `unexpected EOF`) as provider-scoped retryable network errors when adapters return them without wrapping in `ProxyError`
- keep client cancellations/deadlines non-retryable
- add regression coverage for direct provider proxy retrying a raw `io.ErrUnexpectedEOF`

## Tests
- `go test ./internal/executor ./internal/adapter/provider/custom ./internal/adapter/provider/cliproxyerr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **错误修复**
  - 改进上游网络错误识别，将部分未包装的连接中断、意外结束等网络错误正确标记为可重试错误。
  - 相关请求失败时可自动重试，提升临时网络问题下的请求成功率。
  - 上下文取消和请求超时不会被误判为网络错误。

- **测试**
  - 新增裸网络错误触发重试并最终成功的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->