### PR TITLE
feat(providers): add configurable clone naming policy

### DIFF
--- a/tests/e2e/playwright/provider-clone-name-policy-real.spec.ts
+++ b/tests/e2e/playwright/provider-clone-name-policy-real.spec.ts
@@ -1,0 +1,206 @@
+import { expect, test } from "playwright/test";
+
+import { adminAPI, bodyText, loginToAdminAPI, PASS, USER } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+test.use({ video: "on" });
+
+async function loginToAdminFrontend(page: Parameters<typeof bodyText>[0]) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  const passwordInput = page.locator('input[type="password"]').first();
+  const passwordVisible = await passwordInput
+    .waitFor({ state: "visible", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (passwordVisible) {
+    const adminTab = page.getByRole("tab", { name: /Admin Login|管理员登录/i });
+    if (await adminTab.isVisible().catch(() => false)) {
+      await adminTab.click();
+    }
+
+    const usernameInput = page.locator('input[type="text"]').first();
+    if (await usernameInput.isVisible().catch(() => false)) {
+      await usernameInput.fill(USER);
+    }
+    await passwordInput.fill(PASS);
+    await page.getByRole("button", { name: /^Login$|登录/i }).click();
+  }
+
+  await expect
+    .poll(async () => /dashboard/i.test(await bodyText(page)), {
+      timeout: 10000,
+    })
+    .toBe(true);
+}
+
+test("provider clone naming numeric policy persists through real settings and provider APIs", async ({
+  page,
+}, testInfo) => {
+  const jwt = await loginToAdminAPI();
+  const createdProviderIds: number[] = [];
+  const runId = Date.now();
+  const baseName = `Clone Policy OpenAI ${runId} 009`;
+  const conflictName = `Clone Policy OpenAI ${runId} 010`;
+  const expectedCloneName = `Clone Policy OpenAI ${runId} 011`;
+
+  try {
+    const source = await adminAPI(
+      "POST",
+      "/providers",
+      {
+        name: baseName,
+        type: "custom",
+        config: {
+          custom: {
+            baseURL: "https://mock-clone-policy.example.test/v1",
+            apiKey: "mock-key-source",
+          },
+        },
+        supportedClientTypes: ["openai"],
+        supportModels: ["gpt-clone-policy-real"],
+        exposedModelsEnabled: true,
+        exposedModels: ["gpt-clone-policy-public"],
+        maxConcurrency: 3,
+      },
+      jwt,
+    );
+    createdProviderIds.push(source.id);
+
+    const conflict = await adminAPI(
+      "POST",
+      "/providers",
+      {
+        name: conflictName,
+        type: "custom",
+        config: {
+          custom: {
+            baseURL: "https://mock-clone-policy-conflict.example.test/v1",
+            apiKey: "mock-key-conflict",
+          },
+        },
+        supportedClientTypes: ["openai"],
+      },
+      jwt,
+    );
+    createdProviderIds.push(conflict.id);
+
+    await loginToAdminFrontend(page);
+    await page.goto("/settings", { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("Provider clone naming")).toBeVisible();
+    await page.getByLabel("Clone naming strategy").click();
+    const settingSaved = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes("/api/admin/settings/provider_clone_name_strategy") &&
+        response.request().method() === "PUT" &&
+        response.ok(),
+    );
+    await page
+      .getByRole("option", { name: "Increment trailing number" })
+      .click();
+    await settingSaved;
+    await expect(
+      page.getByText("Number increment advances a trailing number"),
+    ).toBeVisible();
+    await expect
+      .poll(
+        async () => {
+          const value = await adminAPI(
+            "GET",
+            "/settings/provider_clone_name_strategy",
+            undefined,
+            jwt,
+          );
+          return value.value;
+        },
+        { timeout: 10000 },
+      )
+      .toBe("increment-number");
+    await page.screenshot({
+      path: testInfo.outputPath("01-real-settings-numeric-policy.png"),
+      fullPage: true,
+    });
+
+    await page.goto(`/providers/${source.id}/edit`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.locator(`input[value="${baseName}"]`)).toBeVisible();
+
+    const cloneCreated = page.waitForResponse((response) => {
+      const url = response.url();
+      return (
+        (url.endsWith("/api/admin/providers") ||
+          url.endsWith("/api/providers")) &&
+        response.request().method() === "POST" &&
+        response.ok()
+      );
+    });
+    await page.getByRole("button", { name: /^Clone$/ }).click();
+    const cloneResponse = await cloneCreated;
+    const createdClone = (await cloneResponse.json()) as {
+      id: number;
+      name?: string;
+    };
+    createdProviderIds.push(createdClone.id);
+    await expect(page).toHaveURL(
+      new RegExp(`/providers/${createdClone.id}/edit`),
+      {
+        timeout: 10000,
+      },
+    );
+
+    const providers = await adminAPI("GET", "/providers", undefined, jwt);
+    const clone = providers.find(
+      (item: { name?: string }) => item.name === expectedCloneName,
+    );
+    expect(
+      clone,
+      `expected clone ${expectedCloneName}; visible clone-policy providers: ${providers
+        .filter((item: { name?: string }) => item.name?.includes(String(runId)))
+        .map((item: { name?: string }) => item.name)
+        .join(", ")}`,
+    ).toBeTruthy();
+
+    expect(clone).toMatchObject({
+      name: expectedCloneName,
+      type: "custom",
+      supportedClientTypes: ["openai"],
+      supportModels: ["gpt-clone-policy-real"],
+      exposedModelsEnabled: true,
+      exposedModels: ["gpt-clone-policy-public"],
+      maxConcurrency: 3,
+    });
+
+    await expect(
+      page.locator(`input[value="${expectedCloneName}"]`),
+    ).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath("02-real-provider-clone-numeric-policy.png"),
+      fullPage: true,
+    });
+  } finally {
+    await adminAPI(
+      "DELETE",
+      "/settings/provider_clone_name_strategy",
+      undefined,
+      jwt,
+    ).catch(() => undefined);
+    const remaining = await adminAPI("GET", "/providers", undefined, jwt).catch(
+      () => [] as Array<{ id: number; name?: string }>,
+    );
+    for (const item of remaining) {
+      if (item.name?.includes(`Clone Policy OpenAI ${runId}`)) {
+        createdProviderIds.push(item.id);
+      }
+    }
+    for (const id of [...new Set(createdProviderIds)].reverse()) {
+      await adminAPI("DELETE", `/providers/${id}`, undefined, jwt).catch(
+        () => undefined,
+      );
+    }
+  }
+});

--- a/tests/e2e/playwright/provider-clone-name-policy.spec.ts
+++ b/tests/e2e/playwright/provider-clone-name-policy.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test, type Page, type Route } from "playwright/test";
+
+type ProviderPayload = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  type: string;
+  name: string;
+  supportedClientTypes: string[];
+  supportModels?: string[];
+  exposedModelsEnabled?: boolean;
+  exposedModels?: string[];
+  excludeFromExport?: boolean;
+  blackBox?: boolean;
+  config: {
+    quotaEnabled?: boolean;
+    disableErrorCooldown?: boolean;
+    smartMappingRetryEnabled?: boolean;
+    smartMappingRetryLimit?: number;
+    custom: {
+      baseURL: string;
+      apiKey: string;
+      responseModelMapping?: Record<string, string>;
+    };
+  };
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function provider(id: number, name: string): ProviderPayload {
+  return {
+    id,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    type: "custom",
+    name,
+    supportedClientTypes: ["openai"],
+    supportModels: ["gpt-clone-e2e"],
+    exposedModelsEnabled: false,
+    config: {
+      quotaEnabled: false,
+      disableErrorCooldown: false,
+      smartMappingRetryEnabled: false,
+      smartMappingRetryLimit: 1,
+      custom: {
+        baseURL: "https://mock-provider.example.test/v1",
+        apiKey: "mock-key",
+      },
+    },
+  };
+}
+
+async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMocks(page: Page, createdPayloads: unknown[]) {
+  const settings: Record<string, string> = {
+    api_token_auth_enabled: "true",
+    force_project_binding: "false",
+    ui_multitenant_enabled: "false",
+  };
+  const providers = [provider(42, "OpenAI 009"), provider(99, "OpenAI 010")];
+
+  await page.addInitScript(() => {
+    localStorage.setItem("maxx-admin-token", "mock-token");
+    localStorage.setItem("maxx-ui-language", "en");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const { pathname } = url;
+    const method = request.method();
+
+    if (pathname === "/api/admin/auth/status") {
+      return json(route, {
+        authEnabled: true,
+        user: { id: 1, username: "admin", tenantID: 1, role: "admin" },
+      });
+    }
+
+    if (pathname === "/api/settings" || pathname === "/api/admin/settings") {
+      if (method === "GET") return json(route, settings);
+    }
+
+    const settingMatch = pathname.match(/^\/api\/admin\/settings\/(.+)$/u);
+    if (settingMatch && (method === "PUT" || method === "POST")) {
+      const body = JSON.parse(request.postData() || "{}") as { value?: string };
+      settings[decodeURIComponent(settingMatch[1])] = body.value || "";
+      return json(route, {
+        key: decodeURIComponent(settingMatch[1]),
+        value: body.value || "",
+      });
+    }
+
+    if (
+      pathname === "/api/proxy-status" ||
+      pathname === "/api/admin/proxy-status"
+    ) {
+      return json(route, {
+        running: true,
+        address: "127.0.0.1",
+        port: 9880,
+        version: "e2e",
+      });
+    }
+
+    if (pathname === "/api/providers" || pathname === "/api/admin/providers") {
+      if (method === "GET") return json(route, providers);
+      if (method === "POST") {
+        const payload = JSON.parse(request.postData() || "{}");
+        createdPayloads.push(payload);
+        const created = {
+          ...provider(100 + createdPayloads.length, payload.name),
+          ...payload,
+        };
+        providers.push(created);
+        return json(route, created, 201);
+      }
+    }
+
+    if (
+      pathname === "/api/providers/42" ||
+      pathname === "/api/admin/providers/42"
+    ) {
+      if (method === "GET") return json(route, providers[0]);
+    }
+
+    if (
+      pathname === "/api/admin/provider-stats" ||
+      pathname === "/api/admin/streaming-requests/counts" ||
+      pathname === "/api/admin/routes" ||
+      pathname === "/api/admin/model-mappings" ||
+      pathname === "/api/admin/response-models" ||
+      pathname === "/api/admin/projects" ||
+      pathname === "/api/projects" ||
+      pathname === "/api/admin/api-tokens" ||
+      pathname === "/api/api-tokens"
+    ) {
+      return json(route, pathname.includes("counts") ? {} : []);
+    }
+
+    return json(route, { error: "Unmocked endpoint", pathname, method }, 404);
+  });
+}
+
+test.use({
+  viewport: { width: 1440, height: 1100 },
+  locale: "en-US",
+  video: "on",
+});
+
+test("provider clone naming follows configured numeric policy without regressing old clone flow", async ({
+  page,
+}, testInfo) => {
+  const createdPayloads: unknown[] = [];
+  await installMocks(page, createdPayloads);
+
+  await page.goto("/settings", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("Provider clone naming")).toBeVisible();
+  await page.getByLabel("Clone naming strategy").click();
+  await page.getByRole("option", { name: "Increment trailing number" }).click();
+  await expect(
+    page.getByText("Number increment advances a trailing number"),
+  ).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("01-clone-naming-setting.png"),
+    fullPage: true,
+  });
+
+  await page.goto("/providers/42/edit", { waitUntil: "domcontentloaded" });
+  await expect(page.locator('input[value="OpenAI 009"]')).toBeVisible();
+  await page.getByRole("button", { name: /^Clone$/ }).click();
+
+  await expect.poll(() => createdPayloads.length, { timeout: 10000 }).toBe(1);
+  expect(createdPayloads[0]).toMatchObject({
+    name: "OpenAI 011",
+    type: "custom",
+    supportedClientTypes: ["openai"],
+    supportModels: ["gpt-clone-e2e"],
+  });
+
+  await expect(page).toHaveURL(/\/providers\/101\/edit/);
+  await expect(page.locator('input[value="OpenAI 011"]')).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("02-provider-cloned-with-numeric-policy.png"),
+    fullPage: true,
+  });
+});

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -1568,7 +1568,16 @@
     "externalModelListLabel": "Use custom external model list",
     "externalModelListDesc": "When enabled, model-list APIs and the user console available-models list use the models managed on the new External Models tab.",
     "externalModelListHint": "Turn this on only when you want to hide auto-discovered/provider-derived models behind an explicit public list.",
-    "externalModelListSaveError": "Failed to save the external model list switch. Please try again."
+    "externalModelListSaveError": "Failed to save the external model list switch. Please try again.",
+    "providerCloneName": "Provider clone naming",
+    "providerCloneNameStrategy": "Clone naming strategy",
+    "providerCloneNameStrategyDesc": "The default keeps the existing copy suffix. Number increment advances a trailing number. Template mode uses the custom template and avoids conflicts automatically.",
+    "providerCloneNameStrategySuffix": "Copy suffix (default)",
+    "providerCloneNameStrategyIncrementNumber": "Increment trailing number",
+    "providerCloneNameStrategyTemplate": "Custom template",
+    "providerCloneNameTemplate": "Clone name template",
+    "providerCloneNameTemplateDesc": "Supports {{name}}, {{base}}, {{suffix}}, and {{n}}. Empty templates fall back to {{name}}{{suffix}}.",
+    "providerCloneNameSaveError": "Failed to save provider clone naming settings."
   },
   "modelMappings": {
     "title": "Model Mappings",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -1565,7 +1565,16 @@
     "externalModelListLabel": "使用自定义外部模型列表",
     "externalModelListDesc": "开启后，模型列表接口和用户控制台的可用模型列表都使用「外部模型」tab 管理的模型。",
     "externalModelListHint": "只在需要用显式公开列表隐藏自动发现/provider 派生模型时开启。",
-    "externalModelListSaveError": "外部模型列表开关保存失败，请重试。"
+    "externalModelListSaveError": "外部模型列表开关保存失败，请重试。",
+    "providerCloneName": "提供商克隆命名",
+    "providerCloneNameStrategy": "克隆命名策略",
+    "providerCloneNameStrategyDesc": "默认保持旧的副本后缀；数字自增会递增名称末尾数字；模板模式按自定义模板生成，并在冲突时自动避让。",
+    "providerCloneNameStrategySuffix": "副本后缀（默认）",
+    "providerCloneNameStrategyIncrementNumber": "名称末尾数字自增",
+    "providerCloneNameStrategyTemplate": "自定义模板",
+    "providerCloneNameTemplate": "克隆名称模板",
+    "providerCloneNameTemplateDesc": "支持 {{name}}、{{base}}、{{suffix}}、{{n}}。模板为空时使用 {{name}}{{suffix}}。",
+    "providerCloneNameSaveError": "保存提供商克隆命名设置失败。"
   },
   "modelMappings": {
     "title": "模型映射",

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -25,6 +25,8 @@ import {
 } from '@/components/ui/dialog';
 import {
   useCreateProvider,
+  useProviders,
+  useSettings,
   useUpdateProvider,
   useDeleteProvider,
   useModelMappings,
@@ -71,6 +73,7 @@ import { ModelInput } from '@/components/ui/model-input';
 import { PageHeader } from '@/components/layout/page-header';
 import { ProviderProxyURLCard } from './provider-proxy-url-card';
 import { normalizeProviderArrayField } from '../utils/provider-normalize';
+import { buildProviderCloneName } from '../utils/provider-clone-name';
 
 function ProviderEditSection({
   id,
@@ -537,6 +540,8 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
   const deleteProvider = useDeleteProvider();
   const createModelMapping = useCreateModelMapping();
   const { data: allMappings } = useModelMappings();
+  const { data: providers } = useProviders();
+  const { data: settings } = useSettings();
 
   const initClients = (): ClientConfig[] => {
     const supportedTypes = normalizeProviderArrayField(provider.supportedClientTypes);
@@ -665,7 +670,10 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
     return hasEnabledClient && (providerConfigIsWriteOnly || !!hasVisibleURL());
   };
 
+  const isCloneNameContextReady = providers !== undefined && settings !== undefined;
+
   const isCloneValid = () => {
+    if (!isCloneNameContextReady) return false;
     if (!formData.name.trim()) return false;
     const hasEnabledClient = formData.clients.some((c) => c.enabled);
     return hasEnabledClient && !!hasVisibleURL();
@@ -770,9 +778,13 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
         }
       });
 
-      const baseName = formData.name.trim() || provider.name;
-      const suffix = t('provider.cloneSuffix');
-      const cloneName = baseName.endsWith(suffix) ? baseName : `${baseName}${suffix}`;
+      const cloneName = buildProviderCloneName({
+        provider,
+        formName: formData.name,
+        providers,
+        settings,
+        localizedSuffix: t('provider.cloneSuffix'),
+      });
 
       const data: CreateProviderData = {
         type: provider.type || 'custom',

--- a/web/src/pages/providers/utils/provider-clone-name.test.ts
+++ b/web/src/pages/providers/utils/provider-clone-name.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { buildProviderCloneName } from './provider-clone-name';
+
+const source = { id: 1, name: 'OpenAI 009' };
+
+function name(settings?: Record<string, string>, providers = [{ id: 1, name: 'OpenAI 009' }]) {
+  return buildProviderCloneName({
+    provider: source,
+    providers,
+    settings,
+    localizedSuffix: '（副本）',
+  });
+}
+
+describe('buildProviderCloneName', () => {
+  it('preserves the old suffix behavior by default', () => {
+    expect(name()).toBe('OpenAI 009（副本）');
+  });
+
+  it('deduplicates suffix clones without mutating the source provider name', () => {
+    expect(
+      name(undefined, [
+        source,
+        { id: 2, name: 'OpenAI 009（副本）' },
+        { id: 3, name: 'OpenAI 009（副本） 2' },
+      ]),
+    ).toBe('OpenAI 009（副本） 3');
+  });
+
+  it('does not clone to the exact source name when the source already has the localized suffix', () => {
+    expect(
+      buildProviderCloneName({
+        provider: { id: 1, name: 'OpenAI（副本）' },
+        providers: [{ id: 1, name: 'OpenAI（副本）' }],
+        localizedSuffix: '（副本）',
+      }),
+    ).toBe('OpenAI（副本） 2');
+  });
+
+  it('does not clone to the exact source name when a template renders the source name', () => {
+    expect(
+      buildProviderCloneName({
+        provider: source,
+        providers: [source],
+        settings: {
+          provider_clone_name_strategy: 'template',
+          provider_clone_name_template: '{{name}}',
+        },
+        localizedSuffix: '（副本）',
+      }),
+    ).toBe('OpenAI 009 2');
+  });
+
+  it('increments trailing numbers and preserves zero padding', () => {
+    expect(name({ provider_clone_name_strategy: 'increment-number' })).toBe('OpenAI 010');
+  });
+
+  it('increments from the cloned provider name instead of the global max with the same prefix', () => {
+    expect(
+      buildProviderCloneName({
+        provider: { id: 1, name: 'NVIDIA（3）' },
+        providers: [
+          { id: 1, name: 'NVIDIA（3）' },
+          { id: 2, name: 'NVIDIA（100）' },
+        ],
+        settings: { provider_clone_name_strategy: 'increment-number' },
+        localizedSuffix: '（副本）',
+      }),
+    ).toBe('NVIDIA（4）');
+  });
+
+  it('keeps incrementing the numeric token when the first numeric clone conflicts', () => {
+    expect(
+      name({ provider_clone_name_strategy: 'increment-number' }, [
+        source,
+        { id: 2, name: 'OpenAI 010' },
+        { id: 3, name: 'OpenAI 011' },
+      ]),
+    ).toBe('OpenAI 012');
+  });
+
+  it('increments large numeric text without losing precision', () => {
+    expect(
+      buildProviderCloneName({
+        provider: { id: 1, name: 'OpenAI 999999999999999999999999999999' },
+        settings: { provider_clone_name_strategy: 'increment-number' },
+        localizedSuffix: '（副本）',
+      }),
+    ).toBe('OpenAI 1000000000000000000000000000000');
+  });
+
+  it('uses the configured template and counter', () => {
+    expect(
+      name(
+        {
+          provider_clone_name_strategy: 'template',
+          provider_clone_name_template: '{{base}}-clone-{{n}}',
+        },
+        [source, { id: 2, name: 'OpenAI 009-clone-2' }],
+      ),
+    ).toBe('OpenAI 009-clone-3');
+  });
+});

--- a/web/src/pages/providers/utils/provider-clone-name.ts
+++ b/web/src/pages/providers/utils/provider-clone-name.ts
@@ -1,0 +1,149 @@
+import type { Provider } from '@/lib/transport';
+
+export const PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY = 'provider_clone_name_strategy';
+export const PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY = 'provider_clone_name_template';
+
+export type ProviderCloneNameStrategy = 'suffix' | 'increment-number' | 'template';
+
+export interface BuildProviderCloneNameOptions {
+  provider: Pick<Provider, 'id' | 'name'>;
+  formName?: string;
+  providers?: Array<Pick<Provider, 'id' | 'name'>>;
+  settings?: Record<string, string>;
+  localizedSuffix: string;
+}
+
+const DEFAULT_TEMPLATE = '{{name}}{{suffix}}';
+const TRAILING_NUMBER_RE = /^(.*?)(\d+)(\D*)$/u;
+
+function normalizeStrategy(value: string | undefined): ProviderCloneNameStrategy {
+  if (value === 'increment-number' || value === 'template') return value;
+  return 'suffix';
+}
+
+function normalizeBaseName(formName: string | undefined, fallback: string): string {
+  return formName?.trim() || fallback;
+}
+
+function providerNameSet(providers: Array<Pick<Provider, 'id' | 'name'>> | undefined): Set<string> {
+  return new Set((providers || []).map((candidate) => candidate.name.trim()).filter(Boolean));
+}
+
+function nextAvailableName(candidate: string, existingNames: Set<string>): string {
+  const trimmed = candidate.trim();
+  if (!existingNames.has(trimmed)) return trimmed;
+
+  let index = 2;
+  while (existingNames.has(`${trimmed} ${index}`)) {
+    index += 1;
+  }
+  return `${trimmed} ${index}`;
+}
+
+function buildSuffixName(baseName: string, suffix: string): string {
+  return baseName.endsWith(suffix) ? baseName : `${baseName}${suffix}`;
+}
+
+function incrementNumericText(digits: string): string {
+  const chars = digits.split('');
+  let carry = 1;
+
+  for (let index = chars.length - 1; index >= 0; index -= 1) {
+    const next = Number(chars[index]) + carry;
+    if (next < 10) {
+      chars[index] = String(next);
+      carry = 0;
+      break;
+    }
+    chars[index] = '0';
+  }
+
+  if (carry > 0) {
+    chars.unshift('1');
+  }
+
+  return chars.join('');
+}
+
+function incrementTrailingNumber(
+  baseName: string,
+  fallbackSuffix: string,
+  existingNames?: Set<string>,
+): string {
+  const match = baseName.match(TRAILING_NUMBER_RE);
+  if (!match) return buildSuffixName(baseName, fallbackSuffix);
+
+  const [, prefix, digits, suffix] = match;
+  let nextDigits = incrementNumericText(digits);
+  let candidate = `${prefix}${nextDigits}${suffix}`;
+
+  while (existingNames?.has(candidate)) {
+    nextDigits = incrementNumericText(nextDigits);
+    candidate = `${prefix}${nextDigits}${suffix}`;
+  }
+
+  return candidate;
+}
+
+function renderTemplate(template: string, baseName: string, suffix: string, n: number): string {
+  const fallbackBase = buildSuffixName(baseName, suffix);
+  const rendered = template
+    .replaceAll('{{name}}', baseName)
+    .replaceAll('{{base}}', baseName.replace(new RegExp(`${escapeRegExp(suffix)}$`, 'u'), ''))
+    .replaceAll('{{suffix}}', suffix)
+    .replaceAll('{{n}}', String(n))
+    .trim();
+  return rendered || fallbackBase;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildTemplateName(
+  baseName: string,
+  suffix: string,
+  template: string | undefined,
+  existingNames: Set<string>,
+): string {
+  const pattern = template?.trim() || DEFAULT_TEMPLATE;
+  const hasCounter = pattern.includes('{{n}}');
+
+  for (let n = 2; n < 10000; n += 1) {
+    const candidate = renderTemplate(pattern, baseName, suffix, n);
+    if (!existingNames.has(candidate)) return candidate;
+    if (!hasCounter) break;
+  }
+
+  return nextAvailableName(renderTemplate(pattern, baseName, suffix, 2), existingNames);
+}
+
+export function buildProviderCloneName({
+  provider,
+  formName,
+  providers,
+  settings,
+  localizedSuffix,
+}: BuildProviderCloneNameOptions): string {
+  const baseName = normalizeBaseName(formName, provider.name);
+  const existingNames = providerNameSet(providers);
+  const strategy = normalizeStrategy(settings?.[PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY]);
+
+  if (strategy === 'increment-number') {
+    return nextAvailableName(
+      incrementTrailingNumber(baseName, localizedSuffix, existingNames),
+      existingNames,
+    );
+  }
+
+  if (strategy === 'template') {
+    return buildTemplateName(
+      baseName,
+      localizedSuffix,
+      settings?.[PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY],
+      existingNames,
+    );
+  }
+
+  return nextAvailableName(buildSuffixName(baseName, localizedSuffix), existingNames);
+}

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -15,6 +15,7 @@ import {
   Activity,
   Eye,
   EyeOff,
+  Copy,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/components/theme-provider';
@@ -47,6 +48,10 @@ import { useTransport } from '@/lib/transport/context';
 import type { BackupFile, BackupImportResult } from '@/lib/transport/types';
 import { getDefaultThemes, getLuxuryThemes, isLuxuryTheme } from '@/lib/theme';
 import { cn } from '@/lib/utils';
+import {
+  PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY,
+  PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY,
+} from '@/pages/providers/utils/provider-clone-name';
 
 function parseRetentionInteger(value: string): number | null {
   const trimmed = value.trim();
@@ -81,6 +86,7 @@ const MULTITENANT_UI_LAYOUT_SETTING_KEY = 'ui_multitenant_layout';
 const USER_PANEL_DAILY_CHECKIN_SETTING_KEY = 'user_panel_daily_checkin_enabled';
 const USER_PANEL_DAILY_CHECKIN_AMOUNT_SETTING_KEY = 'user_panel_daily_checkin_amount';
 const INVITE_REGISTRATION_AUTO_APPROVE_SETTING_KEY = 'invite_registration_auto_approve_enabled';
+const DEFAULT_PROVIDER_CLONE_NAME_TEMPLATE = '{{name}}{{suffix}}';
 const DEFAULT_USER_PANEL_DAILY_CHECKIN_AMOUNT = '10';
 type MultiTenantUILayout = 'current' | 'user_panel';
 
@@ -148,6 +154,7 @@ export function SettingsPage() {
               <TestFieldTabSection />
               <ModelMappingDebuggerSection />
               <ExternalModelListSection />
+              <ProviderCloneNameSection />
               <MultiTenantUISection />
               <TimezoneSection />
             </>
@@ -1217,6 +1224,115 @@ export function ExternalModelListSection() {
         )}
         <p className="text-xs text-muted-foreground">{t('settings.externalModelListHint')}</p>
         <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ProviderCloneNameSection() {
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const { t } = useTranslation();
+  const strategy = settings?.[PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY] || 'suffix';
+  const template =
+    settings?.[PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY] || DEFAULT_PROVIDER_CLONE_NAME_TEMPLATE;
+  const [localTemplate, setLocalTemplate] = useState(template);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalTemplate(template);
+  }, [template]);
+
+  const handleStrategyChange = async (value: string | null) => {
+    if (!value) return;
+    setError(null);
+    try {
+      await updateSetting.mutateAsync({
+        key: PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY,
+        value,
+      });
+    } catch {
+      setError(t('settings.providerCloneNameSaveError'));
+    }
+  };
+
+  const handleTemplateBlur = async () => {
+    const nextTemplate = localTemplate.trim() || DEFAULT_PROVIDER_CLONE_NAME_TEMPLATE;
+    setLocalTemplate(nextTemplate);
+    if (nextTemplate === template) return;
+    setError(null);
+    try {
+      await updateSetting.mutateAsync({
+        key: PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY,
+        value: nextTemplate,
+      });
+    } catch {
+      setError(t('settings.providerCloneNameSaveError'));
+    }
+  };
+
+  if (isLoading) return null;
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Copy className="h-4 w-4 text-muted-foreground" />
+          {t('settings.providerCloneName')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-foreground">
+            {t('settings.providerCloneNameStrategy')}
+          </Label>
+          <Select
+            value={strategy}
+            onValueChange={handleStrategyChange}
+            disabled={updateSetting.isPending}
+          >
+            <SelectTrigger aria-label={t('settings.providerCloneNameStrategy')}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="suffix">
+                {t('settings.providerCloneNameStrategySuffix')}
+              </SelectItem>
+              <SelectItem value="increment-number">
+                {t('settings.providerCloneNameStrategyIncrementNumber')}
+              </SelectItem>
+              <SelectItem value="template">
+                {t('settings.providerCloneNameStrategyTemplate')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.providerCloneNameStrategyDesc')}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="provider-clone-name-template" className="text-sm font-medium">
+            {t('settings.providerCloneNameTemplate')}
+          </Label>
+          <Input
+            id="provider-clone-name-template"
+            value={localTemplate}
+            onChange={(event) => setLocalTemplate(event.target.value)}
+            onBlur={handleTemplateBlur}
+            disabled={updateSetting.isPending}
+            placeholder={DEFAULT_PROVIDER_CLONE_NAME_TEMPLATE}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t('settings.providerCloneNameTemplateDesc')}
+          </p>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-xs text-destructive">
+            {error}
+          </p>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add configurable provider clone naming strategies: copy suffix (default), trailing-number increment, and custom template
- wire the clone flow to settings and existing provider names so clone names avoid conflicts without changing old default behavior
- add settings UI copy in zh/en plus focused unit and Playwright E2E coverage

## Validation
- `pnpm --dir web test`
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`
- `go test ./internal/handler ./internal/service ./tests/e2e -run 'Test.*Provider|Test.*Settings'`
- `pnpm --dir tests/e2e/playwright exec playwright test -c playwright.config.ts provider-clone-name-policy.spec.ts provider-clone-name-policy-real.spec.ts --project=e2e-chromium`

## E2E evidence
- real settings + provider APIs flow records `video.webm` and screenshots under Playwright test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增提供商克隆命名设置，支持复制后缀、递增尾号和自定义模板三种策略。
  * 递增尾号会自动避开重名，并保留原有数字格式。
  * 自定义模板支持名称、基础名称、后缀和序号占位符。
  * 设置页面新增相关说明及保存失败提示，并支持中英文界面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->