### PR TITLE
fix(proxy): stop counting restart orphans as failures

### DIFF
--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -214,13 +214,16 @@ type ProxyRequestRepository interface {
 	DeleteFailedWithFilter(tenantID uint64, filter *ProxyRequestFilter) (deletedRequests int64, deletedAttempts int64, err error)
 	// UpdateProjectIDBySessionID 批量更新指定 sessionID 的所有请求的 projectID
 	UpdateProjectIDBySessionID(tenantID uint64, sessionID string, projectID uint64) (int64, error)
-	// MarkStaleAsFailed marks IN_PROGRESS/PENDING requests as FAILED when their
-	// owning instance is no longer alive, or when start_time is older than 30 minutes.
+	// MarkStaleAsFailed finalizes stale IN_PROGRESS/PENDING requests. Requests
+	// owned by a dead instance are marked CANCELLED because the client connection
+	// and original executor stack are gone; they must not be counted as upstream
+	// route/provider failures. Requests older than the hard timeout are still
+	// marked FAILED because the owning instance is alive but wedged.
 	//
 	// aliveInstanceIDs 必须由 coordinator.ListAliveInstances 提供。一个安全门:
-	// 当 aliveInstanceIDs 为空(说明 coordinator 异常或刚启动)时,实现应跳过
-	// 清理,绝不基于"没有活实例"的假设把所有 in-progress 请求都标记 FAILED。
-	// 这样多实例环境下后启动的实例不会误杀先启动实例的在飞请求。
+	// 当 aliveInstanceIDs 为 nil(说明 coordinator 异常或调用方未拿到权威列表)
+	// 时,实现应跳过清理。空但非 nil 的列表表示当前没有存活实例,允许
+	// 把超过 dead-instance grace 的 orphan 请求终结为 CANCELLED。
 	MarkStaleAsFailed(aliveInstanceIDs []string) (int64, error)
 	// FixFailedRequestsWithoutEndTime fixes FAILED requests that have no end_time set
 	FixFailedRequestsWithoutEndTime() (int64, error)
@@ -259,7 +262,7 @@ type ProxyUpstreamAttemptRepository interface {
 	// BatchUpdateCosts 批量更新 attempt 的 cost 和 model_price_id。
 	// model_price_id 跟随 cost 一起更新到当前匹配的价格记录,保证审计字段与金额一致。
 	BatchUpdateCosts(updates map[uint64]domain.AttemptCostUpdate) error
-	// MarkStaleAttemptsFailed marks stale attempts as failed with proper end_time and duration
+	// MarkStaleAttemptsFailed finalizes stale attempts with the parent request terminal status and proper end_time/duration.
 	MarkStaleAttemptsFailed() (int64, error)
 	// FixFailedAttemptsWithoutEndTime fixes FAILED attempts that have no end_time set
 	FixFailedAttemptsWithoutEndTime() (int64, error)

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -454,7 +454,7 @@ func (r *ProxyRequestRepository) GetErrorStats(tenantID uint64, filter *reposito
 }
 
 // 死实例孤儿请求的回收宽限期。当一个请求的 instance_id 不在活实例列表里时,
-// 等它的 start_time 早于 (now - DeadInstanceGracePeriod) 才标记为 FAILED。
+// 等它的 start_time 早于 (now - DeadInstanceGracePeriod) 才标记为 CANCELLED。
 // 这个宽限期覆盖以下场景:
 //   - 新启动的实例完成 RegisterInstance 之前可能已经下发了少量请求
 //   - 实例 ID 一时未来得及同步到 coordinator(网络抖动)
@@ -463,23 +463,32 @@ func (r *ProxyRequestRepository) GetErrorStats(tenantID uint64, filter *reposito
 // 远好于原行为(立刻杀)和过保守行为(等 30min)之间。
 const deadInstanceGraceMillis = int64(60 * 1000)
 
-// MarkStaleAsFailed marks IN_PROGRESS/PENDING requests as FAILED when their
-// owning instance is no longer alive, or when the request has been in flight
-// for more than 30 minutes (timeout).
+// MarkStaleAsFailed finalizes stale IN_PROGRESS/PENDING requests. Dead-instance
+// orphans become CANCELLED: the original client connection and executor stack
+// are gone, so treating them as provider/route failures is misleading and keeps
+// poisoning error-mode filtering/retry diagnosis. Hard-stuck requests on an
+// alive instance still become FAILED because that instance is wedged.
 //
 // 关键安全语义:
-//   - aliveInstanceIDs 为空 → 直接返回 0,不做任何回收。防止 coordinator
-//     异常导致全表误杀。调用方在 coordinator 健康时才该调用。
+//   - aliveInstanceIDs 为 nil → 直接返回 0,不做任何回收。防止 coordinator
+//     异常导致全表误杀。空但非 nil 的列表表示当前没有存活实例,允许
+//     终结超过 grace 的 dead-instance orphans。调用方在 coordinator 健康时才该调用。
 //   - 多实例环境下,只清理 (a) instance_id 不在活实例集合且过了 60s 宽限期,
 //     或 (b) 任意实例上 start_time 超过 30min 的卡死请求。
 func (r *ProxyRequestRepository) MarkStaleAsFailed(aliveInstanceIDs []string) (int64, error) {
-	if len(aliveInstanceIDs) == 0 {
+	if aliveInstanceIDs == nil {
 		return 0, nil
 	}
 
 	nowMs := time.Now().UnixMilli()
 	timeoutThreshold := nowMs - int64(30*time.Minute/time.Millisecond)
 	deadGraceThreshold := nowMs - deadInstanceGraceMillis
+	deadInstanceCondition := "1 = 1"
+	deadInstanceArgs := []interface{}{deadGraceThreshold}
+	if len(aliveInstanceIDs) > 0 {
+		deadInstanceCondition = "(instance_id IS NULL OR instance_id NOT IN (?))"
+		deadInstanceArgs = []interface{}{aliveInstanceIDs, deadGraceThreshold}
+	}
 
 	// 死实例分支用 COALESCE(NULLIF(start_time, 0), created_at):PENDING 状态
 	// 请求可能 start_time = 0(还没真正开始处理就被卡在队列),如果只看
@@ -488,12 +497,15 @@ func (r *ProxyRequestRepository) MarkStaleAsFailed(aliveInstanceIDs []string) (i
 	//
 	// 30min 硬超时分支仍只看 start_time > 0:超时本质上是"已开始但卡死太久",
 	// 还没开始的 PENDING 不算超时(它由死实例分支或 hourly cleanup 处理)。
-	result := r.db.gorm.Exec(`
+	query := fmt.Sprintf(`
 		UPDATE proxy_requests
-		SET status = 'FAILED',
+		SET status = CASE
+		        WHEN (%s AND COALESCE(NULLIF(start_time, 0), created_at) < ?) THEN 'CANCELLED'
+		        ELSE 'FAILED'
+		    END,
 		    error = CASE
-		        WHEN start_time > 0 AND start_time < ? THEN 'Request timed out (stuck in progress)'
-		        ELSE 'Instance no longer alive'
+		        WHEN (%s AND COALESCE(NULLIF(start_time, 0), created_at) < ?) THEN 'Server restarted'
+		        ELSE 'Request timed out (stuck in progress)'
 		    END,
 		    end_time = ?,
 		    duration_ms = CASE
@@ -503,15 +515,18 @@ func (r *ProxyRequestRepository) MarkStaleAsFailed(aliveInstanceIDs []string) (i
 		    updated_at = ?
 		WHERE status IN ('PENDING', 'IN_PROGRESS')
 		  AND (
-		      ((instance_id IS NULL OR instance_id NOT IN (?))
-		         AND COALESCE(NULLIF(start_time, 0), created_at) < ?)
+		      (%s AND COALESCE(NULLIF(start_time, 0), created_at) < ?)
 		      OR
 		      (start_time > 0 AND start_time < ?)
-		  )`,
-		timeoutThreshold, nowMs, nowMs, nowMs,
-		aliveInstanceIDs, deadGraceThreshold,
-		timeoutThreshold,
-	)
+		  )`, deadInstanceCondition, deadInstanceCondition, deadInstanceCondition)
+	args := make([]interface{}, 0, len(deadInstanceArgs)*3+4)
+	args = append(args, deadInstanceArgs...)
+	args = append(args, deadInstanceArgs...)
+	args = append(args, nowMs, nowMs, nowMs)
+	args = append(args, deadInstanceArgs...)
+	args = append(args, timeoutThreshold)
+
+	result := r.db.gorm.Exec(query, args...)
 	if result.Error != nil {
 		return 0, result.Error
 	}

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -1123,6 +1123,171 @@ func TestProxyRequestErrorModeFiltersStatusAndHTTPFailures(t *testing.T) {
 	}
 }
 
+func TestMarkStaleAsFailedCancelsDeadInstanceOrphansAndFailsHardStuckRequests(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	attemptRepo := NewProxyUpstreamAttemptRepository(db)
+	now := time.Now()
+
+	dead := buildTestProxyRequest("IN_PROGRESS", 201)
+	dead.InstanceID = "dead-instance"
+	dead.StartTime = now.Add(-90 * time.Second)
+	deadVeryOld := buildTestProxyRequest("IN_PROGRESS", 204)
+	deadVeryOld.InstanceID = "dead-instance"
+	deadVeryOld.StartTime = now.Add(-45 * time.Minute)
+	alive := buildTestProxyRequest("IN_PROGRESS", 202)
+	alive.InstanceID = "alive-instance"
+	alive.StartTime = now.Add(-90 * time.Second)
+	stuck := buildTestProxyRequest("IN_PROGRESS", 203)
+	stuck.InstanceID = "alive-instance"
+	stuck.StartTime = now.Add(-45 * time.Minute)
+
+	for _, req := range []*domain.ProxyRequest{dead, deadVeryOld, alive, stuck} {
+		if err := repo.Create(req); err != nil {
+			t.Fatalf("create request %s: %v", req.RequestID, err)
+		}
+		attempt := seedAttemptForRequest(t, attemptRepo, db, req.ID, req.StartTime)
+		if err := db.gorm.Model(&ProxyUpstreamAttempt{}).Where("id = ?", attempt.ID).Update("status", "IN_PROGRESS").Error; err != nil {
+			t.Fatalf("mark attempt in progress: %v", err)
+		}
+	}
+
+	changed, err := repo.MarkStaleAsFailed([]string{"alive-instance"})
+	if err != nil {
+		t.Fatalf("MarkStaleAsFailed: %v", err)
+	}
+	if changed != 3 {
+		t.Fatalf("changed requests = %d, want 3", changed)
+	}
+
+	attemptsChanged, err := attemptRepo.MarkStaleAttemptsFailed()
+	if err != nil {
+		t.Fatalf("MarkStaleAttemptsFailed: %v", err)
+	}
+	if attemptsChanged != 3 {
+		t.Fatalf("changed attempts = %d, want 3", attemptsChanged)
+	}
+
+	gotDead, err := repo.GetByID(1, dead.ID)
+	if err != nil {
+		t.Fatalf("read dead request: %v", err)
+	}
+	if gotDead.Status != "CANCELLED" || gotDead.Error != "Server restarted" {
+		t.Fatalf("dead request = status %s error %q, want CANCELLED Server restarted", gotDead.Status, gotDead.Error)
+	}
+
+	gotDeadVeryOld, err := repo.GetByID(1, deadVeryOld.ID)
+	if err != nil {
+		t.Fatalf("read very old dead request: %v", err)
+	}
+	if gotDeadVeryOld.Status != "CANCELLED" || gotDeadVeryOld.Error != "Server restarted" {
+		t.Fatalf("very old dead request = status %s error %q, want CANCELLED Server restarted", gotDeadVeryOld.Status, gotDeadVeryOld.Error)
+	}
+
+	gotAlive, err := repo.GetByID(1, alive.ID)
+	if err != nil {
+		t.Fatalf("read alive request: %v", err)
+	}
+	if gotAlive.Status != "IN_PROGRESS" {
+		t.Fatalf("alive request status = %s, want IN_PROGRESS", gotAlive.Status)
+	}
+
+	gotStuck, err := repo.GetByID(1, stuck.ID)
+	if err != nil {
+		t.Fatalf("read stuck request: %v", err)
+	}
+	if gotStuck.Status != "FAILED" || gotStuck.Error != "Request timed out (stuck in progress)" {
+		t.Fatalf("stuck request = status %s error %q, want FAILED timeout", gotStuck.Status, gotStuck.Error)
+	}
+
+	deadAttempts, err := attemptRepo.ListByProxyRequestID(dead.ID)
+	if err != nil {
+		t.Fatalf("list dead attempts: %v", err)
+	}
+	if len(deadAttempts) != 1 || deadAttempts[0].Status != "CANCELLED" {
+		t.Fatalf("dead attempt status = %+v, want CANCELLED", deadAttempts)
+	}
+
+	stuckAttempts, err := attemptRepo.ListByProxyRequestID(stuck.ID)
+	if err != nil {
+		t.Fatalf("list stuck attempts: %v", err)
+	}
+	if len(stuckAttempts) != 1 || stuckAttempts[0].Status != "FAILED" {
+		t.Fatalf("stuck attempt status = %+v, want FAILED", stuckAttempts)
+	}
+}
+
+func TestMarkStaleAsFailedCancelsDeadInstanceOrphansWhenNoInstancesAlive(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	attemptRepo := NewProxyUpstreamAttemptRepository(db)
+	now := time.Now()
+
+	fresh := buildTestProxyRequest("IN_PROGRESS", 301)
+	fresh.InstanceID = "dead-instance"
+	fresh.StartTime = now.Add(-30 * time.Second)
+	stale := buildTestProxyRequest("IN_PROGRESS", 302)
+	stale.InstanceID = "dead-instance"
+	stale.StartTime = now.Add(-90 * time.Second)
+
+	for _, req := range []*domain.ProxyRequest{fresh, stale} {
+		if err := repo.Create(req); err != nil {
+			t.Fatalf("create request %s: %v", req.RequestID, err)
+		}
+		attempt := seedAttemptForRequest(t, attemptRepo, db, req.ID, req.StartTime)
+		if err := db.gorm.Model(&ProxyUpstreamAttempt{}).Where("id = ?", attempt.ID).Update("status", "IN_PROGRESS").Error; err != nil {
+			t.Fatalf("mark attempt in progress: %v", err)
+		}
+	}
+
+	changed, err := repo.MarkStaleAsFailed([]string{})
+	if err != nil {
+		t.Fatalf("MarkStaleAsFailed: %v", err)
+	}
+	if changed != 1 {
+		t.Fatalf("changed requests = %d, want 1", changed)
+	}
+	attemptsChanged, err := attemptRepo.MarkStaleAttemptsFailed()
+	if err != nil {
+		t.Fatalf("MarkStaleAttemptsFailed: %v", err)
+	}
+	if attemptsChanged != 1 {
+		t.Fatalf("changed attempts = %d, want 1", attemptsChanged)
+	}
+
+	gotFresh, err := repo.GetByID(1, fresh.ID)
+	if err != nil {
+		t.Fatalf("read fresh request: %v", err)
+	}
+	if gotFresh.Status != "IN_PROGRESS" {
+		t.Fatalf("fresh request status = %s, want IN_PROGRESS", gotFresh.Status)
+	}
+	gotStale, err := repo.GetByID(1, stale.ID)
+	if err != nil {
+		t.Fatalf("read stale request: %v", err)
+	}
+	if gotStale.Status != "CANCELLED" || gotStale.Error != "Server restarted" {
+		t.Fatalf("stale request = status %s error %q, want CANCELLED Server restarted", gotStale.Status, gotStale.Error)
+	}
+	staleAttempts, err := attemptRepo.ListByProxyRequestID(stale.ID)
+	if err != nil {
+		t.Fatalf("list stale attempts: %v", err)
+	}
+	if len(staleAttempts) != 1 || staleAttempts[0].Status != "CANCELLED" {
+		t.Fatalf("stale attempt status = %+v, want CANCELLED", staleAttempts)
+	}
+}
+
 func TestProxyRequestErrorStatsAggregatesCurrentFilter(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/internal/repository/sqlite/proxy_upstream_attempt.go
+++ b/internal/repository/sqlite/proxy_upstream_attempt.go
@@ -149,16 +149,21 @@ func (r *ProxyUpstreamAttemptRepository) StreamForCostCalc(batchSize int, callba
 	return nil
 }
 
-// MarkStaleAttemptsFailed marks all IN_PROGRESS/PENDING attempts belonging to stale requests as FAILED
-// This should be called after MarkStaleAsFailed on proxy_requests to clean up orphaned attempts
-// Sets proper end_time and duration_ms for complete failure handling
+// MarkStaleAttemptsFailed finalizes IN_PROGRESS/PENDING attempts belonging to
+// stale requests after MarkStaleAsFailed. Attempts inherit the parent terminal
+// status so dead-instance orphans are CANCELLED while hard-stuck live-instance
+// attempts remain FAILED.
 func (r *ProxyUpstreamAttemptRepository) MarkStaleAttemptsFailed() (int64, error) {
 	now := time.Now().UnixMilli()
 
-	// Update attempts that belong to FAILED requests but are still in progress
+	// Update attempts that belong to terminal stale requests but are still in progress.
 	result := r.db.gorm.Exec(`
 		UPDATE proxy_upstream_attempts
-		SET status = 'FAILED',
+		SET status = (
+		        SELECT proxy_requests.status
+		        FROM proxy_requests
+		        WHERE proxy_requests.id = proxy_upstream_attempts.proxy_request_id
+		    ),
 		    end_time = ?,
 		    duration_ms = CASE
 		        WHEN start_time > 0 THEN ? - start_time
@@ -167,7 +172,7 @@ func (r *ProxyUpstreamAttemptRepository) MarkStaleAttemptsFailed() (int64, error
 		    updated_at = ?
 		WHERE status IN ('PENDING', 'IN_PROGRESS')
 		  AND proxy_request_id IN (
-		      SELECT id FROM proxy_requests WHERE status = 'FAILED'
+		      SELECT id FROM proxy_requests WHERE status IN ('FAILED', 'CANCELLED')
 		  )`,
 		now, now, now,
 	)

--- a/tests/multiinstance/rolling_update_test.go
+++ b/tests/multiinstance/rolling_update_test.go
@@ -116,7 +116,7 @@ func TestSeamlessRollingUpdate(t *testing.T) {
 		t.Fatal("A still showing as alive after shutdown")
 	}
 
-	// ─── t3: B 周期 sweep,回收 A 留下的卡死请求 ──────────────────
+	// ─── t3: B 周期 sweep,终结 A 留下的死实例孤儿请求 ───────────────
 	alive, _ = b.Coord.ListAliveInstances(context.Background())
 	if _, err := b.Comp.ProxyRequest.MarkStaleAsFailed(alive); err != nil {
 		t.Fatalf("post-shutdown sweep: %v", err)
@@ -127,8 +127,8 @@ func TestSeamlessRollingUpdate(t *testing.T) {
 		t.Fatalf("completed request was tampered with; status=%s", status)
 	}
 
-	// 卡死的请求被回收成 FAILED
-	if status := b.requestStatus(t, wedged.ID); status != "FAILED" {
-		t.Fatalf("wedged orphan should be reaped after A shutdown; status=%s", status)
+	// 死实例孤儿请求被取消,不再作为 provider/route 失败污染重试诊断
+	if status := b.requestStatus(t, wedged.ID); status != "CANCELLED" {
+		t.Fatalf("wedged orphan should be cancelled after A shutdown; status=%s", status)
 	}
 }

--- a/tests/multiinstance/sweep_test.go
+++ b/tests/multiinstance/sweep_test.go
@@ -72,10 +72,10 @@ func TestRollingUpdateDoesNotKillRunningInstanceRequests(t *testing.T) {
 	}
 }
 
-// A 优雅退出后,A 留下的 in-progress 请求超过 60s grace 才会被 B 的 sweep 清掉。
+// A 优雅退出后,A 留下的 in-progress 请求超过 60s grace 才会被 B 的 sweep 终结。
 // 测试两个时间点:
 //   - A unregister 时立即 sweep:start_time = 30s ago → 仍然 IN_PROGRESS(grace 未过)
-//   - 同样的请求 start_time = 90s ago → 被标记 FAILED(grace 已过)
+//   - 同样的请求 start_time = 90s ago → 被标记 CANCELLED(grace 已过,但不算 provider/route 失败)
 func TestDeadInstanceOrphansClearedOnlyAfterGrace(t *testing.T) {
 	c := newCluster(t)
 	a := c.newInstance(t, "inst-A")
@@ -99,26 +99,33 @@ func TestDeadInstanceOrphansClearedOnlyAfterGrace(t *testing.T) {
 	if s := b.requestStatus(t, freshReq.ID); s != "IN_PROGRESS" {
 		t.Fatalf("fresh request within grace should not be reaped, status=%s", s)
 	}
-	if s := b.requestStatus(t, staleReq.ID); s != "FAILED" {
-		t.Fatalf("stale request past grace should be reaped, status=%s", s)
+	if s := b.requestStatus(t, staleReq.ID); s != "CANCELLED" {
+		t.Fatalf("stale dead-instance request should be cancelled, status=%s", s)
+	}
+	got, err := b.Comp.ProxyRequest.GetByID(domain.DefaultTenantID, staleReq.ID)
+	if err != nil {
+		t.Fatalf("read stale request: %v", err)
+	}
+	if got.Error != "Server restarted" {
+		t.Fatalf("dead-instance error = %q, want Server restarted", got.Error)
 	}
 }
 
-// MarkStaleAsFailed 的安全门:当 coordinator 异常导致 alive list 为空时,
+// MarkStaleAsFailed 的安全门:当 coordinator 异常导致 alive list 为 nil 时,
 // 不应该把 in-progress 都误杀。
-func TestEmptyAliveListSkipsSweep(t *testing.T) {
+func TestNilAliveListSkipsSweep(t *testing.T) {
 	c := newCluster(t)
 	a := c.newInstance(t, "inst-A")
 
 	req := a.seedInProgressRequest(t, "fragile", time.Now().Add(-2*time.Hour))
 
-	// 空 alive list 模拟"coord 异常"
+	// nil alive list 模拟"coord 异常"
 	count, err := a.Comp.ProxyRequest.MarkStaleAsFailed(nil)
 	if err != nil {
 		t.Fatalf("MarkStaleAsFailed: %v", err)
 	}
 	if count != 0 {
-		t.Fatalf("empty alive list should sweep 0 rows, got %d", count)
+		t.Fatalf("nil alive list should sweep 0 rows, got %d", count)
 	}
 
 	if s := a.requestStatus(t, req.ID); s != "IN_PROGRESS" {

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -164,7 +164,7 @@ function dateToISOString(value: Date | undefined): string | undefined {
 }
 
 function isServerRestartedFailure(request: Pick<ProxyRequest, 'status' | 'error'>): boolean {
-  return request.status === 'FAILED' && request.error.trim() === 'Server restarted';
+  return (request.status === 'FAILED' || request.status === 'CANCELLED') && request.error.trim() === 'Server restarted';
 }
 
 /** Reads a positive numeric value from localStorage, returning undefined if absent or invalid. */


### PR DESCRIPTION
## Summary
- Mark dead-instance orphan requests as `CANCELLED / Server restarted` instead of `FAILED / Instance no longer alive`.
- Keep alive-instance hard timeouts as `FAILED / Request timed out (stuck in progress)`.
- Finalize stale upstream attempts with the parent request terminal status and keep request UI restart filtering compatible with cancelled restart records.

## Validation
- `go test ./internal/repository/sqlite ./tests/multiinstance`
- `go test ./internal/core ./internal/coordinator ./internal/cooldown`
- `pnpm -C web typecheck`

## Worked on by
- awsldev <awsl233777@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误处理**
  * 服务器重启后遗留的请求现在标记为“已取消”，并显示“Server restarted”，不再计入上游或路由失败。
  * 超过硬超时的请求仍标记为“失败”，并保留超时错误信息。
  * 请求尝试记录会与所属请求保持一致的最终状态。

* **界面**
  * 请求列表继续将服务器重启导致的取消请求识别为服务器重启失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->