### PR TITLE
fix(executor): honor disabled provider switching

### DIFF
--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -261,7 +261,7 @@ func TestDispatchDisableErrorCooldownDoesNotFreezeOn500WhenConsecutiveFreezeEnab
 	}
 }
 
-func TestDispatchDisableErrorCooldownFreezesAfterConsecutive429AndFailsOver(t *testing.T) {
+func TestDispatchDisableErrorCooldownFreezesAfterConsecutive429WithoutSwitching(t *testing.T) {
 	cooldown.Default().ClearCooldown(31, "", "")
 	defer cooldown.Default().ClearCooldown(31, "", "")
 	cooldown.Default().ResetFailures(31, "", "")
@@ -302,20 +302,20 @@ func TestDispatchDisableErrorCooldownFreezesAfterConsecutive429AndFailsOver(t *t
 
 	e.dispatch(c)
 
-	if c.Err != nil {
-		t.Fatalf("dispatch returned error: %v", c.Err)
+	if c.Err == nil {
+		t.Fatal("expected dispatch to fail instead of switching providers")
 	}
 	if firstAdapter.calls != 2 {
 		t.Fatalf("first adapter calls = %d, want 2", firstAdapter.calls)
 	}
-	if secondAdapter.calls != 1 {
-		t.Fatalf("second adapter calls = %d, want 1", secondAdapter.calls)
+	if secondAdapter.calls != 0 {
+		t.Fatalf("second adapter calls = %d, want 0; disable switch must not fall through after consecutive freeze", secondAdapter.calls)
 	}
 	if !cooldown.Default().IsInCooldown(31, string(domain.ClientTypeOpenAI), "gpt-4o") {
 		t.Fatal("429 should freeze provider after consecutive threshold")
 	}
-	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "COMPLETED" {
-		t.Fatalf("expected completed proxy request update, got %#v", proxyRepo.updated)
+	if len(proxyRepo.updated) == 0 || proxyRepo.updated[len(proxyRepo.updated)-1].Status != "FAILED" {
+		t.Fatalf("expected failed proxy request update, got %#v", proxyRepo.updated)
 	}
 }
 

--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -36,12 +36,13 @@ const maxUpstreamAttemptsPerRequest = 200
 // single provider may absorb for one request while disableErrorCooldown is on.
 //
 // disableErrorCooldown is an operator escape hatch meaning "do not build
-// cooldown state from this provider's failures". It used to also mean "retry
-// this provider forever", which turned any persistent retryable failure into a
-// tight loop that only the global ceiling could stop — proxy_request 75010 hit
-// a rate-limited Codex account 200 times in 99 seconds that way. Bounding the
-// per-provider budget keeps the escape hatch (far more retries than the
-// configured RetryConfig allows) while still failing over to the next route.
+// cooldown state from this provider's failures and do not automatically switch
+// away from it". It used to also mean "retry this provider forever", which
+// turned persistent retryable failures into tight loops that only the global
+// ceiling could stop — proxy_request 75010 hit a rate-limited Codex account 200
+// times in 99 seconds that way. Bounding the per-provider budget preserves the
+// no-switch semantics while still failing the request promptly when one provider
+// keeps failing.
 const maxAttemptsPerProviderWithoutErrorCooldown = 10
 
 func (e *Executor) dispatch(c *flow.Ctx) {
@@ -117,9 +118,9 @@ routeLoop:
 				break
 			}
 			if shouldSkipErrorCooldown(matchedRoute.Provider) && providerAttempts >= maxAttemptsPerProviderWithoutErrorCooldown {
-				log.Printf("[Executor] Provider %d reached the disableErrorCooldown attempt cap (%d) for this request; failing over. lastErr=%v",
+				log.Printf("[Executor] Provider %d reached the disableErrorCooldown attempt cap (%d) for this request; stopping without switching providers. lastErr=%v",
 					matchedRoute.Provider.ID, maxAttemptsPerProviderWithoutErrorCooldown, state.lastErr)
-				break
+				break routeLoop
 			}
 			if ctx.Err() != nil {
 				state.lastErr = ctx.Err()
@@ -577,8 +578,8 @@ routeLoop:
 			}
 
 			if providerFrozenAfterThreshold {
-				log.Printf("[Executor] Provider %d reached consecutive error freeze threshold; failing over to next provider", matchedRoute.Provider.ID)
-				continue routeLoop
+				log.Printf("[Executor] Provider %d reached consecutive error freeze threshold; stopping without switching providers because disableErrorCooldown is enabled", matchedRoute.Provider.ID)
+				break routeLoop
 			}
 
 			if !ok || !proxyErr.Retryable {
@@ -594,6 +595,10 @@ routeLoop:
 					responseCapture.WroteToClient(),
 					err,
 				)
+				if shouldSkipErrorCooldown(matchedRoute.Provider) {
+					log.Printf("[Executor] Disable switching is enabled for provider %d; stopping without falling through after non-retryable provider error", matchedRoute.Provider.ID)
+					break routeLoop
+				}
 				break
 			}
 

--- a/internal/executor/retry_amplification_test.go
+++ b/internal/executor/retry_amplification_test.go
@@ -188,24 +188,22 @@ func TestDispatchCapsRetriesWhenErrorCooldownDisabled(t *testing.T) {
 	}
 }
 
-// TestDispatchHardCapsRunawayRetryableErrors is the backstop test: even a
-// genuinely-retryable error that (via a classification bug or misconfiguration)
-// never stops retrying must be bounded by the hard per-request ceiling, instead
-// of running for hours. Enough routes are matched that the per-provider cap
-// alone would allow more calls than the ceiling permits.
-func TestDispatchHardCapsRunawayRetryableErrors(t *testing.T) {
-	routeCount := maxUpstreamAttemptsPerRequest/maxAttemptsPerProviderWithoutErrorCooldown + 1
+// TestDispatchDisableErrorCooldownStopsAtProviderCapWithoutFailover pins the
+// no-switch semantics: disableErrorCooldown may retry the selected provider up
+// to the per-provider cap, but it must not fall through to later routes when the
+// cap is exhausted.
+func TestDispatchDisableErrorCooldownStopsAtProviderCapWithoutFailover(t *testing.T) {
 	adapter := newAlways500Adapter()
-	c, proxyRepo := newMultiRouteAmplificationDispatchCtx(routeCount, true, adapter)
+	c, proxyRepo := newMultiRouteAmplificationDispatchCtx(2, true, adapter)
 	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
 
 	e.dispatch(c)
 
 	if c.Err == nil {
-		t.Fatal("expected dispatch to fail once the hard cap is hit")
+		t.Fatal("expected dispatch to fail once the selected provider cap is hit")
 	}
-	if adapter.calls != maxUpstreamAttemptsPerRequest {
-		t.Fatalf("adapter calls = %d, want %d (hard ceiling)", adapter.calls, maxUpstreamAttemptsPerRequest)
+	if adapter.calls != maxAttemptsPerProviderWithoutErrorCooldown {
+		t.Fatalf("adapter calls = %d, want %d (single provider cap, no failover)", adapter.calls, maxAttemptsPerProviderWithoutErrorCooldown)
 	}
 	if last := lastProxyStatus(proxyRepo); last != "FAILED" {
 		t.Fatalf("final proxy status = %q, want FAILED", last)

--- a/tests/e2e/disable_error_cooldown_retry_test.go
+++ b/tests/e2e/disable_error_cooldown_retry_test.go
@@ -11,9 +11,10 @@ import (
 
 // TestDisableErrorCooldownRetriesBeyondRetryPolicy verifies the updated
 // contract: when disableErrorCooldown is enabled, retry-attempt limits are
-// still ignored, but only genuinely retryable classes keep retrying on the
-// same provider. Most 4xx errors must fail over immediately; 429 and 5xx may
-// continue retrying until success or context cancellation.
+// still ignored, but automatic cross-provider switching is disabled for errors
+// from this provider. Non-retryable errors fail the request in place; genuinely
+// retryable classes keep retrying on the same provider until success, cap, or
+// context cancellation.
 func TestDisableErrorCooldownRetriesBeyondRetryPolicy(t *testing.T) {
 	cases := []struct {
 		status               int
@@ -25,10 +26,10 @@ func TestDisableErrorCooldownRetriesBeyondRetryPolicy(t *testing.T) {
 		expectCooldownAbsent bool
 	}{
 		{status: http.StatusBadRequest, name: "400_request_error", expectStatus: http.StatusBadRequest, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
-		{status: http.StatusUnauthorized, name: "401_auth_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
-		{status: http.StatusForbidden, name: "403_auth_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
-		{status: http.StatusNotFound, name: "404_not_found", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
-		{status: http.StatusPaymentRequired, name: "402_quota_error", expectStatus: http.StatusOK, expectFailingHits: 1, expectFallbackHits: 1, expectProviderBody: "fallback-ok", expectCooldownAbsent: true},
+		{status: http.StatusUnauthorized, name: "401_auth_error", expectStatus: http.StatusUnauthorized, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusForbidden, name: "403_auth_error", expectStatus: http.StatusForbidden, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusNotFound, name: "404_not_found", expectStatus: http.StatusNotFound, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
+		{status: http.StatusPaymentRequired, name: "402_quota_error", expectStatus: http.StatusPaymentRequired, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
 		{status: http.StatusTeapot, name: "418_other_client_error", expectStatus: http.StatusTeapot, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
 		{status: http.StatusUnprocessableEntity, name: "422_request_error", expectStatus: http.StatusUnprocessableEntity, expectFailingHits: 1, expectFallbackHits: 0, expectProviderBody: "", expectCooldownAbsent: true},
 		{status: http.StatusTooManyRequests, name: "429_rate_limit", expectStatus: http.StatusOK, expectFailingHits: 5, expectFallbackHits: 0, expectProviderBody: "eventual-success", expectCooldownAbsent: true},

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1929,7 +1929,7 @@
     "quotaEnabled": "Enable Quota Check",
     "quotaEnabledDesc": "When enabled, requests through this provider require the matching API token to have quota; tokens without quota are rejected.",
     "consecutiveErrorFreeze": "Temporarily freeze after consecutive errors",
-    "consecutiveErrorFreezeDesc": "When enabled, this provider is temporarily frozen after consecutive upstream-attributed errors reach the threshold, then routing falls through to later providers.",
+    "consecutiveErrorFreezeDesc": "When enabled, this provider is temporarily frozen after consecutive upstream-attributed errors reach the threshold. If Disable Switching is also enabled, the request fails instead of falling through to later providers.",
     "consecutiveErrorFreezeThreshold": "Consecutive error threshold",
     "consecutiveErrorFreezeHint": "Only non-request-level HTTP 429 responses are counted. All other errors do not trigger this consecutive-error freeze. Freeze duration reuses the default cooldown setting."
   },

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1926,7 +1926,7 @@
     "quotaEnabled": "启用额度检查",
     "quotaEnabledDesc": "开启后，使用该提供商的请求会检查对应 API 令牌的额度；令牌无额度时直接拦截。",
     "consecutiveErrorFreeze": "连续错误后临时冻结",
-    "consecutiveErrorFreezeDesc": "开启后，当该提供商连续发生可归因于上游的错误达到阈值时，会按全局冷却时间临时冻结，并切到后续提供商。",
+    "consecutiveErrorFreezeDesc": "开启后，当该提供商连续发生可归因于上游的错误达到阈值时，会按全局冷却时间临时冻结；若已启用禁止切换，则请求会直接失败，不再切到后续提供商。",
     "consecutiveErrorFreezeThreshold": "连续错误阈值",
     "consecutiveErrorFreezeHint": "只统计非请求级的 HTTP 429 错误；其他错误都不会触发这条连续错误冻结。冻结时长复用设置里的默认冷却时间。"
   },


### PR DESCRIPTION
## Summary
- stop `disableErrorCooldown` routes from falling through to later providers after the per-provider retry cap
- stop consecutive 429 freeze from switching providers when Disable Switching is enabled
- stop non-retryable provider errors from falling through when Disable Switching is enabled
- update executor/e2e regression coverage and provider setting copy to match the no-switch semantics

## Verification
- `go test ./internal/executor -count=1`
- `go test ./tests/e2e -run DisableErrorCooldown -count=1`
- `pnpm -C web exec tsc -b --pretty false`
- `go test $(go list -e -f '{{if and (not .Error) (ne .ImportPath "github.com/awsl-project/maxx")}}{{.ImportPath}}{{end}}' ./...)`
- `git diff --check`

## Notes
- `go test ./...` is not a valid local gate in this fresh clone before building web assets because the root package embeds `web/dist`; it fails with `pattern all:web/dist: no matching files found`. The package suite above excludes only that root embed package and passed.