### PR TITLE
fix: 为 Dashboard 首次使用时间查询添加联合索引

### DIFF
--- a/internal/repository/sqlite/migrations.go
+++ b/internal/repository/sqlite/migrations.go
@@ -588,6 +588,44 @@ var migrations = []Migration{
 			return nil
 		},
 	},
+	{
+		Version:     22,
+		Description: "Add tenant created_at index for dashboard first use time",
+		Up:          runProxyRequestFirstUseIndexMigration,
+		Down: func(db *gorm.DB) error {
+			if !db.Migrator().HasIndex(&ProxyRequest{}, proxyRequestFirstUseIndex) {
+				return nil
+			}
+			return db.Migrator().DropIndex(&ProxyRequest{}, proxyRequestFirstUseIndex)
+		},
+	},
+}
+
+const proxyRequestFirstUseIndex = "idx_proxy_requests_tenant_created_at"
+
+func runProxyRequestFirstUseIndexMigration(db *gorm.DB) error {
+	if db.Migrator().HasIndex(&ProxyRequest{}, proxyRequestFirstUseIndex) {
+		return nil
+	}
+	ddl := "CREATE INDEX IF NOT EXISTS " + proxyRequestFirstUseIndex + " ON proxy_requests(tenant_id, created_at)"
+	if db.Dialector.Name() == "mysql" {
+		ddl = "ALTER TABLE proxy_requests ADD INDEX " + proxyRequestFirstUseIndex + " (tenant_id, created_at), ALGORITHM=INPLACE, LOCK=NONE"
+	}
+	exceeds, err := tableExceedsRowThreshold(db, "proxy_requests", detailCleanupIndexRowThreshold)
+	if err != nil {
+		log.Printf("[Migration v22] could not probe proxy_requests row threshold (%v); skipping index build. Apply manually during a maintenance window: %s;", err, ddl)
+		return nil
+	}
+	if exceeds {
+		log.Printf("[Migration v22] SKIPPING %s: proxy_requests has more than %d rows. Apply manually during a maintenance window: %s;",
+			proxyRequestFirstUseIndex, detailCleanupIndexRowThreshold, ddl)
+		return nil
+	}
+	err = db.Exec(ddl).Error
+	if db.Dialector.Name() == "mysql" && isMySQLDuplicateIndexError(err) {
+		return nil
+	}
+	return err
 }
 
 func backfillRouteNativeFlags(db *gorm.DB) error {

--- a/internal/repository/sqlite/migrations_test.go
+++ b/internal/repository/sqlite/migrations_test.go
@@ -136,8 +136,8 @@ func TestLatestMigrationsAreOrderedAndUnique(t *testing.T) {
 			v21Count++
 		}
 	}
-	if lastVersion != 21 {
-		t.Fatalf("latest migration = v%d, want v21", lastVersion)
+	if lastVersion != 22 {
+		t.Fatalf("latest migration = v%d, want v22", lastVersion)
 	}
 	if v18Count != 1 {
 		t.Fatalf("migration v18 registered %d times, want once", v18Count)


### PR DESCRIPTION
Dashboard 每次计算首次使用时间时，会执行按租户过滤的 `MIN(created_at)`。缺少联合索引时需要扫描该租户的大量请求记录。

新增 v22 迁移，为 `proxy_requests` 添加 `(tenant_id, created_at)` 联合索引。保留已有的 50 万行保护：超过阈值或探测失败时跳过自动创建并记录手动 SQL，因此 91.5 万行的现有表仍需在维护窗口补建索引。MySQL 使用在线 DDL，并直接在当前迁移事务连接执行，避免跨连接等待自身持有的元数据锁。

验证：`go test ./internal/repository/sqlite` 通过；同条索引 SQL 已在 MySQL 8.0 实际执行，SQLite 查询计划已验证命中覆盖索引。PostgreSQL 未实机验证。
