### PR TITLE
feat(models): add configurable external model list

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -501,6 +501,7 @@ func main() {
 
 	// Use already-created cached project repository for project proxy handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
+	modelsHandler.SetSettingsRepository(settingRepo)
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)

--- a/tests/e2e/proxy_setup_test.go
+++ b/tests/e2e/proxy_setup_test.go
@@ -194,6 +194,7 @@ func NewProxyTestEnv(t *testing.T) *ProxyTestEnv {
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
+	modelsHandler.SetSettingsRepository(settingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -181,6 +181,7 @@ func newTestEnv(t *testing.T, opts testEnvOptions) *TestEnv {
 
 	// Create models handler
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo)
+	modelsHandler.SetSettingsRepository(settingRepo)
 	tokenAuthMiddleware := handler.NewTokenAuthMiddleware(cachedAPITokenRepo, settingRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 


### PR DESCRIPTION
## Summary

- Add a settings-controlled External Models page for managing an explicit public model list.
- Make model-list APIs and user-panel available-models use the configured external list when enabled.
- Wire the external-model-list setting repository through both server construction paths, including `cmd/maxx/main.go`.

## Fix

This includes the follow-up fix for the invalid open behavior: the CLI server path now passes `settingRepo` into `ModelsHandler`, so enabling `external_model_list_enabled` actually affects model-list responses outside the core/database initialization path.

## Validation

- `go test ./internal/handler ./internal/service ./tests/e2e -run 'TestModelsHandlerUsesConfiguredExternalModelListWhenEnabled|TestModelsHandlerConfiguredExternalModelListDisabledKeepsExistingSources|TestGetModels|TestGetModels_OnlyCurrentAvailableModelsAcrossScopes'`
