### PR TITLE
fix(executor): preserve failover attempts under retry ceiling

### DIFF
--- a/internal/executor/middleware_dispatch.go
+++ b/internal/executor/middleware_dispatch.go
@@ -89,7 +89,7 @@ func (e *Executor) dispatch(c *flow.Ctx) {
 	totalUpstreamAttempts := 0
 
 routeLoop:
-	for _, matchedRoute := range state.routes {
+	for routeIndex, matchedRoute := range state.routes {
 		if ctx.Err() != nil {
 			state.lastErr = ctx.Err()
 			c.Err = state.lastErr
@@ -116,6 +116,14 @@ routeLoop:
 		for attempt := 0; ; {
 			if attempt > retryConfig.MaxRetries && !shouldSkipErrorCooldown(matchedRoute.Provider) {
 				break
+			}
+			if !shouldSkipErrorCooldown(matchedRoute.Provider) {
+				remainingRoutes := len(state.routes) - routeIndex - 1
+				if totalUpstreamAttempts >= maxUpstreamAttemptsPerRequest-remainingRoutes {
+					log.Printf("[Executor] Upstream attempt ceiling budget reached after %d attempts; reserving first attempts for %d remaining route(s) after provider %d",
+						totalUpstreamAttempts, remainingRoutes, matchedRoute.Provider.ID)
+					break
+				}
 			}
 			if shouldSkipErrorCooldown(matchedRoute.Provider) && providerAttempts >= maxAttemptsPerProviderWithoutErrorCooldown {
 				log.Printf("[Executor] Provider %d reached the disableErrorCooldown attempt cap (%d) for this request; stopping without switching providers. lastErr=%v",

--- a/internal/executor/retry_amplification_test.go
+++ b/internal/executor/retry_amplification_test.go
@@ -121,6 +121,49 @@ func TestDispatchDoesNotAmplify404ToolUseError(t *testing.T) {
 	}
 }
 
+func TestDispatchHardCeilingPreservesOneAttemptForLaterRoutes(t *testing.T) {
+	adapter := newAlways500Adapter()
+	// 25 routes with MaxRetries=39 would allow 1,000 upstream attempts without the
+	// global hard ceiling. The ceiling must cap amplification, but it must not let
+	// the early routes spend the entire budget before later healthy routes get even
+	// one chance.
+	c, proxyRepo := newMultiRouteAmplificationDispatchCtx(25, false, adapter)
+	storedState, ok := c.Get(flow.KeyExecutorState)
+	if !ok {
+		t.Fatal("executor state missing")
+	}
+	state := storedState.(*execState)
+	for _, matched := range state.routes {
+		matched.RetryConfig = &domain.RetryConfig{MaxRetries: 39, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0}
+	}
+	// If dispatch reaches the 25th route, it succeeds. Before the fix, the first
+	// five routes consumed all 200 attempts and the 25th route was never called.
+	adapter.build = func() *domain.ProxyError {
+		if adapter.calls >= maxUpstreamAttemptsPerRequest {
+			return nil
+		}
+		pe := domain.NewUpstreamConnectionError("failed to connect to upstream")
+		pe.HTTPStatusCode = http.StatusServiceUnavailable
+		return pe
+	}
+	e := newDisabledCooldownStreamTestExecutor(proxyRepo, &recordingAttemptRepo{})
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch error = %v", c.Err)
+	}
+	if adapter.calls != maxUpstreamAttemptsPerRequest {
+		t.Fatalf("adapter calls = %d, want %d", adapter.calls, maxUpstreamAttemptsPerRequest)
+	}
+	if got := state.proxyReq.ProviderID; got != 44 {
+		t.Fatalf("final provider ID = %d, want 44 (last route got a chance)", got)
+	}
+	if last := lastProxyStatus(proxyRepo); last != "COMPLETED" {
+		t.Fatalf("final proxy status = %q, want COMPLETED", last)
+	}
+}
+
 // TestDispatchDoesNotAmplifyInvalidImageError reproduces the 400 "invalid
 // image" case (11 requests → 4,321 calls before the fix).
 func TestDispatchDoesNotAmplifyInvalidImageError(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve one upstream attempt for each remaining route before the global retry ceiling is exhausted
- keep the 200-attempt hard ceiling for retry amplification protection
- add a regression test for high route × retry fan-out where later routes must still get a chance

## Validation
- `go test ./internal/executor -run 'TestDispatchHardCeilingPreservesOneAttemptForLaterRoutes|TestDispatchCapsRetriesWhenErrorCooldownDisabled|TestDispatchRetryableUpstreamConnectionErrorFallsThroughToNextRouteAfterBudget' -count=100`
- `go test ./internal/... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化多路由请求的重试调度：达到全局上游调用上限时，将停止当前路由继续重试，并为后续匹配路由保留至少一次调用机会。
  - 保留既有的单路由重试限制及特殊冷却配置，避免重试放大耗尽后续路由的可用机会。
  - 在调用预算耗尽后，后续仍可用的路由能够正常完成请求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->