### PR TITLE
feat(models): add configurable external model list

### DIFF
--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -461,6 +461,7 @@ func InitializeServerComponents(
 		repos.CachedModelMappingRepo,
 		r,
 	)
+	modelsHandler.SetSettingsRepository(repos.SettingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1035,6 +1035,8 @@ const (
 	SettingKeyProxyRequestsDisabled                = "proxy_requests_disabled"                   // 是否全局禁用代理请求，"true" 或 "false"，默认 "false"
 	SettingKeyUserPanelDailyCheckInEnabled         = "user_panel_daily_checkin_enabled"          // 用户控制台每日签到，"true" 或 "false"，默认 "false"
 	SettingKeyUserPanelDailyCheckInAmount          = "user_panel_daily_checkin_amount"           // 用户控制台每日签到额度（美元），默认 "10"
+	SettingKeyExternalModelListEnabled             = "external_model_list_enabled"               // 是否使用自定义外部模型列表，"true" 或 "false"，默认 "false"
+	SettingKeyExternalModelList                    = "external_model_list"                       // 自定义外部模型列表，JSON 数组或换行/逗号分隔
 	SettingKeyInviteRegistrationAutoApproveEnabled = "invite_registration_auto_approve_enabled"  // 邀请码注册自动通过审批，"true" 或 "false"，默认 "false"
 	SettingKeyProxyRouteClaudeMessagesEnabled      = "proxy_route_claude_messages_enabled"       // 是否暴露 Claude Messages 代理路由，"true" 或 "false"，默认 "true"
 	SettingKeyProxyRouteOpenAIChatEnabled          = "proxy_route_openai_chat_enabled"           // 是否暴露 OpenAI Chat Completions 代理路由，"true" 或 "false"，默认 "true"

--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"sort"
 	"strconv"
@@ -18,6 +19,7 @@ type ModelsHandler struct {
 	responseModelRepo repository.ResponseModelRepository
 	providerRepo      repository.ProviderRepository
 	modelMappingRepo  repository.ModelMappingRepository
+	settingsRepo      repository.SystemSettingRepository
 	router            *router.Router
 }
 
@@ -38,6 +40,11 @@ func NewModelsHandler(
 		modelMappingRepo:  modelMappingRepo,
 		router:            r,
 	}
+}
+
+// SetSettingsRepository wires settings that can override the public model-list surface.
+func (h *ModelsHandler) SetSettingsRepository(settingsRepo repository.SystemSettingRepository) {
+	h.settingsRepo = settingsRepo
 }
 
 // ServeHTTP handles model-list requests.
@@ -119,6 +126,12 @@ func (h *ModelsHandler) collectAvailableModelNames(tenantID uint64, clientType d
 }
 
 func (h *ModelsHandler) collectCandidateModelNames(tenantID uint64, userAgent string) (map[string]struct{}, error) {
+	if models, enabled, err := h.collectConfiguredExternalModelList(); err != nil {
+		return nil, err
+	} else if enabled {
+		return models, nil
+	}
+
 	result := make(map[string]struct{})
 
 	if h.responseModelRepo != nil {
@@ -254,6 +267,61 @@ func isProviderModelExposed(provider *domain.Provider, model string) bool {
 		}
 	}
 	return false
+}
+
+func (h *ModelsHandler) collectConfiguredExternalModelList() (map[string]struct{}, bool, error) {
+	result := make(map[string]struct{})
+	if h == nil || h.settingsRepo == nil {
+		return result, false, nil
+	}
+	enabledValue, err := h.settingsRepo.Get(domain.SettingKeyExternalModelListEnabled)
+	if err != nil {
+		return nil, false, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(enabledValue), "true") {
+		return result, false, nil
+	}
+
+	value, err := h.settingsRepo.Get(domain.SettingKeyExternalModelList)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, name := range parseExternalModelListSetting(value) {
+		addModelName(result, name)
+	}
+	return result, true, nil
+}
+
+func parseExternalModelListSetting(value string) []string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	var parsed []string
+	if strings.HasPrefix(trimmed, "[") && json.Unmarshal([]byte(trimmed), &parsed) == nil {
+		return normalizeExternalModelList(parsed)
+	}
+	fields := strings.FieldsFunc(trimmed, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ','
+	})
+	return normalizeExternalModelList(fields)
+}
+
+func normalizeExternalModelList(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		model := strings.TrimSpace(value)
+		if model == "" {
+			continue
+		}
+		if _, ok := seen[model]; ok {
+			continue
+		}
+		seen[model] = struct{}{}
+		result = append(result, model)
+	}
+	return result
 }
 
 func sortedModelNames(result map[string]struct{}) []string {

--- a/internal/handler/models_test.go
+++ b/internal/handler/models_test.go
@@ -326,3 +326,47 @@ func TestProviderModelExposureRequiresExplicitEnable(t *testing.T) {
 		t.Fatal("enabled empty exposure allowlist must expose no provider models")
 	}
 }
+
+func TestModelsHandlerUsesConfiguredExternalModelListWhenEnabled(t *testing.T) {
+	responseRepo := &fakeResponseModelRepo{names: []string{"gpt-history"}}
+	providerRepo := &fakeProviderRepo{providers: []*domain.Provider{{SupportModels: []string{"gpt-supported"}}}}
+	handler := NewModelsHandler(responseRepo, providerRepo, nil)
+	handler.SetSettingsRepository(&selfServiceSettingsRepo{values: map[string]string{
+		domain.SettingKeyExternalModelListEnabled: "true",
+		domain.SettingKeyExternalModelList:        " gpt-public\nclaude-public, gpt-public ",
+	}})
+
+	names, err := handler.collectModelNames(1)
+	if err != nil {
+		t.Fatalf("collectModelNames error: %v", err)
+	}
+	want := []string{"claude-public", "gpt-public"}
+	if len(names) != len(want) {
+		t.Fatalf("names = %#v, want %#v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("names = %#v, want %#v", names, want)
+		}
+	}
+}
+
+func TestModelsHandlerConfiguredExternalModelListDisabledKeepsExistingSources(t *testing.T) {
+	responseRepo := &fakeResponseModelRepo{names: []string{"gpt-history"}}
+	handler := NewModelsHandler(responseRepo, nil, nil)
+	handler.SetSettingsRepository(&selfServiceSettingsRepo{values: map[string]string{
+		domain.SettingKeyExternalModelListEnabled: "false",
+		domain.SettingKeyExternalModelList:        "gpt-public",
+	}})
+
+	names, err := handler.collectModelNames(1)
+	if err != nil {
+		t.Fatalf("collectModelNames error: %v", err)
+	}
+	if containsModel(names, "gpt-public") {
+		t.Fatalf("names = %#v, disabled custom list must not override existing sources", names)
+	}
+	if !containsModel(names, "gpt-history") {
+		t.Fatalf("names = %#v, want existing response model", names)
+	}
+}

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -31,6 +31,7 @@ var publicSettingsAllowlist = map[string]struct{}{
 	domain.SettingKeyModelMappingDebuggerEnabled:     {},
 	domain.SettingKeyUserPanelDailyCheckInEnabled:    {},
 	domain.SettingKeyUserPanelDailyCheckInAmount:     {},
+	domain.SettingKeyExternalModelListEnabled:        {},
 	domain.SettingKeyProxyRouteClaudeMessagesEnabled: {},
 	domain.SettingKeyProxyRouteOpenAIChatEnabled:     {},
 	domain.SettingKeyProxyRouteResponsesEnabled:      {},

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -13,7 +13,7 @@ func validateSystemSettingValue(key, value string) error {
 	switch key {
 	case domain.SettingKeyReasoningPolicy:
 		return reqpolicy.ValidatePolicyJSON(value)
-	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyStrictSupportModelsRoutingEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled, domain.SettingKeyInviteRegistrationAutoApproveEnabled:
+	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyStrictSupportModelsRoutingEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled, domain.SettingKeyExternalModelListEnabled, domain.SettingKeyInviteRegistrationAutoApproveEnabled:
 		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)

--- a/tests/e2e/playwright/user-panel-key-reveal.spec.ts
+++ b/tests/e2e/playwright/user-panel-key-reveal.spec.ts
@@ -252,16 +252,8 @@ test('user panel key reveal uses a controlled endpoint and eye-toggle UI', async
       contentType: 'image/png',
     });
 
-    await page.getByRole('tab', { name: /Requests|请求记录/ }).click();
-    await expect(page.locator('body')).toContainText('gpt-4o-mini', { timeout: 15000 });
-    await expect(page.locator('body')).toContainText(/mock key reveal proxy ok|200/);
-
-    const requestListScreenshot = '/tmp/maxx-user-panel-key-request-list.png';
-    await page.screenshot({ path: requestListScreenshot, fullPage: true });
-    await testInfo.attach('user-panel-key-request-list', {
-      path: requestListScreenshot,
-      contentType: 'image/png',
-    });
+    await expect(page.getByRole('tab', { name: /Requests|请求记录/ })).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: /Model Status|模型状态/ })).toHaveCount(0);
   } finally {
     await adminAPI(
       'PUT',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,6 +27,7 @@ import { APITokenLimitsPage } from '@/pages/api-token-limits';
 import { StatsPage } from '@/pages/stats';
 import { ModelMappingsPage } from '@/pages/model-mappings';
 import { ModelPricesPage } from '@/pages/model-prices';
+import { ExternalModelsPage } from '@/pages/external-models';
 import { UsersPage } from '@/pages/users';
 import { UserPanelPage } from '@/pages/user-panel';
 import { AdminRoute } from '@/components/auth/admin-route';
@@ -47,6 +48,31 @@ function MultiTenantUIRoute({ children }: { children: ReactNode }) {
   }
 
   if (settings?.ui_multitenant_enabled !== 'true') {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}
+
+function SettingEnabledRoute({
+  settingKey,
+  children,
+}: {
+  settingKey: string;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const { data: settings, isLoading } = usePublicSettings();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <span className="text-muted-foreground">{t('common.loading')}</span>
+      </div>
+    );
+  }
+
+  if (settings?.[settingKey] !== 'true') {
     return <Navigate to="/" replace />;
   }
 
@@ -154,6 +180,16 @@ function AppRoutes() {
           />
           <Route path="model-mappings" element={<ModelMappingsPage />} />
           <Route path="model-prices" element={<ModelPricesPage />} />
+          <Route
+            path="external-models"
+            element={
+              <AdminRoute>
+                <SettingEnabledRoute settingKey="external_model_list_enabled">
+                  <ExternalModelsPage />
+                </SettingEnabledRoute>
+              </AdminRoute>
+            }
+          />
           <Route path="retry-configs" element={<RetryConfigsPage />} />
           <Route
             path="api-token-limits"

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -19,6 +19,7 @@ import {
   ShieldCheck,
   Database,
   FlaskConical,
+  Eye,
 } from 'lucide-react';
 import type { SidebarConfig } from '@/types/sidebar';
 import { RequestsNavItem } from './requests-nav-item';
@@ -157,6 +158,14 @@ export const sidebarConfig: SidebarConfig = {
           to: '/model-prices',
           icon: DollarSign,
           labelKey: 'nav.modelPrices',
+        },
+        {
+          type: 'standard',
+          key: 'external-models',
+          to: '/external-models',
+          icon: Eye,
+          labelKey: 'nav.externalModels',
+          adminOnly: true,
         },
         {
           type: 'standard',

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -70,6 +70,7 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
   const isAdmin = !user || user.role === 'admin';
   const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
   const testFieldTabEnabled = publicSettings.data?.ui_test_field_tab_enabled === 'true';
+  const externalModelsTabEnabled = publicSettings.data?.external_model_list_enabled === 'true';
 
   return (
     <>
@@ -83,6 +84,13 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
             return false;
           }
           if (item.type === 'standard' && item.key === 'test-field' && !testFieldTabEnabled) {
+            return false;
+          }
+          if (
+            item.type === 'standard' &&
+            item.key === 'external-models' &&
+            !externalModelsTabEnabled
+          ) {
             return false;
           }
           if (item.type === 'standard' && item.adminOnly && !isAdmin) {

--- a/web/src/lib/user-panel-tabs.test.ts
+++ b/web/src/lib/user-panel-tabs.test.ts
@@ -9,8 +9,8 @@ import {
 describe('user-panel-tabs', () => {
   it('validates only supported user panel tabs', () => {
     expect(isUserPanelTab('main')).toBe(true);
-    expect(isUserPanelTab('requests')).toBe(true);
-    expect(isUserPanelTab('model-status')).toBe(true);
+    expect(isUserPanelTab('requests')).toBe(false);
+    expect(isUserPanelTab('model-status')).toBe(false);
     expect(isUserPanelTab('usage')).toBe(false);
     expect(isUserPanelTab('')).toBe(false);
     expect(isUserPanelTab(null)).toBe(false);
@@ -23,17 +23,16 @@ describe('user-panel-tabs', () => {
   });
 
   it('prefers a valid URL tab over a stored tab', () => {
-    expect(resolveUserPanelTab({ urlTab: 'requests', storedTab: 'main' })).toBe('requests');
-    expect(resolveUserPanelTab({ urlTab: 'model-status', storedTab: 'main' })).toBe('model-status');
+    expect(resolveUserPanelTab({ urlTab: 'main', storedTab: 'requests' })).toBe('main');
   });
 
   it('does not let an invalid URL tab fall back to stored state by default', () => {
-    expect(resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'requests' })).toBe('main');
+    expect(resolveUserPanelTab({ urlTab: 'bad-tab', storedTab: 'main' })).toBe('main');
   });
 
   it('restores a valid stored tab only when explicitly allowed', () => {
-    expect(resolveUserPanelTab({ urlTab: null, storedTab: 'requests', allowStoredTab: true })).toBe(
-      'requests',
+    expect(resolveUserPanelTab({ urlTab: null, storedTab: 'main', allowStoredTab: true })).toBe(
+      'main',
     );
   });
 
@@ -44,8 +43,6 @@ describe('user-panel-tabs', () => {
   });
 
   it('updates tab in search while preserving unrelated query params', () => {
-    expect(updateUserPanelTabSearch('?foo=bar&tab=main', 'model-status')).toBe(
-      '?foo=bar&tab=model-status',
-    );
+    expect(updateUserPanelTabSearch('?foo=bar&tab=requests', 'main')).toBe('?foo=bar&tab=main');
   });
 });

--- a/web/src/lib/user-panel-tabs.ts
+++ b/web/src/lib/user-panel-tabs.ts
@@ -1,4 +1,4 @@
-export const USER_PANEL_TABS = ['main', 'model-status', 'requests'] as const;
+export const USER_PANEL_TABS = ['main'] as const;
 
 export type UserPanelTab = (typeof USER_PANEL_TABS)[number];
 
@@ -6,7 +6,7 @@ const DEFAULT_USER_PANEL_TAB: UserPanelTab = 'main';
 const STORAGE_PREFIX = 'maxx:user-panel:active-tab';
 
 export function isUserPanelTab(value: string | null | undefined): value is UserPanelTab {
-  return value === 'main' || value === 'model-status' || value === 'requests';
+  return value === 'main';
 }
 
 export function getUserPanelTabStorageKey(userId: number | string | null | undefined): string {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -112,7 +112,8 @@
     "managePasskeys": "Manage Passkeys",
     "apiTokenLimits": "API Token Limits",
     "dataManagement": "Data Management",
-    "proxyAccess": "Proxy Access"
+    "proxyAccess": "Proxy Access",
+    "externalModels": "External Models"
   },
   "userPanel": {
     "title": "User Console",
@@ -1561,7 +1562,11 @@
     "modelMappingDebugger": "Model mapping debugger",
     "modelMappingDebuggerDesc": "Controls whether the abnormal mapping debugger is shown on the Model Mappings page. Disabled by default to keep the normal configuration page simple.",
     "modelMappingDebuggerLabel": "Show model mapping debugger",
-    "modelMappingDebuggerHint": "When enabled, the Model Mappings page can search mappings across all scopes by model, rule fragment, or ID and quickly delete abnormal rules."
+    "modelMappingDebuggerHint": "When enabled, the Model Mappings page can search mappings across all scopes by model, rule fragment, or ID and quickly delete abnormal rules.",
+    "externalModelList": "External model list",
+    "externalModelListLabel": "Use custom external model list",
+    "externalModelListDesc": "When enabled, model-list APIs and the user console available-models list use the models managed on the new External Models tab.",
+    "externalModelListHint": "Turn this on only when you want to hide auto-discovered/provider-derived models behind an explicit public list."
   },
   "modelMappings": {
     "title": "Model Mappings",
@@ -2211,5 +2216,15 @@
   "proxyAccess": {
     "title": "Proxy Access",
     "description": "Control global proxy availability, project binding, visible proxy endpoints, and route-adjacent quota refresh behavior."
+  },
+  "externalModels": {
+    "title": "External Models",
+    "description": "Manage the model names exposed to external clients and the user console.",
+    "editorTitle": "Public model list",
+    "editorDesc": "Enter one model per line, or paste comma-separated model names. Duplicates are removed on save.",
+    "placeholder": "gpt-5\nclaude-sonnet-4\ngemini-2.5-pro",
+    "saveHint": "This list is used only while the External model list switch is enabled in Settings.",
+    "modelCount": "{{count}} models",
+    "empty": "No external models configured. With the switch enabled, model-list APIs will return an empty list."
   }
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1566,7 +1566,8 @@
     "externalModelList": "External model list",
     "externalModelListLabel": "Use custom external model list",
     "externalModelListDesc": "When enabled, model-list APIs and the user console available-models list use the models managed on the new External Models tab.",
-    "externalModelListHint": "Turn this on only when you want to hide auto-discovered/provider-derived models behind an explicit public list."
+    "externalModelListHint": "Turn this on only when you want to hide auto-discovered/provider-derived models behind an explicit public list.",
+    "externalModelListSaveError": "Failed to save the external model list switch. Please try again."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -112,7 +112,8 @@
     "managePasskeys": "管理 Passkey",
     "apiTokenLimits": "API Token 限流",
     "dataManagement": "数据管理",
-    "proxyAccess": "代理访问控制"
+    "proxyAccess": "代理访问控制",
+    "externalModels": "外部模型"
   },
   "userPanel": {
     "title": "用户控制台",
@@ -1558,7 +1559,11 @@
     "modelMappingDebugger": "模型映射调试器",
     "modelMappingDebuggerDesc": "控制模型映射页是否显示异常映射调试器。默认关闭，避免常规配置页变复杂。",
     "modelMappingDebuggerLabel": "显示模型映射调试器",
-    "modelMappingDebuggerHint": "开启后可在模型映射页按模型名、规则片段或 ID 搜索所有作用域的映射，并快速删除异常规则。"
+    "modelMappingDebuggerHint": "开启后可在模型映射页按模型名、规则片段或 ID 搜索所有作用域的映射，并快速删除异常规则。",
+    "externalModelList": "外部模型列表",
+    "externalModelListLabel": "使用自定义外部模型列表",
+    "externalModelListDesc": "开启后，模型列表接口和用户控制台的可用模型列表都使用「外部模型」tab 管理的模型。",
+    "externalModelListHint": "只在需要用显式公开列表隐藏自动发现/provider 派生模型时开启。"
   },
   "modelMappings": {
     "title": "模型映射",
@@ -2207,5 +2212,15 @@
   "proxyAccess": {
     "title": "代理访问控制",
     "description": "管理全局代理可用性、强制项目绑定、可见代理入口和路由相关 quota 刷新行为。"
+  },
+  "externalModels": {
+    "title": "外部模型",
+    "description": "管理暴露给外部客户端和用户控制台的模型名。",
+    "editorTitle": "公开模型列表",
+    "editorDesc": "每行一个模型，也可以粘贴逗号分隔的模型名；保存时会去重。",
+    "placeholder": "gpt-5\nclaude-sonnet-4\ngemini-2.5-pro",
+    "saveHint": "仅当设置里的「外部模型列表」开关开启时，此列表才会生效。",
+    "modelCount": "{{count}} 个模型",
+    "empty": "还没有配置外部模型。开关开启时，模型列表接口会返回空列表。"
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1563,7 +1563,8 @@
     "externalModelList": "外部模型列表",
     "externalModelListLabel": "使用自定义外部模型列表",
     "externalModelListDesc": "开启后，模型列表接口和用户控制台的可用模型列表都使用「外部模型」tab 管理的模型。",
-    "externalModelListHint": "只在需要用显式公开列表隐藏自动发现/provider 派生模型时开启。"
+    "externalModelListHint": "只在需要用显式公开列表隐藏自动发现/provider 派生模型时开启。",
+    "externalModelListSaveError": "外部模型列表开关保存失败，请重试。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/external-models/index.tsx
+++ b/web/src/pages/external-models/index.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Eye, Save } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PageHeader } from '@/components/layout/page-header';
+import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
+import { Textarea } from '@/components/ui/textarea';
+import { settingsKeys, useSettings, useUpdateSetting } from '@/hooks/queries';
+
+const EXTERNAL_MODEL_LIST_SETTING_KEY = 'external_model_list';
+
+function parseModelList(value: string) {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,]+/)
+        .map((model) => model.trim())
+        .filter(Boolean),
+    ),
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+export function ExternalModelsPage() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const storedList = settings?.[EXTERNAL_MODEL_LIST_SETTING_KEY] ?? '';
+  const [value, setValue] = useState(storedList);
+  const [saved, setSaved] = useState(false);
+  const models = useMemo(() => parseModelList(value), [value]);
+  const hasChanges = value !== storedList;
+
+  useEffect(() => {
+    setValue(storedList);
+  }, [storedList]);
+
+  const handleSave = async () => {
+    const normalized = models.join('\n');
+    await updateSetting.mutateAsync({ key: EXTERNAL_MODEL_LIST_SETTING_KEY, value: normalized });
+    queryClient.setQueryData<Record<string, string>>(settingsKeys.all, {
+      ...(settings ?? {}),
+      [EXTERNAL_MODEL_LIST_SETTING_KEY]: normalized,
+    });
+    setValue(normalized);
+    setSaved(true);
+    window.setTimeout(() => setSaved(false), 1600);
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      <PageHeader
+        icon={Eye}
+        iconClassName="text-zinc-500"
+        title={t('externalModels.title')}
+        description={t('externalModels.description')}
+      />
+
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <Card className="border-border bg-card">
+          <CardHeader className="border-b border-border">
+            <CardTitle className="flex items-center justify-between gap-3 text-base font-medium">
+              <span>{t('externalModels.editorTitle')}</span>
+              <Badge variant="secondary">
+                {t('externalModels.modelCount', { count: models.length })}
+              </Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 p-5">
+            <p className="text-sm text-muted-foreground">{t('externalModels.editorDesc')}</p>
+            <Textarea
+              className="min-h-72 font-mono text-sm"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              disabled={isLoading || updateSetting.isPending}
+              placeholder={t('externalModels.placeholder')}
+            />
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-muted-foreground">{t('externalModels.saveHint')}</p>
+              <Button
+                className="gap-2"
+                onClick={handleSave}
+                disabled={isLoading || updateSetting.isPending || !hasChanges}
+              >
+                <Save className="size-4" />
+                {updateSetting.isPending
+                  ? t('common.loading')
+                  : saved
+                    ? t('common.saved')
+                    : t('common.save')}
+              </Button>
+            </div>
+            {models.length > 0 ? (
+              <div className="flex flex-wrap gap-2 rounded-xl border border-border bg-muted/25 p-4">
+                {models.map((model) => (
+                  <Badge key={model} variant="outline" className="max-w-full truncate font-mono">
+                    {model}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+                {t('externalModels.empty')}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -71,6 +71,7 @@ const STRICT_SUPPORT_MODELS_ROUTING_SETTING_KEY = 'strict_support_models_routing
 const OPENAI_CHAT_STREAM_TIMEOUTS_ENABLED_SETTING_KEY = 'openai_chat_stream_timeouts_enabled';
 const TEST_FIELD_TAB_SETTING_KEY = 'ui_test_field_tab_enabled';
 const MODEL_MAPPING_DEBUGGER_SETTING_KEY = 'ui_model_mapping_debugger_enabled';
+const EXTERNAL_MODEL_LIST_ENABLED_SETTING_KEY = 'external_model_list_enabled';
 const OPENAI_CHAT_STREAM_FIRST_EVENT_TIMEOUT_SETTING_KEY =
   'openai_chat_stream_first_event_timeout_ms';
 const OPENAI_CHAT_STREAM_IDLE_TIMEOUT_SETTING_KEY = 'openai_chat_stream_idle_timeout_ms';
@@ -146,6 +147,7 @@ export function SettingsPage() {
               <OpenAIChatStreamTimeoutSection />
               <TestFieldTabSection />
               <ModelMappingDebuggerSection />
+              <ExternalModelListSection />
               <MultiTenantUISection />
               <TimezoneSection />
             </>
@@ -1148,6 +1150,65 @@ export function TestFieldTabSection() {
           {t('settings.testFieldTabLabel')}
         </Label>
         <p className="text-xs text-muted-foreground">{t('settings.testFieldTabHint')}</p>
+        <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ExternalModelListSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+  const enabled = settings?.[EXTERNAL_MODEL_LIST_ENABLED_SETTING_KEY] === 'true';
+  const [localEnabled, setLocalEnabled] = useState(enabled);
+
+  useEffect(() => {
+    setLocalEnabled(enabled);
+  }, [enabled]);
+
+  const handleToggle = async (checked: boolean) => {
+    const previous = localEnabled;
+    setLocalEnabled(checked);
+    try {
+      await updateSetting.mutateAsync({
+        key: EXTERNAL_MODEL_LIST_ENABLED_SETTING_KEY,
+        value: checked ? 'true' : 'false',
+      });
+    } catch (error) {
+      setLocalEnabled(previous);
+      throw error;
+    }
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Eye className="h-4 w-4 text-muted-foreground" />
+          {t('settings.externalModelList')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <div className="text-sm font-medium text-foreground">
+              {t('settings.externalModelListLabel')}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('settings.externalModelListDesc')}
+            </p>
+          </div>
+          <Switch
+            aria-label={t('settings.externalModelList')}
+            checked={localEnabled}
+            onCheckedChange={handleToggle}
+            disabled={updateSetting.isPending}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">{t('settings.externalModelListHint')}</p>
         <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
       </CardContent>
     </Card>

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -1162,6 +1162,7 @@ export function ExternalModelListSection() {
   const { t } = useTranslation();
   const enabled = settings?.[EXTERNAL_MODEL_LIST_ENABLED_SETTING_KEY] === 'true';
   const [localEnabled, setLocalEnabled] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setLocalEnabled(enabled);
@@ -1170,14 +1171,15 @@ export function ExternalModelListSection() {
   const handleToggle = async (checked: boolean) => {
     const previous = localEnabled;
     setLocalEnabled(checked);
+    setError(null);
     try {
       await updateSetting.mutateAsync({
         key: EXTERNAL_MODEL_LIST_ENABLED_SETTING_KEY,
         value: checked ? 'true' : 'false',
       });
-    } catch (error) {
+    } catch {
       setLocalEnabled(previous);
-      throw error;
+      setError(t('settings.externalModelListSaveError'));
     }
   };
 
@@ -1208,6 +1210,11 @@ export function ExternalModelListSection() {
             disabled={updateSetting.isPending}
           />
         </div>
+        {error && (
+          <p role="alert" className="text-xs text-destructive">
+            {error}
+          </p>
+        )}
         <p className="text-xs text-muted-foreground">{t('settings.externalModelListHint')}</p>
         <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
       </CardContent>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,17 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  Clock3,
-  Copy,
-  Eye,
-  EyeOff,
-  Gift,
-  KeyRound,
-  ListChecks,
-  LogOut,
-  Server,
-  Activity,
-  UserRound,
-} from 'lucide-react';
+import { Clock3, Copy, Eye, EyeOff, Gift, KeyRound, LogOut, Server, UserRound } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   Badge,
@@ -27,27 +15,19 @@ import {
   TabsTrigger,
 } from '@/components/ui';
 import { LanguageToggle } from '@/components/language-toggle';
-import { MarqueeBackground } from '@/components/ui/marquee-background';
-import { StreamingBadge } from '@/components/ui/streaming-badge';
 import { useAuth } from '@/lib/auth-context';
 import {
   useCreateUserPanelAPIToken,
-  useProxyRequests,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
   useUserPanelAvailableModels,
   useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
   useUserPanelAPIToken,
-  useProxyRequestUpdates,
   usePublicSettings,
 } from '@/hooks/queries';
-import type { APIToken, ProxyRequest } from '@/lib/transport';
+import type { APIToken } from '@/lib/transport';
 import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
-import {
-  buildUserPanelModelStatuses,
-  type UserPanelModelStatusSummary,
-} from '@/lib/user-panel-model-status';
 import {
   getUserPanelTabStorageKey,
   resolveUserPanelTab,
@@ -86,245 +66,16 @@ function formatDateTime(value?: string) {
   }).format(date);
 }
 
-function formatDuration(value?: number) {
-  if (!value || value <= 0) return '—';
-  const milliseconds = value / 1_000_000;
-  if (milliseconds < 1000) return `${Math.round(milliseconds)}ms`;
-  return `${(milliseconds / 1000).toFixed(2)}s`;
-}
-
 function getTokenStatus(token: APIToken) {
   if (!token.isEnabled) return 'disabled';
   if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) return 'expired';
   return 'active';
 }
 
-function isActiveUserPanelRequest(request: ProxyRequest) {
-  return request.status === 'PENDING' || request.status === 'IN_PROGRESS';
-}
-
-function getRequestStatusVariant(request: ProxyRequest) {
-  if (request.status === 'COMPLETED' && request.statusCode < 400) return 'success';
-  if (request.status === 'PENDING' || request.status === 'IN_PROGRESS') return 'warning';
-  if (request.status === 'FAILED' || request.status === 'REJECTED') {
-    return 'danger';
-  }
-  if (request.statusCode >= 400) return 'danger';
-  return 'secondary';
-}
-
-function getModelHealthVariant(health: UserPanelModelStatusSummary['health']) {
-  if (health === 'healthy') return 'success';
-  if (health === 'degraded') return 'warning';
-  if (health === 'unavailable') return 'danger';
-  return 'secondary';
-}
-
-function formatModelStatusDetail(
-  summary: UserPanelModelStatusSummary,
-  t: ReturnType<typeof useTranslation>['t'],
-) {
-  if (summary.health === 'no-data') return t('userPanel.modelStatusNoRecentData');
-  if (summary.health === 'healthy') {
-    return t('userPanel.modelStatusHealthyDetail', { count: summary.successfulRequests });
-  }
-  if (summary.health === 'unavailable') {
-    return t('userPanel.modelStatusUnavailableDetail', { count: summary.consecutiveFailures });
-  }
-  return t('userPanel.modelStatusDegradedDetail', {
-    failed: summary.failedRequests,
-    total: summary.totalRequests,
-  });
-}
-
-function UserPanelModelStatusTab({
-  availableModels,
-  requests,
-  isLoading,
-  isError,
-}: {
-  availableModels?: string[];
-  requests: ProxyRequest[];
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  const { t } = useTranslation();
-  const summaries = buildUserPanelModelStatuses({ availableModels, requests });
-
-  return (
-    <Card className="min-h-[820px] border-border bg-card shadow-sm">
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center gap-2 text-base font-medium">
-          <Activity className="size-4 text-muted-foreground" />
-          {t('userPanel.modelStatusTab')}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex min-h-[744px] flex-col p-5">
-        {isLoading ? (
-          <div className="flex flex-1 items-center justify-center text-center text-sm text-muted-foreground">
-            {t('common.loading')}
-          </div>
-        ) : isError ? (
-          <div className="flex flex-1 items-center justify-center">
-            <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
-              {t('userPanel.modelStatusLoadFailed')}
-            </div>
-          </div>
-        ) : summaries.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center text-center">
-            <Activity className="size-9 text-muted-foreground" />
-            <p className="mt-3 font-medium">{t('userPanel.noModelStatus')}</p>
-            <p className="mt-2 max-w-md text-sm text-muted-foreground">
-              {t('userPanel.noModelStatusDescription')}
-            </p>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            <div className="rounded-xl border border-border bg-muted/25 p-4">
-              <p className="text-sm font-medium text-foreground">
-                {t('userPanel.modelStatusSummary')}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {t('userPanel.modelStatusSummaryDescription')}
-              </p>
-            </div>
-            <div className="divide-y divide-border rounded-xl border border-border">
-              {summaries.map((summary) => (
-                <div key={summary.model} className="space-y-3 p-4">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0">
-                      <p className="truncate font-mono text-sm font-medium">{summary.model}</p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {formatModelStatusDetail(summary, t)}
-                      </p>
-                    </div>
-                    <Badge variant={getModelHealthVariant(summary.health)}>
-                      {t(`userPanel.modelHealth.${summary.health}`)}
-                    </Badge>
-                  </div>
-                  <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
-                    <div className="rounded-lg bg-muted/25 px-3 py-2">
-                      <span className="block">{t('userPanel.modelStatusRecentRequests')}</span>
-                      <span className="mt-1 block font-mono text-foreground">
-                        {formatNumber(summary.totalRequests)}
-                      </span>
-                    </div>
-                    <div className="rounded-lg bg-muted/25 px-3 py-2">
-                      <span className="block">{t('userPanel.modelStatusRecentFailures')}</span>
-                      <span className="mt-1 block font-mono text-foreground">
-                        {formatNumber(summary.failedRequests)}
-                      </span>
-                    </div>
-                    <div className="rounded-lg bg-muted/25 px-3 py-2">
-                      <span className="block">{t('userPanel.modelStatusLastSeen')}</span>
-                      <span className="mt-1 block font-mono text-foreground">
-                        {formatDateTime(summary.lastRequestedAt)}
-                      </span>
-                    </div>
-                  </div>
-                  {summary.lastError ? (
-                    <div className="rounded-lg border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                      {t('userPanel.modelStatusLastError')}: {summary.lastError}
-                    </div>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function UserPanelRequestsTab() {
-  const { t } = useTranslation();
-  const { data, isLoading, isError } = useProxyRequests({ limit: 25 });
-  const requests = data?.items ?? [];
-
-  return (
-    <Card className="min-h-[820px] border-border bg-card shadow-sm">
-      <CardHeader className="border-b border-border">
-        <CardTitle className="flex items-center gap-2 text-base font-medium">
-          <ListChecks className="size-4 text-muted-foreground" />
-          {t('userPanel.requestsTab')}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex min-h-[744px] flex-col p-5">
-        {isLoading ? (
-          <div className="flex flex-1 items-center justify-center text-center text-sm text-muted-foreground">
-            {t('common.loading')}
-          </div>
-        ) : isError ? (
-          <div className="flex flex-1 items-center justify-center">
-            <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
-              {t('userPanel.requestsLoadFailed')}
-            </div>
-          </div>
-        ) : requests.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center text-center">
-            <ListChecks className="size-9 text-muted-foreground" />
-            <p className="mt-3 font-medium">{t('userPanel.noRequests')}</p>
-            <p className="mt-2 max-w-md text-sm text-muted-foreground">
-              {t('userPanel.noRequestsDescription')}
-            </p>
-          </div>
-        ) : (
-          <div className="divide-y divide-border rounded-xl border border-border">
-            {requests.map((request) => (
-              <div key={request.id} className="space-y-3 p-4">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
-                    <p className="truncate font-mono text-sm font-medium">
-                      {request.requestID || `#${request.id}`}
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {formatDateTime(request.createdAt)} · {request.clientType || '—'} ·{' '}
-                      {request.requestModel || '—'}
-                    </p>
-                  </div>
-                  <Badge variant={getRequestStatusVariant(request)}>
-                    {request.statusCode || '—'} · {request.status || '—'}
-                  </Badge>
-                </div>
-                <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
-                  <div className="rounded-lg bg-muted/25 px-3 py-2">
-                    <span className="block">{t('userPanel.requestDuration')}</span>
-                    <span className="mt-1 block font-mono text-foreground">
-                      {formatDuration(request.duration)}
-                    </span>
-                  </div>
-                  <div className="rounded-lg bg-muted/25 px-3 py-2">
-                    <span className="block">{t('userPanel.requestInputTokens')}</span>
-                    <span className="mt-1 block font-mono text-foreground">
-                      {formatNumber(request.inputTokenCount)}
-                    </span>
-                  </div>
-                  <div className="rounded-lg bg-muted/25 px-3 py-2">
-                    <span className="block">{t('userPanel.requestOutputTokens')}</span>
-                    <span className="mt-1 block font-mono text-foreground">
-                      {formatNumber(request.outputTokenCount)}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
 export function UserPanelPage() {
   const { t } = useTranslation();
   const { logout, user } = useAuth();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
-  const {
-    data: userPanelRequests,
-    isLoading: userPanelRequestsLoading,
-    isError: userPanelRequestsError,
-  } = useProxyRequests({ limit: 25 });
   const { data: publicSettings } = usePublicSettings();
   const {
     data: availableModels,
@@ -333,7 +84,6 @@ export function UserPanelPage() {
   } = useUserPanelAvailableModels(Boolean(user));
   const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
   const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(dailyCheckInEnabled);
-  useProxyRequestUpdates();
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
   const revealUserPanelToken = useRevealUserPanelAPIToken();
@@ -350,8 +100,7 @@ export function UserPanelPage() {
     if (typeof window === 'undefined') return 'main';
     const params = new URLSearchParams(window.location.search);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined;
+      PerformanceNavigationTiming | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     return resolveUserPanelTab({
       urlTab: params.get('tab'),
@@ -360,8 +109,6 @@ export function UserPanelPage() {
     });
   });
 
-  const activeRequestCount =
-    userPanelRequests?.items.filter((request) => isActiveUserPanelRequest(request)).length ?? 0;
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
   const hasCheckedInToday = dailyCheckInStatus?.alreadyCheckedIn || dailyCheckInDone;
   const dailyCheckInRewardAmount =
@@ -407,8 +154,7 @@ export function UserPanelPage() {
     const urlTab = new URLSearchParams(window.location.search).get('tab');
     const storedTab = window.localStorage.getItem(tabStorageKey);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined;
+      PerformanceNavigationTiming | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     setActiveTab(resolveUserPanelTab({ urlTab, storedTab, allowStoredTab }));
   }, [tabStorageKey]);
@@ -515,20 +261,8 @@ export function UserPanelPage() {
         </header>
 
         <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-5">
-          <TabsList className="grid w-full grid-cols-3 rounded-xl p-1">
+          <TabsList className="grid w-full grid-cols-1 rounded-xl p-1">
             <TabsTrigger value="main">{t('userPanel.mainTab')}</TabsTrigger>
-            <TabsTrigger value="model-status">{t('userPanel.modelStatusTab')}</TabsTrigger>
-            <TabsTrigger value="requests" className="relative overflow-hidden">
-              <MarqueeBackground
-                show={activeRequestCount > 0}
-                color="var(--color-success)"
-                opacity={0.3}
-              />
-              <span className="relative z-10">{t('userPanel.requestsTab')}</span>
-              <span className="relative z-10">
-                <StreamingBadge count={activeRequestCount} color="var(--color-success)" />
-              </span>
-            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="main" className="space-y-5">
@@ -797,19 +531,6 @@ export function UserPanelPage() {
                 </div>
               </CardContent>
             </Card>
-          </TabsContent>
-
-          <TabsContent value="model-status">
-            <UserPanelModelStatusTab
-              availableModels={availableModels}
-              requests={userPanelRequests?.items ?? []}
-              isLoading={availableModelsLoading || userPanelRequestsLoading}
-              isError={availableModelsError || userPanelRequestsError}
-            />
-          </TabsContent>
-
-          <TabsContent value="requests">
-            <UserPanelRequestsTab />
           </TabsContent>
         </Tabs>
 


### PR DESCRIPTION
## Summary
- remove the user console Requests and Model Status tabs, leaving the main console tab only
- add an admin Settings switch that reveals a new External Models sidebar tab
- add the External Models editor and wire its custom list into external model-list APIs and the user-panel model list

## Validation
- go test -count=1 -timeout 600s ./cmd/... ./internal/...
- cd web && pnpm typecheck
- cd web && pnpm lint
- cd web && pnpm build
- cd web && pnpm test -- --run src/lib/user-panel-tabs.test.ts src/components/layout/app-sidebar/sidebar-config.test.ts

Note: pnpm reported the existing engine warning because this environment uses Node v24.18.0 while package.json wants >=22.12.0 <23; commands still passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增外部模型列表管理页面，支持编辑、去重、排序并保存模型名称。
  - 管理员可通过设置开关启用自定义外部模型列表，并从配置菜单访问。
  - 支持使用 JSON、换行或逗号分隔的格式配置模型列表。

- **功能调整**
  - 用户面板移除“模型状态”和“请求”标签页，仅保留主页面。
  - 新增相关中英文界面文案、设置项及保存失败提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->