### PR TITLE
feat(provider): add outbound proxy management

### DIFF
--- a/internal/adapter/provider/claude/adapter.go
+++ b/internal/adapter/provider/claude/adapter.go
@@ -56,10 +56,15 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 
 	config := p.Config.Claude
 
+	httpClient, err := newUpstreamHTTPClient(p)
+	if err != nil {
+		return nil, err
+	}
+
 	adapter := &ClaudeAdapter{
 		provider:   p,
 		tokenCache: &TokenCache{},
-		httpClient: newUpstreamHTTPClient(p),
+		httpClient: httpClient,
 	}
 
 	// Initialize token cache from persisted config if available
@@ -609,16 +614,8 @@ func ensureHeader(dst http.Header, clientReq *http.Request, key, defaultValue st
 	dst.Set(key, defaultValue)
 }
 
-func newUpstreamHTTPClient(providers ...*domain.Provider) *http.Client {
-	var p *domain.Provider
-	if len(providers) > 0 {
-		p = providers[0]
-	}
-	client, err := provider.NewHTTPClient(p, 600*time.Second, true)
-	if err != nil {
-		return &http.Client{Timeout: 600 * time.Second}
-	}
-	return client
+func newUpstreamHTTPClient(p *domain.Provider) (*http.Client, error) {
+	return provider.NewHTTPClient(p, 600*time.Second, true)
 }
 
 func flattenHeaders(h http.Header) map[string]string {

--- a/internal/adapter/provider/claude/adapter.go
+++ b/internal/adapter/provider/claude/adapter.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -60,7 +59,7 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 	adapter := &ClaudeAdapter{
 		provider:   p,
 		tokenCache: &TokenCache{},
-		httpClient: newUpstreamHTTPClient(),
+		httpClient: newUpstreamHTTPClient(p),
 	}
 
 	// Initialize token cache from persisted config if available
@@ -610,26 +609,16 @@ func ensureHeader(dst http.Header, clientReq *http.Request, key, defaultValue st
 	dst.Set(key, defaultValue)
 }
 
-func newUpstreamHTTPClient() *http.Client {
-	dialer := &net.Dialer{
-		Timeout:   20 * time.Second,
-		KeepAlive: 60 * time.Second,
+func newUpstreamHTTPClient(providers ...*domain.Provider) *http.Client {
+	var p *domain.Provider
+	if len(providers) > 0 {
+		p = providers[0]
 	}
-
-	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConnsPerHost:   16,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   20 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+	client, err := provider.NewHTTPClient(p, 600*time.Second, true)
+	if err != nil {
+		return &http.Client{Timeout: 600 * time.Second}
 	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   600 * time.Second,
-	}
+	return client
 }
 
 func flattenHeaders(h http.Header) map[string]string {

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -99,10 +99,15 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 		return cliproxyapi.NewAdapter(p)
 	}
 
+	httpClient, err := newUpstreamHTTPClient(p)
+	if err != nil {
+		return nil, err
+	}
+
 	adapter := &CodexAdapter{
 		provider:   p,
 		tokenCache: &TokenCache{},
-		httpClient: newUpstreamHTTPClient(p),
+		httpClient: httpClient,
 	}
 
 	// Initialize token cache from persisted config if available
@@ -832,16 +837,8 @@ func applyCodexRequestTuning(c *flow.Ctx, body []byte) (string, []byte) {
 	return cacheID, body
 }
 
-func newUpstreamHTTPClient(providers ...*domain.Provider) *http.Client {
-	var p *domain.Provider
-	if len(providers) > 0 {
-		p = providers[0]
-	}
-	client, err := provider.NewHTTPClient(p, 600*time.Second, true)
-	if err != nil {
-		return &http.Client{Timeout: 600 * time.Second}
-	}
-	return client
+func newUpstreamHTTPClient(p *domain.Provider) (*http.Client, error) {
+	return provider.NewHTTPClient(p, 600*time.Second, true)
 }
 
 func flattenHeaders(h http.Header) map[string]string {

--- a/internal/adapter/provider/codex/adapter.go
+++ b/internal/adapter/provider/codex/adapter.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -103,7 +102,7 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 	adapter := &CodexAdapter{
 		provider:   p,
 		tokenCache: &TokenCache{},
-		httpClient: newUpstreamHTTPClient(),
+		httpClient: newUpstreamHTTPClient(p),
 	}
 
 	// Initialize token cache from persisted config if available
@@ -833,26 +832,16 @@ func applyCodexRequestTuning(c *flow.Ctx, body []byte) (string, []byte) {
 	return cacheID, body
 }
 
-func newUpstreamHTTPClient() *http.Client {
-	dialer := &net.Dialer{
-		Timeout:   20 * time.Second,
-		KeepAlive: 60 * time.Second,
+func newUpstreamHTTPClient(providers ...*domain.Provider) *http.Client {
+	var p *domain.Provider
+	if len(providers) > 0 {
+		p = providers[0]
 	}
-
-	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
-		ForceAttemptHTTP2:     true,
-		MaxIdleConnsPerHost:   16,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   20 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+	client, err := provider.NewHTTPClient(p, 600*time.Second, true)
+	if err != nil {
+		return &http.Client{Timeout: 600 * time.Second}
 	}
-
-	return &http.Client{
-		Transport: transport,
-		Timeout:   600 * time.Second,
-	}
+	return client
 }
 
 func flattenHeaders(h http.Header) map[string]string {

--- a/internal/adapter/provider/codex/websocket_test.go
+++ b/internal/adapter/provider/codex/websocket_test.go
@@ -84,7 +84,7 @@ func TestExecuteResponsesWebSocket_PreservesOfficialWirePayload(t *testing.T) {
 	adapter := &CodexAdapter{
 		provider:   provider,
 		tokenCache: &TokenCache{AccessToken: "test-token"},
-		httpClient: newUpstreamHTTPClient(),
+		httpClient: &http.Client{Timeout: 600 * time.Second},
 	}
 	connectionID := uuid.NewString()
 	var acquiredSlots atomic.Int32

--- a/internal/adapter/provider/custom/adapter.go
+++ b/internal/adapter/provider/custom/adapter.go
@@ -53,10 +53,10 @@ func (a *CustomAdapter) SupportedClientTypes() []domain.ClientType {
 	return a.provider.SupportedClientTypes
 }
 
-func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
+func (a *CustomAdapter) Execute(c *flow.Ctx, upstreamProvider *domain.Provider) error {
 	clientType := flow.GetClientType(c)
 	if strings.EqualFold(strings.TrimSpace(a.provider.Config.Custom.Backend), customBackendOllama) {
-		return a.executeOllama(c, provider)
+		return a.executeOllama(c, upstreamProvider)
 	}
 
 	mappedModel := flow.GetMappedModel(c)
@@ -290,8 +290,9 @@ func (a *CustomAdapter) Execute(c *flow.Ctx, provider *domain.Provider) error {
 	}
 
 	// Execute request with reasonable timeout
-	client := &http.Client{
-		Timeout: 10 * time.Minute, // Long timeout for LLM requests
+	client, err := provider.NewHTTPClient(a.provider, 10*time.Minute, false)
+	if err != nil {
+		return domain.NewUpstreamConnectionError("invalid provider proxy configuration")
 	}
 	resp, err := client.Do(upstreamReq)
 	if err != nil {

--- a/internal/adapter/provider/fal/adapter.go
+++ b/internal/adapter/provider/fal/adapter.go
@@ -79,10 +79,14 @@ func NewAdapter(p *domain.Provider) (provider.ProviderAdapter, error) {
 	if p.Config == nil || p.Config.Fal == nil {
 		return nil, fmt.Errorf("provider %s missing fal config", p.Name)
 	}
+	client, err := provider.NewHTTPClient(p, 10*time.Minute, false)
+	if err != nil {
+		return nil, err
+	}
 	return &Adapter{
 		apiKey:   p.Config.Fal.APIKey,
 		provider: p,
-		client:   &http.Client{Timeout: 10 * time.Minute},
+		client:   client,
 	}, nil
 }
 

--- a/internal/adapter/provider/http_client.go
+++ b/internal/adapter/provider/http_client.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+	golangproxy "golang.org/x/net/proxy"
+)
+
+// NewHTTPClient builds an upstream HTTP client for provider adapters. A provider
+// proxyURL is explicit and never falls back to direct on parse/setup errors.
+// When proxyURL is empty, inheritEnvProxy controls whether HTTP(S)_PROXY from
+// the process environment remains active for legacy native adapters.
+func NewHTTPClient(p *domain.Provider, timeout time.Duration, inheritEnvProxy bool) (*http.Client, error) {
+	transport, err := NewHTTPTransport(p, inheritEnvProxy)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{Transport: transport, Timeout: timeout}, nil
+}
+
+func NewHTTPTransport(p *domain.Provider, inheritEnvProxy bool) (*http.Transport, error) {
+	dialer := &net.Dialer{Timeout: 20 * time.Second, KeepAlive: 60 * time.Second}
+	transport := &http.Transport{
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   16,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   20 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	rawProxy := providerProxyURL(p)
+	if rawProxy == "" {
+		if inheritEnvProxy {
+			transport.Proxy = http.ProxyFromEnvironment
+		}
+		return transport, nil
+	}
+
+	proxyURL, err := url.Parse(rawProxy)
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
+		return nil, fmt.Errorf("invalid provider proxy URL")
+	}
+
+	switch strings.ToLower(proxyURL.Scheme) {
+	case "http", "https":
+		transport.Proxy = http.ProxyURL(proxyURL)
+	case "socks5", "socks5h":
+		proxyForDialer := *proxyURL
+		proxyForDialer.Scheme = "socks5"
+		dialer, err := golangproxy.FromURL(&proxyForDialer, golangproxy.Direct)
+		if err != nil {
+			return nil, fmt.Errorf("invalid provider SOCKS proxy")
+		}
+		ctxDialer, ok := dialer.(golangproxy.ContextDialer)
+		if ok {
+			transport.DialContext = ctxDialer.DialContext
+		} else {
+			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				type result struct {
+					conn net.Conn
+					err  error
+				}
+				ch := make(chan result, 1)
+				go func() { conn, err := dialer.Dial(network, addr); ch <- result{conn: conn, err: err} }()
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case r := <-ch:
+					return r.conn, r.err
+				}
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unsupported provider proxy scheme")
+	}
+	return transport, nil
+}
+
+func providerProxyURL(p *domain.Provider) string {
+	if p == nil || p.Config == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.Config.ProxyURL)
+}

--- a/internal/adapter/provider/http_client_test.go
+++ b/internal/adapter/provider/http_client_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,11 @@ func TestNewHTTPClientUsesExplicitHTTPProxy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHTTPClient returned error: %v", err)
 	}
-	resp, err := client.Get("http://example.test/probe")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.test/probe", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("proxied request failed: %v", err)
 	}

--- a/internal/adapter/provider/http_client_test.go
+++ b/internal/adapter/provider/http_client_test.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+func TestNewHTTPClientUsesExplicitHTTPProxy(t *testing.T) {
+	proxyHit := make(chan string, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHit <- r.URL.String()
+		_, _ = io.WriteString(w, "proxied")
+	}))
+	defer proxy.Close()
+
+	client, err := NewHTTPClient(&domain.Provider{Config: &domain.ProviderConfig{ProxyURL: proxy.URL}}, time.Second, false)
+	if err != nil {
+		t.Fatalf("NewHTTPClient returned error: %v", err)
+	}
+	resp, err := client.Get("http://example.test/probe")
+	if err != nil {
+		t.Fatalf("proxied request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case got := <-proxyHit:
+		if got != "http://example.test/probe" {
+			t.Fatalf("proxy saw %q, want absolute upstream URL", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("proxy was not used")
+	}
+}
+
+func TestNewHTTPClientRejectsInvalidExplicitProxy(t *testing.T) {
+	_, err := NewHTTPClient(&domain.Provider{Config: &domain.ProviderConfig{ProxyURL: "127.0.0.1:7890"}}, time.Second, false)
+	if err == nil {
+		t.Fatal("invalid explicit proxy must fail instead of falling back direct")
+	}
+}
+
+func TestNewHTTPClientEmptyProxyDoesNotSetExplicitProxy(t *testing.T) {
+	client, err := NewHTTPClient(&domain.Provider{Config: &domain.ProviderConfig{}}, time.Second, false)
+	if err != nil {
+		t.Fatalf("NewHTTPClient returned error: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("empty provider proxy should not install explicit proxy")
+	}
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -434,6 +434,9 @@ type ProviderConfig struct {
 	SmartMappingRetryEnabled bool `json:"smartMappingRetryEnabled,omitempty"`
 	// 每个映射模型失败多少次后切换到下一个候选模型。
 	SmartMappingRetryLimit int `json:"smartMappingRetryLimit,omitempty"`
+	// ProxyURL is an optional explicit outbound proxy for this provider.
+	// Empty preserves the adapter default. Supported schemes: http, https, socks5, socks5h.
+	ProxyURL string `json:"proxyURL,omitempty"`
 
 	Custom      *ProviderConfigCustom      `json:"custom,omitempty"`
 	Antigravity *ProviderConfigAntigravity `json:"antigravity,omitempty"`
@@ -1029,6 +1032,7 @@ const (
 	SettingKeyOpenAIChatStreamIdleTimeoutMS        = "openai_chat_stream_idle_timeout_ms"        // OpenAI Chat 路由 provider 事件间 idle 超时毫秒数，默认 45000，仅启用 openai_chat_stream_timeouts_enabled 时生效
 	SettingKeyRequestFailureDetailsEnabled         = "request_failure_details_enabled"           // 是否在请求详情 Metadata 中展示增强失败详情，"true" 或 "false"，默认 "false"
 	SettingKeyTestFieldTabEnabled                  = "ui_test_field_tab_enabled"                 // 是否显示测试场 tab，"true" 或 "false"，默认 "false"
+	SettingKeyProxyManagementEnabled                = "ui_proxy_management_enabled"              // 是否显示代理管理 tab，"true" 或 "false"，默认 "false"
 	SettingKeyModelMappingDebuggerEnabled          = "ui_model_mapping_debugger_enabled"         // 是否显示模型映射调试器，"true" 或 "false"，默认 "false"
 	SettingKeyStrictSupportModelsRoutingEnabled    = "strict_support_models_routing_enabled"     // 是否按提供商支持模型严格跳过不匹配路由，"true" 或 "false"，默认 "false"
 	SettingKeyCodexOpenRouterBridgeEnabled         = "codex_openrouter_bridge_enabled"           // 是否把 Codex→OpenRouter 请求桥接为 OpenAI Chat Completions；"false"（默认）走原生 /responses 透传，保留 custom/freeform 工具（code mode）；"true" 恢复旧的 chat 桥接作为应急开关

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -28,6 +28,7 @@ var publicSettingsAllowlist = map[string]struct{}{
 	"ui_multitenant_layout":                          {},
 	domain.SettingKeyRequestFailureDetailsEnabled:    {},
 	domain.SettingKeyTestFieldTabEnabled:             {},
+	domain.SettingKeyProxyManagementEnabled:          {},
 	domain.SettingKeyModelMappingDebuggerEnabled:     {},
 	domain.SettingKeyUserPanelDailyCheckInEnabled:    {},
 	domain.SettingKeyUserPanelDailyCheckInAmount:     {},

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -1454,6 +1454,7 @@ func TestSelfServiceHandler_GetPublicSettings_FiltersSensitiveKeys(t *testing.T)
 				"auto_sort_codex":                             "false",
 				domain.SettingKeyRequestFailureDetailsEnabled: "true",
 				domain.SettingKeyTestFieldTabEnabled:          "true",
+				domain.SettingKeyProxyManagementEnabled:       "false",
 				"jwt_secret":                                  "hidden",
 				"pprof_password":                              "secret",
 			},
@@ -1471,8 +1472,8 @@ func TestSelfServiceHandler_GetPublicSettings_FiltersSensitiveKeys(t *testing.T)
 	if err := json.Unmarshal(rec.Body.Bytes(), &settings); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(settings) != 7 {
-		t.Fatalf("settings length = %d, want 7, settings = %+v", len(settings), settings)
+	if len(settings) != 8 {
+		t.Fatalf("settings length = %d, want 8, settings = %+v", len(settings), settings)
 	}
 	if settings["api_token_auth_enabled"] != "true" ||
 		settings["force_project_binding"] != "true" ||
@@ -1480,7 +1481,8 @@ func TestSelfServiceHandler_GetPublicSettings_FiltersSensitiveKeys(t *testing.T)
 		settings["auto_sort_antigravity"] != "true" ||
 		settings["auto_sort_codex"] != "false" ||
 		settings[domain.SettingKeyRequestFailureDetailsEnabled] != "true" ||
-		settings[domain.SettingKeyTestFieldTabEnabled] != "true" {
+		settings[domain.SettingKeyTestFieldTabEnabled] != "true" ||
+		settings[domain.SettingKeyProxyManagementEnabled] != "false" {
 		t.Fatalf("settings = %+v, want public setting values", settings)
 	}
 	if _, ok := settings["jwt_secret"]; ok {

--- a/internal/service/system_setting_validation.go
+++ b/internal/service/system_setting_validation.go
@@ -13,7 +13,7 @@ func validateSystemSettingValue(key, value string) error {
 	switch key {
 	case domain.SettingKeyReasoningPolicy:
 		return reqpolicy.ValidatePolicyJSON(value)
-	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyStrictSupportModelsRoutingEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled, domain.SettingKeyExternalModelListEnabled, domain.SettingKeyInviteRegistrationAutoApproveEnabled:
+	case domain.SettingKeyForceRetryUpstreamErrors, domain.SettingKeyOpenAIChatStreamTimeoutsEnabled, domain.SettingKeyRequestFailureDetailsEnabled, domain.SettingKeyStrictSupportModelsRoutingEnabled, domain.SettingKeyProxyRequestsDisabled, domain.SettingKeyUserPanelDailyCheckInEnabled, domain.SettingKeyExternalModelListEnabled, domain.SettingKeyInviteRegistrationAutoApproveEnabled, domain.SettingKeyProxyManagementEnabled:
 		return validateBooleanSystemSetting(key, value)
 	case domain.SettingKeyRateLimitCooldownDefaultSeconds:
 		return validateRateLimitCooldownDefaultSeconds(value)

--- a/internal/service/system_setting_validation_test.go
+++ b/internal/service/system_setting_validation_test.go
@@ -43,6 +43,7 @@ func TestValidateSystemSettingValueBooleanSettings(t *testing.T) {
 		domain.SettingKeyOpenAIChatStreamTimeoutsEnabled,
 		domain.SettingKeyRequestFailureDetailsEnabled,
 		domain.SettingKeyProxyRequestsDisabled,
+		domain.SettingKeyProxyManagementEnabled,
 		domain.SettingKeyUserPanelDailyCheckInEnabled,
 	}
 	tests := []struct {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import { StatsPage } from '@/pages/stats';
 import { ModelMappingsPage } from '@/pages/model-mappings';
 import { ModelPricesPage } from '@/pages/model-prices';
 import { ExternalModelsPage } from '@/pages/external-models';
+import { ProxiesPage } from '@/pages/proxies';
 import { UsersPage } from '@/pages/users';
 import { UserPanelPage } from '@/pages/user-panel';
 import { AdminRoute } from '@/components/auth/admin-route';
@@ -186,6 +187,16 @@ function AppRoutes() {
               <AdminRoute>
                 <SettingEnabledRoute settingKey="external_model_list_enabled">
                   <ExternalModelsPage />
+                </SettingEnabledRoute>
+              </AdminRoute>
+            }
+          />
+          <Route
+            path="proxies"
+            element={
+              <AdminRoute>
+                <SettingEnabledRoute settingKey="ui_proxy_management_enabled">
+                  <ProxiesPage />
                 </SettingEnabledRoute>
               </AdminRoute>
             }

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -20,6 +20,7 @@ import {
   Database,
   FlaskConical,
   Eye,
+  NetworkIcon,
 } from 'lucide-react';
 import type { SidebarConfig } from '@/types/sidebar';
 import { RequestsNavItem } from './requests-nav-item';
@@ -175,6 +176,14 @@ export const sidebarConfig: SidebarConfig = {
           labelKey: 'nav.routingStrategies',
           adminOnly: true,
           authOnly: true,
+        },
+        {
+          type: 'standard',
+          key: 'proxies',
+          to: '/proxies',
+          icon: NetworkIcon,
+          labelKey: 'nav.proxies',
+          adminOnly: true,
         },
         {
           type: 'standard',

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.test.ts
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { MenuItem } from '@/types/sidebar';
+import { shouldRenderSidebarItem } from './sidebar-renderer';
+
+const standardItem = (key: string): MenuItem => ({
+  type: 'standard',
+  key,
+  to: `/${key}`,
+  icon: () => null,
+  labelKey: `nav.${key}`,
+});
+
+describe('shouldRenderSidebarItem', () => {
+  it('hides the proxy management tab by default', () => {
+    expect(
+      shouldRenderSidebarItem(standardItem('proxies'), {
+        settings: {},
+        isAdmin: true,
+        authEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('shows the proxy management tab only when the setting is true', () => {
+    expect(
+      shouldRenderSidebarItem(standardItem('proxies'), {
+        settings: { ui_proxy_management_enabled: 'false' },
+        isAdmin: true,
+        authEnabled: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldRenderSidebarItem(standardItem('proxies'), {
+        settings: { ui_proxy_management_enabled: 'true' },
+        isAdmin: true,
+        authEnabled: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps unrelated config tabs visible when proxy management is off', () => {
+    expect(
+      shouldRenderSidebarItem(standardItem('retry-configs'), {
+        settings: {},
+        isAdmin: true,
+        authEnabled: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -71,6 +71,7 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
   const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
   const testFieldTabEnabled = publicSettings.data?.ui_test_field_tab_enabled === 'true';
   const externalModelsTabEnabled = publicSettings.data?.external_model_list_enabled === 'true';
+  const proxyManagementTabEnabled = publicSettings.data?.ui_proxy_management_enabled === 'true';
 
   return (
     <>
@@ -91,6 +92,9 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
             item.key === 'external-models' &&
             !externalModelsTabEnabled
           ) {
+            return false;
+          }
+          if (item.type === 'standard' && item.key === 'proxies' && !proxyManagementTabEnabled) {
             return false;
           }
           if (item.type === 'standard' && item.adminOnly && !isAdmin) {

--- a/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-renderer.tsx
@@ -17,6 +17,44 @@ interface SidebarRendererProps {
   config: SidebarConfig;
 }
 
+export function shouldRenderSidebarItem(
+  item: MenuItem,
+  {
+    settings,
+    isAdmin,
+    authEnabled,
+  }: { settings?: Record<string, string>; isAdmin: boolean; authEnabled: boolean },
+) {
+  const multiTenantUIEnabled = settings?.ui_multitenant_enabled === 'true';
+  const testFieldTabEnabled = settings?.ui_test_field_tab_enabled === 'true';
+  const externalModelsTabEnabled = settings?.external_model_list_enabled === 'true';
+  const proxyManagementTabEnabled = settings?.ui_proxy_management_enabled === 'true';
+
+  if (
+    !multiTenantUIEnabled &&
+    item.type === 'standard' &&
+    (item.key === 'invite-codes' || item.key === 'users')
+  ) {
+    return false;
+  }
+  if (item.type === 'standard' && item.key === 'test-field' && !testFieldTabEnabled) {
+    return false;
+  }
+  if (item.type === 'standard' && item.key === 'external-models' && !externalModelsTabEnabled) {
+    return false;
+  }
+  if (item.type === 'standard' && item.key === 'proxies' && !proxyManagementTabEnabled) {
+    return false;
+  }
+  if (item.type === 'standard' && item.adminOnly && !isAdmin) {
+    return false;
+  }
+  if (item.type === 'standard' && item.authOnly && !authEnabled) {
+    return false;
+  }
+  return true;
+}
+
 /**
  * Renders a single menu item based on its type
  */
@@ -68,43 +106,13 @@ export function SidebarRenderer({ config }: SidebarRendererProps) {
   const { user, authEnabled } = useAuth();
   const publicSettings = usePublicSettings();
   const isAdmin = !user || user.role === 'admin';
-  const multiTenantUIEnabled = publicSettings.data?.ui_multitenant_enabled === 'true';
-  const testFieldTabEnabled = publicSettings.data?.ui_test_field_tab_enabled === 'true';
-  const externalModelsTabEnabled = publicSettings.data?.external_model_list_enabled === 'true';
-  const proxyManagementTabEnabled = publicSettings.data?.ui_proxy_management_enabled === 'true';
 
   return (
     <>
       {config.sections.map((section) => {
-        const filteredItems = section.items.filter((item) => {
-          if (
-            !multiTenantUIEnabled &&
-            item.type === 'standard' &&
-            (item.key === 'invite-codes' || item.key === 'users')
-          ) {
-            return false;
-          }
-          if (item.type === 'standard' && item.key === 'test-field' && !testFieldTabEnabled) {
-            return false;
-          }
-          if (
-            item.type === 'standard' &&
-            item.key === 'external-models' &&
-            !externalModelsTabEnabled
-          ) {
-            return false;
-          }
-          if (item.type === 'standard' && item.key === 'proxies' && !proxyManagementTabEnabled) {
-            return false;
-          }
-          if (item.type === 'standard' && item.adminOnly && !isAdmin) {
-            return false;
-          }
-          if (item.type === 'standard' && item.authOnly && !authEnabled) {
-            return false;
-          }
-          return true;
-        });
+        const filteredItems = section.items.filter((item) =>
+          shouldRenderSidebarItem(item, { settings: publicSettings.data, isAdmin, authEnabled }),
+        );
 
         if (filteredItems.length === 0) return null;
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -257,6 +257,7 @@ export interface ProviderModelCheckResponse {
 
 export interface ProviderConfig {
   quotaEnabled?: boolean;
+  proxyURL?: string;
   disableErrorCooldown?: boolean;
   consecutiveErrorFreezeEnabled?: boolean;
   consecutiveErrorFreezeThreshold?: number;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2261,6 +2261,7 @@
     "url": "Proxy URL",
     "preview": "Preview",
     "hint": "Supported schemes: http, https, socks5, socks5h. Passwords are masked in the UI preview.",
+    "saveFailed": "Failed to save proxy settings.",
     "invalidURL": "Proxy URL must start with http://, https://, socks5://, or socks5h://."
   }
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -113,7 +113,8 @@
     "apiTokenLimits": "API Token Limits",
     "dataManagement": "Data Management",
     "proxyAccess": "Proxy Access",
-    "externalModels": "External Models"
+    "externalModels": "External Models",
+    "proxies": "Proxies"
   },
   "userPanel": {
     "title": "User Console",
@@ -1579,7 +1580,10 @@
     "providerCloneNameStrategyTemplate": "Custom template",
     "providerCloneNameTemplate": "Clone name template",
     "providerCloneNameTemplateDesc": "Supports {{name}}, {{base}}, {{suffix}}, and {{n}}. Empty templates fall back to {{name}}{{suffix}}.",
-    "providerCloneNameSaveError": "Failed to save provider clone naming settings."
+    "providerCloneNameSaveError": "Failed to save provider clone naming settings.",
+    "proxyManagement": "Proxy management",
+    "proxyManagementLabel": "Show proxy tab",
+    "proxyManagementDesc": "Default off. When enabled, admins can manage outbound proxies and bind providers to one proxy."
   },
   "modelMappings": {
     "title": "Model Mappings",
@@ -1940,7 +1944,11 @@
     "consecutiveErrorFreeze": "Temporarily freeze after consecutive errors",
     "consecutiveErrorFreezeDesc": "When enabled, this provider is temporarily frozen after consecutive upstream-attributed errors reach the threshold. If Disable Switching is also enabled, the request fails instead of falling through to later providers.",
     "consecutiveErrorFreezeThreshold": "Consecutive error threshold",
-    "consecutiveErrorFreezeHint": "Only non-request-level HTTP 429 responses are counted. All other errors do not trigger this consecutive-error freeze. Freeze duration reuses the default cooldown setting."
+    "consecutiveErrorFreezeHint": "Only non-request-level HTTP 429 responses are counted. All other errors do not trigger this consecutive-error freeze. Freeze duration reuses the default cooldown setting.",
+    "outboundProxy": "Outbound proxy",
+    "outboundProxyLabel": "Provider outbound proxy",
+    "outboundProxyDirect": "Direct / adapter default",
+    "outboundProxyDesc": "Select a proxy from the proxy tab. Explicit proxy config fails closed instead of silently going direct."
   },
   "cooldown": {
     "title": "Cooldown Protection",
@@ -2242,5 +2250,17 @@
     "saveHint": "This list is used only while the External model list switch is enabled in Settings.",
     "modelCount": "{{count}} models",
     "empty": "No external models configured. With the switch enabled, model-list APIs will return an empty list."
+  },
+  "proxies": {
+    "title": "Proxies",
+    "description": "Manage reusable outbound proxies for provider requests.",
+    "add": "Add proxy",
+    "list": "Proxy list",
+    "empty": "No proxies yet. Add one to bind providers to it.",
+    "name": "Name",
+    "url": "Proxy URL",
+    "preview": "Preview",
+    "hint": "Supported schemes: http, https, socks5, socks5h. Passwords are masked in the UI preview.",
+    "invalidURL": "Proxy URL must start with http://, https://, socks5://, or socks5h://."
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -113,7 +113,8 @@
     "apiTokenLimits": "API Token 限流",
     "dataManagement": "数据管理",
     "proxyAccess": "代理访问控制",
-    "externalModels": "外部模型"
+    "externalModels": "外部模型",
+    "proxies": "代理"
   },
   "userPanel": {
     "title": "用户控制台",
@@ -1576,7 +1577,10 @@
     "providerCloneNameStrategyTemplate": "自定义模板",
     "providerCloneNameTemplate": "克隆名称模板",
     "providerCloneNameTemplateDesc": "支持 {{name}}、{{base}}、{{suffix}}、{{n}}。模板为空时使用 {{name}}{{suffix}}。",
-    "providerCloneNameSaveError": "保存提供商克隆命名设置失败。"
+    "providerCloneNameSaveError": "保存提供商克隆命名设置失败。",
+    "proxyManagement": "代理管理",
+    "proxyManagementLabel": "显示代理 tab",
+    "proxyManagementDesc": "默认关闭。开启后管理员可以维护出站代理，并把 provider 绑定到指定代理。"
   },
   "modelMappings": {
     "title": "模型映射",
@@ -1937,7 +1941,11 @@
     "consecutiveErrorFreeze": "连续错误后临时冻结",
     "consecutiveErrorFreezeDesc": "开启后，当该提供商连续发生可归因于上游的错误达到阈值时，会按全局冷却时间临时冻结；若已启用禁止切换，则请求会直接失败，不再切到后续提供商。",
     "consecutiveErrorFreezeThreshold": "连续错误阈值",
-    "consecutiveErrorFreezeHint": "只统计非请求级的 HTTP 429 错误；其他错误都不会触发这条连续错误冻结。冻结时长复用设置里的默认冷却时间。"
+    "consecutiveErrorFreezeHint": "只统计非请求级的 HTTP 429 错误；其他错误都不会触发这条连续错误冻结。冻结时长复用设置里的默认冷却时间。",
+    "outboundProxy": "出站代理",
+    "outboundProxyLabel": "Provider 出站代理",
+    "outboundProxyDirect": "直连 / 适配器默认",
+    "outboundProxyDesc": "从代理 tab 选择代理。显式代理配置错误时会失败关闭，不会偷偷直连。"
   },
   "cooldown": {
     "title": "冷却保护中",
@@ -2238,5 +2246,17 @@
     "saveHint": "仅当设置里的「外部模型列表」开关开启时，此列表才会生效。",
     "modelCount": "{{count}} 个模型",
     "empty": "还没有配置外部模型。开关开启时，模型列表接口会返回空列表。"
+  },
+  "proxies": {
+    "title": "代理",
+    "description": "管理 provider 请求可复用的出站代理。",
+    "add": "新增代理",
+    "list": "代理列表",
+    "empty": "还没有代理。新增后可以绑定到 provider。",
+    "name": "名称",
+    "url": "代理 URL",
+    "preview": "预览",
+    "hint": "支持协议：http、https、socks5、socks5h。UI 预览会遮蔽密码。",
+    "invalidURL": "代理 URL 必须以 http://、https://、socks5:// 或 socks5h:// 开头。"
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2257,6 +2257,7 @@
     "url": "代理 URL",
     "preview": "预览",
     "hint": "支持协议：http、https、socks5、socks5h。UI 预览会遮蔽密码。",
+    "saveFailed": "保存代理设置失败。",
     "invalidURL": "代理 URL 必须以 http://、https://、socks5:// 或 socks5h:// 开头。"
   }
 }

--- a/web/src/pages/providers/components/custom-config-step.tsx
+++ b/web/src/pages/providers/components/custom-config-step.tsx
@@ -44,6 +44,7 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import { ProviderOutboundProxyField } from './provider-outbound-proxy-field';
 
 export function CustomConfigStep() {
   const [showApiKey, setShowApiKey] = useState(false);
@@ -147,6 +148,7 @@ export function CustomConfigStep() {
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
           reasoning: formData.reasoning,
+          proxyURL: formData.proxyURL?.trim() || undefined,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -234,6 +236,11 @@ export function CustomConfigStep() {
               <ProviderMaxConcurrencyField
                 value={formData.maxConcurrency ?? 0}
                 onChange={(maxConcurrency) => updateFormData({ maxConcurrency })}
+              />
+
+              <ProviderOutboundProxyField
+                value={formData.proxyURL}
+                onChange={(proxyURL) => updateFormData({ proxyURL })}
               />
 
               <div>

--- a/web/src/pages/providers/components/provider-edit-flow.tsx
+++ b/web/src/pages/providers/components/provider-edit-flow.tsx
@@ -59,6 +59,7 @@ import {
   normalizeMaxConcurrency,
   ProviderMaxConcurrencyField,
 } from './provider-max-concurrency-field';
+import { ProviderOutboundProxyField } from './provider-outbound-proxy-field';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui';
@@ -518,6 +519,7 @@ type EditFormData = {
   smartMappingRetryLimit?: number;
   reasoning?: NonNullable<Provider['config']>['reasoning'];
   maxConcurrency: number;
+  proxyURL?: string;
   excludeFromExport: boolean;
   blackBox: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。
@@ -601,6 +603,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
       smartMappingRetryLimit: provider.config?.smartMappingRetryLimit ?? 1,
       reasoning: provider.config?.reasoning,
       maxConcurrency: normalizeMaxConcurrency(provider.maxConcurrency),
+      proxyURL: provider.config?.proxyURL || '',
       excludeFromExport: !!provider.excludeFromExport || !!provider.blackBox,
       blackBox: !!provider.blackBox,
       responsesPassthrough: provider.config?.custom?.responsesPassthrough,
@@ -719,6 +722,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
           reasoning: formData.reasoning,
+          proxyURL: formData.proxyURL?.trim() || undefined,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -797,6 +801,7 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
           smartMappingRetryEnabled,
           smartMappingRetryLimit: formData.smartMappingRetryLimit ?? 1,
           reasoning: formData.reasoning,
+          proxyURL: formData.proxyURL?.trim() || undefined,
           custom: {
             baseURL: formData.baseURL,
             backend: formData.backend === 'ollama' ? 'ollama' : undefined,
@@ -1416,6 +1421,11 @@ export function ProviderEditFlow({ provider, onClose }: ProviderEditFlowProps) {
                   onChange={(maxConcurrency) =>
                     setFormData((prev) => ({ ...prev, maxConcurrency }))
                   }
+                />
+
+                <ProviderOutboundProxyField
+                  value={formData.proxyURL}
+                  onChange={(proxyURL) => setFormData((prev) => ({ ...prev, proxyURL }))}
                 />
 
                 <div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">

--- a/web/src/pages/providers/components/provider-outbound-proxy-field.tsx
+++ b/web/src/pages/providers/components/provider-outbound-proxy-field.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui';
+import { useSettings } from '@/hooks/queries';
+import { OUTBOUND_PROXIES_SETTING_KEY, parseOutboundProxies, proxyLabel } from '@/pages/proxies/utils/proxy-settings';
+
+export function ProviderOutboundProxyField({ value, onChange }: { value?: string; onChange: (value: string) => void }) {
+  const { t } = useTranslation();
+  const { data: settings } = useSettings();
+  const proxies = useMemo(
+    () => parseOutboundProxies(settings?.[OUTBOUND_PROXIES_SETTING_KEY]).filter((proxy) => !proxy.disabled),
+    [settings],
+  );
+  const selected = value?.trim() || '__direct__';
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="text-base font-medium">{t('provider.outboundProxy')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2 pt-5">
+        <Label>{t('provider.outboundProxyLabel')}</Label>
+        <Select value={selected} onValueChange={(next) => onChange(next === '__direct__' ? '' : (next ?? ''))}>
+          <SelectTrigger data-testid="provider-outbound-proxy-select" aria-label={t('provider.outboundProxyLabel')}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__direct__">{t('provider.outboundProxyDirect')}</SelectItem>
+            {proxies.map((proxy) => (
+              <SelectItem key={proxy.id} value={proxy.url}>{proxyLabel(proxy)}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">{t('provider.outboundProxyDesc')}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/pages/providers/context/provider-form-context.tsx
+++ b/web/src/pages/providers/context/provider-form-context.tsx
@@ -47,6 +47,7 @@ const initialFormData: ProviderFormData = {
   smartMappingRetryLimit: 1,
   reasoning: undefined,
   maxConcurrency: 0,
+  proxyURL: '',
   excludeFromExport: false,
   blackBox: false,
 };

--- a/web/src/pages/providers/types.ts
+++ b/web/src/pages/providers/types.ts
@@ -389,6 +389,7 @@ export type ProviderFormData = {
   smartMappingRetryLimit?: number;
   reasoning?: ReasoningPolicy;
   maxConcurrency?: number;
+  proxyURL?: string;
   excludeFromExport?: boolean;
   blackBox?: boolean;
   // undefined = 默认透传;false = 旧的硬编码 /responses。

--- a/web/src/pages/proxies/index.tsx
+++ b/web/src/pages/proxies/index.tsx
@@ -2,7 +2,16 @@ import { useMemo, useState } from 'react';
 import { Network, Plus, Save, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { PageHeader } from '@/components/layout/page-header';
-import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label, Switch } from '@/components/ui';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Switch,
+} from '@/components/ui';
 import { useSettings, useUpdateSetting } from '@/hooks/queries';
 import {
   OUTBOUND_PROXIES_SETTING_KEY,
@@ -41,29 +50,87 @@ export function ProxiesPage() {
       return;
     }
     setError(null);
-    await updateSetting.mutateAsync({ key: OUTBOUND_PROXIES_SETTING_KEY, value: serializeOutboundProxies(proxies) });
-    setItems(null);
+    try {
+      await updateSetting.mutateAsync({
+        key: OUTBOUND_PROXIES_SETTING_KEY,
+        value: serializeOutboundProxies(proxies),
+      });
+      setItems(null);
+    } catch {
+      setError(t('proxies.saveFailed'));
+    }
   };
 
   return (
     <div className="flex flex-col h-full bg-background">
-      <PageHeader icon={Network} iconClassName="text-zinc-500" title={t('proxies.title')} description={t('proxies.description')}>
-        <Button onClick={() => setItems([...proxies, newProxy()])} variant="secondary"><Plus size={14} />{t('proxies.add')}</Button>
-        <Button onClick={save} disabled={!dirty || updateSetting.isPending}><Save size={14} />{t('common.save')}</Button>
+      <PageHeader
+        icon={Network}
+        iconClassName="text-zinc-500"
+        title={t('proxies.title')}
+        description={t('proxies.description')}
+      >
+        <Button onClick={() => setItems([...proxies, newProxy()])} variant="secondary">
+          <Plus size={14} />
+          {t('proxies.add')}
+        </Button>
+        <Button onClick={save} disabled={!dirty || updateSetting.isPending}>
+          <Save size={14} />
+          {t('common.save')}
+        </Button>
       </PageHeader>
       <div className="flex-1 overflow-y-auto p-4 md:p-6">
         <div className="mx-auto max-w-5xl space-y-4">
           <Card className="border-border bg-card">
-            <CardHeader className="border-b border-border"><CardTitle className="text-base font-medium">{t('proxies.list')}</CardTitle></CardHeader>
+            <CardHeader className="border-b border-border">
+              <CardTitle className="text-base font-medium">{t('proxies.list')}</CardTitle>
+            </CardHeader>
             <CardContent className="space-y-4 pt-5">
-              {proxies.length === 0 ? <p className="text-sm text-muted-foreground">{t('proxies.empty')}</p> : null}
+              {proxies.length === 0 ? (
+                <p className="text-sm text-muted-foreground">{t('proxies.empty')}</p>
+              ) : null}
               {proxies.map((proxy) => (
-                <div key={proxy.id} data-testid="proxy-row" className="grid gap-3 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-[1fr_2fr_auto_auto] md:items-end">
-                  <div className="space-y-2"><Label>{t('proxies.name')}</Label><Input value={proxy.name} onChange={(e) => update(proxy.id, { name: e.target.value })} /></div>
-                  <div className="space-y-2"><Label>{t('proxies.url')}</Label><Input value={proxy.url} onChange={(e) => update(proxy.id, { url: e.target.value })} placeholder="http://127.0.0.1:7890" /></div>
-                  <div className="flex items-center gap-2 pb-2"><Switch checked={!proxy.disabled} onCheckedChange={(checked) => update(proxy.id, { disabled: !checked })} /><span className="text-sm text-muted-foreground">{proxy.disabled ? t('common.disabled') : t('common.enabled')}</span></div>
-                  <Button variant="ghost" size="sm" onClick={() => setItems(proxies.filter((item) => item.id !== proxy.id))}><Trash2 size={14} />{t('common.delete')}</Button>
-                  <p className="md:col-span-4 text-xs text-muted-foreground">{t('proxies.preview')}: {maskProxyURL(proxy.url)}</p>
+                <div
+                  key={proxy.id}
+                  data-testid="proxy-row"
+                  className="grid gap-3 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-[1fr_2fr_auto_auto] md:items-end"
+                >
+                  <div className="space-y-2">
+                    <Label htmlFor={`proxy-name-${proxy.id}`}>{t('proxies.name')}</Label>
+                    <Input
+                      id={`proxy-name-${proxy.id}`}
+                      value={proxy.name}
+                      onChange={(e) => update(proxy.id, { name: e.target.value })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor={`proxy-url-${proxy.id}`}>{t('proxies.url')}</Label>
+                    <Input
+                      id={`proxy-url-${proxy.id}`}
+                      value={proxy.url}
+                      onChange={(e) => update(proxy.id, { url: e.target.value })}
+                      placeholder="http://127.0.0.1:7890"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2 pb-2">
+                    <Switch
+                      checked={!proxy.disabled}
+                      onCheckedChange={(checked) => update(proxy.id, { disabled: !checked })}
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      {proxy.disabled ? t('common.disabled') : t('common.enabled')}
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setItems(proxies.filter((item) => item.id !== proxy.id))}
+                  >
+                    <Trash2 size={14} />
+                    {t('common.delete')}
+                  </Button>
+                  <p className="md:col-span-4 text-xs text-muted-foreground">
+                    {t('proxies.preview')}: {maskProxyURL(proxy.url)}
+                  </p>
                 </div>
               ))}
               {error ? <p className="text-sm text-destructive">{error}</p> : null}

--- a/web/src/pages/proxies/index.tsx
+++ b/web/src/pages/proxies/index.tsx
@@ -1,0 +1,77 @@
+import { useMemo, useState } from 'react';
+import { Network, Plus, Save, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { PageHeader } from '@/components/layout/page-header';
+import { Button, Card, CardContent, CardHeader, CardTitle, Input, Label, Switch } from '@/components/ui';
+import { useSettings, useUpdateSetting } from '@/hooks/queries';
+import {
+  OUTBOUND_PROXIES_SETTING_KEY,
+  isSupportedProxyURL,
+  maskProxyURL,
+  parseOutboundProxies,
+  serializeOutboundProxies,
+  type OutboundProxyDefinition,
+} from './utils/proxy-settings';
+
+function newProxy(): OutboundProxyDefinition {
+  return { id: crypto.randomUUID(), name: 'Proxy', url: 'http://127.0.0.1:7890' };
+}
+
+export function ProxiesPage() {
+  const { t } = useTranslation();
+  const { data: settings } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const saved = useMemo(
+    () => parseOutboundProxies(settings?.[OUTBOUND_PROXIES_SETTING_KEY]),
+    [settings],
+  );
+  const [items, setItems] = useState<OutboundProxyDefinition[] | null>(null);
+  const proxies = items ?? saved;
+  const [error, setError] = useState<string | null>(null);
+  const dirty = items !== null;
+
+  const update = (id: string, patch: Partial<OutboundProxyDefinition>) => {
+    setItems(proxies.map((item) => (item.id === id ? { ...item, ...patch } : item)));
+  };
+
+  const save = async () => {
+    const invalid = proxies.find((item) => item.url.trim() && !isSupportedProxyURL(item.url));
+    if (invalid) {
+      setError(t('proxies.invalidURL'));
+      return;
+    }
+    setError(null);
+    await updateSetting.mutateAsync({ key: OUTBOUND_PROXIES_SETTING_KEY, value: serializeOutboundProxies(proxies) });
+    setItems(null);
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <PageHeader icon={Network} iconClassName="text-zinc-500" title={t('proxies.title')} description={t('proxies.description')}>
+        <Button onClick={() => setItems([...proxies, newProxy()])} variant="secondary"><Plus size={14} />{t('proxies.add')}</Button>
+        <Button onClick={save} disabled={!dirty || updateSetting.isPending}><Save size={14} />{t('common.save')}</Button>
+      </PageHeader>
+      <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        <div className="mx-auto max-w-5xl space-y-4">
+          <Card className="border-border bg-card">
+            <CardHeader className="border-b border-border"><CardTitle className="text-base font-medium">{t('proxies.list')}</CardTitle></CardHeader>
+            <CardContent className="space-y-4 pt-5">
+              {proxies.length === 0 ? <p className="text-sm text-muted-foreground">{t('proxies.empty')}</p> : null}
+              {proxies.map((proxy) => (
+                <div key={proxy.id} data-testid="proxy-row" className="grid gap-3 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-[1fr_2fr_auto_auto] md:items-end">
+                  <div className="space-y-2"><Label>{t('proxies.name')}</Label><Input value={proxy.name} onChange={(e) => update(proxy.id, { name: e.target.value })} /></div>
+                  <div className="space-y-2"><Label>{t('proxies.url')}</Label><Input value={proxy.url} onChange={(e) => update(proxy.id, { url: e.target.value })} placeholder="http://127.0.0.1:7890" /></div>
+                  <div className="flex items-center gap-2 pb-2"><Switch checked={!proxy.disabled} onCheckedChange={(checked) => update(proxy.id, { disabled: !checked })} /><span className="text-sm text-muted-foreground">{proxy.disabled ? t('common.disabled') : t('common.enabled')}</span></div>
+                  <Button variant="ghost" size="sm" onClick={() => setItems(proxies.filter((item) => item.id !== proxy.id))}><Trash2 size={14} />{t('common.delete')}</Button>
+                  <p className="md:col-span-4 text-xs text-muted-foreground">{t('proxies.preview')}: {maskProxyURL(proxy.url)}</p>
+                </div>
+              ))}
+              {error ? <p className="text-sm text-destructive">{error}</p> : null}
+              <p className="text-xs text-muted-foreground">{t('proxies.hint')}</p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/proxies/utils/proxy-settings.test.ts
+++ b/web/src/pages/proxies/utils/proxy-settings.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { isSupportedProxyURL, maskProxyURL, parseOutboundProxies } from './proxy-settings';
+
+describe('proxy-settings', () => {
+  it('parses only complete proxy definitions', () => {
+    expect(
+      parseOutboundProxies(
+        JSON.stringify([
+          { id: 'p1', name: 'Fast', url: 'http://user:pass@127.0.0.1:7890' },
+          { id: '', name: 'bad', url: 'http://127.0.0.1:7890' },
+        ]),
+      ),
+    ).toEqual([{ id: 'p1', name: 'Fast', url: 'http://user:pass@127.0.0.1:7890', disabled: false }]);
+  });
+
+  it('validates supported proxy schemes', () => {
+    expect(isSupportedProxyURL('http://127.0.0.1:7890')).toBe(true);
+    expect(isSupportedProxyURL('https://proxy.example:443')).toBe(true);
+    expect(isSupportedProxyURL('socks5://127.0.0.1:7891')).toBe(true);
+    expect(isSupportedProxyURL('socks5h://proxy.example:1080')).toBe(true);
+    expect(isSupportedProxyURL('127.0.0.1:7890')).toBe(false);
+  });
+
+  it('masks proxy credentials in previews', () => {
+    expect(maskProxyURL('http://user:pass@127.0.0.1:7890/')).toBe('http://***:***@127.0.0.1:7890/');
+  });
+});

--- a/web/src/pages/proxies/utils/proxy-settings.ts
+++ b/web/src/pages/proxies/utils/proxy-settings.ts
@@ -1,0 +1,59 @@
+export const PROXY_MANAGEMENT_ENABLED_SETTING_KEY = 'ui_proxy_management_enabled';
+export const OUTBOUND_PROXIES_SETTING_KEY = 'outbound_proxies';
+
+export type OutboundProxyDefinition = {
+  id: string;
+  name: string;
+  url: string;
+  disabled?: boolean;
+};
+
+export function parseOutboundProxies(raw?: string): OutboundProxyDefinition[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((item): OutboundProxyDefinition | null => {
+        if (!item || typeof item !== 'object') return null;
+        const id = String((item as any).id || '').trim();
+        const name = String((item as any).name || '').trim();
+        const url = String((item as any).url || '').trim();
+        if (!id || !name || !url) return null;
+        return { id, name, url, disabled: !!(item as any).disabled };
+      })
+      .filter((item): item is OutboundProxyDefinition => !!item);
+  } catch {
+    return [];
+  }
+}
+
+export function serializeOutboundProxies(proxies: OutboundProxyDefinition[]): string {
+  return JSON.stringify(proxies);
+}
+
+export function proxyLabel(proxy: OutboundProxyDefinition): string {
+  return `${proxy.name} · ${maskProxyURL(proxy.url)}`;
+}
+
+export function maskProxyURL(raw: string): string {
+  try {
+    const url = new URL(raw);
+    if (url.username || url.password) {
+      url.username = url.username ? '***' : '';
+      url.password = url.password ? '***' : '';
+    }
+    return url.toString();
+  } catch {
+    return raw;
+  }
+}
+
+export function isSupportedProxyURL(raw: string): boolean {
+  try {
+    const url = new URL(raw.trim());
+    return ['http:', 'https:', 'socks5:', 'socks5h:'].includes(url.protocol) && !!url.host;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/pages/settings/index.tsx
+++ b/web/src/pages/settings/index.tsx
@@ -16,6 +16,7 @@ import {
   Eye,
   EyeOff,
   Copy,
+  Network,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/components/theme-provider';
@@ -52,6 +53,7 @@ import {
   PROVIDER_CLONE_NAME_STRATEGY_SETTING_KEY,
   PROVIDER_CLONE_NAME_TEMPLATE_SETTING_KEY,
 } from '@/pages/providers/utils/provider-clone-name';
+import { PROXY_MANAGEMENT_ENABLED_SETTING_KEY } from '@/pages/proxies/utils/proxy-settings';
 
 function parseRetentionInteger(value: string): number | null {
   const trimmed = value.trim();
@@ -151,6 +153,7 @@ export function SettingsPage() {
             <>
               <SupportModelRoutingSection />
               <OpenAIChatStreamTimeoutSection />
+              <ProxyManagementTabSection />
               <TestFieldTabSection />
               <ModelMappingDebuggerSection />
               <ExternalModelListSection />
@@ -1117,7 +1120,42 @@ export function SupportModelRoutingSection() {
   );
 }
 
-export function TestFieldTabSection() {
+export function ProxyManagementTabSection() {
+  const { t } = useTranslation();
+  const { data: settings, isLoading } = useSettings();
+  const updateSetting = useUpdateSetting();
+  const enabled = settings?.[PROXY_MANAGEMENT_ENABLED_SETTING_KEY] === 'true';
+
+  const handleToggle = async (checked: boolean) => {
+    await updateSetting.mutateAsync({
+      key: PROXY_MANAGEMENT_ENABLED_SETTING_KEY,
+      value: checked ? 'true' : 'false',
+    });
+  };
+
+  return (
+    <Card className="border-border bg-card">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="text-base font-medium flex items-center gap-2">
+          <Network className="h-4 w-4 text-muted-foreground" />
+          {t('settings.proxyManagement')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 pt-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Label className="text-sm font-medium">{t('settings.proxyManagementLabel')}</Label>
+            <p className="text-xs text-muted-foreground mt-1">{t('settings.proxyManagementDesc')}</p>
+          </div>
+          <Switch checked={enabled} onCheckedChange={handleToggle} disabled={isLoading || updateSetting.isPending} aria-label={t('settings.proxyManagementLabel')} />
+        </div>
+        <p className="text-xs text-muted-foreground">{t('settings.defaultOff')}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TestFieldTabSection() {
   const { data: settings, isLoading } = useSettings();
   const updateSetting = useUpdateSetting();
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- add provider-level outbound proxy support with explicit fail-closed proxy parsing
- add settings-gated Proxy Management tab for reusable outbound proxies
- add provider create/edit UI binding to select an outbound proxy

## Verification
- `git diff --check`
- `go test ./internal/adapter/provider ./internal/adapter/provider/custom ./internal/adapter/provider/claude ./internal/adapter/provider/codex ./internal/adapter/provider/fal ./internal/handler ./internal/service`
- `pnpm -C web typecheck`
- `pnpm -C web exec vitest run src/pages/proxies/utils/proxy-settings.test.ts`
- `pnpm -C web build`
- Playwright smoke: settings proxy toggle, `/proxies` tab, provider create outbound proxy dropdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增管理员代理管理页面，支持添加、编辑、启用、禁用和删除出站代理。
  - 支持为服务提供商配置出站代理或直连，并支持 HTTP、HTTPS、SOCKS5 和 SOCKS5H 协议。
  - 新增代理管理开关，可控制相关菜单和设置区域的显示。
  - 代理凭据在界面中自动脱敏。

- **改进**
  - 保存代理前校验 URL 格式，无效配置会提示错误。
  - 上游连接统一应用代理配置与连接超时设置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->