### PR TITLE
fix(providers): show custom add command copy icon

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -476,7 +476,8 @@
     "importProviders": "Import Providers",
     "exportProviders": "Export Providers",
     "shareProviderAddCommand": {
-      "copy": "Copy add command"
+      "copy": "Copy add command",
+      "copied": "Add command copied"
     },
     "readOnlyHint": "Read-only for members. Admin access required to edit providers.",
     "importProvidersAdminOnly": "Only admins can import providers.",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -475,7 +475,8 @@
     "importProviders": "导入提供商",
     "exportProviders": "导出提供商",
     "shareProviderAddCommand": {
-      "copy": "复制添加命令"
+      "copy": "复制添加命令",
+      "copied": "添加命令已复制"
     },
     "readOnlyHint": "成员仅可查看，编辑提供商需要管理员权限。",
     "importProvidersAdminOnly": "只有管理员可以导入提供商。",

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -1,5 +1,5 @@
 import { useState, type KeyboardEvent, type MouseEvent } from 'react';
-import { Activity, Ban, Copy, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
+import { Activity, Ban, Check, Copy, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import { useCooldowns } from '@/hooks/use-cooldowns';
 import { ClientIcon } from '@/components/icons/client-icons';
@@ -540,14 +540,24 @@ export function ProviderRow({
           type="button"
           onClick={handleCopyProviderAddCommand}
           onKeyDown={handleShareCommandKeyDown}
-          className="relative z-10 inline-flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background/70 px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          title={t('providers.shareProviderAddCommand.copy')}
-          aria-label={t('providers.shareProviderAddCommand.copy')}
+          className={cn(
+            'relative z-10 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-background/70 text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            shareCopied
+              ? 'border-emerald-500/40 text-emerald-500'
+              : 'border-border hover:border-primary/40 hover:text-foreground',
+          )}
+          title={
+            shareCopied
+              ? t('providers.shareProviderAddCommand.copied')
+              : t('providers.shareProviderAddCommand.copy')
+          }
+          aria-label={
+            shareCopied
+              ? t('providers.shareProviderAddCommand.copied')
+              : t('providers.shareProviderAddCommand.copy')
+          }
         >
-          <Copy className="h-3.5 w-3.5" />
-          <span className="hidden md:inline">
-            {shareCopied ? t('common.copied') : t('providers.shareProviderAddCommand.copy')}
-          </span>
+          {shareCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
         </button>
       )}
 

--- a/web/src/pages/providers/utils/provider-add-command.test.ts
+++ b/web/src/pages/providers/utils/provider-add-command.test.ts
@@ -171,8 +171,28 @@ describe('provider-add-command', () => {
     expect(parsed.errors).toEqual([]);
   });
 
+  it('supports any provider type backed by custom config as an add command', () => {
+    for (const type of ['custom', 'claude', 'codex', 'newapi', 'ollama', 'fal']) {
+      const provider: Provider = {
+        ...baseProvider,
+        type,
+        config: {
+          custom: {
+            baseURL: 'https://api.example.com/v1',
+            apiKey: 'sk-custom-backed',
+          },
+        },
+      };
+
+      expect(canBuildProviderAddCommand(provider)).toBe(true);
+      expect(buildProviderAddCommand(provider)).toContain(
+        "--base-url 'https://api.example.com/v1'",
+      );
+    }
+  });
+
   it('refuses providers that cannot be safely shared as provider add commands', () => {
-    expect(canBuildProviderAddCommand({ ...baseProvider, type: 'claude' })).toBe(false);
+    expect(canBuildProviderAddCommand({ ...baseProvider, type: 'claude', config: {} })).toBe(false);
     expect(canBuildProviderAddCommand({ ...baseProvider, blackBox: true })).toBe(false);
     expect(canBuildProviderAddCommand({ ...baseProvider, excludeFromExport: true })).toBe(false);
     expect(buildProviderAddCommand({ ...baseProvider, blackBox: true })).toBeNull();

--- a/web/src/pages/providers/utils/provider-add-command.ts
+++ b/web/src/pages/providers/utils/provider-add-command.ts
@@ -44,7 +44,7 @@ function providerDisguise(provider: Provider): ProviderConfigCustomDisguise | un
 export function canBuildProviderAddCommand(provider: Provider): boolean {
   const custom = provider.config?.custom;
   if (provider.blackBox || provider.excludeFromExport) return false;
-  if (provider.type !== 'custom' || !custom) return false;
+  if (!custom) return false;
   if (!custom.baseURL?.trim()) return false;
   if (custom.backend !== 'ollama' && !custom.apiKey?.trim()) return false;
   return true;


### PR DESCRIPTION
## Summary

- Show the provider add-command copy action as an icon-only button with copied-state feedback.
- Allow the copy action for any provider backed by `config.custom`, including custom Claude/Codex/NewAPI/Ollama/fal provider types.
- Keep unsafe/non-exportable providers blocked: black-box, export-excluded, missing base URL, and HTTP custom providers without an API key.

## Validation

- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm test -- --run src/pages/providers/utils/provider-add-command.test.ts`
- `cd web && pnpm build`
- Browser E2E regression with mocked full provider-page dependency chain:
  - auth/status, providers, provider-stats, routes, model-mappings, settings/admin settings, cooldowns, active requests, quotas, proxy-status
  - copyable examples: custom, custom-backed claude, custom-backed codex, newapi, ollama, fal
  - blocked examples: native claude without `config.custom`, blackBox, excludeFromExport, missing baseURL, missing HTTP apiKey
  - mouse copy, keyboard copy, clipboard content, no row-click navigation from copy button, normal row navigation

## Notes

- Local validation ran on Node v24.18.0; pnpm reports the existing engine warning because the project declares `>=22.12.0 <23`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 支持更多提供商类型生成添加命令，命令中会包含基础 URL。
  - 分享添加命令后，复制按钮会显示成功状态，并提供相应的提示文本。
- **界面优化**
  - 添加命令按钮改为更简洁的图标按钮，并根据复制状态切换图标、标题和无障碍标签。
  - 新增中文和英文的复制成功提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->