### PR TITLE
fix(requests): keep live request counts in sync

### DIFF
--- a/web/src/hooks/queries/use-requests.test.ts
+++ b/web/src/hooks/queries/use-requests.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { ProxyRequest } from '@/lib/transport';
 import {
+  getProxyRequestCountDelta,
   isProxyRequestError,
   mergeProxyRequestAttemptUpdate,
+  normalizeProxyRequestPage,
   shouldRefetchCleanupFailedCount,
+  type RequestsCountQueryKey,
 } from './use-requests';
 
 const baseRequest = {
@@ -44,8 +47,12 @@ const baseRequest = {
   apiTokenID: 0,
 } satisfies Omit<ProxyRequest, 'status'>;
 
-function request(status: ProxyRequest['status'], statusCode = 200): ProxyRequest {
-  return { ...baseRequest, status, statusCode };
+function request(
+  status: ProxyRequest['status'],
+  statusCode = 200,
+  overrides: Partial<ProxyRequest> = {},
+): ProxyRequest {
+  return { ...baseRequest, status, statusCode, ...overrides };
 }
 
 describe('isProxyRequestError', () => {
@@ -179,5 +186,91 @@ describe('mergeProxyRequestAttemptUpdate', () => {
     const merged = mergeProxyRequestAttemptUpdate(original, { ...attempt, proxyRequestID: 2 });
 
     expect(merged).toBe(original);
+  });
+});
+
+describe('getProxyRequestCountDelta', () => {
+  const allCountKey: RequestsCountQueryKey = [
+    'requestsCount',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ];
+  const pendingCountKey: RequestsCountQueryKey = [
+    'requestsCount',
+    undefined,
+    'PENDING',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ];
+  const completedCountKey: RequestsCountQueryKey = [
+    'requestsCount',
+    undefined,
+    'COMPLETED',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+  ];
+  const onlyErrorsCountKey: RequestsCountQueryKey = [
+    'requestsCount',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'only',
+  ];
+
+  it('decrements and increments filtered counts when a known request settles', () => {
+    const previous = request('PENDING');
+    const updated = request('COMPLETED');
+
+    expect(getProxyRequestCountDelta(previous, updated, allCountKey)).toBe(0);
+    expect(getProxyRequestCountDelta(previous, updated, pendingCountKey)).toBe(-1);
+    expect(getProxyRequestCountDelta(previous, updated, completedCountKey)).toBe(1);
+  });
+
+  it('updates error-mode counts when status code changes classification', () => {
+    const previous = request('IN_PROGRESS', 200);
+    const updated = request('COMPLETED', 503);
+
+    expect(getProxyRequestCountDelta(previous, updated, onlyErrorsCountKey)).toBe(1);
+  });
+
+  it('only increments unknown requests when they match the active count query', () => {
+    expect(getProxyRequestCountDelta(undefined, request('PENDING'), pendingCountKey)).toBe(1);
+    expect(getProxyRequestCountDelta(undefined, request('COMPLETED'), pendingCountKey)).toBe(0);
+  });
+});
+
+describe('normalizeProxyRequestPage', () => {
+  it('keeps live-updated pages capped and refreshes cursor metadata', () => {
+    const page = {
+      items: [request('COMPLETED', 200, { id: 2 }), request('COMPLETED', 200, { id: 1 })],
+      hasMore: false,
+      firstId: 2,
+      lastId: 1,
+    };
+
+    const normalized = normalizeProxyRequestPage(
+      page,
+      [request('PENDING', 200, { id: 4 }), request('COMPLETED', 200, { id: 3 }), ...page.items],
+      3,
+    );
+
+    expect(normalized.items.map((item) => item.id)).toEqual([4, 3, 2]);
+    expect(normalized.hasMore).toBe(true);
+    expect(normalized.firstId).toBe(4);
+    expect(normalized.lastId).toBe(2);
   });
 });

--- a/web/src/hooks/queries/use-requests.test.ts
+++ b/web/src/hooks/queries/use-requests.test.ts
@@ -5,6 +5,7 @@ import {
   isProxyRequestError,
   mergeProxyRequestAttemptUpdate,
   normalizeProxyRequestPage,
+  normalizeProxyRequestPages,
   shouldRefetchCleanupFailedCount,
   type RequestsCountQueryKey,
 } from './use-requests';
@@ -272,5 +273,40 @@ describe('normalizeProxyRequestPage', () => {
     expect(normalized.hasMore).toBe(true);
     expect(normalized.firstId).toBe(4);
     expect(normalized.lastId).toBe(2);
+  });
+});
+
+describe('normalizeProxyRequestPages', () => {
+  it('cascades overflow into loaded pages when a new request enters a full first page', () => {
+    const pages = [
+      {
+        items: [request('COMPLETED', 200, { id: 4 }), request('COMPLETED', 200, { id: 3 })],
+        hasMore: true,
+        firstId: 4,
+        lastId: 3,
+      },
+      {
+        items: [request('COMPLETED', 200, { id: 2 }), request('COMPLETED', 200, { id: 1 })],
+        hasMore: false,
+        firstId: 2,
+        lastId: 1,
+      },
+    ];
+
+    const normalized = normalizeProxyRequestPages(
+      pages,
+      [request('PENDING', 200, { id: 5 }), ...pages.flatMap((page) => page.items)],
+      2,
+    );
+
+    expect(normalized.map((page) => page.items.map((item) => item.id))).toEqual([
+      [5, 4],
+      [3, 2],
+    ]);
+    expect(normalized[0].firstId).toBe(5);
+    expect(normalized[0].lastId).toBe(4);
+    expect(normalized[1].firstId).toBe(3);
+    expect(normalized[1].lastId).toBe(2);
+    expect(normalized[1].hasMore).toBe(true);
   });
 });

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -14,6 +14,8 @@ import {
 } from '@/lib/transport';
 import { prioritizeActiveRequests } from '@/lib/request-order';
 
+const REQUESTS_INFINITE_PAGE_LIMIT = 100;
+
 /** Query key factory for proxy request related queries. */
 export const requestKeys = {
   all: ['requests'] as const,
@@ -133,6 +135,70 @@ function matchesProxyRequestParams(
   return true;
 }
 
+export type RequestsCountQueryKey = readonly [
+  'requestsCount',
+  number | undefined,
+  string | undefined,
+  number | undefined,
+  number | undefined,
+  string | undefined,
+  string | undefined,
+  ProxyRequestErrorMode | undefined,
+];
+
+export function matchesProxyRequestCountQuery(
+  request: ProxyRequest,
+  queryKey: RequestsCountQueryKey,
+): boolean {
+  return matchesProxyRequestParams(request, {
+    providerId: queryKey[1],
+    status: queryKey[2],
+    apiTokenId: queryKey[3],
+    projectId: queryKey[4],
+    startTime: queryKey[5],
+    endTime: queryKey[6],
+    errorMode: queryKey[7],
+  });
+}
+
+export function getProxyRequestCountDelta(
+  previousRequest: ProxyRequest | undefined,
+  updatedRequest: ProxyRequest,
+  queryKey: RequestsCountQueryKey,
+): number {
+  const matchedBefore = previousRequest
+    ? matchesProxyRequestCountQuery(previousRequest, queryKey)
+    : false;
+  const matchesAfter = matchesProxyRequestCountQuery(updatedRequest, queryKey);
+
+  if (matchedBefore === matchesAfter) {
+    return 0;
+  }
+  return matchesAfter ? 1 : -1;
+}
+
+export function normalizeProxyRequestPage<T extends ProxyRequest>(
+  page: CursorPaginationResult<T>,
+  items: T[],
+  limit?: number,
+): CursorPaginationResult<T> {
+  let nextItems = prioritizeActiveRequests(items);
+  let hasMore = page.hasMore;
+
+  if (typeof limit === 'number' && limit > 0 && nextItems.length > limit) {
+    nextItems = nextItems.slice(0, limit);
+    hasMore = true;
+  }
+
+  return {
+    ...page,
+    items: nextItems,
+    hasMore,
+    firstId: nextItems[0]?.id,
+    lastId: nextItems[nextItems.length - 1]?.id,
+  };
+}
+
 /** Fetches proxy requests with cursor-based pagination. */
 export function useProxyRequests(params?: CursorPaginationParams) {
   return useQuery({
@@ -167,7 +233,7 @@ export function useInfiniteProxyRequests(
     ),
     queryFn: ({ pageParam }) =>
       getTransport().getProxyRequests({
-        limit: 100,
+        limit: REQUESTS_INFINITE_PAGE_LIMIT,
         before: pageParam,
         providerId,
         status,
@@ -469,6 +535,7 @@ export function useProxyRequestUpdates() {
       for (const updatedRequest of updates) {
         const requestId = updatedRequest.id;
         let isKnown = knownRequestIds.has(requestId);
+        let previousRequest: ProxyRequest | undefined;
 
         // 仅当详情查询正在被观察时才更新详情缓存，避免列表页“写缓存造内存”
         const detailKey = requestKeys.detail(requestId);
@@ -480,6 +547,7 @@ export function useProxyRequestUpdates() {
             if (!old) {
               return updatedRequest;
             }
+            previousRequest ??= old;
             return {
               ...old,
               ...updatedRequest,
@@ -531,32 +599,13 @@ export function useProxyRequestUpdates() {
             if (!old || !old.items) return old;
             const limit = typeof params?.limit === 'number' ? params.limit : undefined;
 
-            const normalizePage = (items: ProxyRequest[]) => {
-              // 首屏列表和 WS 增量更新都统一走这里，避免同一页里出现
-              // “已完成/失败”仍停留在活跃请求前面的短暂错序。
-              let nextItems = prioritizeActiveRequests(items);
-              let hasMore = old.hasMore;
-
-              if (typeof limit === 'number' && limit > 0 && nextItems.length > limit) {
-                nextItems = nextItems.slice(0, limit);
-                hasMore = true;
-              }
-
-              const firstId = nextItems[0]?.id;
-              const lastId = nextItems[nextItems.length - 1]?.id;
-
-              return {
-                ...old,
-                items: nextItems,
-                hasMore,
-                firstId,
-                lastId,
-              };
-            };
+            const normalizePage = (items: ProxyRequest[]) =>
+              normalizeProxyRequestPage(old, items, limit);
 
             const index = old.items.findIndex((r) => r.id === requestId);
             if (index >= 0) {
               isKnown = true;
+              previousRequest ??= old.items[index];
               if (!matchesFilter(updatedRequest)) {
                 const newItems = old.items.filter((r) => r.id !== requestId);
                 return normalizePage(newItems);
@@ -629,15 +678,16 @@ export function useProxyRequestUpdates() {
               }
 
               hasExisting = true;
+              previousRequest ??= page.items[index];
 
               if (!matchesFilter(updatedRequest)) {
                 const newItems = page.items.filter((r) => r.id !== requestId);
-                return { ...page, items: prioritizeActiveRequests(newItems) };
+                return normalizeProxyRequestPage(page, newItems, REQUESTS_INFINITE_PAGE_LIMIT);
               }
 
               const newItems = [...page.items];
               newItems[index] = updatedRequest;
-              return { ...page, items: prioritizeActiveRequests(newItems) };
+              return normalizeProxyRequestPage(page, newItems, REQUESTS_INFINITE_PAGE_LIMIT);
             });
 
             if (hasExisting) {
@@ -658,62 +708,36 @@ export function useProxyRequestUpdates() {
             return {
               ...old,
               pages: [
-                {
-                  ...firstPage,
-                  items: prioritizeActiveRequests([updatedRequest, ...firstPage.items]),
-                },
+                normalizeProxyRequestPage(
+                  firstPage,
+                  [updatedRequest, ...firstPage.items],
+                  REQUESTS_INFINITE_PAGE_LIMIT,
+                ),
                 ...updatedPages.slice(1),
               ],
             };
           });
         }
 
-        // 新请求时乐观更新 count。重连后首个看到的增量可能已经是 COMPLETED，
-        // 不能只盯 PENDING，否则会把断线窗口内完成的新请求漏掉。
-        if (!isKnown) {
-          const startTimeMs = new Date(updatedRequest.startTime).getTime();
-          const looksLikeRecentRequest =
-            Number.isFinite(startTimeMs) && Date.now() - startTimeMs < 15_000;
-
-          if (looksLikeRecentRequest) {
-            for (const query of countQueries) {
-              const filterProviderId = query.queryKey[1] as number | undefined;
-              const filterStatus = query.queryKey[2] as string | undefined;
-              const filterAPITokenId = query.queryKey[3] as number | undefined;
-              const filterProjectId = query.queryKey[4] as number | undefined;
-              const filterStartTime = query.queryKey[5] as string | undefined;
-              const filterEndTime = query.queryKey[6] as string | undefined;
-              const filterErrorMode = query.queryKey[7] as ProxyRequestErrorMode | undefined;
-              if (
-                filterProviderId !== undefined &&
-                updatedRequest.providerID !== filterProviderId
-              ) {
-                continue;
-              }
-              if (filterStatus !== undefined && updatedRequest.status !== filterStatus) {
-                continue;
-              }
-              if (
-                filterAPITokenId !== undefined &&
-                updatedRequest.apiTokenID !== filterAPITokenId
-              ) {
-                continue;
-              }
-              if (filterProjectId !== undefined && updatedRequest.projectID !== filterProjectId) {
-                continue;
-              }
-              if (!matchesRequestTimeRange(updatedRequest, filterStartTime, filterEndTime)) {
-                continue;
-              }
-              if (filterErrorMode === 'only' && !isProxyRequestError(updatedRequest)) {
-                continue;
-              }
-              if (filterErrorMode === 'exclude' && isProxyRequestError(updatedRequest)) {
-                continue;
-              }
-              queryClient.setQueryData<number>(query.queryKey, (old) => (old ?? 0) + 1);
+        // 同步 count 查询：已知请求跨过滤器移动时要做 old -> new 差量；
+        // 新请求仍只对最近事件乐观 +1，避免重连后把历史广播重复计数。
+        const startTimeMs = new Date(updatedRequest.startTime).getTime();
+        const looksLikeRecentRequest =
+          Number.isFinite(startTimeMs) && Date.now() - startTimeMs < 15_000;
+        const shouldReconcileUnknownRequest = !isKnown && looksLikeRecentRequest;
+        if (previousRequest || shouldReconcileUnknownRequest) {
+          for (const query of countQueries) {
+            const queryKey = query.queryKey as RequestsCountQueryKey;
+            const delta = getProxyRequestCountDelta(previousRequest, updatedRequest, queryKey);
+            if (delta === 0) {
+              continue;
             }
+            queryClient.setQueryData<number>(queryKey, (old) => Math.max(0, (old ?? 0) + delta));
           }
+        } else if (isKnown) {
+          // 这个请求此前只被其他过滤器看见过；当前 count 查询没有旧行可对比，
+          // 直接补偿 refetch，避免“进入当前过滤器”的计数被永远漏掉。
+          void queryClient.refetchQueries({ queryKey: ['requestsCount'], type: 'active' });
         }
 
         knownRequestIds.add(requestId);

--- a/web/src/hooks/queries/use-requests.ts
+++ b/web/src/hooks/queries/use-requests.ts
@@ -199,6 +199,34 @@ export function normalizeProxyRequestPage<T extends ProxyRequest>(
   };
 }
 
+export function normalizeProxyRequestPages<T extends ProxyRequest>(
+  pages: CursorPaginationResult<T>[],
+  items: T[],
+  limit: number,
+): CursorPaginationResult<T>[] {
+  if (pages.length === 0) {
+    return pages;
+  }
+
+  const orderedItems = prioritizeActiveRequests(items);
+  let offset = 0;
+
+  return pages.map((page, index) => {
+    const pageLimit = limit > 0 ? limit : page.items.length;
+    const nextItems = orderedItems.slice(offset, offset + pageLimit);
+    offset += pageLimit;
+
+    const droppedItems = index === pages.length - 1 && offset < orderedItems.length;
+    return {
+      ...page,
+      items: nextItems,
+      hasMore: page.hasMore || droppedItems,
+      firstId: nextItems[0]?.id,
+      lastId: nextItems[nextItems.length - 1]?.id,
+    };
+  });
+}
+
 /** Fetches proxy requests with cursor-based pagination. */
 export function useProxyRequests(params?: CursorPaginationParams) {
   return useQuery({
@@ -669,52 +697,40 @@ export function useProxyRequestUpdates() {
           }>(queryKey, (old) => {
             if (!old || !old.pages || old.pages.length === 0) return old;
 
-            let hasExisting = false;
+            const items = old.pages.flatMap((page) => page.items);
+            const index = items.findIndex((r) => r.id === requestId);
 
-            const updatedPages = old.pages.map((page) => {
-              const index = page.items.findIndex((r) => r.id === requestId);
-              if (index < 0) {
-                return page;
-              }
-
-              hasExisting = true;
-              previousRequest ??= page.items[index];
-
-              if (!matchesFilter(updatedRequest)) {
-                const newItems = page.items.filter((r) => r.id !== requestId);
-                return normalizeProxyRequestPage(page, newItems, REQUESTS_INFINITE_PAGE_LIMIT);
-              }
-
-              const newItems = [...page.items];
-              newItems[index] = updatedRequest;
-              return normalizeProxyRequestPage(page, newItems, REQUESTS_INFINITE_PAGE_LIMIT);
-            });
-
-            if (hasExisting) {
+            if (index >= 0) {
               isKnown = true;
-              return { ...old, pages: updatedPages };
+              previousRequest ??= items[index];
+
+              const nextItems = matchesFilter(updatedRequest)
+                ? [...items.slice(0, index), updatedRequest, ...items.slice(index + 1)]
+                : items.filter((r) => r.id !== requestId);
+
+              return {
+                ...old,
+                pages: normalizeProxyRequestPages(
+                  old.pages,
+                  nextItems,
+                  REQUESTS_INFINITE_PAGE_LIMIT,
+                ),
+              };
             }
 
             if (!matchesFilter(updatedRequest)) {
-              return { ...old, pages: updatedPages };
+              return old;
             }
 
-            // 仅在第一页插入“新请求”，避免重复插入导致列表膨胀
-            const firstPage = updatedPages[0];
-            if (!firstPage) {
-              return { ...old, pages: updatedPages };
-            }
-
+            // 仅在第一页插入“新请求”，但对已加载页做级联规范化，
+            // 避免第一页满载时把尾部记录直接丢掉造成分页空洞。
             return {
               ...old,
-              pages: [
-                normalizeProxyRequestPage(
-                  firstPage,
-                  [updatedRequest, ...firstPage.items],
-                  REQUESTS_INFINITE_PAGE_LIMIT,
-                ),
-                ...updatedPages.slice(1),
-              ],
+              pages: normalizeProxyRequestPages(
+                old.pages,
+                [updatedRequest, ...items],
+                REQUESTS_INFINITE_PAGE_LIMIT,
+              ),
             };
           });
         }


### PR DESCRIPTION
## Summary
- reconcile Requests tab live count caches with old-to-new filter membership when WebSocket updates move a request between statuses/error modes
- cap live-updated infinite-query first pages back to the backend page size and refresh cursor metadata
- add unit coverage for count deltas and live page normalization

## Repro / root cause
- With a status filter such as `PENDING`, live updates removed a completed row from the list but left `requestsCount` stale until the 10s polling fallback.
- The infinite query path prepended every matching live request into page 0 without slicing back to the page limit, so a long-lived Requests tab could grow page 0 beyond the backend cursor shape.

## Validation
- `pnpm -C web exec vitest run src/hooks/queries/use-requests.test.ts`
- `pnpm -C web exec tsc -b --pretty false`
- `pnpm -C web exec eslint src/hooks/queries/use-requests.ts src/hooks/queries/use-requests.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化请求列表的分页处理，统一不同分页场景下的数据展示。
  * 改进实时请求更新时的计数计算，减少筛选条件切换导致的计数不准确。
  * 对无法直接判断的请求计数变化自动刷新统计结果。

* **测试**
  * 新增请求计数变化与分页规范化相关测试，提升请求列表功能的可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->