### PR TITLE
fix(provider): ignore disabled managed proxies

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1032,7 +1032,8 @@ const (
 	SettingKeyOpenAIChatStreamIdleTimeoutMS        = "openai_chat_stream_idle_timeout_ms"        // OpenAI Chat 路由 provider 事件间 idle 超时毫秒数，默认 45000，仅启用 openai_chat_stream_timeouts_enabled 时生效
 	SettingKeyRequestFailureDetailsEnabled         = "request_failure_details_enabled"           // 是否在请求详情 Metadata 中展示增强失败详情，"true" 或 "false"，默认 "false"
 	SettingKeyTestFieldTabEnabled                  = "ui_test_field_tab_enabled"                 // 是否显示测试场 tab，"true" 或 "false"，默认 "false"
-	SettingKeyProxyManagementEnabled                = "ui_proxy_management_enabled"              // 是否显示代理管理 tab，"true" 或 "false"，默认 "false"
+	SettingKeyProxyManagementEnabled               = "ui_proxy_management_enabled"               // 是否显示代理管理 tab，"true" 或 "false"，默认 "false"
+	SettingKeyOutboundProxies                      = "outbound_proxies"                          // 出站代理列表 JSON 配置
 	SettingKeyModelMappingDebuggerEnabled          = "ui_model_mapping_debugger_enabled"         // 是否显示模型映射调试器，"true" 或 "false"，默认 "false"
 	SettingKeyStrictSupportModelsRoutingEnabled    = "strict_support_models_routing_enabled"     // 是否按提供商支持模型严格跳过不匹配路由，"true" 或 "false"，默认 "false"
 	SettingKeyCodexOpenRouterBridgeEnabled         = "codex_openrouter_bridge_enabled"           // 是否把 Codex→OpenRouter 请求桥接为 OpenAI Chat Completions；"false"（默认）走原生 /responses 透传，保留 custom/freeform 工具（code mode）；"true" 恢复旧的 chat 桥接作为应急开关

--- a/internal/router/provider_proxy_settings_test.go
+++ b/internal/router/provider_proxy_settings_test.go
@@ -1,0 +1,63 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/awsl-project/maxx/internal/domain"
+)
+
+type providerProxySettingRepo struct {
+	values map[string]string
+}
+
+func (r *providerProxySettingRepo) Get(key string) (string, error) {
+	return r.values[key], nil
+}
+
+func (r *providerProxySettingRepo) Set(key, value string) error {
+	if r.values == nil {
+		r.values = make(map[string]string)
+	}
+	r.values[key] = value
+	return nil
+}
+
+func (r *providerProxySettingRepo) GetAll() ([]*domain.SystemSetting, error) { return nil, nil }
+
+func (r *providerProxySettingRepo) Delete(key string) error {
+	delete(r.values, key)
+	return nil
+}
+
+func TestProviderForAdapterClearsDisabledManagedProxy(t *testing.T) {
+	r := &Router{settingRepo: &providerProxySettingRepo{values: map[string]string{
+		domain.SettingKeyOutboundProxies: `[{"id":"p1","name":"slow","url":"http://127.0.0.1:7890","disabled":true}]`,
+	}}}
+	p := &domain.Provider{ID: 1, Type: "custom", Config: &domain.ProviderConfig{ProxyURL: "http://127.0.0.1:7890"}}
+
+	adapterProvider := r.providerForAdapter(p)
+	if adapterProvider == p {
+		t.Fatal("expected disabled proxy to return a cloned provider for adapter construction")
+	}
+	if got := adapterProvider.Config.ProxyURL; got != "" {
+		t.Fatalf("adapter proxyURL = %q, want empty for disabled managed proxy", got)
+	}
+	if got := p.Config.ProxyURL; got != "http://127.0.0.1:7890" {
+		t.Fatalf("stored provider proxyURL mutated to %q", got)
+	}
+}
+
+func TestProviderForAdapterKeepsEnabledManagedProxy(t *testing.T) {
+	r := &Router{settingRepo: &providerProxySettingRepo{values: map[string]string{
+		domain.SettingKeyOutboundProxies: `[{"id":"p1","name":"fast","url":"http://127.0.0.1:7890","disabled":false}]`,
+	}}}
+	p := &domain.Provider{ID: 1, Type: "custom", Config: &domain.ProviderConfig{ProxyURL: "http://127.0.0.1:7890"}}
+
+	adapterProvider := r.providerForAdapter(p)
+	if adapterProvider != p {
+		t.Fatal("expected enabled managed proxy to keep original provider")
+	}
+	if got := adapterProvider.Config.ProxyURL; got != "http://127.0.0.1:7890" {
+		t.Fatalf("adapter proxyURL = %q, want original proxy", got)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -125,6 +126,44 @@ func (r *Router) isProviderAtConcurrencyLimit(p *domain.Provider) bool {
 	return r != nil && p != nil && r.limiter.IsAtLimit(p.ID, p.MaxConcurrency)
 }
 
+type outboundProxySettingEntry struct {
+	ID       string `json:"id"`
+	URL      string `json:"url"`
+	Disabled bool   `json:"disabled"`
+}
+
+func (r *Router) providerForAdapter(p *domain.Provider) *domain.Provider {
+	if p == nil || p.Config == nil || r == nil || r.settingRepo == nil {
+		return p
+	}
+	rawProxy := strings.TrimSpace(p.Config.ProxyURL)
+	if rawProxy == "" {
+		return p
+	}
+	rawSetting, err := r.settingRepo.Get(domain.SettingKeyOutboundProxies)
+	if err != nil || strings.TrimSpace(rawSetting) == "" {
+		return p
+	}
+	var entries []outboundProxySettingEntry
+	if err := json.Unmarshal([]byte(rawSetting), &entries); err != nil {
+		return p
+	}
+	for _, entry := range entries {
+		if strings.TrimSpace(entry.URL) != rawProxy {
+			continue
+		}
+		if !entry.Disabled {
+			return p
+		}
+		clone := *p
+		configClone := *p.Config
+		configClone.ProxyURL = ""
+		clone.Config = &configClone
+		return &clone
+	}
+	return p
+}
+
 // InitAdapters initializes adapters for all providers
 func (r *Router) InitAdapters() error {
 	providers := r.providerRepo.GetAll()
@@ -132,11 +171,12 @@ func (r *Router) InitAdapters() error {
 	nextFingerprints := make(map[uint64]string, len(providers))
 
 	for _, p := range providers {
-		factory, ok := provider.GetAdapterFactory(p.Type)
+		adapterProvider := r.providerForAdapter(p)
+		factory, ok := provider.GetAdapterFactory(adapterProvider.Type)
 		if !ok {
 			continue // Skip providers without registered adapters
 		}
-		a, err := factory(p)
+		a, err := factory(adapterProvider)
 		if err != nil {
 			// A single mis-configured provider (e.g. empty config) must not
 			// abort building adapters for every other provider. Log and skip
@@ -146,7 +186,7 @@ func (r *Router) InitAdapters() error {
 		}
 		r.injectProviderUpdate(a, p)
 		next[p.ID] = a
-		nextFingerprints[p.ID] = adapterFingerprint(p)
+		nextFingerprints[p.ID] = adapterFingerprint(adapterProvider)
 	}
 
 	r.mu.Lock()
@@ -177,19 +217,20 @@ func (r *Router) ReconcileAdapters() error {
 	nextFingerprints := make(map[uint64]string, len(providers))
 	var changedProviderIDs []uint64
 	for _, p := range providers {
-		fingerprint := adapterFingerprint(p)
+		adapterProvider := r.providerForAdapter(p)
+		fingerprint := adapterFingerprint(adapterProvider)
 		if current, ok := currentAdapters[p.ID]; ok && currentFingerprints[p.ID] == fingerprint {
 			next[p.ID] = current
 			nextFingerprints[p.ID] = fingerprint
 			continue
 		}
 
-		factory, ok := provider.GetAdapterFactory(p.Type)
+		factory, ok := provider.GetAdapterFactory(adapterProvider.Type)
 		if !ok {
 			changedProviderIDs = append(changedProviderIDs, p.ID)
 			continue
 		}
-		a, err := factory(p)
+		a, err := factory(adapterProvider)
 		if err != nil {
 			// A single mis-configured provider must not abort reconciliation
 			// for every other provider (which would freeze hot-reload until a
@@ -220,11 +261,15 @@ func (r *Router) ReconcileAdapters() error {
 
 // RefreshAdapter refreshes the adapter for a specific provider
 func (r *Router) RefreshAdapter(p *domain.Provider) error {
-	factory, ok := provider.GetAdapterFactory(p.Type)
+	if p == nil {
+		return nil
+	}
+	adapterProvider := r.providerForAdapter(p)
+	factory, ok := provider.GetAdapterFactory(adapterProvider.Type)
 	if !ok {
 		return nil
 	}
-	a, err := factory(p)
+	a, err := factory(adapterProvider)
 	if err != nil {
 		return err
 	}
@@ -232,7 +277,7 @@ func (r *Router) RefreshAdapter(p *domain.Provider) error {
 	provider.ClearResponsesWebSocketTransportCooldown(p.ID)
 	r.mu.Lock()
 	r.adapters[p.ID] = a
-	r.adapterFingerprints[p.ID] = adapterFingerprint(p)
+	r.adapterFingerprints[p.ID] = adapterFingerprint(adapterProvider)
 	r.mu.Unlock()
 	return nil
 }

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1361,6 +1361,9 @@ func (s *AdminService) UpdateSetting(key, value string) error {
 		return err
 	}
 	systemsettingcache.Invalidate(key)
+	if key == domain.SettingKeyOutboundProxies {
+		s.refreshAllProviderAdapters()
+	}
 
 	// 如果更新的是 pprof 相关设置，触发重载
 	switch key {
@@ -1373,6 +1376,23 @@ func (s *AdminService) UpdateSetting(key, value string) error {
 	}
 
 	return nil
+}
+
+type providerAllGetter interface {
+	GetAll() map[uint64]*domain.Provider
+}
+
+func (s *AdminService) refreshAllProviderAdapters() {
+	if s == nil || s.adapterRefresher == nil || s.providerRepo == nil {
+		return
+	}
+	providerRepo, ok := s.providerRepo.(providerAllGetter)
+	if !ok {
+		return
+	}
+	for _, p := range providerRepo.GetAll() {
+		_ = s.adapterRefresher.RefreshAdapter(p)
+	}
 }
 
 var publicProxyRouteExposureSettingKeys = []string{
@@ -1428,6 +1448,9 @@ func (s *AdminService) DeleteSetting(key string) error {
 		return err
 	}
 	systemsettingcache.Invalidate(key)
+	if key == domain.SettingKeyOutboundProxies {
+		s.refreshAllProviderAdapters()
+	}
 
 	// 如果删除的是 pprof 相关设置，触发重载
 	switch key {


### PR DESCRIPTION
## Summary\n- Treat provider proxy URLs that match disabled managed proxy entries as direct/no-proxy during adapter construction\n- Refresh provider adapters when the outbound proxy settings list changes\n- Add router regression coverage for enabled vs disabled managed proxy entries\n\n## Validation\n- git diff --check\n- go test ./internal/router ./internal/service ./internal/adapter/provider ./internal/adapter/provider/custom ./internal/adapter/provider/claude ./internal/adapter/provider/codex ./internal/adapter/provider/fal ./internal/handler\n- pnpm -C web typecheck\n- pnpm -C web exec vitest run src/components/layout/app-sidebar/sidebar-config.test.ts src/components/layout/app-sidebar/sidebar-renderer.test.ts src/pages/proxies/utils/proxy-settings.test.ts\n- pnpm -C web build