### PR TITLE
chore(ui): reduce provider status noise

### DIFF
--- a/tests/e2e/playwright/ui-status-cleanup.spec.ts
+++ b/tests/e2e/playwright/ui-status-cleanup.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test, type Page, type Route } from "playwright/test";
+
+type ProviderPayload = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  type: string;
+  name: string;
+  supportedClientTypes: string[];
+  supportModels?: string[];
+  exposedModelsEnabled?: boolean;
+  config: {
+    quotaEnabled?: boolean;
+    custom: {
+      baseURL: string;
+      apiKey: string;
+    };
+  };
+};
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function provider(id: number, name: string): ProviderPayload {
+  return {
+    id,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+    type: "custom",
+    name,
+    supportedClientTypes: ["openai"],
+    supportModels: ["gpt-ui-cleanup"],
+    exposedModelsEnabled: false,
+    config: {
+      quotaEnabled: false,
+      custom: {
+        baseURL: "https://mock-provider.example.test/v1",
+        apiKey: "mock-key",
+      },
+    },
+  };
+}
+
+async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMocks(page: Page) {
+  const providers = [provider(42, "OpenAI Quiet Row")];
+  const routes = [
+    {
+      id: 7,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      isEnabled: true,
+      isNative: false,
+      projectID: 0,
+      clientType: "openai",
+      providerID: 42,
+      position: 1,
+      weight: 1,
+      retryConfigID: 0,
+      modelMapping: {},
+    },
+  ];
+  const mappings = [
+    {
+      id: 11,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      scope: "global",
+      clientType: "openai",
+      providerType: "custom",
+      providerID: 0,
+      projectID: 0,
+      routeID: 0,
+      apiTokenID: 0,
+      pattern: "gpt-source",
+      target: "gpt-target",
+      priority: 1000,
+      isEnabled: true,
+      isBuiltin: false,
+    },
+  ];
+  const activeRequests = [
+    {
+      id: 100,
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+      instanceID: "mock",
+      requestID: "active-openai-1",
+      sessionID: "session-1",
+      clientType: "openai",
+      requestModel: "gpt-ui-cleanup",
+      mappedModel: "gpt-ui-cleanup",
+      responseModel: "",
+      reasoningEffort: "",
+      startTime: nowIso(),
+      endTime: "",
+      duration: 0,
+      ttft: 0,
+      isStream: true,
+      protocol: "sse",
+      status: "IN_PROGRESS",
+      statusCode: 0,
+      requestInfo: null,
+      responseInfo: null,
+      error: "",
+      proxyUpstreamAttemptCount: 1,
+      finalProxyUpstreamAttemptID: 0,
+      routeID: 7,
+      providerID: 42,
+      projectID: 0,
+      inputTokenCount: 0,
+      outputTokenCount: 0,
+      cacheReadCount: 0,
+      cacheWriteCount: 0,
+      cache5mWriteCount: 0,
+    },
+  ];
+
+  await page.addInitScript(() => {
+    localStorage.setItem("maxx-admin-token", "mock-token");
+    localStorage.setItem("maxx-ui-language", "zh");
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const { pathname } = url;
+    const method = request.method();
+
+    if (pathname === "/api/admin/auth/status") {
+      return json(route, {
+        authEnabled: true,
+        user: { id: 1, username: "admin", tenantID: 1, role: "admin" },
+      });
+    }
+
+    if (pathname === "/api/settings" || pathname === "/api/admin/settings") {
+      return json(route, {
+        api_token_auth_enabled: "true",
+        force_project_binding: "false",
+        ui_multitenant_enabled: "false",
+      });
+    }
+
+    if (
+      pathname === "/api/proxy-status" ||
+      pathname === "/api/admin/proxy-status"
+    ) {
+      return json(route, {
+        running: true,
+        address: "127.0.0.1",
+        port: 9880,
+        version: "e2e",
+      });
+    }
+
+    if (pathname === "/api/providers" || pathname === "/api/admin/providers")
+      return json(route, providers);
+    if (pathname === "/api/routes" || pathname === "/api/admin/routes")
+      return json(route, routes);
+    if (
+      pathname === "/api/admin/model-mappings" ||
+      pathname === "/api/model-mappings"
+    )
+      return json(route, mappings);
+    if (
+      pathname === "/api/admin/requests/active" ||
+      pathname === "/api/requests/active"
+    )
+      return json(route, activeRequests);
+    if (pathname === "/api/admin/provider-stats") return json(route, {});
+    if (pathname === "/api/admin/streaming-requests/counts")
+      return json(route, { "42:openai": 1 });
+    if (pathname === "/api/admin/projects" || pathname === "/api/projects")
+      return json(route, []);
+    if (pathname === "/api/admin/routing-strategies") return json(route, []);
+    if (pathname === "/api/admin/api-tokens" || pathname === "/api/api-tokens")
+      return json(route, []);
+    if (pathname === "/api/admin/response-models") return json(route, []);
+
+    return json(route, { error: "Unmocked endpoint", pathname, method }, 404);
+  });
+}
+
+test.use({
+  viewport: { width: 1440, height: 1100 },
+  locale: "zh-CN",
+  video: "on",
+});
+
+test("provider route and model mapping tabs keep status controls quiet", async ({
+  page,
+}, testInfo) => {
+  await installMocks(page);
+
+  await page.goto("/providers", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("OpenAI Quiet Row")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /复制.*命令|Copy add command/i }),
+  ).toHaveCount(0);
+  await expect(page.getByText(/复制命令|Copy add command/i)).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("01-provider-tab-no-copy-command.png"),
+    fullPage: true,
+  });
+
+  await page.goto("/routes/openai", { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("OpenAI Quiet Row")).toBeVisible();
+  await expect(
+    page.getByLabel(/当前有 1 个活跃请求|1 active request/i),
+  ).toBeVisible();
+  await expect(page.getByText("请求中")).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("02-route-tab-icon-only-active.png"),
+    fullPage: true,
+  });
+
+  await page.goto("/model-mappings", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("button", { name: "gpt-source" })).toBeVisible();
+  await expect(page.getByRole("switch")).toBeVisible();
+  await expect(
+    page.getByText(/^启用$|^禁用$|^Enabled$|^Disabled$/),
+  ).toHaveCount(0);
+  await page.screenshot({
+    path: testInfo.outputPath("03-model-mapping-status-icon-only.png"),
+    fullPage: true,
+  });
+});

--- a/web/src/pages/client-routes/components/provider-row-active-indicator.test.ts
+++ b/web/src/pages/client-routes/components/provider-row-active-indicator.test.ts
@@ -18,7 +18,7 @@ describe('client route provider active indicator', () => {
 
   it('uses active streaming as the row border and glow priority', () => {
     expect(source).toContain("hasActiveStreaming && 'ring-2 ring-offset-1 ring-offset-background'");
-    expect(source).toContain('hasActiveStreaming\n            ? `${color}80`');
+    expect(source).toMatch(/borderColor:\s*hasActiveStreaming\s*\? `\$\{color\}80`/);
     expect(source).toContain('boxShadow: hasActiveStreaming ? `0 0 20px ${color}25` : undefined');
   });
 });

--- a/web/src/pages/client-routes/components/provider-row.tsx
+++ b/web/src/pages/client-routes/components/provider-row.tsx
@@ -396,16 +396,15 @@ function ProviderRowContentBase({
         hasActiveStreaming && 'ring-2 ring-offset-1 ring-offset-background',
       )}
       style={{
-        borderColor:
-          hasActiveStreaming
-            ? `${color}80`
-            : healthLevel === 'frozen'
-              ? 'rgb(6 182 212 / 0.3)'
-              : healthLevel === 'limited'
-                ? 'rgb(234 179 8 / 0.3)'
-                : healthLevel === 'degraded'
-                  ? 'rgb(249 115 22 / 0.2)'
-                  : undefined,
+        borderColor: hasActiveStreaming
+          ? `${color}80`
+          : healthLevel === 'frozen'
+            ? 'rgb(6 182 212 / 0.3)'
+            : healthLevel === 'limited'
+              ? 'rgb(234 179 8 / 0.3)'
+              : healthLevel === 'degraded'
+                ? 'rgb(249 115 22 / 0.2)'
+                : undefined,
         boxShadow: hasActiveStreaming ? `0 0 20px ${color}25` : undefined,
       }}
       title={hasActiveStreaming ? activeStreamingLabel : undefined}
@@ -517,11 +516,11 @@ function ProviderRowContentBase({
               )}
               {hasActiveStreaming && (
                 <span
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-black bg-emerald-500/15 text-emerald-500 border border-emerald-500/30 animate-pulse-soft"
+                  className="flex h-5 w-5 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-500 border border-emerald-500/30 animate-pulse-soft"
                   title={activeStreamingLabel}
+                  aria-label={activeStreamingLabel}
                 >
                   <Activity size={10} />
-                  {t('routes.providerActive')}
                 </span>
               )}
             </div>

--- a/web/src/pages/model-mappings/index.tsx
+++ b/web/src/pages/model-mappings/index.tsx
@@ -194,7 +194,7 @@ function SortableRuleItem({
         {rule.projectID || '-'}
       </span>
 
-      <div className="w-[72px] h-7 shrink-0 flex items-center gap-2">
+      <div className="w-[72px] h-7 shrink-0 flex items-center">
         <Switch
           checked={isMappingEnabled(rule)}
           onCheckedChange={(checked) => onUpdate({ isEnabled: checked })}
@@ -203,12 +203,8 @@ function SortableRuleItem({
             pattern: rule.pattern || '*',
             target: rule.target || '-',
           })}
+          title={isMappingEnabled(rule) ? t('common.enabled') : t('common.disabled')}
         />
-        <span
-          className={`text-[11px] ${isMappingEnabled(rule) ? 'text-emerald-600 dark:text-emerald-400' : 'text-muted-foreground'}`}
-        >
-          {isMappingEnabled(rule) ? t('common.enabled') : t('common.disabled')}
-        </span>
       </div>
 
       <Button variant="ghost" size="sm" onClick={onRemove} disabled={disabled} className="shrink-0">

--- a/web/src/pages/providers/components/provider-row-ui-cleanup.test.ts
+++ b/web/src/pages/providers/components/provider-row-ui-cleanup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), 'utf8');
+}
+
+describe('provider and route row UI cleanup', () => {
+  it('does not render the provider add-command copy affordance in provider rows', () => {
+    const source = readSource('src/pages/providers/components/provider-row.tsx');
+
+    expect(source).not.toContain('shareProviderAddCommand');
+    expect(source).not.toContain('handleCopyProviderAddCommand');
+    expect(source).not.toContain('buildProviderAddCommand');
+    expect(source).not.toContain('navigator.clipboard');
+  });
+
+  it('keeps active route rows icon-only while preserving accessible labeling', () => {
+    const source = readSource('src/pages/client-routes/components/provider-row.tsx');
+
+    expect(source).toContain('aria-label={activeStreamingLabel}');
+    expect(source).toContain('<Activity size={10} />');
+    expect(source).not.toContain("{t('routes.providerActive')}");
+  });
+
+  it('keeps model mapping status switches icon-only without inline status text', () => {
+    const source = readSource('src/pages/model-mappings/index.tsx');
+
+    expect(source).toContain(
+      "title={isMappingEnabled(rule) ? t('common.enabled') : t('common.disabled')}",
+    );
+    expect(source).not.toMatch(
+      /<span[^>]*>\s*\{isMappingEnabled\(rule\) \? t\('common\.enabled'\) : t\('common\.disabled'\)\}\s*<\/span>/s,
+    );
+  });
+});

--- a/web/src/pages/providers/components/provider-row.tsx
+++ b/web/src/pages/providers/components/provider-row.tsx
@@ -1,5 +1,5 @@
-import { useState, type KeyboardEvent, type MouseEvent } from 'react';
-import { Activity, Ban, Check, Copy, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
+import { type KeyboardEvent } from 'react';
+import { Activity, Ban, Globe, Mail, Repeat2, Snowflake } from 'lucide-react';
 import { CooldownTimer } from '@/components/cooldown-timer';
 import { useCooldowns } from '@/hooks/use-cooldowns';
 import { ClientIcon } from '@/components/icons/client-icons';
@@ -23,7 +23,6 @@ import {
   getAntigravityAvailabilityBadgeClass,
   getAntigravityAvailabilityInfo,
 } from '@/lib/antigravity-availability';
-import { buildProviderAddCommand, canBuildProviderAddCommand } from '../utils/provider-add-command';
 
 // 格式化 Token 数量
 function formatTokens(count: number): string {
@@ -254,31 +253,7 @@ export function ProviderRow({
   const worstCooldown = providerCooldowns[0];
   const modelCooldowns = providerCooldowns.filter((cd) => cd.model);
 
-  const [shareCopied, setShareCopied] = useState(false);
-  const shareCommand = canBuildProviderAddCommand(provider)
-    ? buildProviderAddCommand(provider)
-    : null;
   const isInteractive = !!onClick;
-  const handleCopyProviderAddCommand = async (event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    if (!shareCommand || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(shareCommand);
-      setShareCopied(true);
-      window.setTimeout(() => setShareCopied(false), 2000);
-    } catch (error) {
-      console.error('Failed to copy provider add command:', error);
-      setShareCopied(false);
-    }
-  };
-
-  const handleShareCommandKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-  };
-
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (!onClick) return;
     if ((event.target as HTMLElement | null)?.closest('button, input, textarea, select, a')) return;
@@ -535,32 +510,6 @@ export function ProviderRow({
           )}
         </div>
       </div>
-      {shareCommand && (
-        <button
-          type="button"
-          onClick={handleCopyProviderAddCommand}
-          onKeyDown={handleShareCommandKeyDown}
-          className={cn(
-            'relative z-10 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-background/70 text-muted-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-            shareCopied
-              ? 'border-emerald-500/40 text-emerald-500'
-              : 'border-border hover:border-primary/40 hover:text-foreground',
-          )}
-          title={
-            shareCopied
-              ? t('providers.shareProviderAddCommand.copied')
-              : t('providers.shareProviderAddCommand.copy')
-          }
-          aria-label={
-            shareCopied
-              ? t('providers.shareProviderAddCommand.copied')
-              : t('providers.shareProviderAddCommand.copy')
-          }
-        >
-          {shareCopied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-        </button>
-      )}
-
       {(provider.config?.disableErrorCooldown || provider.config?.smartMappingRetryEnabled) && (
         <div className="relative z-10 flex shrink-0 items-center self-stretch gap-1">
           {provider.config?.disableErrorCooldown && (


### PR DESCRIPTION
## Summary
- remove provider-tab add-command copy icon and clipboard interaction
- make active route status icon-only while keeping tooltip/aria context
- remove inline enabled/disabled text from model mapping status rows

## Validation
- pnpm --dir web test -- src/pages/providers/components/provider-row-ui-cleanup.test.ts src/pages/client-routes/components/provider-row-active-indicator.test.ts
- pnpm --dir web typecheck
- pnpm --dir web lint
- pnpm --dir web build
- pnpm --dir tests/e2e/playwright exec playwright test -c playwright.config.ts ui-status-cleanup.spec.ts --project=e2e-chromium
- pnpm --dir tests/e2e/playwright exec playwright test -c playwright.config.ts ui-status-cleanup.spec.ts --project=e2e-chromium --repeat-each=5