### PR TITLE
fix(routes): keep active provider indicator visible

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -956,6 +956,8 @@
     "strategyWeightedHint": "Order is weighted-random — adjust each route's weight.",
     "weight": "Weight",
     "weightTooltip": "Higher weight = higher chance of being picked (weighted_random strategy).",
+    "providerActive": "Active",
+    "providerActiveRequests": "{{count}} active request(s) are currently using this provider.",
     "affinityOn": "Affinity on",
     "affinityOff": "Affinity off",
     "affinityScopeToken": "by token",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -953,6 +953,8 @@
     "strategyWeightedHint": "按权重随机排序——可调整每条路由的权重。",
     "weight": "权重",
     "weightTooltip": "权重越大被选中的概率越高（加权随机策略）。",
+    "providerActive": "请求中",
+    "providerActiveRequests": "当前有 {{count}} 个活跃请求正在使用此提供商。",
     "affinityOn": "已开启亲和",
     "affinityOff": "亲和关闭",
     "affinityScopeToken": "按 token",

--- a/web/src/pages/client-routes/components/provider-row-active-indicator.test.ts
+++ b/web/src/pages/client-routes/components/provider-row-active-indicator.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  join(process.cwd(), 'src/pages/client-routes/components/provider-row.tsx'),
+  'utf8',
+);
+
+describe('client route provider active indicator', () => {
+  it('keeps active request indicators visible even when cooldown UI is present', () => {
+    expect(source).toContain('const hasActiveStreaming = enabled && streamingCount > 0;');
+    expect(source).toContain('show={hasActiveStreaming}');
+    expect(source).toContain('{hasActiveStreaming && (');
+    expect(source).toContain('<StreamingBadge count={streamingCount} color={color} />');
+    expect(source).not.toContain('enabled && streamingCount > 0 && !effectiveIsInCooldown && (');
+  });
+
+  it('uses active streaming as the row border and glow priority', () => {
+    expect(source).toContain("hasActiveStreaming && 'ring-2 ring-offset-1 ring-offset-background'");
+    expect(source).toContain('hasActiveStreaming\n            ? `${color}80`');
+    expect(source).toContain('boxShadow: hasActiveStreaming ? `0 0 20px ${color}25` : undefined');
+  });
+});

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -372,6 +372,8 @@ function ProviderRowContentBase({
   const antigravityAvailability = isAntigravity
     ? getAntigravityAvailabilityInfo(quota, healthLevel)
     : null;
+  const hasActiveStreaming = enabled && streamingCount > 0;
+  const activeStreamingLabel = t('routes.providerActiveRequests', { count: streamingCount });
 
   const handleContentClick = (e: React.MouseEvent) => {
     // 所有状态都打开详情弹窗
@@ -387,33 +389,32 @@ function ProviderRowContentBase({
         healthLevel === 'frozen' || healthLevel === 'limited'
           ? 'bg-transparent border-slate-400/50 dark:border-slate-500/40 hover:bg-slate-200/50 dark:hover:bg-slate-700/30 hover:border-slate-500 dark:hover:border-slate-400 hover:shadow-md'
           : enabled
-            ? streamingCount > 0
+            ? hasActiveStreaming
               ? 'bg-accent/5 border-transparent ring-1 ring-black/5 dark:ring-white/10'
               : 'bg-card/60 border-border hover:border-emerald-500/30 hover:bg-card shadow-sm'
             : 'bg-muted/40 border-dashed border-border opacity-70 grayscale-[0.5] hover:opacity-100 hover:grayscale-0',
+        hasActiveStreaming && 'ring-2 ring-offset-1 ring-offset-background',
       )}
       style={{
         borderColor:
-          healthLevel === 'frozen'
-            ? 'rgb(6 182 212 / 0.3)'
-            : healthLevel === 'limited'
-              ? 'rgb(234 179 8 / 0.3)'
-              : healthLevel === 'degraded'
-                ? 'rgb(249 115 22 / 0.2)'
-                : !effectiveIsInCooldown && enabled && streamingCount > 0
-                  ? `${color}40`
+          hasActiveStreaming
+            ? `${color}80`
+            : healthLevel === 'frozen'
+              ? 'rgb(6 182 212 / 0.3)'
+              : healthLevel === 'limited'
+                ? 'rgb(234 179 8 / 0.3)'
+                : healthLevel === 'degraded'
+                  ? 'rgb(249 115 22 / 0.2)'
                   : undefined,
-        boxShadow:
-          !effectiveIsInCooldown && enabled && streamingCount > 0
-            ? `0 0 20px ${color}15`
-            : undefined,
+        boxShadow: hasActiveStreaming ? `0 0 20px ${color}25` : undefined,
       }}
+      title={hasActiveStreaming ? activeStreamingLabel : undefined}
       {...dragHandleListeners}
     >
       <MarqueeBackground
-        show={streamingCount > 0 && enabled && !effectiveIsInCooldown}
+        show={hasActiveStreaming}
         color={`${color}15`}
-        opacity={0.4}
+        opacity={effectiveIsInCooldown ? 0.25 : 0.4}
       />
 
       {/* Cooldown 冰冻效果 - 落雪 (only for frozen/limited, NOT degraded) */}
@@ -472,7 +473,7 @@ function ProviderRowContentBase({
               className="absolute text-slate-500/70 dark:text-white/70 animate-pulse drop-shadow-[0_0_8px_rgba(100,116,139,0.4)] dark:drop-shadow-[0_0_8px_rgba(255,255,255,0.4)]"
             />
           )}
-          {enabled && streamingCount > 0 && healthLevel === 'healthy' && (
+          {hasActiveStreaming && (healthLevel === 'healthy' || healthLevel === 'degraded') && (
             <div className="absolute inset-0 bg-black/5 dark:bg-white/5 animate-pulse" />
           )}
         </div>
@@ -512,6 +513,15 @@ function ProviderRowContentBase({
                   title={t(antigravityAvailability.descriptionKey)}
                 >
                   {t(antigravityAvailability.labelKey)}
+                </span>
+              )}
+              {hasActiveStreaming && (
+                <span
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-black bg-emerald-500/15 text-emerald-500 border border-emerald-500/30 animate-pulse-soft"
+                  title={activeStreamingLabel}
+                >
+                  <Activity size={10} />
+                  {t('routes.providerActive')}
                 </span>
               )}
             </div>
@@ -655,8 +665,8 @@ function ProviderRowContentBase({
         )}
       </div>
       {/* Streaming Indicator */}
-      {enabled && streamingCount > 0 && !effectiveIsInCooldown && (
-        <div className="relative z-10 flex items-center shrink-0">
+      {hasActiveStreaming && (
+        <div className="relative z-10 flex items-center shrink-0" title={activeStreamingLabel}>
           <StreamingBadge count={streamingCount} color={color} />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Keep the route provider active/requesting state visible even when cooldown/degraded UI is present.
- Add an explicit active request badge plus tooltip on active route rows.
- Add route-row source regression checks and i18n strings.

## Validation
- `pnpm --dir web test -- src/pages/client-routes/components/provider-row-active-indicator.test.ts` (Vitest ran full suite: 37 files / 168 tests)
- `pnpm --dir web typecheck`
- `pnpm --dir web lint`
- `pnpm --dir web build`
- Local non-destructive stress loop: repeated the active-indicator Vitest command 10/10 successful runs
- Local visual WebM recording generated from a mock route list covering active + cooldown overlap
