### PR TITLE
fix(proxy): retry incomplete SSE stream failures

### DIFF
--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -1354,7 +1354,19 @@ func proxyErrorFromErrObj(errObj map[string]interface{}, label string) *domain.P
 	)
 	proxyErr.Scope = domain.ScopeProvider
 	proxyErr.Reason = domain.CooldownReasonServerError
+	if isIncompleteUpstreamStreamSSEError(msg) {
+		proxyErr.Retryable = true
+		proxyErr.Reason = domain.CooldownReasonNetworkError
+		proxyErr.HTTPStatusCode = 0
+	}
 	return proxyErr
+}
+
+func isIncompleteUpstreamStreamSSEError(msg string) bool {
+	lowerMsg := strings.ToLower(msg)
+	return strings.Contains(lowerMsg, "upstream response stream ended before completion") ||
+		strings.Contains(lowerMsg, "response stream ended before completion") ||
+		strings.Contains(lowerMsg, "stream ended before completion")
 }
 
 // classifyHTTPError creates a structured ProxyError from an HTTP error response.

--- a/internal/adapter/provider/custom/stream_eof_test.go
+++ b/internal/adapter/provider/custom/stream_eof_test.go
@@ -211,6 +211,26 @@ func TestCustomAdapterStreamClassifiesUnexpectedEOFAfterResponseStarted(t *testi
 	}
 }
 
+func TestCustomAdapterClassifiesIncompleteSSEStreamAsCommittedRetryableNetworkError(t *testing.T) {
+	proxyErr := proxyErrorFromErrObj(map[string]interface{}{
+		"message": "Upstream response stream ended before completion",
+		"code":    float64(0),
+	}, "SSE error")
+
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Fatalf("scope = %s, want %s", proxyErr.Scope, domain.ScopeProvider)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Fatalf("reason = %s, want %s", proxyErr.Reason, domain.CooldownReasonNetworkError)
+	}
+	if proxyErr.HTTPStatusCode != 0 {
+		t.Fatalf("http status = %d, want 0", proxyErr.HTTPStatusCode)
+	}
+	if !proxyErr.Retryable {
+		t.Fatal("incomplete upstream stream SSE error should be retryable")
+	}
+}
+
 func newTestCustomAdapter() *CustomAdapter {
 	return &CustomAdapter{provider: &domain.Provider{
 		Type: "custom",

--- a/internal/executor/disabled_error_cooldown_test.go
+++ b/internal/executor/disabled_error_cooldown_test.go
@@ -939,6 +939,11 @@ func TestCommittedStreamReadRetryClassifierMatchesRemoteResetVariants(t *testing
 			msg:  "upstream response stream was interrupted",
 			err:  errors.New("unexpected EOF"),
 		},
+		{
+			name: "incomplete upstream sse stream",
+			msg:  "Upstream response stream ended before completion",
+			err:  errors.New("SSE error (code=0): Upstream response stream ended before completion"),
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -558,6 +558,7 @@ func isCommittedStreamReadRetryableError(proxyErr *domain.ProxyError) bool {
 	msg = strings.ToLower(msg)
 	return strings.Contains(msg, "upstream stream read error after response started") ||
 		strings.Contains(msg, "upstream response stream was interrupted") ||
+		strings.Contains(msg, "stream ended before completion") ||
 		strings.Contains(msg, "stream transport reset") ||
 		strings.Contains(msg, "wsarecv") ||
 		strings.Contains(msg, "forcibly closed by the remote host") ||


### PR DESCRIPTION
## Summary
- classify `Upstream response stream ended before completion` SSE error frames as provider network failures
- allow the committed-stream retry guard to recognize `stream ended before completion`
- add focused regression coverage for custom SSE classification and executor committed-stream retry matching

## Tests
- `go test ./internal/adapter/provider/custom ./internal/executor`
- `go test ./internal/adapter/provider/custom ./internal/executor ./tests/e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进上游流在未完成即中断时的错误分类。
  * 此类网络错误现在会被标记为可重试，并正确触发已提交响应的重试策略。
  * 清除不适用的 HTTP 状态码，避免显示误导性错误信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->