### PR TITLE
fix(model-mappings): move toggle into status column

### DIFF
--- a/internal/repository/cached/model_mapping.go
+++ b/internal/repository/cached/model_mapping.go
@@ -150,7 +150,18 @@ func (r *ModelMappingRepository) List(tenantID uint64) ([]*domain.ModelMapping, 
 }
 
 func (r *ModelMappingRepository) ListEnabled(tenantID uint64) ([]*domain.ModelMapping, error) {
-	return r.List(tenantID)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*domain.ModelMapping, 0, len(r.cache))
+	for _, m := range r.cache {
+		if !m.IsEnabled {
+			continue
+		}
+		if tenantID == domain.TenantIDAll || m.TenantID == tenantID {
+			result = append(result, m)
+		}
+	}
+	return result, nil
 }
 
 func (r *ModelMappingRepository) ListByClientType(tenantID uint64, clientType domain.ClientType) ([]*domain.ModelMapping, error) {
@@ -158,6 +169,9 @@ func (r *ModelMappingRepository) ListByClientType(tenantID uint64, clientType do
 	defer r.mu.RUnlock()
 	result := make([]*domain.ModelMapping, 0)
 	for _, m := range r.cache {
+		if !m.IsEnabled {
+			continue
+		}
 		if tenantID != domain.TenantIDAll && m.TenantID != tenantID {
 			continue
 		}
@@ -168,12 +182,15 @@ func (r *ModelMappingRepository) ListByClientType(tenantID uint64, clientType do
 	return result, nil
 }
 
-// ListByQuery returns all mappings matching the query conditions
+// ListByQuery returns all enabled mappings matching the query conditions
 func (r *ModelMappingRepository) ListByQuery(tenantID uint64, query *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	result := make([]*domain.ModelMapping, 0)
 	for _, m := range r.cache {
+		if !m.IsEnabled {
+			continue
+		}
 		if tenantID != domain.TenantIDAll && m.TenantID != tenantID {
 			continue
 		}

--- a/internal/repository/cached/model_mapping_test.go
+++ b/internal/repository/cached/model_mapping_test.go
@@ -1,0 +1,88 @@
+package cached
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type modelMappingTestRepo struct {
+	mappings []*domain.ModelMapping
+}
+
+func (r *modelMappingTestRepo) Create(mapping *domain.ModelMapping) error {
+	if mapping.ID == 0 {
+		mapping.ID = uint64(len(r.mappings) + 1)
+	}
+	r.mappings = append(r.mappings, mapping)
+	return nil
+}
+
+func (r *modelMappingTestRepo) Update(mapping *domain.ModelMapping) error { return nil }
+func (r *modelMappingTestRepo) Delete(uint64, uint64) error               { return nil }
+func (r *modelMappingTestRepo) GetByID(uint64, uint64) (*domain.ModelMapping, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *modelMappingTestRepo) List(uint64) ([]*domain.ModelMapping, error) {
+	return append([]*domain.ModelMapping(nil), r.mappings...), nil
+}
+func (r *modelMappingTestRepo) ListEnabled(tenantID uint64) ([]*domain.ModelMapping, error) {
+	list, err := r.List(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*domain.ModelMapping, 0, len(list))
+	for _, mapping := range list {
+		if mapping.IsEnabled {
+			result = append(result, mapping)
+		}
+	}
+	return result, nil
+}
+func (r *modelMappingTestRepo) ListByClientType(uint64, domain.ClientType) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *modelMappingTestRepo) ListByQuery(uint64, *domain.ModelMappingQuery) ([]*domain.ModelMapping, error) {
+	return nil, nil
+}
+func (r *modelMappingTestRepo) Reorder(uint64, domain.ModelMappingReorderRequest) error { return nil }
+func (r *modelMappingTestRepo) Count(uint64) (int, error)                               { return len(r.mappings), nil }
+func (r *modelMappingTestRepo) DeleteAll(uint64) error                                  { return nil }
+func (r *modelMappingTestRepo) ClearAll(uint64) error                                   { return nil }
+func (r *modelMappingTestRepo) SeedDefaults(uint64) error                               { return nil }
+
+func TestModelMappingRepositoryCachedReadMethodsSkipDisabledMappings(t *testing.T) {
+	baseRepo := &modelMappingTestRepo{mappings: []*domain.ModelMapping{
+		{ID: 1, TenantID: 1, Scope: domain.ModelMappingScopeGlobal, ClientType: domain.ClientTypeClaude, Pattern: "disabled-*", Target: "disabled-target", IsEnabled: false},
+		{ID: 2, TenantID: 1, Scope: domain.ModelMappingScopeGlobal, ClientType: domain.ClientTypeClaude, Pattern: "enabled-*", Target: "enabled-target", IsEnabled: true},
+		{ID: 3, TenantID: 2, Scope: domain.ModelMappingScopeGlobal, ClientType: domain.ClientTypeClaude, Pattern: "other-*", Target: "other-target", IsEnabled: true},
+	}}
+	repo := NewModelMappingRepository(baseRepo)
+	if err := repo.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	enabled, err := repo.ListEnabled(1)
+	if err != nil {
+		t.Fatalf("ListEnabled() error = %v", err)
+	}
+	if len(enabled) != 1 || enabled[0].ID != 2 {
+		t.Fatalf("ListEnabled() = %#v, want only enabled tenant mapping", enabled)
+	}
+
+	byClient, err := repo.ListByClientType(1, domain.ClientTypeClaude)
+	if err != nil {
+		t.Fatalf("ListByClientType() error = %v", err)
+	}
+	if len(byClient) != 1 || byClient[0].ID != 2 {
+		t.Fatalf("ListByClientType() = %#v, want only enabled tenant mapping", byClient)
+	}
+
+	byQuery, err := repo.ListByQuery(1, &domain.ModelMappingQuery{ClientType: domain.ClientTypeClaude})
+	if err != nil {
+		t.Fatalf("ListByQuery() error = %v", err)
+	}
+	if len(byQuery) != 1 || byQuery[0].ID != 2 {
+		t.Fatalf("ListByQuery() = %#v, want only enabled tenant mapping", byQuery)
+	}
+}

--- a/internal/repository/sqlite/model_mapping.go
+++ b/internal/repository/sqlite/model_mapping.go
@@ -27,6 +27,7 @@ func (r *ModelMappingRepository) Create(mapping *domain.ModelMapping) error {
 		return err
 	}
 	mapping.ID = model.ID
+	mapping.IsEnabled = model.IsEnabled != 0
 	return nil
 }
 

--- a/web/src/pages/model-mappings/index.tsx
+++ b/web/src/pages/model-mappings/index.tsx
@@ -157,16 +157,6 @@ function SortableRuleItem({
         <GripVertical className="h-4 w-4 text-muted-foreground" />
       </button>
       <span className="text-xs text-muted-foreground w-6 shrink-0">{index + 1}.</span>
-      <Switch
-        checked={isMappingEnabled(rule)}
-        onCheckedChange={(checked) => onUpdate({ isEnabled: checked })}
-        disabled={disabled}
-        aria-label={t('modelMappings.toggleRule', {
-          pattern: rule.pattern || '*',
-          target: rule.target || '-',
-        })}
-      />
-
       {/* Pattern -> Target */}
       <ModelInput
         value={rule.pattern}
@@ -204,11 +194,22 @@ function SortableRuleItem({
         {rule.projectID || '-'}
       </span>
 
-      <span
-        className={`w-[72px] h-7 text-[11px] shrink-0 flex items-center ${isMappingEnabled(rule) ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`}
-      >
-        {isMappingEnabled(rule) ? t('common.enabled') : t('common.disabled')}
-      </span>
+      <div className="w-[72px] h-7 shrink-0 flex items-center gap-2">
+        <Switch
+          checked={isMappingEnabled(rule)}
+          onCheckedChange={(checked) => onUpdate({ isEnabled: checked })}
+          disabled={disabled}
+          aria-label={t('modelMappings.toggleRule', {
+            pattern: rule.pattern || '*',
+            target: rule.target || '-',
+          })}
+        />
+        <span
+          className={`text-[11px] ${isMappingEnabled(rule) ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`}
+        >
+          {isMappingEnabled(rule) ? t('common.enabled') : t('common.disabled')}
+        </span>
+      </div>
 
       <Button variant="ghost" size="sm" onClick={onRemove} disabled={disabled} className="shrink-0">
         <Trash2 className="h-4 w-4 text-destructive" />
@@ -269,8 +270,8 @@ export function ModelMappingsPage() {
         return a.id - b.id;
       });
   }, [debugQuery, mappings]);
-  const effectiveDebugMatches = debugMatches.filter((rule) =>
-    isMappingEnabled(rule) && matchWildcard(rule.pattern, debugQuery),
+  const effectiveDebugMatches = debugMatches.filter(
+    (rule) => isMappingEnabled(rule) && matchWildcard(rule.pattern, debugQuery),
   );
 
   const sensors = useSensors(
@@ -357,18 +358,18 @@ export function ModelMappingsPage() {
   const handleUpdateRule = async (rule: ModelMapping, data: Partial<ModelMappingInput>) => {
     await updateMapping.mutateAsync({
       id: rule.id,
-        data: {
-          pattern: data.pattern ?? rule.pattern,
-          target: data.target ?? rule.target,
-          scope: 'global',
-          clientType: data.clientType ?? rule.clientType,
-          providerType: data.providerType ?? rule.providerType,
-          providerID: data.providerID ?? rule.providerID,
-          projectID: data.projectID ?? rule.projectID,
-          priority: rule.priority,
-          isEnabled: data.isEnabled ?? rule.isEnabled,
-        },
-      });
+      data: {
+        pattern: data.pattern ?? rule.pattern,
+        target: data.target ?? rule.target,
+        scope: 'global',
+        clientType: data.clientType ?? rule.clientType,
+        providerType: data.providerType ?? rule.providerType,
+        providerID: data.providerID ?? rule.providerID,
+        projectID: data.projectID ?? rule.projectID,
+        priority: rule.priority,
+        isEnabled: data.isEnabled ?? rule.isEnabled,
+      },
+    });
   };
 
   const handleReset = async () => {
@@ -551,7 +552,6 @@ export function ModelMappingsPage() {
               <div className="flex items-center gap-3 text-xs text-muted-foreground font-medium border-b pb-2">
                 <div className="w-6 shrink-0"></div>
                 <div className="w-6 shrink-0">#</div>
-                <div className="w-11 shrink-0">{t('common.enabled')}</div>
                 <div className="flex-1 min-w-0">{t('modelMappings.matchPattern')}</div>
                 <div className="w-3"></div>
                 <div className="flex-1 min-w-0">{t('modelMappings.targetModel')}</div>


### PR DESCRIPTION
## Summary

- Move the model mapping enable/disable switch into the Status column.
- Remove the separate Enabled column so the status cell is the single control/display for mapping enabled state.

## Validation

- `cd web && pnpm typecheck`
- `cd web && pnpm lint`
- `cd web && pnpm test -- --run src/pages/model-mappings src/pages/providers/components/provider-model-mappings.test.ts`
- `cd web && pnpm build`
