### PR TITLE
fix(proxy): classify direct incomplete stream errors

### DIFF
--- a/internal/adapter/provider/cliproxyerr/classify.go
+++ b/internal/adapter/provider/cliproxyerr/classify.go
@@ -55,6 +55,13 @@ func Classify(err error, model, msg string, fallbackScope domain.ErrorScope, fal
 	body := err.Error()
 	proxyErr.HTTPStatusCode = statusCodeOf(err)
 	applyRetryHint(proxyErr, err)
+	if isIncompleteUpstreamStreamError(body) {
+		proxyErr.Scope = domain.ScopeProvider
+		proxyErr.Reason = domain.CooldownReasonNetworkError
+		proxyErr.Retryable = true
+		proxyErr.HTTPStatusCode = 0
+		return proxyErr
+	}
 
 	// The body is the more specific signal and wins: the SDK rewrites a
 	// usage-limit rejection to HTTP 429, which the status rules alone would
@@ -157,6 +164,13 @@ func classifyBody(proxyErr *domain.ProxyError, body string) bool {
 // classifyStatus maps the upstream HTTP status onto scope/reason/retryable,
 // mirroring the native codex adapter's classifyCodexHTTPError. A zero status
 // means the SDK gave us nothing to go on, so the caller's fallback stands.
+func isIncompleteUpstreamStreamError(msg string) bool {
+	lowerMsg := strings.ToLower(msg)
+	return strings.Contains(lowerMsg, "upstream response stream ended before completion") ||
+		strings.Contains(lowerMsg, "response stream ended before completion") ||
+		strings.Contains(lowerMsg, "stream ended before completion")
+}
+
 func classifyStatus(proxyErr *domain.ProxyError, body string) {
 	switch status := proxyErr.HTTPStatusCode; {
 	case status == 0:

--- a/internal/adapter/provider/cliproxyerr/classify_test.go
+++ b/internal/adapter/provider/cliproxyerr/classify_test.go
@@ -152,6 +152,24 @@ func TestClassifyRateLimitBodyWithoutStatus(t *testing.T) {
 	}
 }
 
+func TestClassifyIncompleteUpstreamStreamErrorIsNetworkRetryable(t *testing.T) {
+	proxyErr := Classify(errors.New("Error: Upstream response stream ended before completion"), "gpt-5.6-sol", "executor stream request failed",
+		domain.ScopeProvider, domain.CooldownReasonServerError)
+
+	if proxyErr.Scope != domain.ScopeProvider {
+		t.Errorf("scope = %q, want %q", proxyErr.Scope, domain.ScopeProvider)
+	}
+	if proxyErr.Reason != domain.CooldownReasonNetworkError {
+		t.Errorf("reason = %q, want %q", proxyErr.Reason, domain.CooldownReasonNetworkError)
+	}
+	if !proxyErr.Retryable {
+		t.Error("incomplete upstream stream error should be retryable")
+	}
+	if proxyErr.HTTPStatusCode != 0 {
+		t.Errorf("status = %d, want 0", proxyErr.HTTPStatusCode)
+	}
+}
+
 func TestClassifyStatusCodes(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- classify direct CLIProxyAPI `Upstream response stream ended before completion` errors as provider network failures
- keep status at `0` so the committed-stream retry guard can allow the existing retry/failover path
- add regression coverage for the exact `Error: Upstream response stream ended before completion` shape

## Tests
- `go test ./internal/adapter/provider/cliproxyerr ./internal/adapter/provider/cliproxyapi_codex ./internal/adapter/provider/cliproxyapi_grok ./internal/adapter/provider/cliproxyapi_antigravity ./internal/executor`
