### PR TITLE
feat(user-panel): show token usage totals

### DIFF
--- a/cmd/maxx/main.go
+++ b/cmd/maxx/main.go
@@ -503,6 +503,7 @@ func main() {
 	modelsHandler := handler.NewModelsHandler(responseModelRepo, cachedProviderRepo, cachedModelMappingRepo, r)
 	modelsHandler.SetSettingsRepository(settingRepo)
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)
+	selfServiceHandler.SetUserRepo(userRepo)
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	projectProxyHandler := handler.NewProjectProxyHandler(proxyHandler, protectedModelsHandler, cachedProjectRepo, settingRepo)
 	providerProxyHandler := handler.NewProviderProxyHandler(proxyHandler, protectedModelsHandler, cachedProviderRepo, cachedRouteRepo, proxyRequestRepo, settingRepo)

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -465,6 +465,7 @@ func InitializeServerComponents(
 	protectedModelsHandler := tokenAuthMiddleware.WrapModelList(modelsHandler)
 	adminHandler := handler.NewAdminHandler(adminService, backupService, logPath)
 	selfServiceHandler := handler.NewSelfServiceHandler(adminService, modelsHandler)
+	selfServiceHandler.SetUserRepo(repos.UserRepo)
 	adminHandler.SetUserRepo(repos.UserRepo)
 	adminHandler.SetAuthEnabled(authEnabled)
 	antigravityHandler := handler.NewAntigravityHandler(adminService, repos.AntigravityQuotaRepo, wailsBroadcaster)

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -46,6 +46,7 @@ const defaultUserPanelDailyCheckInAmountUSD = "10"
 type SelfServiceHandler struct {
 	svc           *service.AdminService
 	modelsHandler *ModelsHandler
+	userRepo      repository.UserRepository
 }
 
 // NewSelfServiceHandler creates a new self-service handler.
@@ -55,6 +56,11 @@ func NewSelfServiceHandler(svc *service.AdminService, modelsHandler ...*ModelsHa
 		mh = modelsHandler[0]
 	}
 	return &SelfServiceHandler{svc: svc, modelsHandler: mh}
+}
+
+// SetUserRepo sets the user repository for user-panel cross-user leaderboard endpoints.
+func (h *SelfServiceHandler) SetUserRepo(repo repository.UserRepository) {
+	h.userRepo = repo
 }
 
 func writeSelfServiceInternalError(w http.ResponseWriter, context string, err error) {
@@ -258,6 +264,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleUserPanelModels(w, r)
 		case len(parts) == 3 && parts[2] == "check-in":
 			h.handleUserPanelDailyCheckIn(w, r)
+		case len(parts) == 3 && parts[2] == "consumption-leaderboard":
+			h.handleUserPanelConsumptionLeaderboard(w, r)
 		default:
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		}
@@ -1581,6 +1589,108 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 		"checkInDate":      checkInDate,
 		"rewardAmount":     rewardAmount,
 	})
+}
+
+type userPanelConsumptionLeaderboardRow struct {
+	UserID   uint64 `json:"userID"`
+	Username string `json:"username"`
+	Cost     uint64 `json:"cost"`
+}
+
+type userPanelConsumptionLeaderboardResponse struct {
+	Today []userPanelConsumptionLeaderboardRow `json:"today"`
+	All   []userPanelConsumptionLeaderboardRow `json:"all"`
+}
+
+func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if h.userRepo == nil {
+		writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "user management not available"})
+		return
+	}
+
+	tenantID := maxxctx.GetTenantID(r.Context())
+	users, err := h.userRepo.ListByTenant(tenantID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "ListUsers failed", err)
+		return
+	}
+	tokens, err := h.svc.GetAPITokens(tenantID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetAPITokens failed", err)
+		return
+	}
+
+	now := time.Now()
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	todayFilter := repository.UsageStatsFilter{Granularity: domain.GranularityDay, StartTime: &start, EndTime: &now}
+	todayStats, err := h.svc.GetUsageStats(tenantID, todayFilter)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetTodayConsumptionStats failed", err)
+		return
+	}
+	allFilter := repository.UsageStatsFilter{Granularity: domain.GranularityMonth}
+	allStats, err := h.svc.GetUsageStats(tenantID, allFilter)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetAllConsumptionStats failed", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, userPanelConsumptionLeaderboardResponse{
+		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users),
+		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users),
+	})
+}
+
+func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users []*domain.User) []userPanelConsumptionLeaderboardRow {
+	usernames := make(map[uint64]string, len(users))
+	for _, user := range users {
+		if user != nil {
+			usernames[user.ID] = user.Username
+		}
+	}
+
+	tokenUsers := make(map[uint64]uint64, len(tokens))
+	for _, token := range tokens {
+		if token == nil || !strings.HasPrefix(token.Description, userPanelAPITokenDescriptionPrefix) {
+			continue
+		}
+		id, err := strconv.ParseUint(strings.TrimPrefix(token.Description, userPanelAPITokenDescriptionPrefix), 10, 64)
+		if err == nil && id > 0 {
+			tokenUsers[token.ID] = id
+		}
+	}
+
+	costs := make(map[uint64]uint64)
+	for _, item := range stats {
+		if item == nil {
+			continue
+		}
+		userID := tokenUsers[item.APITokenID]
+		if userID == 0 {
+			continue
+		}
+		costs[userID] += item.Cost
+	}
+
+	rows := make([]userPanelConsumptionLeaderboardRow, 0, len(costs))
+	for userID, cost := range costs {
+		username := usernames[userID]
+		if username == "" {
+			username = userPanelAPITokenName(userID)
+		}
+		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Username: username, Cost: cost})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Cost == rows[j].Cost {
+			return rows[i].Username < rows[j].Username
+		}
+		return rows[i].Cost > rows[j].Cost
+	})
+	return rows
 }
 
 func findUserPanelAPITokensForUser(svc *service.AdminService, tenantID uint64, userID uint64) ([]*domain.APIToken, error) {

--- a/internal/handler/self_service_routes.go
+++ b/internal/handler/self_service_routes.go
@@ -23,6 +23,8 @@ var protectedSelfServiceRoutePatterns = []string{
 	"/api/user-panel/models/",
 	"/api/user-panel/check-in",
 	"/api/user-panel/check-in/",
+	"/api/user-panel/consumption-leaderboard",
+	"/api/user-panel/consumption-leaderboard/",
 	"/api/model-mappings",
 	"/api/model-mappings/",
 	"/api/proxy-status",

--- a/web/src/components/layout/app-sidebar/sidebar-config.test.ts
+++ b/web/src/components/layout/app-sidebar/sidebar-config.test.ts
@@ -53,4 +53,21 @@ describe('sidebarConfig', () => {
       labelKey: 'nav.testField',
     });
   });
+  it('keeps config navigation in conceptual order', () => {
+    const configSection = sidebarConfig.sections.find((section) => section.key === 'config');
+
+    expect(configSection?.items.map((item) => item.key)).toEqual([
+      'model-mappings',
+      'model-prices',
+      'external-models',
+      'routing-strategies',
+      'retry-configs',
+      'proxies',
+      'proxy-access',
+      'api-token-limits',
+      'data-management',
+      'diagnostics',
+      'settings',
+    ]);
+  });
 });

--- a/web/src/components/layout/app-sidebar/sidebar-config.tsx
+++ b/web/src/components/layout/app-sidebar/sidebar-config.tsx
@@ -179,6 +179,13 @@ export const sidebarConfig: SidebarConfig = {
         },
         {
           type: 'standard',
+          key: 'retry-configs',
+          to: '/retry-configs',
+          icon: RefreshCw,
+          labelKey: 'nav.retryConfigs',
+        },
+        {
+          type: 'standard',
           key: 'proxies',
           to: '/proxies',
           icon: NetworkIcon,
@@ -187,10 +194,11 @@ export const sidebarConfig: SidebarConfig = {
         },
         {
           type: 'standard',
-          key: 'retry-configs',
-          to: '/retry-configs',
-          icon: RefreshCw,
-          labelKey: 'nav.retryConfigs',
+          key: 'proxy-access',
+          to: '/proxy-access',
+          icon: ShieldCheck,
+          labelKey: 'nav.proxyAccess',
+          adminOnly: true,
         },
         {
           type: 'standard',
@@ -198,14 +206,6 @@ export const sidebarConfig: SidebarConfig = {
           to: '/api-token-limits',
           icon: Gauge,
           labelKey: 'nav.apiTokenLimits',
-          adminOnly: true,
-        },
-        {
-          type: 'standard',
-          key: 'proxy-access',
-          to: '/proxy-access',
-          icon: ShieldCheck,
-          labelKey: 'nav.proxyAccess',
           adminOnly: true,
         },
         {

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -149,6 +149,7 @@ export {
 export {
   usageStatsKeys,
   useUsageStats,
+  useUserPanelUsageStats,
   useUsageStatsWithPreset,
   useRecalculateUsageStats,
   useRecalculateCosts,

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -129,6 +129,7 @@ export {
   useCreateUserPanelAPIToken,
   useRegenerateUserPanelAPIToken,
   useRevealUserPanelAPIToken,
+  useUserPanelConsumptionLeaderboard,
   useUserPanelAvailableModels,
   useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,

--- a/web/src/hooks/queries/use-usage-stats.ts
+++ b/web/src/hooks/queries/use-usage-stats.ts
@@ -122,6 +122,15 @@ export function useUsageStats(filter?: UsageStatsFilter, options?: { enabled?: b
   });
 }
 
+export function useUserPanelUsageStats(filter?: UsageStatsFilter, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: [...usageStatsKeys.list(filter), 'userPanel'] as const,
+    queryFn: () => getTransport().getUserPanelUsageStats(filter),
+    placeholderData: keepPreviousData,
+    enabled: options?.enabled ?? true,
+  });
+}
+
 /**
  * 使用预设时间范围获取统计数据
  */

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -7,6 +7,7 @@ export const userPanelTokenKeys = {
   detail: () => [...userPanelTokenKeys.all, 'detail'] as const,
   availableModels: () => [...userPanelTokenKeys.all, 'available-models'] as const,
   dailyCheckInStatus: () => [...userPanelTokenKeys.all, 'daily-check-in-status'] as const,
+  consumptionLeaderboard: () => [...userPanelTokenKeys.all, 'consumption-leaderboard'] as const,
 };
 
 async function refreshUserPanelTokenDependents(queryClient: QueryClient) {
@@ -73,5 +74,13 @@ export function useUserPanelDailyCheckIn() {
   return useMutation({
     mutationFn: () => getTransport().checkInUserPanelDailyQuota(),
     onSuccess: () => refreshUserPanelTokenDependents(queryClient),
+  });
+}
+
+export function useUserPanelConsumptionLeaderboard(enabled = true) {
+  return useQuery({
+    queryKey: userPanelTokenKeys.consumptionLeaderboard(),
+    queryFn: () => getTransport().getUserPanelConsumptionLeaderboard(),
+    enabled,
   });
 }

--- a/web/src/hooks/queries/use-user-panel-token.ts
+++ b/web/src/hooks/queries/use-user-panel-token.ts
@@ -6,7 +6,8 @@ export const userPanelTokenKeys = {
   all: ['user-panel-token'] as const,
   detail: () => [...userPanelTokenKeys.all, 'detail'] as const,
   availableModels: () => [...userPanelTokenKeys.all, 'available-models'] as const,
-  dailyCheckInStatus: () => [...userPanelTokenKeys.all, 'daily-check-in-status'] as const,
+  dailyCheckInStatus: (dayKey?: string) =>
+    [...userPanelTokenKeys.all, 'daily-check-in-status', dayKey] as const,
   consumptionLeaderboard: () => [...userPanelTokenKeys.all, 'consumption-leaderboard'] as const,
 };
 
@@ -60,9 +61,9 @@ export function useUserPanelAvailableModels(enabled = true) {
   });
 }
 
-export function useUserPanelDailyCheckInStatus(enabled = true) {
+export function useUserPanelDailyCheckInStatus(enabled = true, dayKey?: string) {
   return useQuery({
-    queryKey: userPanelTokenKeys.dailyCheckInStatus(),
+    queryKey: userPanelTokenKeys.dailyCheckInStatus(dayKey),
     queryFn: () => getTransport().getUserPanelDailyCheckInStatus(),
     enabled,
   });

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -1263,7 +1263,7 @@ export class HttpTransport implements Transport {
 
   // ===== Usage Stats API =====
 
-  async getUsageStats(filter?: UsageStatsFilter): Promise<UsageStats[]> {
+  private usageStatsPath(filter?: UsageStatsFilter): string {
     const params = new URLSearchParams();
     if (filter?.granularity) params.set('granularity', filter.granularity);
     if (filter?.start) params.set('start', filter.start);
@@ -1276,8 +1276,18 @@ export class HttpTransport implements Transport {
     if (filter?.model) params.set('model', filter.model);
 
     const query = params.toString();
-    const url = query ? `/usage-stats?${query}` : '/usage-stats';
+    return query ? `/usage-stats?${query}` : '/usage-stats';
+  }
+
+  async getUsageStats(filter?: UsageStatsFilter): Promise<UsageStats[]> {
+    const url = this.usageStatsPath(filter);
     const { data } = await this.adminClient.get<UsageStats[]>(url);
+    return this.expectArray<UsageStats>(data, '/usage-stats');
+  }
+
+  async getUserPanelUsageStats(filter?: UsageStatsFilter): Promise<UsageStats[]> {
+    const url = this.usageStatsPath(filter);
+    const { data } = await this.client.get<UsageStats[]>(url);
     return this.expectArray<UsageStats>(data, '/usage-stats');
   }
 

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -82,6 +82,7 @@ import type {
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
   UserPanelDailyCheckInResult,
+  UserPanelConsumptionLeaderboardResult,
   RouteBulkDeleteRequest,
   RouteBulkDeleteResult,
   RouteSyncRequest,
@@ -1197,6 +1198,16 @@ export class HttpTransport implements Transport {
   async checkInUserPanelDailyQuota(): Promise<UserPanelDailyCheckInResult> {
     const { data } = await this.client.post<UserPanelDailyCheckInResult>('/user-panel/check-in');
     return data;
+  }
+
+  async getUserPanelConsumptionLeaderboard(): Promise<UserPanelConsumptionLeaderboardResult> {
+    const { data } = await this.client.get<UserPanelConsumptionLeaderboardResult>(
+      '/user-panel/consumption-leaderboard',
+    );
+    return this.expectObject<UserPanelConsumptionLeaderboardResult>(
+      data,
+      '/user-panel/consumption-leaderboard',
+    );
   }
 
   async createAPIToken(payload: CreateAPITokenData): Promise<APITokenCreateResult> {

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -139,6 +139,8 @@ export type {
   APITokenQuotaRechargeData,
   APITokenQuotaRechargeResult,
   UserPanelAPITokenResponse,
+  UserPanelConsumptionLeaderboardRow,
+  UserPanelConsumptionLeaderboardResult,
   // Usage Stats
   UsageStats,
   UsageStatsFilter,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -81,6 +81,7 @@ import type {
   UserPanelAPITokenResponse,
   UserPanelAPITokenRevealResult,
   UserPanelDailyCheckInResult,
+  UserPanelConsumptionLeaderboardResult,
   RouteBulkDeleteRequest,
   RouteBulkDeleteResult,
   RouteSyncRequest,
@@ -332,6 +333,7 @@ export interface Transport {
   getUserPanelAvailableModels(): Promise<string[]>;
   getUserPanelDailyCheckInStatus(): Promise<UserPanelDailyCheckInResult>;
   checkInUserPanelDailyQuota(): Promise<UserPanelDailyCheckInResult>;
+  getUserPanelConsumptionLeaderboard(): Promise<UserPanelConsumptionLeaderboardResult>;
   createAPIToken(data: CreateAPITokenData): Promise<APITokenCreateResult>;
   updateAPIToken(id: number, data: APITokenUpdateData): Promise<APIToken>;
   rechargeAPITokenQuota(data: APITokenQuotaRechargeData): Promise<APITokenQuotaRechargeResult>;

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -348,6 +348,7 @@ export interface Transport {
 
   // ===== Usage Stats API =====
   getUsageStats(filter?: UsageStatsFilter): Promise<UsageStats[]>;
+  getUserPanelUsageStats(filter?: UsageStatsFilter): Promise<UsageStats[]>;
   recalculateUsageStats(): Promise<void>;
   recalculateCosts(): Promise<RecalculateCostsResult>;
   recalculateRequestCost(requestId: number): Promise<RecalculateRequestCostResult>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -627,12 +627,7 @@ export interface ResponseInfo {
 }
 
 export type ProxyRequestStatus =
-  | 'PENDING'
-  | 'IN_PROGRESS'
-  | 'COMPLETED'
-  | 'FAILED'
-  | 'CANCELLED'
-  | 'REJECTED';
+  'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'CANCELLED' | 'REJECTED';
 
 export type ProxyRequestErrorMode = 'all' | 'only' | 'exclude';
 
@@ -721,11 +716,7 @@ export interface ProxyRequest {
 // ===== ProxyUpstreamAttempt =====
 
 export type ProxyUpstreamAttemptStatus =
-  | 'PENDING'
-  | 'IN_PROGRESS'
-  | 'COMPLETED'
-  | 'FAILED'
-  | 'CANCELLED';
+  'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
 
 export interface ProxyUpstreamAttempt {
   id: number;
@@ -1338,6 +1329,17 @@ export interface UserPanelDailyCheckInResult {
   checkedIn: boolean;
   checkInDate: string;
   rewardAmount: number;
+}
+
+export interface UserPanelConsumptionLeaderboardRow {
+  userID: number;
+  username: string;
+  cost: number;
+}
+
+export interface UserPanelConsumptionLeaderboardResult {
+  today: UserPanelConsumptionLeaderboardRow[];
+  all: UserPanelConsumptionLeaderboardRow[];
 }
 
 export interface APITokenCleanupItem {

--- a/web/src/lib/user-panel-tabs.ts
+++ b/web/src/lib/user-panel-tabs.ts
@@ -1,4 +1,4 @@
-export const USER_PANEL_TABS = ['main'] as const;
+export const USER_PANEL_TABS = ['main', 'consumption'] as const;
 
 export type UserPanelTab = (typeof USER_PANEL_TABS)[number];
 
@@ -6,7 +6,7 @@ const DEFAULT_USER_PANEL_TAB: UserPanelTab = 'main';
 const STORAGE_PREFIX = 'maxx:user-panel:active-tab';
 
 export function isUserPanelTab(value: string | null | undefined): value is UserPanelTab {
-  return value === 'main';
+  return value === 'main' || value === 'consumption';
 }
 
 export function getUserPanelTabStorageKey(userId: number | string | null | undefined): string {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2065,7 +2065,13 @@
     "failed": "Failed",
     "recalculate": "Recalculate",
     "recalculateCosts": "Recalculate Costs",
-    "recalculateStats": "Re-aggregate Stats"
+    "recalculateStats": "Re-aggregate Stats",
+    "overviewTab": "Overview",
+    "consumptionLeaderboardTab": "Consumption",
+    "todayConsumptionLeaderboard": "Today consumption",
+    "allConsumptionLeaderboard": "All-time consumption",
+    "username": "Username",
+    "amount": "Amount"
   },
   "addProvider": {
     "title": "Add Provider",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -230,7 +230,8 @@
     "todayConsumptionLeaderboard": "Today consumption",
     "allConsumptionLeaderboard": "All-time consumption",
     "amount": "Amount",
-    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard"
+    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard",
+    "me": "Me"
   },
   "testField": {
     "title": "Test Field",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -225,7 +225,12 @@
       "degraded": "Degraded",
       "no-data": "No data",
       "unavailable": "Unavailable"
-    }
+    },
+    "consumptionTab": "Consumption",
+    "todayConsumptionLeaderboard": "Today consumption",
+    "allConsumptionLeaderboard": "All-time consumption",
+    "amount": "Amount",
+    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard"
   },
   "testField": {
     "title": "Test Field",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2065,13 +2065,7 @@
     "failed": "Failed",
     "recalculate": "Recalculate",
     "recalculateCosts": "Recalculate Costs",
-    "recalculateStats": "Re-aggregate Stats",
-    "overviewTab": "Overview",
-    "consumptionLeaderboardTab": "Consumption",
-    "todayConsumptionLeaderboard": "Today consumption",
-    "allConsumptionLeaderboard": "All-time consumption",
-    "username": "Username",
-    "amount": "Amount"
+    "recalculateStats": "Re-aggregate Stats"
   },
   "addProvider": {
     "title": "Add Provider",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -142,6 +142,8 @@
     "unnamedKey": "Unnamed key",
     "useCount": "Uses",
     "quotaBalance": "Balance",
+    "todayTokenUsage": "Today tokens",
+    "totalTokenUsage": "Total tokens",
     "lastUsed": "Recent",
     "apiAccess": "API Access",
     "baseURL": "Base URL",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -169,8 +169,7 @@
     "expiresAt": "Expires",
     "noDedicatedKey": "No key",
     "dailyCheckInTitle": "Daily check-in",
-    "dailyCheckInReward": "Claim {{amount}} quota each day",
-    "dailyCheckInAction": "Check in",
+    "dailyCheckInReward": "Automatically claim {{amount}} quota each day",
     "dailyCheckInDone": "Claimed today",
     "dailyCheckInSuccess": "Checked in. {{amount}} quota added.",
     "dailyCheckInAlreadyDone": "Already checked in today.",
@@ -230,7 +229,9 @@
     "todayConsumptionLeaderboard": "Today consumption",
     "allConsumptionLeaderboard": "All-time consumption",
     "amount": "Amount",
-    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard"
+    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard",
+    "dailyCheckInAutoPending": "Waiting for auto check-in",
+    "dailyCheckInAutoRunning": "Auto check-in…"
   },
   "testField": {
     "title": "Test Field",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -230,8 +230,7 @@
     "todayConsumptionLeaderboard": "Today consumption",
     "allConsumptionLeaderboard": "All-time consumption",
     "amount": "Amount",
-    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard",
-    "me": "Me"
+    "consumptionLeaderboardLoadFailed": "Failed to load consumption leaderboard"
   },
   "testField": {
     "title": "Test Field",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -110,7 +110,7 @@
     "users": "Users",
     "changePassword": "Change Password",
     "managePasskeys": "Manage Passkeys",
-    "apiTokenLimits": "API Token Limits",
+    "apiTokenLimits": "Request Limits",
     "dataManagement": "Data Management",
     "proxyAccess": "Proxy Access",
     "externalModels": "External Models",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -142,6 +142,8 @@
     "unnamedKey": "未命名 Key",
     "useCount": "调用",
     "quotaBalance": "余额",
+    "todayTokenUsage": "今日 Token",
+    "totalTokenUsage": "总 Token",
     "lastUsed": "最近",
     "apiAccess": "接口接入",
     "baseURL": "基础地址",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2061,7 +2061,13 @@
     "failed": "失败",
     "recalculate": "重新计算",
     "recalculateCosts": "重算成本",
-    "recalculateStats": "重新聚合"
+    "recalculateStats": "重新聚合",
+    "overviewTab": "概览",
+    "consumptionLeaderboardTab": "消耗榜",
+    "todayConsumptionLeaderboard": "今日消耗榜",
+    "allConsumptionLeaderboard": "全部消耗榜",
+    "username": "用户名",
+    "amount": "金额"
   },
   "addProvider": {
     "title": "添加提供商",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -230,7 +230,8 @@
     "todayConsumptionLeaderboard": "今日消耗榜",
     "allConsumptionLeaderboard": "全部消耗榜",
     "amount": "金额",
-    "consumptionLeaderboardLoadFailed": "消耗榜加载失败"
+    "consumptionLeaderboardLoadFailed": "消耗榜加载失败",
+    "me": "我"
   },
   "testField": {
     "title": "测试场",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2061,13 +2061,7 @@
     "failed": "失败",
     "recalculate": "重新计算",
     "recalculateCosts": "重算成本",
-    "recalculateStats": "重新聚合",
-    "overviewTab": "概览",
-    "consumptionLeaderboardTab": "消耗榜",
-    "todayConsumptionLeaderboard": "今日消耗榜",
-    "allConsumptionLeaderboard": "全部消耗榜",
-    "username": "用户名",
-    "amount": "金额"
+    "recalculateStats": "重新聚合"
   },
   "addProvider": {
     "title": "添加提供商",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -110,7 +110,7 @@
     "users": "用户管理",
     "changePassword": "修改密码",
     "managePasskeys": "管理 Passkey",
-    "apiTokenLimits": "API Token 限流",
+    "apiTokenLimits": "请求限制",
     "dataManagement": "数据管理",
     "proxyAccess": "代理访问控制",
     "externalModels": "外部模型",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -230,8 +230,7 @@
     "todayConsumptionLeaderboard": "今日消耗榜",
     "allConsumptionLeaderboard": "全部消耗榜",
     "amount": "金额",
-    "consumptionLeaderboardLoadFailed": "消耗榜加载失败",
-    "me": "我"
+    "consumptionLeaderboardLoadFailed": "消耗榜加载失败"
   },
   "testField": {
     "title": "测试场",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -225,7 +225,12 @@
       "degraded": "波动",
       "no-data": "暂无数据",
       "unavailable": "不可用"
-    }
+    },
+    "consumptionTab": "消耗榜",
+    "todayConsumptionLeaderboard": "今日消耗榜",
+    "allConsumptionLeaderboard": "全部消耗榜",
+    "amount": "金额",
+    "consumptionLeaderboardLoadFailed": "消耗榜加载失败"
   },
   "testField": {
     "title": "测试场",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -169,8 +169,7 @@
     "expiresAt": "过期",
     "noDedicatedKey": "暂无 Key",
     "dailyCheckInTitle": "每日签到",
-    "dailyCheckInReward": "每日领取 {{amount}} 额度",
-    "dailyCheckInAction": "签到领取",
+    "dailyCheckInReward": "每日自动领取 {{amount}} 额度",
     "dailyCheckInDone": "今日已领取",
     "dailyCheckInSuccess": "签到成功，已增加 {{amount}} 额度。",
     "dailyCheckInAlreadyDone": "今日已签到。",
@@ -230,7 +229,9 @@
     "todayConsumptionLeaderboard": "今日消耗榜",
     "allConsumptionLeaderboard": "全部消耗榜",
     "amount": "金额",
-    "consumptionLeaderboardLoadFailed": "消耗榜加载失败"
+    "consumptionLeaderboardLoadFailed": "消耗榜加载失败",
+    "dailyCheckInAutoPending": "等待自动签到",
+    "dailyCheckInAutoRunning": "自动签到中…"
   },
   "testField": {
     "title": "测试场",

--- a/web/src/pages/stats/index.tsx
+++ b/web/src/pages/stats/index.tsx
@@ -9,6 +9,7 @@ import {
   Cpu,
   Coins,
   CheckCircle,
+  Trophy,
   Check,
   X,
 } from 'lucide-react';
@@ -21,6 +22,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  TabsContent,
   Button,
   Progress,
   Dialog,
@@ -29,6 +31,12 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from '@/components/ui';
 import { cn } from '@/lib/utils';
 import {
@@ -36,6 +44,7 @@ import {
   useProviders,
   useProjects,
   useVisibleAPITokens,
+  useUsers,
   useRecalculateUsageStats,
   useRecalculateCosts,
   useResponseModels,
@@ -45,11 +54,15 @@ import type {
   UsageStatsFilter,
   UsageStats,
   StatsGranularity,
+  APIToken,
+  User,
   RecalculateCostsProgress,
   RecalculateStatsProgress,
 } from '@/lib/transport';
 import { getTransport } from '@/lib/transport';
 import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+
+type StatsTab = 'overview' | 'consumptionLeaderboard';
 
 type TimeRange =
   | '1h'
@@ -70,6 +83,77 @@ interface TimeRangeConfig {
   end: Date;
   granularity: StatsGranularity;
   durationMinutes: number; // Total duration in minutes for RPM/TPM calculation
+}
+
+const USER_PANEL_TOKEN_DESCRIPTION_PREFIX = 'managed-by=maxx-user-panel;user-id=';
+
+interface ConsumptionLeaderboardRow {
+  userID: number;
+  username: string;
+  cost: number;
+}
+
+function getUsageStatAPITokenID(stat: UsageStats): number {
+  const raw = stat.apiTokenID ?? (stat as unknown as { apiTokenId?: number }).apiTokenId ?? 0;
+  return Number(raw) || 0;
+}
+
+function getUserIDFromUserPanelToken(token: APIToken): number | null {
+  if (!token.description?.startsWith(USER_PANEL_TOKEN_DESCRIPTION_PREFIX)) return null;
+  const id = Number(token.description.slice(USER_PANEL_TOKEN_DESCRIPTION_PREFIX.length));
+  return Number.isFinite(id) && id > 0 ? id : null;
+}
+
+function aggregateConsumptionLeaderboard(
+  stats: UsageStats[] | undefined,
+  apiTokens: APIToken[] | undefined,
+  users: User[] | undefined,
+): ConsumptionLeaderboardRow[] {
+  if (!stats?.length || !apiTokens?.length || !users?.length) return [];
+
+  const tokenUserMap = new Map<number, number>();
+  for (const token of apiTokens) {
+    const userID = getUserIDFromUserPanelToken(token);
+    if (userID) tokenUserMap.set(token.id, userID);
+  }
+
+  const userNameMap = new Map(users.map((user) => [user.id, user.username]));
+  const costByUser = new Map<number, number>();
+  for (const item of stats) {
+    const userID = tokenUserMap.get(getUsageStatAPITokenID(item));
+    if (!userID) continue;
+    costByUser.set(userID, (costByUser.get(userID) ?? 0) + item.cost);
+  }
+
+  return Array.from(costByUser.entries())
+    .map(([userID, cost]) => ({
+      userID,
+      username: userNameMap.get(userID) ?? `user ${userID}`,
+      cost,
+    }))
+    .sort((a, b) => b.cost - a.cost || a.username.localeCompare(b.username));
+}
+
+function formatCost(value: number) {
+  return `$${(value / 1_000_000_000).toFixed(4)}`;
+}
+
+function getTodayUsageFilter(): UsageStatsFilter {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    granularity: 'day',
+    start: start.toISOString(),
+    end: now.toISOString(),
+  };
+}
+
+function getAllUsageFilter(): UsageStatsFilter {
+  return {
+    granularity: 'month',
+    start: '2020-01-01T00:00:00.000Z',
+    end: new Date().toISOString(),
+  };
 }
 
 /**
@@ -412,6 +496,7 @@ export function StatsPage() {
   const [chartView, setChartView] = useState<ChartView>('requests');
   const [costsProgress, setCostsProgress] = useState<RecalculateCostsProgress | null>(null);
   const [statsProgress, setStatsProgress] = useState<RecalculateStatsProgress | null>(null);
+  const [activeStatsTab, setActiveStatsTab] = useState<StatsTab>('overview');
 
   // Reset all filters to 'all'
   const handleResetFilters = () => {
@@ -459,6 +544,7 @@ export function StatsPage() {
   const { data: providers } = useProviders();
   const { data: projects } = useProjects();
   const { data: apiTokens } = useVisibleAPITokens();
+  const { data: users } = useUsers();
   const { data: responseModels } = useResponseModels();
 
   const timeConfig = useMemo(() => getTimeRangeConfig(timeRange), [timeRange]);
@@ -480,6 +566,20 @@ export function StatsPage() {
   }, [timeConfig, providerId, projectId, clientType, apiTokenId, model]);
 
   const { data: stats, isLoading } = useUsageStats(filter);
+  const todayLeaderboardFilter = useMemo(() => getTodayUsageFilter(), []);
+  const allLeaderboardFilter = useMemo(() => getAllUsageFilter(), []);
+  const { data: todayLeaderboardStats, isLoading: todayLeaderboardLoading } =
+    useUsageStats(todayLeaderboardFilter);
+  const { data: allLeaderboardStats, isLoading: allLeaderboardLoading } =
+    useUsageStats(allLeaderboardFilter);
+  const todayLeaderboard = useMemo(
+    () => aggregateConsumptionLeaderboard(todayLeaderboardStats, apiTokens, users),
+    [todayLeaderboardStats, apiTokens, users],
+  );
+  const allLeaderboard = useMemo(
+    () => aggregateConsumptionLeaderboard(allLeaderboardStats, apiTokens, users),
+    [allLeaderboardStats, apiTokens, users],
+  );
   const chartData = useMemo(
     () => aggregateForChart(stats, timeConfig.granularity, timeRange, timeConfig),
     [stats, timeConfig, timeRange],
@@ -801,234 +901,327 @@ export function StatsPage() {
           data-testid="stats-results-region"
           className="flex-none min-w-0 flex flex-col p-4 @3xl/main:flex-1 @3xl/main:min-h-0 @3xl/main:p-6 @3xl/main:overflow-y-auto"
         >
-          <div className="max-w-7xl mx-auto w-full flex shrink-0 flex-col gap-6">
-            {/* 当前筛选条件摘要 */}
-            <div className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
-              <span className="font-medium text-foreground">{t('stats.filterSummary')}:</span>
-              <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                {timeConfig.start
-                  ? `${timeConfig.start.toLocaleString()} - ${timeConfig.end.toLocaleString()}`
-                  : t('stats.allTime')}
-              </span>
-              {providerId !== 'all' && (
-                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                  {t('stats.provider')}:{' '}
-                  {providers?.find((p) => String(p.id) === providerId)?.name || providerId}
-                </span>
-              )}
-              {projectId !== 'all' && (
-                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                  {t('stats.project')}:{' '}
-                  {projects?.find((p) => String(p.id) === projectId)?.name || projectId}
-                </span>
-              )}
-              {clientType !== 'all' && (
-                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                  {t('stats.clientType')}: {clientType}
-                </span>
-              )}
-              {apiTokenId !== 'all' && (
-                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                  {t('stats.apiToken')}:{' '}
-                  {apiTokens?.find((t) => String(t.id) === apiTokenId)?.name || apiTokenId}
-                </span>
-              )}
-              {model !== 'all' && (
-                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs break-all">
-                  {t('stats.model')}: {model}
-                </span>
-              )}
-            </div>
+          <Tabs
+            value={activeStatsTab}
+            onValueChange={(value) => setActiveStatsTab(value as StatsTab)}
+            className="max-w-7xl mx-auto w-full flex shrink-0 flex-col gap-6"
+          >
+            <TabsList className="w-fit">
+              <TabsTrigger value="overview">{t('stats.overviewTab')}</TabsTrigger>
+              <TabsTrigger value="consumptionLeaderboard">
+                {t('stats.consumptionLeaderboardTab')}
+              </TabsTrigger>
+            </TabsList>
 
-            {/* 汇总卡片 - 与 Dashboard 一致的排列顺序 */}
-            <div data-testid="stats-summary-grid" className="grid gap-4 grid-cols-2 lg:grid-cols-4">
-              <StatCard
-                title={t('stats.requests')}
-                value={summary.totalRequests.toLocaleString()}
-                subtitle={`${formatNumber(summary.avgRpm)} RPM · ${summary.avgTtft.toFixed(2)}s TTFT`}
-                icon={Activity}
-                iconClassName="text-blue-600 dark:text-blue-400"
-              />
-              <StatCard
-                title={t('stats.tokens')}
-                value={formatNumber(summary.totalTokens)}
-                subtitle={`${formatNumber(summary.avgTpm)} TPM · ${summary.cacheHitRate.toFixed(1)}% ${t('stats.cacheHit')}`}
-                icon={Cpu}
-                iconClassName="text-violet-600 dark:text-violet-400"
-              />
-              <StatCard
-                title={t('stats.totalCost')}
-                value={`$${(summary.totalCost / 1_000_000_000).toFixed(4)}`}
-                icon={Coins}
-                iconClassName="text-amber-600 dark:text-amber-400"
-              />
-              <StatCard
-                title={t('stats.successRate')}
-                value={`${summary.totalRequests > 0 ? ((summary.successfulRequests / summary.totalRequests) * 100).toFixed(1) : 0}%`}
-                icon={CheckCircle}
-                iconClassName={cn(
-                  summary.successfulRequests / summary.totalRequests >= 0.95
-                    ? 'text-emerald-600 dark:text-emerald-400'
-                    : summary.successfulRequests / summary.totalRequests >= 0.8
-                      ? 'text-amber-600 dark:text-amber-400'
-                      : 'text-red-600 dark:text-red-400',
+            <TabsContent value="overview" className="mt-0 flex flex-col gap-6">
+              {/* 当前筛选条件摘要 */}
+              <div className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
+                <span className="font-medium text-foreground">{t('stats.filterSummary')}:</span>
+                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                  {timeConfig.start
+                    ? `${timeConfig.start.toLocaleString()} - ${timeConfig.end.toLocaleString()}`
+                    : t('stats.allTime')}
+                </span>
+                {providerId !== 'all' && (
+                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                    {t('stats.provider')}:{' '}
+                    {providers?.find((p) => String(p.id) === providerId)?.name || providerId}
+                  </span>
                 )}
-              />
-            </div>
+                {projectId !== 'all' && (
+                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                    {t('stats.project')}:{' '}
+                    {projects?.find((p) => String(p.id) === projectId)?.name || projectId}
+                  </span>
+                )}
+                {clientType !== 'all' && (
+                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                    {t('stats.clientType')}: {clientType}
+                  </span>
+                )}
+                {apiTokenId !== 'all' && (
+                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                    {t('stats.apiToken')}:{' '}
+                    {apiTokens?.find((t) => String(t.id) === apiTokenId)?.name || apiTokenId}
+                  </span>
+                )}
+                {model !== 'all' && (
+                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs break-all">
+                    {t('stats.model')}: {model}
+                  </span>
+                )}
+              </div>
 
-            {isLoading ? (
-              <div className="text-center text-muted-foreground py-8">{t('common.loading')}</div>
-            ) : chartData.length === 0 ? (
-              <div className="text-center text-muted-foreground py-8">{t('common.noData')}</div>
-            ) : (
-              <Card
-                data-testid="stats-chart-card"
-                className="border-border/50 bg-card/50 backdrop-blur-sm"
+              {/* 汇总卡片 - 与 Dashboard 一致的排列顺序 */}
+              <div
+                data-testid="stats-summary-grid"
+                className="grid gap-4 grid-cols-2 lg:grid-cols-4"
               >
-                <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
-                  <CardTitle className="text-base font-semibold flex items-center gap-2">
-                    <BarChart3 className="h-4 w-4 text-emerald-500" />
-                    {t('stats.chart')}
-                  </CardTitle>
-                  <Tabs value={chartView} onValueChange={(v) => setChartView(v as ChartView)}>
-                    <TabsList>
-                      <TabsTrigger value="requests">{t('stats.requests')}</TabsTrigger>
-                      <TabsTrigger value="tokens">{t('stats.tokens')}</TabsTrigger>
-                    </TabsList>
-                  </Tabs>
-                </CardHeader>
-                <CardContent className="pt-2">
-                  <div ref={chartContainerRef} className="w-full h-[400px] min-h-[400px]">
-                    {chartWidth > 0 && (
-                      <ComposedChart width={chartWidth} height={400} data={chartData}>
-                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
-                        <XAxis
-                          dataKey="label"
-                          tick={{ fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                          interval="preserveStartEnd"
-                        />
-                        <YAxis
-                          yAxisId="left"
-                          tick={{ fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                          tickFormatter={(v) => formatNumber(v)}
-                        />
-                        <YAxis
-                          yAxisId="right"
-                          orientation="right"
-                          tick={{ fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                          tickFormatter={(v) => `${v.toFixed(2)}`}
-                        />
-                        <Tooltip
-                          contentStyle={{
-                            backgroundColor: 'var(--card)',
-                            border: '1px solid var(--border)',
-                            borderRadius: '8px',
-                            fontSize: '12px',
-                            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-                          }}
-                          itemSorter={(a) => (a.name === t('stats.costUSD') ? -1 : 0)}
-                          formatter={(value, name) => {
-                            const numValue = typeof value === 'number' ? value : 0;
-                            const nameStr = name ?? '';
-                            if (nameStr === t('stats.costUSD'))
-                              return [`$${numValue.toFixed(4)}`, nameStr];
-                            return [numValue.toLocaleString(), nameStr];
-                          }}
-                        />
-                        <Legend
-                          wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
-                          itemSorter={(a) => (a.value === t('stats.costUSD') ? -1 : 0)}
-                        />
-                        {chartView === 'requests' && (
-                          <>
-                            <Line
-                              yAxisId="right"
-                              type="monotone"
-                              dataKey="cost"
-                              name={t('stats.costUSD')}
-                              stroke="var(--color-chart-3)"
-                              strokeWidth={2}
-                              dot={false}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="successful"
-                              name={t('stats.successful')}
-                              stackId="a"
-                              fill="var(--color-chart-1)"
-                              radius={[0, 0, 0, 0]}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="failed"
-                              name={t('stats.failed')}
-                              stackId="a"
-                              fill="var(--color-chart-2)"
-                              radius={[4, 4, 0, 0]}
-                            />
-                          </>
-                        )}
-                        {chartView === 'tokens' && (
-                          <>
-                            <Line
-                              yAxisId="right"
-                              type="monotone"
-                              dataKey="cost"
-                              name={t('stats.costUSD')}
-                              stroke="var(--color-chart-3)"
-                              strokeWidth={2}
-                              dot={false}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="inputTokens"
-                              name={t('stats.inputTokens')}
-                              stackId="a"
-                              fill="var(--color-chart-1)"
-                              radius={[0, 0, 0, 0]}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="outputTokens"
-                              name={t('stats.outputTokens')}
-                              stackId="a"
-                              fill="var(--color-chart-2)"
-                              radius={[0, 0, 0, 0]}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="cacheRead"
-                              name={t('stats.cacheRead')}
-                              stackId="a"
-                              fill="var(--color-chart-4)"
-                              radius={[0, 0, 0, 0]}
-                            />
-                            <Bar
-                              yAxisId="left"
-                              dataKey="cacheWrite"
-                              name={t('stats.cacheWrite')}
-                              stackId="a"
-                              fill="var(--color-chart-5)"
-                              radius={[4, 4, 0, 0]}
-                            />
-                          </>
-                        )}
-                      </ComposedChart>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            )}
-          </div>
+                <StatCard
+                  title={t('stats.requests')}
+                  value={summary.totalRequests.toLocaleString()}
+                  subtitle={`${formatNumber(summary.avgRpm)} RPM · ${summary.avgTtft.toFixed(2)}s TTFT`}
+                  icon={Activity}
+                  iconClassName="text-blue-600 dark:text-blue-400"
+                />
+                <StatCard
+                  title={t('stats.tokens')}
+                  value={formatNumber(summary.totalTokens)}
+                  subtitle={`${formatNumber(summary.avgTpm)} TPM · ${summary.cacheHitRate.toFixed(1)}% ${t('stats.cacheHit')}`}
+                  icon={Cpu}
+                  iconClassName="text-violet-600 dark:text-violet-400"
+                />
+                <StatCard
+                  title={t('stats.totalCost')}
+                  value={`$${(summary.totalCost / 1_000_000_000).toFixed(4)}`}
+                  icon={Coins}
+                  iconClassName="text-amber-600 dark:text-amber-400"
+                />
+                <StatCard
+                  title={t('stats.successRate')}
+                  value={`${summary.totalRequests > 0 ? ((summary.successfulRequests / summary.totalRequests) * 100).toFixed(1) : 0}%`}
+                  icon={CheckCircle}
+                  iconClassName={cn(
+                    summary.successfulRequests / summary.totalRequests >= 0.95
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : summary.successfulRequests / summary.totalRequests >= 0.8
+                        ? 'text-amber-600 dark:text-amber-400'
+                        : 'text-red-600 dark:text-red-400',
+                  )}
+                />
+              </div>
+
+              {isLoading ? (
+                <div className="text-center text-muted-foreground py-8">{t('common.loading')}</div>
+              ) : chartData.length === 0 ? (
+                <div className="text-center text-muted-foreground py-8">{t('common.noData')}</div>
+              ) : (
+                <Card
+                  data-testid="stats-chart-card"
+                  className="border-border/50 bg-card/50 backdrop-blur-sm"
+                >
+                  <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
+                    <CardTitle className="text-base font-semibold flex items-center gap-2">
+                      <BarChart3 className="h-4 w-4 text-emerald-500" />
+                      {t('stats.chart')}
+                    </CardTitle>
+                    <Tabs value={chartView} onValueChange={(v) => setChartView(v as ChartView)}>
+                      <TabsList>
+                        <TabsTrigger value="requests">{t('stats.requests')}</TabsTrigger>
+                        <TabsTrigger value="tokens">{t('stats.tokens')}</TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                  </CardHeader>
+                  <CardContent className="pt-2">
+                    <div ref={chartContainerRef} className="w-full h-[400px] min-h-[400px]">
+                      {chartWidth > 0 && (
+                        <ComposedChart width={chartWidth} height={400} data={chartData}>
+                          <CartesianGrid
+                            strokeDasharray="3 3"
+                            stroke="var(--border)"
+                            opacity={0.5}
+                          />
+                          <XAxis
+                            dataKey="label"
+                            tick={{ fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            interval="preserveStartEnd"
+                          />
+                          <YAxis
+                            yAxisId="left"
+                            tick={{ fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            tickFormatter={(v) => formatNumber(v)}
+                          />
+                          <YAxis
+                            yAxisId="right"
+                            orientation="right"
+                            tick={{ fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            tickFormatter={(v) => `${v.toFixed(2)}`}
+                          />
+                          <Tooltip
+                            contentStyle={{
+                              backgroundColor: 'var(--card)',
+                              border: '1px solid var(--border)',
+                              borderRadius: '8px',
+                              fontSize: '12px',
+                              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                            }}
+                            itemSorter={(a) => (a.name === t('stats.costUSD') ? -1 : 0)}
+                            formatter={(value, name) => {
+                              const numValue = typeof value === 'number' ? value : 0;
+                              const nameStr = name ?? '';
+                              if (nameStr === t('stats.costUSD'))
+                                return [`$${numValue.toFixed(4)}`, nameStr];
+                              return [numValue.toLocaleString(), nameStr];
+                            }}
+                          />
+                          <Legend
+                            wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
+                            itemSorter={(a) => (a.value === t('stats.costUSD') ? -1 : 0)}
+                          />
+                          {chartView === 'requests' && (
+                            <>
+                              <Line
+                                yAxisId="right"
+                                type="monotone"
+                                dataKey="cost"
+                                name={t('stats.costUSD')}
+                                stroke="var(--color-chart-3)"
+                                strokeWidth={2}
+                                dot={false}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="successful"
+                                name={t('stats.successful')}
+                                stackId="a"
+                                fill="var(--color-chart-1)"
+                                radius={[0, 0, 0, 0]}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="failed"
+                                name={t('stats.failed')}
+                                stackId="a"
+                                fill="var(--color-chart-2)"
+                                radius={[4, 4, 0, 0]}
+                              />
+                            </>
+                          )}
+                          {chartView === 'tokens' && (
+                            <>
+                              <Line
+                                yAxisId="right"
+                                type="monotone"
+                                dataKey="cost"
+                                name={t('stats.costUSD')}
+                                stroke="var(--color-chart-3)"
+                                strokeWidth={2}
+                                dot={false}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="inputTokens"
+                                name={t('stats.inputTokens')}
+                                stackId="a"
+                                fill="var(--color-chart-1)"
+                                radius={[0, 0, 0, 0]}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="outputTokens"
+                                name={t('stats.outputTokens')}
+                                stackId="a"
+                                fill="var(--color-chart-2)"
+                                radius={[0, 0, 0, 0]}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="cacheRead"
+                                name={t('stats.cacheRead')}
+                                stackId="a"
+                                fill="var(--color-chart-4)"
+                                radius={[0, 0, 0, 0]}
+                              />
+                              <Bar
+                                yAxisId="left"
+                                dataKey="cacheWrite"
+                                name={t('stats.cacheWrite')}
+                                stackId="a"
+                                fill="var(--color-chart-5)"
+                                radius={[4, 4, 0, 0]}
+                              />
+                            </>
+                          )}
+                        </ComposedChart>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
+            </TabsContent>
+
+            <TabsContent value="consumptionLeaderboard" className="mt-0">
+              <div className="grid gap-4 lg:grid-cols-2">
+                <ConsumptionLeaderboardCard
+                  title={t('stats.todayConsumptionLeaderboard')}
+                  rows={todayLeaderboard}
+                  isLoading={todayLeaderboardLoading}
+                />
+                <ConsumptionLeaderboardCard
+                  title={t('stats.allConsumptionLeaderboard')}
+                  rows={allLeaderboard}
+                  isLoading={allLeaderboardLoading}
+                />
+              </div>
+            </TabsContent>
+          </Tabs>
         </div>
       </div>
     </div>
+  );
+}
+
+function ConsumptionLeaderboardCard({
+  title,
+  rows,
+  isLoading,
+}: {
+  title: string;
+  rows: ConsumptionLeaderboardRow[];
+  isLoading: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold flex items-center gap-2">
+          <Trophy className="h-4 w-4 text-amber-500" />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            {t('common.loading')}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">{t('common.noData')}</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('stats.username')}</TableHead>
+                <TableHead className="text-right">{t('stats.amount')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row, index) => (
+                <TableRow key={row.userID}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <span className="flex size-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+                        {index + 1}
+                      </span>
+                      <span className="font-medium text-foreground">{row.username}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right font-mono font-semibold tabular-nums">
+                    {formatCost(row.cost)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/web/src/pages/stats/index.tsx
+++ b/web/src/pages/stats/index.tsx
@@ -9,7 +9,6 @@ import {
   Cpu,
   Coins,
   CheckCircle,
-  Trophy,
   Check,
   X,
 } from 'lucide-react';
@@ -22,7 +21,6 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
-  TabsContent,
   Button,
   Progress,
   Dialog,
@@ -31,12 +29,6 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
 } from '@/components/ui';
 import { cn } from '@/lib/utils';
 import {
@@ -44,7 +36,6 @@ import {
   useProviders,
   useProjects,
   useVisibleAPITokens,
-  useUsers,
   useRecalculateUsageStats,
   useRecalculateCosts,
   useResponseModels,
@@ -54,15 +45,11 @@ import type {
   UsageStatsFilter,
   UsageStats,
   StatsGranularity,
-  APIToken,
-  User,
   RecalculateCostsProgress,
   RecalculateStatsProgress,
 } from '@/lib/transport';
 import { getTransport } from '@/lib/transport';
 import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
-
-type StatsTab = 'overview' | 'consumptionLeaderboard';
 
 type TimeRange =
   | '1h'
@@ -83,77 +70,6 @@ interface TimeRangeConfig {
   end: Date;
   granularity: StatsGranularity;
   durationMinutes: number; // Total duration in minutes for RPM/TPM calculation
-}
-
-const USER_PANEL_TOKEN_DESCRIPTION_PREFIX = 'managed-by=maxx-user-panel;user-id=';
-
-interface ConsumptionLeaderboardRow {
-  userID: number;
-  username: string;
-  cost: number;
-}
-
-function getUsageStatAPITokenID(stat: UsageStats): number {
-  const raw = stat.apiTokenID ?? (stat as unknown as { apiTokenId?: number }).apiTokenId ?? 0;
-  return Number(raw) || 0;
-}
-
-function getUserIDFromUserPanelToken(token: APIToken): number | null {
-  if (!token.description?.startsWith(USER_PANEL_TOKEN_DESCRIPTION_PREFIX)) return null;
-  const id = Number(token.description.slice(USER_PANEL_TOKEN_DESCRIPTION_PREFIX.length));
-  return Number.isFinite(id) && id > 0 ? id : null;
-}
-
-function aggregateConsumptionLeaderboard(
-  stats: UsageStats[] | undefined,
-  apiTokens: APIToken[] | undefined,
-  users: User[] | undefined,
-): ConsumptionLeaderboardRow[] {
-  if (!stats?.length || !apiTokens?.length || !users?.length) return [];
-
-  const tokenUserMap = new Map<number, number>();
-  for (const token of apiTokens) {
-    const userID = getUserIDFromUserPanelToken(token);
-    if (userID) tokenUserMap.set(token.id, userID);
-  }
-
-  const userNameMap = new Map(users.map((user) => [user.id, user.username]));
-  const costByUser = new Map<number, number>();
-  for (const item of stats) {
-    const userID = tokenUserMap.get(getUsageStatAPITokenID(item));
-    if (!userID) continue;
-    costByUser.set(userID, (costByUser.get(userID) ?? 0) + item.cost);
-  }
-
-  return Array.from(costByUser.entries())
-    .map(([userID, cost]) => ({
-      userID,
-      username: userNameMap.get(userID) ?? `user ${userID}`,
-      cost,
-    }))
-    .sort((a, b) => b.cost - a.cost || a.username.localeCompare(b.username));
-}
-
-function formatCost(value: number) {
-  return `$${(value / 1_000_000_000).toFixed(4)}`;
-}
-
-function getTodayUsageFilter(): UsageStatsFilter {
-  const now = new Date();
-  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  return {
-    granularity: 'day',
-    start: start.toISOString(),
-    end: now.toISOString(),
-  };
-}
-
-function getAllUsageFilter(): UsageStatsFilter {
-  return {
-    granularity: 'month',
-    start: '2020-01-01T00:00:00.000Z',
-    end: new Date().toISOString(),
-  };
 }
 
 /**
@@ -496,7 +412,6 @@ export function StatsPage() {
   const [chartView, setChartView] = useState<ChartView>('requests');
   const [costsProgress, setCostsProgress] = useState<RecalculateCostsProgress | null>(null);
   const [statsProgress, setStatsProgress] = useState<RecalculateStatsProgress | null>(null);
-  const [activeStatsTab, setActiveStatsTab] = useState<StatsTab>('overview');
 
   // Reset all filters to 'all'
   const handleResetFilters = () => {
@@ -544,7 +459,6 @@ export function StatsPage() {
   const { data: providers } = useProviders();
   const { data: projects } = useProjects();
   const { data: apiTokens } = useVisibleAPITokens();
-  const { data: users } = useUsers();
   const { data: responseModels } = useResponseModels();
 
   const timeConfig = useMemo(() => getTimeRangeConfig(timeRange), [timeRange]);
@@ -566,20 +480,6 @@ export function StatsPage() {
   }, [timeConfig, providerId, projectId, clientType, apiTokenId, model]);
 
   const { data: stats, isLoading } = useUsageStats(filter);
-  const todayLeaderboardFilter = useMemo(() => getTodayUsageFilter(), []);
-  const allLeaderboardFilter = useMemo(() => getAllUsageFilter(), []);
-  const { data: todayLeaderboardStats, isLoading: todayLeaderboardLoading } =
-    useUsageStats(todayLeaderboardFilter);
-  const { data: allLeaderboardStats, isLoading: allLeaderboardLoading } =
-    useUsageStats(allLeaderboardFilter);
-  const todayLeaderboard = useMemo(
-    () => aggregateConsumptionLeaderboard(todayLeaderboardStats, apiTokens, users),
-    [todayLeaderboardStats, apiTokens, users],
-  );
-  const allLeaderboard = useMemo(
-    () => aggregateConsumptionLeaderboard(allLeaderboardStats, apiTokens, users),
-    [allLeaderboardStats, apiTokens, users],
-  );
   const chartData = useMemo(
     () => aggregateForChart(stats, timeConfig.granularity, timeRange, timeConfig),
     [stats, timeConfig, timeRange],
@@ -901,327 +801,234 @@ export function StatsPage() {
           data-testid="stats-results-region"
           className="flex-none min-w-0 flex flex-col p-4 @3xl/main:flex-1 @3xl/main:min-h-0 @3xl/main:p-6 @3xl/main:overflow-y-auto"
         >
-          <Tabs
-            value={activeStatsTab}
-            onValueChange={(value) => setActiveStatsTab(value as StatsTab)}
-            className="max-w-7xl mx-auto w-full flex shrink-0 flex-col gap-6"
-          >
-            <TabsList className="w-fit">
-              <TabsTrigger value="overview">{t('stats.overviewTab')}</TabsTrigger>
-              <TabsTrigger value="consumptionLeaderboard">
-                {t('stats.consumptionLeaderboardTab')}
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="overview" className="mt-0 flex flex-col gap-6">
-              {/* 当前筛选条件摘要 */}
-              <div className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
-                <span className="font-medium text-foreground">{t('stats.filterSummary')}:</span>
+          <div className="max-w-7xl mx-auto w-full flex shrink-0 flex-col gap-6">
+            {/* 当前筛选条件摘要 */}
+            <div className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
+              <span className="font-medium text-foreground">{t('stats.filterSummary')}:</span>
+              <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                {timeConfig.start
+                  ? `${timeConfig.start.toLocaleString()} - ${timeConfig.end.toLocaleString()}`
+                  : t('stats.allTime')}
+              </span>
+              {providerId !== 'all' && (
                 <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                  {timeConfig.start
-                    ? `${timeConfig.start.toLocaleString()} - ${timeConfig.end.toLocaleString()}`
-                    : t('stats.allTime')}
+                  {t('stats.provider')}:{' '}
+                  {providers?.find((p) => String(p.id) === providerId)?.name || providerId}
                 </span>
-                {providerId !== 'all' && (
-                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                    {t('stats.provider')}:{' '}
-                    {providers?.find((p) => String(p.id) === providerId)?.name || providerId}
-                  </span>
-                )}
-                {projectId !== 'all' && (
-                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                    {t('stats.project')}:{' '}
-                    {projects?.find((p) => String(p.id) === projectId)?.name || projectId}
-                  </span>
-                )}
-                {clientType !== 'all' && (
-                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                    {t('stats.clientType')}: {clientType}
-                  </span>
-                )}
-                {apiTokenId !== 'all' && (
-                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
-                    {t('stats.apiToken')}:{' '}
-                    {apiTokens?.find((t) => String(t.id) === apiTokenId)?.name || apiTokenId}
-                  </span>
-                )}
-                {model !== 'all' && (
-                  <span className="bg-muted/50 px-2 py-0.5 rounded text-xs break-all">
-                    {t('stats.model')}: {model}
-                  </span>
-                )}
-              </div>
-
-              {/* 汇总卡片 - 与 Dashboard 一致的排列顺序 */}
-              <div
-                data-testid="stats-summary-grid"
-                className="grid gap-4 grid-cols-2 lg:grid-cols-4"
-              >
-                <StatCard
-                  title={t('stats.requests')}
-                  value={summary.totalRequests.toLocaleString()}
-                  subtitle={`${formatNumber(summary.avgRpm)} RPM · ${summary.avgTtft.toFixed(2)}s TTFT`}
-                  icon={Activity}
-                  iconClassName="text-blue-600 dark:text-blue-400"
-                />
-                <StatCard
-                  title={t('stats.tokens')}
-                  value={formatNumber(summary.totalTokens)}
-                  subtitle={`${formatNumber(summary.avgTpm)} TPM · ${summary.cacheHitRate.toFixed(1)}% ${t('stats.cacheHit')}`}
-                  icon={Cpu}
-                  iconClassName="text-violet-600 dark:text-violet-400"
-                />
-                <StatCard
-                  title={t('stats.totalCost')}
-                  value={`$${(summary.totalCost / 1_000_000_000).toFixed(4)}`}
-                  icon={Coins}
-                  iconClassName="text-amber-600 dark:text-amber-400"
-                />
-                <StatCard
-                  title={t('stats.successRate')}
-                  value={`${summary.totalRequests > 0 ? ((summary.successfulRequests / summary.totalRequests) * 100).toFixed(1) : 0}%`}
-                  icon={CheckCircle}
-                  iconClassName={cn(
-                    summary.successfulRequests / summary.totalRequests >= 0.95
-                      ? 'text-emerald-600 dark:text-emerald-400'
-                      : summary.successfulRequests / summary.totalRequests >= 0.8
-                        ? 'text-amber-600 dark:text-amber-400'
-                        : 'text-red-600 dark:text-red-400',
-                  )}
-                />
-              </div>
-
-              {isLoading ? (
-                <div className="text-center text-muted-foreground py-8">{t('common.loading')}</div>
-              ) : chartData.length === 0 ? (
-                <div className="text-center text-muted-foreground py-8">{t('common.noData')}</div>
-              ) : (
-                <Card
-                  data-testid="stats-chart-card"
-                  className="border-border/50 bg-card/50 backdrop-blur-sm"
-                >
-                  <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
-                    <CardTitle className="text-base font-semibold flex items-center gap-2">
-                      <BarChart3 className="h-4 w-4 text-emerald-500" />
-                      {t('stats.chart')}
-                    </CardTitle>
-                    <Tabs value={chartView} onValueChange={(v) => setChartView(v as ChartView)}>
-                      <TabsList>
-                        <TabsTrigger value="requests">{t('stats.requests')}</TabsTrigger>
-                        <TabsTrigger value="tokens">{t('stats.tokens')}</TabsTrigger>
-                      </TabsList>
-                    </Tabs>
-                  </CardHeader>
-                  <CardContent className="pt-2">
-                    <div ref={chartContainerRef} className="w-full h-[400px] min-h-[400px]">
-                      {chartWidth > 0 && (
-                        <ComposedChart width={chartWidth} height={400} data={chartData}>
-                          <CartesianGrid
-                            strokeDasharray="3 3"
-                            stroke="var(--border)"
-                            opacity={0.5}
-                          />
-                          <XAxis
-                            dataKey="label"
-                            tick={{ fontSize: 11 }}
-                            tickLine={false}
-                            axisLine={false}
-                            interval="preserveStartEnd"
-                          />
-                          <YAxis
-                            yAxisId="left"
-                            tick={{ fontSize: 11 }}
-                            tickLine={false}
-                            axisLine={false}
-                            tickFormatter={(v) => formatNumber(v)}
-                          />
-                          <YAxis
-                            yAxisId="right"
-                            orientation="right"
-                            tick={{ fontSize: 11 }}
-                            tickLine={false}
-                            axisLine={false}
-                            tickFormatter={(v) => `${v.toFixed(2)}`}
-                          />
-                          <Tooltip
-                            contentStyle={{
-                              backgroundColor: 'var(--card)',
-                              border: '1px solid var(--border)',
-                              borderRadius: '8px',
-                              fontSize: '12px',
-                              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-                            }}
-                            itemSorter={(a) => (a.name === t('stats.costUSD') ? -1 : 0)}
-                            formatter={(value, name) => {
-                              const numValue = typeof value === 'number' ? value : 0;
-                              const nameStr = name ?? '';
-                              if (nameStr === t('stats.costUSD'))
-                                return [`$${numValue.toFixed(4)}`, nameStr];
-                              return [numValue.toLocaleString(), nameStr];
-                            }}
-                          />
-                          <Legend
-                            wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
-                            itemSorter={(a) => (a.value === t('stats.costUSD') ? -1 : 0)}
-                          />
-                          {chartView === 'requests' && (
-                            <>
-                              <Line
-                                yAxisId="right"
-                                type="monotone"
-                                dataKey="cost"
-                                name={t('stats.costUSD')}
-                                stroke="var(--color-chart-3)"
-                                strokeWidth={2}
-                                dot={false}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="successful"
-                                name={t('stats.successful')}
-                                stackId="a"
-                                fill="var(--color-chart-1)"
-                                radius={[0, 0, 0, 0]}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="failed"
-                                name={t('stats.failed')}
-                                stackId="a"
-                                fill="var(--color-chart-2)"
-                                radius={[4, 4, 0, 0]}
-                              />
-                            </>
-                          )}
-                          {chartView === 'tokens' && (
-                            <>
-                              <Line
-                                yAxisId="right"
-                                type="monotone"
-                                dataKey="cost"
-                                name={t('stats.costUSD')}
-                                stroke="var(--color-chart-3)"
-                                strokeWidth={2}
-                                dot={false}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="inputTokens"
-                                name={t('stats.inputTokens')}
-                                stackId="a"
-                                fill="var(--color-chart-1)"
-                                radius={[0, 0, 0, 0]}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="outputTokens"
-                                name={t('stats.outputTokens')}
-                                stackId="a"
-                                fill="var(--color-chart-2)"
-                                radius={[0, 0, 0, 0]}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="cacheRead"
-                                name={t('stats.cacheRead')}
-                                stackId="a"
-                                fill="var(--color-chart-4)"
-                                radius={[0, 0, 0, 0]}
-                              />
-                              <Bar
-                                yAxisId="left"
-                                dataKey="cacheWrite"
-                                name={t('stats.cacheWrite')}
-                                stackId="a"
-                                fill="var(--color-chart-5)"
-                                radius={[4, 4, 0, 0]}
-                              />
-                            </>
-                          )}
-                        </ComposedChart>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
               )}
-            </TabsContent>
+              {projectId !== 'all' && (
+                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                  {t('stats.project')}:{' '}
+                  {projects?.find((p) => String(p.id) === projectId)?.name || projectId}
+                </span>
+              )}
+              {clientType !== 'all' && (
+                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                  {t('stats.clientType')}: {clientType}
+                </span>
+              )}
+              {apiTokenId !== 'all' && (
+                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs">
+                  {t('stats.apiToken')}:{' '}
+                  {apiTokens?.find((t) => String(t.id) === apiTokenId)?.name || apiTokenId}
+                </span>
+              )}
+              {model !== 'all' && (
+                <span className="bg-muted/50 px-2 py-0.5 rounded text-xs break-all">
+                  {t('stats.model')}: {model}
+                </span>
+              )}
+            </div>
 
-            <TabsContent value="consumptionLeaderboard" className="mt-0">
-              <div className="grid gap-4 lg:grid-cols-2">
-                <ConsumptionLeaderboardCard
-                  title={t('stats.todayConsumptionLeaderboard')}
-                  rows={todayLeaderboard}
-                  isLoading={todayLeaderboardLoading}
-                />
-                <ConsumptionLeaderboardCard
-                  title={t('stats.allConsumptionLeaderboard')}
-                  rows={allLeaderboard}
-                  isLoading={allLeaderboardLoading}
-                />
-              </div>
-            </TabsContent>
-          </Tabs>
+            {/* 汇总卡片 - 与 Dashboard 一致的排列顺序 */}
+            <div data-testid="stats-summary-grid" className="grid gap-4 grid-cols-2 lg:grid-cols-4">
+              <StatCard
+                title={t('stats.requests')}
+                value={summary.totalRequests.toLocaleString()}
+                subtitle={`${formatNumber(summary.avgRpm)} RPM · ${summary.avgTtft.toFixed(2)}s TTFT`}
+                icon={Activity}
+                iconClassName="text-blue-600 dark:text-blue-400"
+              />
+              <StatCard
+                title={t('stats.tokens')}
+                value={formatNumber(summary.totalTokens)}
+                subtitle={`${formatNumber(summary.avgTpm)} TPM · ${summary.cacheHitRate.toFixed(1)}% ${t('stats.cacheHit')}`}
+                icon={Cpu}
+                iconClassName="text-violet-600 dark:text-violet-400"
+              />
+              <StatCard
+                title={t('stats.totalCost')}
+                value={`$${(summary.totalCost / 1_000_000_000).toFixed(4)}`}
+                icon={Coins}
+                iconClassName="text-amber-600 dark:text-amber-400"
+              />
+              <StatCard
+                title={t('stats.successRate')}
+                value={`${summary.totalRequests > 0 ? ((summary.successfulRequests / summary.totalRequests) * 100).toFixed(1) : 0}%`}
+                icon={CheckCircle}
+                iconClassName={cn(
+                  summary.successfulRequests / summary.totalRequests >= 0.95
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : summary.successfulRequests / summary.totalRequests >= 0.8
+                      ? 'text-amber-600 dark:text-amber-400'
+                      : 'text-red-600 dark:text-red-400',
+                )}
+              />
+            </div>
+
+            {isLoading ? (
+              <div className="text-center text-muted-foreground py-8">{t('common.loading')}</div>
+            ) : chartData.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">{t('common.noData')}</div>
+            ) : (
+              <Card
+                data-testid="stats-chart-card"
+                className="border-border/50 bg-card/50 backdrop-blur-sm"
+              >
+                <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2 pb-2">
+                  <CardTitle className="text-base font-semibold flex items-center gap-2">
+                    <BarChart3 className="h-4 w-4 text-emerald-500" />
+                    {t('stats.chart')}
+                  </CardTitle>
+                  <Tabs value={chartView} onValueChange={(v) => setChartView(v as ChartView)}>
+                    <TabsList>
+                      <TabsTrigger value="requests">{t('stats.requests')}</TabsTrigger>
+                      <TabsTrigger value="tokens">{t('stats.tokens')}</TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                </CardHeader>
+                <CardContent className="pt-2">
+                  <div ref={chartContainerRef} className="w-full h-[400px] min-h-[400px]">
+                    {chartWidth > 0 && (
+                      <ComposedChart width={chartWidth} height={400} data={chartData}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
+                        <XAxis
+                          dataKey="label"
+                          tick={{ fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          interval="preserveStartEnd"
+                        />
+                        <YAxis
+                          yAxisId="left"
+                          tick={{ fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          tickFormatter={(v) => formatNumber(v)}
+                        />
+                        <YAxis
+                          yAxisId="right"
+                          orientation="right"
+                          tick={{ fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          tickFormatter={(v) => `${v.toFixed(2)}`}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            backgroundColor: 'var(--card)',
+                            border: '1px solid var(--border)',
+                            borderRadius: '8px',
+                            fontSize: '12px',
+                            boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+                          }}
+                          itemSorter={(a) => (a.name === t('stats.costUSD') ? -1 : 0)}
+                          formatter={(value, name) => {
+                            const numValue = typeof value === 'number' ? value : 0;
+                            const nameStr = name ?? '';
+                            if (nameStr === t('stats.costUSD'))
+                              return [`$${numValue.toFixed(4)}`, nameStr];
+                            return [numValue.toLocaleString(), nameStr];
+                          }}
+                        />
+                        <Legend
+                          wrapperStyle={{ fontSize: '12px', paddingTop: '8px' }}
+                          itemSorter={(a) => (a.value === t('stats.costUSD') ? -1 : 0)}
+                        />
+                        {chartView === 'requests' && (
+                          <>
+                            <Line
+                              yAxisId="right"
+                              type="monotone"
+                              dataKey="cost"
+                              name={t('stats.costUSD')}
+                              stroke="var(--color-chart-3)"
+                              strokeWidth={2}
+                              dot={false}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="successful"
+                              name={t('stats.successful')}
+                              stackId="a"
+                              fill="var(--color-chart-1)"
+                              radius={[0, 0, 0, 0]}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="failed"
+                              name={t('stats.failed')}
+                              stackId="a"
+                              fill="var(--color-chart-2)"
+                              radius={[4, 4, 0, 0]}
+                            />
+                          </>
+                        )}
+                        {chartView === 'tokens' && (
+                          <>
+                            <Line
+                              yAxisId="right"
+                              type="monotone"
+                              dataKey="cost"
+                              name={t('stats.costUSD')}
+                              stroke="var(--color-chart-3)"
+                              strokeWidth={2}
+                              dot={false}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="inputTokens"
+                              name={t('stats.inputTokens')}
+                              stackId="a"
+                              fill="var(--color-chart-1)"
+                              radius={[0, 0, 0, 0]}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="outputTokens"
+                              name={t('stats.outputTokens')}
+                              stackId="a"
+                              fill="var(--color-chart-2)"
+                              radius={[0, 0, 0, 0]}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="cacheRead"
+                              name={t('stats.cacheRead')}
+                              stackId="a"
+                              fill="var(--color-chart-4)"
+                              radius={[0, 0, 0, 0]}
+                            />
+                            <Bar
+                              yAxisId="left"
+                              dataKey="cacheWrite"
+                              name={t('stats.cacheWrite')}
+                              stackId="a"
+                              fill="var(--color-chart-5)"
+                              radius={[4, 4, 0, 0]}
+                            />
+                          </>
+                        )}
+                      </ComposedChart>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
         </div>
       </div>
     </div>
-  );
-}
-
-function ConsumptionLeaderboardCard({
-  title,
-  rows,
-  isLoading,
-}: {
-  title: string;
-  rows: ConsumptionLeaderboardRow[];
-  isLoading: boolean;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
-      <CardHeader className="pb-2">
-        <CardTitle className="text-base font-semibold flex items-center gap-2">
-          <Trophy className="h-4 w-4 text-amber-500" />
-          {title}
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {isLoading ? (
-          <div className="py-8 text-center text-sm text-muted-foreground">
-            {t('common.loading')}
-          </div>
-        ) : rows.length === 0 ? (
-          <div className="py-8 text-center text-sm text-muted-foreground">{t('common.noData')}</div>
-        ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{t('stats.username')}</TableHead>
-                <TableHead className="text-right">{t('stats.amount')}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rows.map((row, index) => (
-                <TableRow key={row.userID}>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <span className="flex size-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-                        {index + 1}
-                      </span>
-                      <span className="font-medium text-foreground">{row.username}</span>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right font-mono font-semibold tabular-nums">
-                    {formatCost(row.cost)}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </CardContent>
-    </Card>
   );
 }
 

--- a/web/src/pages/test-field/index.tsx
+++ b/web/src/pages/test-field/index.tsx
@@ -292,7 +292,7 @@ export function TestFieldPage() {
             </CardHeader>
             <CardContent className="space-y-5 p-6">
               <div className="grid gap-3 md:grid-cols-[1fr_auto]">
-                <div className="space-y-2">
+                <div className="flex flex-col gap-2">
                   <Label>{t('testField.benchmark.providerSelect')}</Label>
                   <Combobox
                     value={providerToAdd || null}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Clock3, Copy, Eye, EyeOff, Gift, KeyRound, LogOut, Server, UserRound } from 'lucide-react';
+import {
+  Clock3,
+  Copy,
+  Eye,
+  EyeOff,
+  Gift,
+  KeyRound,
+  Loader2,
+  LogOut,
+  Server,
+  UserRound,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
   Badge,
@@ -397,29 +408,32 @@ export function UserPanelPage() {
 
                     <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_460px] lg:items-center">
                       <div className="space-y-1">
-                        <div className="relative">
+                        <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-1">
                           <Input
                             readOnly
-                            type={userPanelTokenRevealed ? 'text' : 'password'}
+                            type="text"
                             value={userPanelTokenValue}
-                            className="h-9 pr-10 font-mono text-xs"
+                            className="h-9 font-mono text-xs transition-colors"
                             aria-label={t('userPanel.myKey')}
                           />
                           <Button
                             type="button"
-                            variant="ghost"
+                            variant="outline"
                             size="icon"
-                            className="absolute right-1 top-1/2 size-7 -translate-y-1/2"
+                            className="size-9 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                             disabled={tokenActionPending || revealActionPending}
                             aria-label={t(
                               userPanelTokenRevealed ? 'userPanel.hideKey' : 'userPanel.showKey',
                             )}
+                            aria-pressed={userPanelTokenRevealed}
                             title={t(
                               userPanelTokenRevealed ? 'userPanel.hideKey' : 'userPanel.showKey',
                             )}
                             onClick={handleToggleUserPanelTokenReveal}
                           >
-                            {userPanelTokenRevealed ? (
+                            {revealActionPending ? (
+                              <Loader2 className="size-3.5 animate-spin" />
+                            ) : userPanelTokenRevealed ? (
                               <EyeOff className="size-3.5" />
                             ) : (
                               <Eye className="size-3.5" />

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -515,7 +515,7 @@ export function UserPanelPage() {
                         <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-1">
                           <Input
                             readOnly
-                            type="text"
+                            type={userPanelTokenRevealed ? 'text' : 'password'}
                             value={userPanelTokenValue}
                             className="h-9 font-mono text-xs transition-colors"
                             aria-label={t('userPanel.myKey')}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Clock3,
   Copy,
@@ -231,6 +231,7 @@ export function UserPanelPage() {
   const [revealKeyError, setRevealKeyError] = useState('');
   const [dailyCheckInMessage, setDailyCheckInMessage] = useState('');
   const [dailyCheckInDone, setDailyCheckInDone] = useState(false);
+  const autoDailyCheckInStartedRef = useRef(false);
   const tabStorageKey = getUserPanelTabStorageKey(user?.id);
   const [activeTab, setActiveTab] = useState<UserPanelTab>(() => {
     if (typeof window === 'undefined') return 'main';
@@ -279,13 +280,42 @@ export function UserPanelPage() {
   }, [userPanelToken?.id]);
 
   useEffect(() => {
-    if (dailyCheckInStatus?.alreadyCheckedIn) {
-      setDailyCheckInDone(true);
-    } else if (!dailyCheckInEnabled) {
+    if (!dailyCheckInEnabled) {
+      autoDailyCheckInStartedRef.current = false;
       setDailyCheckInDone(false);
       setDailyCheckInMessage('');
+      return;
     }
-  }, [dailyCheckInEnabled, dailyCheckInStatus?.alreadyCheckedIn]);
+
+    if (dailyCheckInStatus?.alreadyCheckedIn) {
+      setDailyCheckInDone(true);
+      setDailyCheckInMessage(t('userPanel.dailyCheckInAlreadyDone'));
+      return;
+    }
+
+    if (!dailyCheckInStatus || autoDailyCheckInStartedRef.current) {
+      return;
+    }
+
+    autoDailyCheckInStartedRef.current = true;
+    setDailyCheckInMessage(t('userPanel.dailyCheckInAutoRunning'));
+    dailyCheckIn
+      .mutateAsync()
+      .then((result) => {
+        setDailyCheckInDone(result.alreadyCheckedIn || result.checkedIn);
+        setDailyCheckInMessage(
+          result.alreadyCheckedIn
+            ? t('userPanel.dailyCheckInAlreadyDone')
+            : t('userPanel.dailyCheckInSuccess', {
+                amount: formatQuotaAmount(result.rewardAmount),
+              }),
+        );
+      })
+      .catch(() => {
+        autoDailyCheckInStartedRef.current = false;
+        setDailyCheckInMessage(t('userPanel.dailyCheckInError'));
+      });
+  }, [dailyCheckIn, dailyCheckInEnabled, dailyCheckInStatus, t]);
 
   useEffect(() => {
     const interval = window.setInterval(() => setUsageClock(new Date()), 60_000);
@@ -359,21 +389,6 @@ export function UserPanelPage() {
     setKeyCopied(false);
   };
 
-  const handleDailyCheckIn = async () => {
-    setDailyCheckInMessage('');
-    try {
-      const result = await dailyCheckIn.mutateAsync();
-      setDailyCheckInDone(result.alreadyCheckedIn || result.checkedIn);
-      setDailyCheckInMessage(
-        result.alreadyCheckedIn
-          ? t('userPanel.dailyCheckInAlreadyDone')
-          : t('userPanel.dailyCheckInSuccess', { amount: formatQuotaAmount(result.rewardAmount) }),
-      );
-    } catch {
-      setDailyCheckInMessage(t('userPanel.dailyCheckInError'));
-    }
-  };
-
   const tokenActionPending = createUserPanelToken.isPending || regenerateUserPanelToken.isPending;
   const revealActionPending = revealUserPanelToken.isPending;
 
@@ -433,21 +448,13 @@ export function UserPanelPage() {
                       ) : null}
                     </div>
                   </div>
-                  <div className="flex items-center gap-3">
-                    <Button
-                      size="sm"
-                      className="h-8 gap-2"
-                      disabled={dailyCheckIn.isPending || hasCheckedInToday}
-                      onClick={handleDailyCheckIn}
-                    >
-                      <Gift className="size-3.5" />
-                      {hasCheckedInToday
-                        ? t('userPanel.dailyCheckInDone')
-                        : dailyCheckIn.isPending
-                          ? t('common.loading')
-                          : t('userPanel.dailyCheckInAction')}
-                    </Button>
-                  </div>
+                  <Badge variant={hasCheckedInToday ? 'success' : 'secondary'} className="shrink-0">
+                    {hasCheckedInToday
+                      ? t('userPanel.dailyCheckInDone')
+                      : dailyCheckIn.isPending
+                        ? t('userPanel.dailyCheckInAutoRunning')
+                        : t('userPanel.dailyCheckInAutoPending')}
+                  </Badge>
                 </CardContent>
               </Card>
             )}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Clock3, Copy, Eye, EyeOff, Gift, KeyRound, LogOut, Server, UserRound } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -25,8 +25,9 @@ import {
   useUserPanelDailyCheckIn,
   useUserPanelAPIToken,
   usePublicSettings,
+  useUserPanelUsageStats,
 } from '@/hooks/queries';
-import type { APIToken } from '@/lib/transport';
+import type { APIToken, UsageStatsFilter, UsageStats } from '@/lib/transport';
 import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
 import {
   getUserPanelTabStorageKey,
@@ -48,22 +49,26 @@ function formatQuotaAmount(value: number) {
   return `$${Number.isInteger(amount) ? amount.toFixed(0) : amount.toFixed(2)}`;
 }
 
+function getLocalDayBounds() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return {
+    start: start.toISOString(),
+    end: now.toISOString(),
+  };
+}
+
+function totalTokens(stats?: UsageStats[]) {
+  return (stats ?? []).reduce(
+    (sum, item) => sum + item.inputTokens + item.outputTokens + item.cacheRead + item.cacheWrite,
+    0,
+  );
+}
+
 function parseDailyCheckInAmountSetting(value?: string) {
   const amount = Number(value);
   if (!Number.isFinite(amount) || amount <= 0) return undefined;
   return Math.round(amount * 1_000_000_000);
-}
-
-function formatDateTime(value?: string) {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  return new Intl.DateTimeFormat(undefined, {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date);
 }
 
 function getTokenStatus(token: APIToken) {
@@ -76,6 +81,35 @@ export function UserPanelPage() {
   const { t } = useTranslation();
   const { logout, user } = useAuth();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
+  const todayBounds = useMemo(() => getLocalDayBounds(), []);
+  const todayUsageFilter = useMemo<UsageStatsFilter>(
+    () => ({
+      granularity: 'day',
+      start: todayBounds.start,
+      end: todayBounds.end,
+    }),
+    [todayBounds.end, todayBounds.start],
+  );
+  const totalUsageFilter = useMemo<UsageStatsFilter>(
+    () => ({
+      granularity: 'month',
+      start: '2020-01-01T00:00:00.000Z',
+      end: todayBounds.end,
+    }),
+    [todayBounds.end],
+  );
+  const { data: todayUsageStats, isLoading: todayUsageLoading } = useUserPanelUsageStats(
+    todayUsageFilter,
+    {
+      enabled: Boolean(user),
+    },
+  );
+  const { data: totalUsageStats, isLoading: totalUsageLoading } = useUserPanelUsageStats(
+    totalUsageFilter,
+    {
+      enabled: Boolean(user),
+    },
+  );
   const { data: publicSettings } = usePublicSettings();
   const {
     data: availableModels,
@@ -110,6 +144,8 @@ export function UserPanelPage() {
   });
 
   const userPanelToken = userPanelTokenResponse?.apiToken ?? undefined;
+  const todayTokenUsage = totalTokens(todayUsageStats);
+  const totalTokenUsage = totalTokens(totalUsageStats);
   const hasCheckedInToday = dailyCheckInStatus?.alreadyCheckedIn || dailyCheckInDone;
   const dailyCheckInRewardAmount =
     dailyCheckInStatus?.rewardAmount ??
@@ -417,18 +453,18 @@ export function UserPanelPage() {
                         </div>
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
                           <p className="text-[11px] text-muted-foreground">
-                            {t('userPanel.lastUsed')}
+                            {t('userPanel.todayTokenUsage')}
                           </p>
-                          <p className="mt-1 truncate font-mono text-xs tabular-nums text-foreground">
-                            {formatDateTime(userPanelToken.lastUsedAt)}
+                          <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
+                            {todayUsageLoading ? '—' : formatNumber(todayTokenUsage)}
                           </p>
                         </div>
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
                           <p className="text-[11px] text-muted-foreground">
-                            {t('userPanel.expiresAt')}
+                            {t('userPanel.totalTokenUsage')}
                           </p>
-                          <p className="mt-1 truncate font-mono text-xs tabular-nums text-foreground">
-                            {formatDateTime(userPanelToken.expiresAt)}
+                          <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
+                            {totalUsageLoading ? '—' : formatNumber(totalTokenUsage)}
                           </p>
                         </div>
                       </div>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   LogOut,
   Server,
+  Trophy,
   UserRound,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -20,6 +21,12 @@ import {
   CardHeader,
   CardTitle,
   Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
   Tabs,
   TabsContent,
   TabsList,
@@ -35,10 +42,16 @@ import {
   useUserPanelDailyCheckInStatus,
   useUserPanelDailyCheckIn,
   useUserPanelAPIToken,
+  useUserPanelConsumptionLeaderboard,
   usePublicSettings,
   useUserPanelUsageStats,
 } from '@/hooks/queries';
-import type { APIToken, UsageStatsFilter, UsageStats } from '@/lib/transport';
+import type {
+  APIToken,
+  UsageStatsFilter,
+  UsageStats,
+  UserPanelConsumptionLeaderboardRow,
+} from '@/lib/transport';
 import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
 import {
   getUserPanelTabStorageKey,
@@ -58,6 +71,10 @@ function formatQuotaBalance(value: number) {
 function formatQuotaAmount(value: number) {
   const amount = (value || 0) / 1_000_000_000;
   return `$${Number.isInteger(amount) ? amount.toFixed(0) : amount.toFixed(2)}`;
+}
+
+function formatCostAmount(value: number) {
+  return `$${((value || 0) / 1_000_000_000).toFixed(4)}`;
 }
 
 function getLocalDayBounds(now = new Date()) {
@@ -85,6 +102,61 @@ function getTokenStatus(token: APIToken) {
   if (!token.isEnabled) return 'disabled';
   if (token.expiresAt && new Date(token.expiresAt).getTime() <= Date.now()) return 'expired';
   return 'active';
+}
+
+function ConsumptionLeaderboardCard({
+  title,
+  rows,
+  isLoading,
+  isError,
+}: {
+  title: string;
+  rows: UserPanelConsumptionLeaderboardRow[];
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="border-border bg-card shadow-sm">
+      <CardHeader className="border-b border-border">
+        <CardTitle className="flex items-center gap-2 text-base font-medium">
+          <Trophy className="size-4 text-amber-500" />
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-5">
+        {isLoading ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">{t('common.loading')}</p>
+        ) : isError ? (
+          <p className="py-8 text-center text-sm text-destructive">
+            {t('userPanel.consumptionLeaderboardLoadFailed')}
+          </p>
+        ) : rows.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">{t('common.noData')}</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t('userPanel.username')}</TableHead>
+                <TableHead className="text-right">{t('userPanel.amount')}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.userID}>
+                  <TableCell className="font-medium text-foreground">{row.username}</TableCell>
+                  <TableCell className="text-right font-mono font-semibold tabular-nums">
+                    {formatCostAmount(row.cost)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 export function UserPanelPage() {
@@ -129,6 +201,11 @@ export function UserPanelPage() {
     isLoading: availableModelsLoading,
     isError: availableModelsError,
   } = useUserPanelAvailableModels(Boolean(user));
+  const {
+    data: consumptionLeaderboard,
+    isLoading: consumptionLeaderboardLoading,
+    isError: consumptionLeaderboardError,
+  } = useUserPanelConsumptionLeaderboard(Boolean(user));
   const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
   const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(dailyCheckInEnabled);
   const createUserPanelToken = useCreateUserPanelAPIToken();
@@ -290,7 +367,7 @@ export function UserPanelPage() {
 
   return (
     <main className="min-h-svh bg-muted/30 px-4 py-6 text-foreground sm:px-6 lg:px-8">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-5">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5">
         <header className="flex flex-col gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
             <div className="flex size-11 items-center justify-center rounded-xl bg-primary text-primary-foreground shadow-sm">
@@ -315,8 +392,9 @@ export function UserPanelPage() {
         </header>
 
         <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-5">
-          <TabsList className="grid w-full grid-cols-1 rounded-xl p-1">
+          <TabsList className="grid w-full grid-cols-2 rounded-xl p-1">
             <TabsTrigger value="main">{t('userPanel.mainTab')}</TabsTrigger>
+            <TabsTrigger value="consumption">{t('userPanel.consumptionTab')}</TabsTrigger>
           </TabsList>
 
           <TabsContent value="main" className="space-y-5">
@@ -592,6 +670,23 @@ export function UserPanelPage() {
                 </div>
               </CardContent>
             </Card>
+          </TabsContent>
+
+          <TabsContent value="consumption" className="space-y-5">
+            <div className="grid gap-4 lg:grid-cols-2">
+              <ConsumptionLeaderboardCard
+                title={t('userPanel.todayConsumptionLeaderboard')}
+                rows={consumptionLeaderboard?.today ?? []}
+                isLoading={consumptionLeaderboardLoading}
+                isError={consumptionLeaderboardError}
+              />
+              <ConsumptionLeaderboardCard
+                title={t('userPanel.allConsumptionLeaderboard')}
+                rows={consumptionLeaderboard?.all ?? []}
+                isLoading={consumptionLeaderboardLoading}
+                isError={consumptionLeaderboardError}
+              />
+            </div>
           </TabsContent>
         </Tabs>
 

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -156,16 +156,7 @@ function ConsumptionLeaderboardCard({
                         : undefined
                     }
                   >
-                    <TableCell className="font-medium text-foreground">
-                      <div className="flex items-center gap-2">
-                        <span>{row.username}</span>
-                        {isCurrentUser ? (
-                          <Badge variant="secondary" className="text-[10px]">
-                            {t('userPanel.me')}
-                          </Badge>
-                        ) : null}
-                      </div>
-                    </TableCell>
+                    <TableCell className="font-medium text-foreground">{row.username}</TableCell>
                     <TableCell className="text-right font-mono font-semibold tabular-nums">
                       {formatCostAmount(row.cost)}
                     </TableCell>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -545,21 +545,13 @@ export function UserPanelPage() {
                           </p>
                         ) : null}
                       </div>
-                      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
                           <p className="text-[11px] text-muted-foreground">
                             {t('userPanel.quotaBalance')}
                           </p>
                           <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
                             {formatQuotaBalance(userPanelToken.quotaBalance)}
-                          </p>
-                        </div>
-                        <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
-                          <p className="text-[11px] text-muted-foreground">
-                            {t('userPanel.useCount')}
-                          </p>
-                          <p className="mt-1 text-base font-semibold tabular-nums text-foreground">
-                            {formatNumber(userPanelToken.useCount)}
                           </p>
                         </div>
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -109,11 +109,13 @@ function ConsumptionLeaderboardCard({
   rows,
   isLoading,
   isError,
+  currentUserID,
 }: {
   title: string;
   rows: UserPanelConsumptionLeaderboardRow[];
   isLoading: boolean;
   isError: boolean;
+  currentUserID?: number;
 }) {
   const { t } = useTranslation();
 
@@ -143,14 +145,33 @@ function ConsumptionLeaderboardCard({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rows.map((row) => (
-                <TableRow key={row.userID}>
-                  <TableCell className="font-medium text-foreground">{row.username}</TableCell>
-                  <TableCell className="text-right font-mono font-semibold tabular-nums">
-                    {formatCostAmount(row.cost)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {rows.map((row) => {
+                const isCurrentUser = currentUserID === row.userID;
+                return (
+                  <TableRow
+                    key={row.userID}
+                    className={
+                      isCurrentUser
+                        ? 'bg-primary/10 ring-1 ring-inset ring-primary/25 hover:bg-primary/15'
+                        : undefined
+                    }
+                  >
+                    <TableCell className="font-medium text-foreground">
+                      <div className="flex items-center gap-2">
+                        <span>{row.username}</span>
+                        {isCurrentUser ? (
+                          <Badge variant="secondary" className="text-[10px]">
+                            {t('userPanel.me')}
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right font-mono font-semibold tabular-nums">
+                      {formatCostAmount(row.cost)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}
@@ -679,12 +700,14 @@ export function UserPanelPage() {
                 rows={consumptionLeaderboard?.today ?? []}
                 isLoading={consumptionLeaderboardLoading}
                 isError={consumptionLeaderboardError}
+                currentUserID={user?.id}
               />
               <ConsumptionLeaderboardCard
                 title={t('userPanel.allConsumptionLeaderboard')}
                 rows={consumptionLeaderboard?.all ?? []}
                 isLoading={consumptionLeaderboardLoading}
                 isError={consumptionLeaderboardError}
+                currentUserID={user?.id}
               />
             </div>
           </TabsContent>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -60,8 +60,7 @@ function formatQuotaAmount(value: number) {
   return `$${Number.isInteger(amount) ? amount.toFixed(0) : amount.toFixed(2)}`;
 }
 
-function getLocalDayBounds() {
-  const now = new Date();
+function getLocalDayBounds(now = new Date()) {
   const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   return {
     start: start.toISOString(),
@@ -92,7 +91,8 @@ export function UserPanelPage() {
   const { t } = useTranslation();
   const { logout, user } = useAuth();
   const { data: userPanelTokenResponse, isLoading: tokenLoading } = useUserPanelAPIToken();
-  const todayBounds = useMemo(() => getLocalDayBounds(), []);
+  const [usageClock, setUsageClock] = useState(() => new Date());
+  const todayBounds = useMemo(() => getLocalDayBounds(usageClock), [usageClock]);
   const todayUsageFilter = useMemo<UsageStatsFilter>(
     () => ({
       granularity: 'day',
@@ -109,18 +109,20 @@ export function UserPanelPage() {
     }),
     [todayBounds.end],
   );
-  const { data: todayUsageStats, isLoading: todayUsageLoading } = useUserPanelUsageStats(
-    todayUsageFilter,
-    {
-      enabled: Boolean(user),
-    },
-  );
-  const { data: totalUsageStats, isLoading: totalUsageLoading } = useUserPanelUsageStats(
-    totalUsageFilter,
-    {
-      enabled: Boolean(user),
-    },
-  );
+  const {
+    data: todayUsageStats,
+    isLoading: todayUsageLoading,
+    isError: todayUsageError,
+  } = useUserPanelUsageStats(todayUsageFilter, {
+    enabled: Boolean(user),
+  });
+  const {
+    data: totalUsageStats,
+    isLoading: totalUsageLoading,
+    isError: totalUsageError,
+  } = useUserPanelUsageStats(totalUsageFilter, {
+    enabled: Boolean(user),
+  });
   const { data: publicSettings } = usePublicSettings();
   const {
     data: availableModels,
@@ -195,6 +197,11 @@ export function UserPanelPage() {
       setDailyCheckInMessage('');
     }
   }, [dailyCheckInEnabled, dailyCheckInStatus?.alreadyCheckedIn]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setUsageClock(new Date()), 60_000);
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -470,7 +477,9 @@ export function UserPanelPage() {
                             {t('userPanel.todayTokenUsage')}
                           </p>
                           <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
-                            {todayUsageLoading ? '—' : formatNumber(todayTokenUsage)}
+                            {todayUsageLoading || (todayUsageError && !todayUsageStats)
+                              ? '—'
+                              : formatNumber(todayTokenUsage)}
                           </p>
                         </div>
                         <div className="rounded-md border border-border bg-muted/25 px-3 py-2">
@@ -478,7 +487,9 @@ export function UserPanelPage() {
                             {t('userPanel.totalTokenUsage')}
                           </p>
                           <p className="mt-1 truncate font-mono text-xs font-semibold tabular-nums text-foreground">
-                            {totalUsageLoading ? '—' : formatNumber(totalTokenUsage)}
+                            {totalUsageLoading || (totalUsageError && !totalUsageStats)
+                              ? '—'
+                              : formatNumber(totalTokenUsage)}
                           </p>
                         </div>
                       </div>

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -218,12 +218,17 @@ export function UserPanelPage() {
     isLoading: consumptionLeaderboardLoading,
     isError: consumptionLeaderboardError,
   } = useUserPanelConsumptionLeaderboard(Boolean(user));
+  const localUserPanelDayKey = useMemo(() => todayBounds.start.slice(0, 10), [todayBounds.start]);
   const dailyCheckInEnabled = publicSettings?.user_panel_daily_checkin_enabled === 'true';
-  const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(dailyCheckInEnabled);
+  const { data: dailyCheckInStatus } = useUserPanelDailyCheckInStatus(
+    dailyCheckInEnabled,
+    localUserPanelDayKey,
+  );
   const createUserPanelToken = useCreateUserPanelAPIToken();
   const regenerateUserPanelToken = useRegenerateUserPanelAPIToken();
   const revealUserPanelToken = useRevealUserPanelAPIToken();
   const dailyCheckIn = useUserPanelDailyCheckIn();
+  const { mutateAsync: runDailyCheckIn } = dailyCheckIn;
   const [copiedEndpointId, setCopiedEndpointId] = useState('');
   const [keyCopied, setKeyCopied] = useState(false);
   const [oneTimeToken, setOneTimeToken] = useState('');
@@ -280,6 +285,12 @@ export function UserPanelPage() {
   }, [userPanelToken?.id]);
 
   useEffect(() => {
+    autoDailyCheckInStartedRef.current = false;
+    setDailyCheckInDone(false);
+    setDailyCheckInMessage('');
+  }, [localUserPanelDayKey]);
+
+  useEffect(() => {
     if (!dailyCheckInEnabled) {
       autoDailyCheckInStartedRef.current = false;
       setDailyCheckInDone(false);
@@ -299,9 +310,7 @@ export function UserPanelPage() {
 
     autoDailyCheckInStartedRef.current = true;
     setDailyCheckInMessage(t('userPanel.dailyCheckInAutoRunning'));
-    dailyCheckIn
-      .mutateAsync()
-      .then((result) => {
+    runDailyCheckIn().then((result) => {
         setDailyCheckInDone(result.alreadyCheckedIn || result.checkedIn);
         setDailyCheckInMessage(
           result.alreadyCheckedIn
@@ -312,10 +321,9 @@ export function UserPanelPage() {
         );
       })
       .catch(() => {
-        autoDailyCheckInStartedRef.current = false;
         setDailyCheckInMessage(t('userPanel.dailyCheckInError'));
       });
-  }, [dailyCheckIn, dailyCheckInEnabled, dailyCheckInStatus, t]);
+  }, [dailyCheckInEnabled, dailyCheckInStatus, runDailyCheckIn, t]);
 
   useEffect(() => {
     const interval = window.setInterval(() => setUsageClock(new Date()), 60_000);


### PR DESCRIPTION
## Summary
- replace the user panel expiry card with simple token usage totals
- show current user's today tokens and all-time tokens across all of their user-panel API tokens
- fetch user-panel usage through the self-service `/api/usage-stats` route instead of the admin route
- add English and Chinese labels for the new cards

## Validation
- `git diff --check`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- `go test ./internal/handler ./internal/service ./internal/repository/sqlite`
- Playwright smoke with mocked user-panel APIs: verifies Today/Total token cards and confirms the old expiry card is hidden


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 用户面板新增“消费”标签页，支持查看今日及累计消费排行榜，并突出显示当前用户。
  - 用量统计支持筛选与自动刷新，新增加载失败及空数据提示。
  - 签到状态就绪后自动领取每日奖励。
  - 新增中英文界面文案，完善相关状态提示。

- **体验优化**
  - 用户面板调整为更宽的双列布局。
  - Token 查看控件支持加载状态和明确的显示操作。
  - 优化侧边栏配置项排列及请求限制相关文案。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->