### PR TITLE
feat(proxy): support v2ray node links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,24 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 FROM alpine:latest
 
 # Install runtime dependencies (tzdata for timezone support)
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata tar
+
+# Bundle sing-box so vmess/vless/trojan/ss node links work in the official image.
+ARG TARGETARCH=amd64
+ARG SING_BOX_VERSION=1.14.0
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) SING_BOX_ARCH="amd64"; SING_BOX_SHA256="d2d6b4543d850269214ced70ffe41b13b1595baa1b6f9c016466abfba162c4d4" ;; \
+      arm64) SING_BOX_ARCH="arm64"; SING_BOX_SHA256="1811c446a4957edee1b62ed2363607f8e99e1f7b6d88179719251d7ed5f30169" ;; \
+      *) echo "unsupported sing-box arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    wget -O /tmp/sing-box.tar.gz "https://github.com/SagerNet/sing-box/releases/download/v${SING_BOX_VERSION}/sing-box-${SING_BOX_VERSION}-linux-${SING_BOX_ARCH}-musl.tar.gz"; \
+    echo "${SING_BOX_SHA256}  /tmp/sing-box.tar.gz" | sha256sum -c -; \
+    mkdir -p /tmp/sing-box /app/bin; \
+    tar -xzf /tmp/sing-box.tar.gz -C /tmp/sing-box --strip-components=1; \
+    install -m 0755 /tmp/sing-box/sing-box /app/bin/sing-box; \
+    /app/bin/sing-box version; \
+    rm -rf /tmp/sing-box /tmp/sing-box.tar.gz
 
 WORKDIR /app
 

--- a/internal/adapter/provider/http_client.go
+++ b/internal/adapter/provider/http_client.go
@@ -45,7 +45,11 @@ func NewHTTPTransport(p *domain.Provider, inheritEnvProxy bool) (*http.Transport
 		return transport, nil
 	}
 
-	proxyURL, err := url.Parse(rawProxy)
+	resolvedProxy, err := resolveProviderProxyURL(rawProxy)
+	if err != nil {
+		return nil, err
+	}
+	proxyURL, err := url.Parse(resolvedProxy)
 	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
 		return nil, fmt.Errorf("invalid provider proxy URL")
 	}

--- a/internal/adapter/provider/node_proxy.go
+++ b/internal/adapter/provider/node_proxy.go
@@ -1,0 +1,565 @@
+package provider
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxManagedNodeProxyCacheEntries = 64
+
+var managedNodeProxyCache = struct {
+	sync.Mutex
+	items  map[string]*managedNodeProxy
+	starts map[string]*nodeProxyStart
+}{items: map[string]*managedNodeProxy{}, starts: map[string]*nodeProxyStart{}}
+
+type managedNodeProxy struct {
+	url    string
+	cancel context.CancelFunc
+	done   chan struct{}
+	config string
+}
+
+type nodeProxyStart struct {
+	done  chan struct{}
+	proxy *managedNodeProxy
+	err   error
+}
+
+func isNodeProxyScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "vmess", "vless", "trojan", "ss":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveProviderProxyURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
+	}
+	scheme := proxyScheme(trimmed)
+	if !isNodeProxyScheme(scheme) {
+		return trimmed, nil
+	}
+	return startManagedNodeProxy(trimmed)
+}
+
+func proxyScheme(raw string) string {
+	idx := strings.Index(raw, "://")
+	if idx <= 0 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(raw[:idx]))
+}
+
+func stripProxyScheme(raw string) string {
+	idx := strings.Index(raw, "://")
+	if idx < 0 {
+		return raw
+	}
+	return raw[idx+3:]
+}
+
+func startManagedNodeProxy(raw string) (string, error) {
+	for {
+		managedNodeProxyCache.Lock()
+		if cached := managedNodeProxyCache.items[raw]; isManagedNodeProxyAlive(cached) {
+			url := cached.url
+			managedNodeProxyCache.Unlock()
+			return url, nil
+		}
+		delete(managedNodeProxyCache.items, raw)
+		if start := managedNodeProxyCache.starts[raw]; start != nil {
+			done := start.done
+			managedNodeProxyCache.Unlock()
+			<-done
+			if start.err != nil {
+				return "", start.err
+			}
+			if isManagedNodeProxyAlive(start.proxy) {
+				return start.proxy.url, nil
+			}
+			continue
+		}
+		if len(managedNodeProxyCache.items)+len(managedNodeProxyCache.starts) >= maxManagedNodeProxyCacheEntries {
+			managedNodeProxyCache.Unlock()
+			return "", fmt.Errorf("too many active managed node proxies")
+		}
+		start := &nodeProxyStart{done: make(chan struct{})}
+		managedNodeProxyCache.starts[raw] = start
+		managedNodeProxyCache.Unlock()
+
+		proxy, err := createManagedNodeProxy(raw)
+
+		managedNodeProxyCache.Lock()
+		start.proxy = proxy
+		start.err = err
+		if err == nil {
+			managedNodeProxyCache.items[raw] = proxy
+		}
+		delete(managedNodeProxyCache.starts, raw)
+		close(start.done)
+		managedNodeProxyCache.Unlock()
+		if err != nil {
+			return "", err
+		}
+		return proxy.url, nil
+	}
+}
+
+func isManagedNodeProxyAlive(proxy *managedNodeProxy) bool {
+	if proxy == nil {
+		return false
+	}
+	select {
+	case <-proxy.done:
+		return false
+	default:
+		return true
+	}
+}
+
+func createManagedNodeProxy(raw string) (*managedNodeProxy, error) {
+	bin, err := findSingBoxBinary()
+	if err != nil {
+		return nil, err
+	}
+	outbound, err := buildSingBoxOutbound(raw)
+	if err != nil {
+		return nil, err
+	}
+	port, err := reserveLocalPort()
+	if err != nil {
+		return nil, fmt.Errorf("reserve node proxy port: %w", err)
+	}
+	configPath, err := writeSingBoxConfig(port, outbound)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin, "run", "-c", configPath)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		cancel()
+		_ = os.Remove(configPath)
+		return nil, fmt.Errorf("start sing-box node proxy: %w", err)
+	}
+	done := make(chan struct{})
+	proxy := &managedNodeProxy{url: fmt.Sprintf("socks5h://127.0.0.1:%d", port), cancel: cancel, done: done, config: configPath}
+	go func() {
+		_ = cmd.Wait()
+		_ = os.Remove(configPath)
+		managedNodeProxyCache.Lock()
+		for key, item := range managedNodeProxyCache.items {
+			if item == proxy {
+				delete(managedNodeProxyCache.items, key)
+			}
+		}
+		managedNodeProxyCache.Unlock()
+		close(done)
+	}()
+	if err := waitForNodeProxyReady(port, done, 3*time.Second); err != nil {
+		cancel()
+		<-done
+		return nil, err
+	}
+	return proxy, nil
+}
+
+func findSingBoxBinary() (string, error) {
+	candidates := []string{}
+	if configured := strings.TrimSpace(os.Getenv("MAXX_SING_BOX_PATH")); configured != "" {
+		candidates = append(candidates, configured)
+	}
+	if executable, err := os.Executable(); err == nil {
+		dir := filepath.Dir(executable)
+		candidates = append(candidates, filepath.Join(dir, "sing-box"), filepath.Join(dir, "bin", "sing-box"))
+	}
+	candidates = append(candidates, "/app/sing-box", "/app/bin/sing-box")
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	if bin, err := exec.LookPath("sing-box"); err == nil {
+		return bin, nil
+	}
+	return "", fmt.Errorf("provider node proxy requires sing-box; set MAXX_SING_BOX_PATH or use a Maxx image that bundles sing-box")
+}
+
+func reserveLocalPort() (int, error) {
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, errors.New("unexpected listener address")
+	}
+	return addr.Port, nil
+}
+
+func waitForNodeProxyReady(port int, done <-chan struct{}, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	address := fmt.Sprintf("127.0.0.1:%d", port)
+	for time.Now().Before(deadline) {
+		select {
+		case <-done:
+			return fmt.Errorf("sing-box node proxy exited during startup")
+		default:
+		}
+		dialCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", address)
+		cancel()
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("sing-box node proxy did not become ready")
+}
+
+func writeSingBoxConfig(port int, outbound map[string]any) (string, error) {
+	config := map[string]any{
+		"log": map[string]any{"disabled": true},
+		"inbounds": []map[string]any{{
+			"type":        "mixed",
+			"tag":         "maxx-node-in",
+			"listen":      "127.0.0.1",
+			"listen_port": port,
+		}},
+		"outbounds": []map[string]any{outbound},
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	file, err := os.CreateTemp("", "maxx-node-proxy-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create sing-box node proxy config: %w", err)
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", fmt.Errorf("secure sing-box node proxy config: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", fmt.Errorf("write sing-box node proxy config: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close sing-box node proxy config: %w", err)
+	}
+	return path, nil
+}
+
+func buildSingBoxOutbound(raw string) (map[string]any, error) {
+	switch proxyScheme(raw) {
+	case "vmess":
+		return buildVMessOutbound(raw)
+	case "vless":
+		return buildVLESSOutbound(raw)
+	case "trojan":
+		return buildTrojanOutbound(raw)
+	case "ss":
+		return buildShadowsocksOutbound(raw)
+	default:
+		return nil, fmt.Errorf("unsupported node proxy scheme")
+	}
+}
+
+func buildVMessOutbound(raw string) (map[string]any, error) {
+	payload := stripProxyScheme(raw)
+	decoded, err := decodeBase64Loose(payload)
+	if err != nil {
+		return nil, fmt.Errorf("invalid vmess link")
+	}
+	var vmess struct {
+		Address  string `json:"add"`
+		Port     any    `json:"port"`
+		UUID     string `json:"id"`
+		AlterID  any    `json:"aid"`
+		Security string `json:"scy"`
+		Network  string `json:"net"`
+		Host     string `json:"host"`
+		Path     string `json:"path"`
+		TLS      string `json:"tls"`
+		SNI      string `json:"sni"`
+		Name     string `json:"ps"`
+	}
+	if err := json.Unmarshal(decoded, &vmess); err != nil {
+		return nil, fmt.Errorf("invalid vmess link")
+	}
+	serverPort, err := parseAnyPort(vmess.Port)
+	if err != nil || vmess.Address == "" || vmess.UUID == "" {
+		return nil, fmt.Errorf("invalid vmess link")
+	}
+	out := map[string]any{
+		"type":        "vmess",
+		"tag":         "maxx-node-out",
+		"server":      vmess.Address,
+		"server_port": serverPort,
+		"uuid":        vmess.UUID,
+		"security":    firstNonEmpty(vmess.Security, "auto"),
+	}
+	if aid, ok := parseOptionalInt(vmess.AlterID); ok {
+		out["alter_id"] = aid
+	}
+	applySingBoxTLS(out, strings.EqualFold(vmess.TLS, "tls"), vmess.SNI, "")
+	if err := applySingBoxTransport(out, vmess.Network, vmess.Host, vmess.Path, ""); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func buildVLESSOutbound(raw string) (map[string]any, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" || u.User == nil || u.User.Username() == "" {
+		return nil, fmt.Errorf("invalid vless link")
+	}
+	port, err := parseURLPort(u)
+	if err != nil {
+		return nil, fmt.Errorf("invalid vless link")
+	}
+	q := u.Query()
+	out := map[string]any{"type": "vless", "tag": "maxx-node-out", "server": u.Hostname(), "server_port": port, "uuid": u.User.Username()}
+	if flow := q.Get("flow"); flow != "" {
+		out["flow"] = flow
+	}
+	security := strings.ToLower(strings.TrimSpace(q.Get("security")))
+	switch security {
+	case "", "none":
+	case "tls", "reality":
+		applySingBoxTLS(out, true, firstNonEmpty(q.Get("sni"), q.Get("serverName")), security)
+	default:
+		return nil, fmt.Errorf("unsupported vless security")
+	}
+	if security == "reality" {
+		applySingBoxRealityOptions(out, q.Get("pbk"), q.Get("sid"), q.Get("fp"))
+	}
+	if err := applySingBoxTransport(out, q.Get("type"), q.Get("host"), q.Get("path"), q.Get("serviceName")); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func buildTrojanOutbound(raw string) (map[string]any, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" || u.User == nil || u.User.Username() == "" {
+		return nil, fmt.Errorf("invalid trojan link")
+	}
+	port, err := parseURLPort(u)
+	if err != nil {
+		return nil, fmt.Errorf("invalid trojan link")
+	}
+	q := u.Query()
+	out := map[string]any{"type": "trojan", "tag": "maxx-node-out", "server": u.Hostname(), "server_port": port, "password": u.User.Username()}
+	applySingBoxTLS(out, true, firstNonEmpty(q.Get("sni"), q.Get("peer")), "")
+	if err := applySingBoxTransport(out, q.Get("type"), q.Get("host"), q.Get("path"), q.Get("serviceName")); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func buildShadowsocksOutbound(raw string) (map[string]any, error) {
+	body := stripProxyScheme(raw)
+	body = strings.SplitN(body, "#", 2)[0]
+	body = strings.SplitN(body, "?", 2)[0]
+	if !strings.Contains(body, "@") {
+		decoded, err := decodeBase64Loose(body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid shadowsocks link")
+		}
+		body = string(decoded)
+	} else {
+		parts := strings.SplitN(body, "@", 2)
+		if decoded, err := decodeBase64Loose(parts[0]); err == nil && strings.Contains(string(decoded), ":") {
+			body = string(decoded) + "@" + parts[1]
+		}
+	}
+	u, err := url.Parse("ss://" + body)
+	if err != nil || u.Hostname() == "" || u.User == nil || u.User.Username() == "" {
+		return nil, fmt.Errorf("invalid shadowsocks link")
+	}
+	password, _ := u.User.Password()
+	if password == "" {
+		return nil, fmt.Errorf("invalid shadowsocks link")
+	}
+	port, err := parseURLPort(u)
+	if err != nil {
+		return nil, fmt.Errorf("invalid shadowsocks link")
+	}
+	return map[string]any{"type": "shadowsocks", "tag": "maxx-node-out", "server": u.Hostname(), "server_port": port, "method": u.User.Username(), "password": password}, nil
+}
+
+func applySingBoxTLS(out map[string]any, enabled bool, serverName string, security string) {
+	if !enabled {
+		return
+	}
+	tls := map[string]any{"enabled": true}
+	if serverName != "" {
+		tls["server_name"] = serverName
+	}
+	if security == "reality" {
+		tls["reality"] = map[string]any{"enabled": true}
+	}
+	out["tls"] = tls
+}
+
+func applySingBoxRealityOptions(out map[string]any, publicKey, shortID, fingerprint string) {
+	tls, ok := out["tls"].(map[string]any)
+	if !ok {
+		return
+	}
+	reality, ok := tls["reality"].(map[string]any)
+	if !ok {
+		return
+	}
+	if publicKey != "" {
+		reality["public_key"] = publicKey
+	}
+	if shortID != "" {
+		reality["short_id"] = shortID
+	}
+	if fingerprint != "" {
+		tls["utls"] = map[string]any{"enabled": true, "fingerprint": fingerprint}
+	}
+}
+
+func applySingBoxTransport(out map[string]any, network, host, path, serviceName string) error {
+	switch strings.ToLower(strings.TrimSpace(network)) {
+	case "", "tcp":
+		return nil
+	case "ws", "websocket":
+		transport := map[string]any{"type": "ws"}
+		if path != "" {
+			transport["path"] = path
+		}
+		if host != "" {
+			transport["headers"] = map[string]any{"Host": host}
+		}
+		out["transport"] = transport
+		return nil
+	case "grpc":
+		transport := map[string]any{"type": "grpc"}
+		if serviceName != "" {
+			transport["service_name"] = serviceName
+		}
+		out["transport"] = transport
+		return nil
+	case "h2", "http":
+		transport := map[string]any{"type": "http"}
+		if host != "" {
+			transport["host"] = []string{host}
+		}
+		if path != "" {
+			transport["path"] = path
+		}
+		out["transport"] = transport
+		return nil
+	default:
+		return fmt.Errorf("unsupported node proxy transport")
+	}
+}
+
+func decodeBase64Loose(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, errors.New("empty base64")
+	}
+	if decoded, err := base64.RawURLEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.RawStdEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	if pad := len(value) % 4; pad != 0 {
+		value += strings.Repeat("=", 4-pad)
+	}
+	if decoded, err := base64.URLEncoding.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	return base64.StdEncoding.DecodeString(value)
+}
+
+func parseURLPort(u *url.URL) (int, error) {
+	if u.Port() == "" {
+		return 0, fmt.Errorf("missing port")
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil || port <= 0 || port > 65535 {
+		return 0, fmt.Errorf("invalid port")
+	}
+	return port, nil
+}
+
+func parseAnyPort(value any) (int, error) {
+	switch v := value.(type) {
+	case float64:
+		if math.Trunc(v) != v {
+			return 0, fmt.Errorf("invalid port")
+		}
+		port := int(v)
+		if port <= 0 || port > 65535 {
+			return 0, fmt.Errorf("invalid port")
+		}
+		return port, nil
+	case string:
+		port, err := strconv.Atoi(v)
+		if err != nil || port <= 0 || port > 65535 {
+			return 0, fmt.Errorf("invalid port")
+		}
+		return port, nil
+	default:
+		return 0, fmt.Errorf("invalid port")
+	}
+}
+
+func parseOptionalInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case float64:
+		if math.Trunc(v) != v {
+			return 0, false
+		}
+		return int(v), true
+	case string:
+		if v == "" {
+			return 0, false
+		}
+		parsed, err := strconv.Atoi(v)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/adapter/provider/node_proxy_test.go
+++ b/internal/adapter/provider/node_proxy_test.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildSingBoxOutboundFromVMessLink(t *testing.T) {
+	payload := map[string]any{
+		"add":  "proxy.example.com",
+		"port": "443",
+		"id":   "11111111-1111-1111-1111-111111111111",
+		"aid":  "0",
+		"net":  "ws",
+		"host": "cdn.example.com",
+		"path": "/ray",
+		"tls":  "tls",
+		"sni":  "sni.example.com",
+	}
+	data, _ := json.Marshal(payload)
+	out, err := buildSingBoxOutbound("vmess://" + base64.StdEncoding.EncodeToString(data))
+	if err != nil {
+		t.Fatalf("buildSingBoxOutbound() error = %v", err)
+	}
+	if out["type"] != "vmess" || out["server"] != "proxy.example.com" || out["server_port"] != 443 {
+		t.Fatalf("unexpected vmess outbound: %#v", out)
+	}
+	if out["uuid"] != "11111111-1111-1111-1111-111111111111" {
+		t.Fatalf("uuid not preserved: %#v", out)
+	}
+	transport := out["transport"].(map[string]any)
+	if transport["type"] != "ws" || transport["path"] != "/ray" {
+		t.Fatalf("ws transport not converted: %#v", transport)
+	}
+	tls := out["tls"].(map[string]any)
+	if tls["enabled"] != true || tls["server_name"] != "sni.example.com" {
+		t.Fatalf("tls not converted: %#v", tls)
+	}
+}
+
+func TestBuildSingBoxOutboundFromUppercaseVMessLink(t *testing.T) {
+	payload := map[string]any{
+		"add":  "proxy.example.com",
+		"port": "443",
+		"id":   "11111111-1111-1111-1111-111111111111",
+	}
+	data, _ := json.Marshal(payload)
+	out, err := buildSingBoxOutbound("VMESS://" + base64.StdEncoding.EncodeToString(data))
+	if err != nil {
+		t.Fatalf("buildSingBoxOutbound() error = %v", err)
+	}
+	if out["type"] != "vmess" {
+		t.Fatalf("uppercase vmess was not converted: %#v", out)
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsFractionalVMessPort(t *testing.T) {
+	payload := map[string]any{
+		"add":  "proxy.example.com",
+		"port": 443.5,
+		"id":   "11111111-1111-1111-1111-111111111111",
+	}
+	data, _ := json.Marshal(payload)
+	if _, err := buildSingBoxOutbound("vmess://" + base64.StdEncoding.EncodeToString(data)); err == nil {
+		t.Fatal("buildSingBoxOutbound() expected fractional port error")
+	}
+}
+
+func TestBuildSingBoxOutboundFromVLESSLink(t *testing.T) {
+	out, err := buildSingBoxOutbound("vless://11111111-1111-1111-1111-111111111111@proxy.example.com:443?security=tls&type=grpc&serviceName=maxx&sni=sni.example.com#demo")
+	if err != nil {
+		t.Fatalf("buildSingBoxOutbound() error = %v", err)
+	}
+	if out["type"] != "vless" || out["server"] != "proxy.example.com" || out["server_port"] != 443 {
+		t.Fatalf("unexpected vless outbound: %#v", out)
+	}
+	transport := out["transport"].(map[string]any)
+	if transport["type"] != "grpc" || transport["service_name"] != "maxx" {
+		t.Fatalf("grpc transport not converted: %#v", transport)
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsVLESSWithoutUser(t *testing.T) {
+	if _, err := buildSingBoxOutbound("vless://proxy.example.com:443?security=tls"); err == nil {
+		t.Fatal("buildSingBoxOutbound() expected missing vless user error")
+	}
+}
+
+func TestBuildSingBoxOutboundFromTrojanLink(t *testing.T) {
+	out, err := buildSingBoxOutbound("trojan://secret@proxy.example.com:443?type=ws&host=cdn.example.com&path=%2Fws&sni=sni.example.com")
+	if err != nil {
+		t.Fatalf("buildSingBoxOutbound() error = %v", err)
+	}
+	if out["type"] != "trojan" || out["password"] != "secret" {
+		t.Fatalf("unexpected trojan outbound: %#v", out)
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsTrojanWithoutUser(t *testing.T) {
+	if _, err := buildSingBoxOutbound("trojan://proxy.example.com:443?security=tls"); err == nil {
+		t.Fatal("buildSingBoxOutbound() expected missing trojan user error")
+	}
+}
+
+func TestBuildSingBoxOutboundFromShadowsocksLink(t *testing.T) {
+	encoded := base64.RawURLEncoding.EncodeToString([]byte("aes-128-gcm:secret"))
+	out, err := buildSingBoxOutbound("ss://" + encoded + "@proxy.example.com:8388#demo")
+	if err != nil {
+		t.Fatalf("buildSingBoxOutbound() error = %v", err)
+	}
+	if out["type"] != "shadowsocks" || out["method"] != "aes-128-gcm" || out["password"] != "secret" {
+		t.Fatalf("unexpected shadowsocks outbound: %#v", out)
+	}
+}
+
+func TestResolveProviderProxyURLPreservesOrdinaryProxyURL(t *testing.T) {
+	got, err := resolveProviderProxyURL("socks5h://127.0.0.1:10808")
+	if err != nil {
+		t.Fatalf("resolveProviderProxyURL() error = %v", err)
+	}
+	if got != "socks5h://127.0.0.1:10808" {
+		t.Fatalf("resolveProviderProxyURL() = %q", got)
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsUnsupportedTransports(t *testing.T) {
+	payload := map[string]any{
+		"add":  "proxy.example.com",
+		"port": "443",
+		"id":   "11111111-1111-1111-1111-111111111111",
+		"net":  "quic",
+	}
+	data, _ := json.Marshal(payload)
+	if _, err := buildSingBoxOutbound("vmess://" + base64.StdEncoding.EncodeToString(data)); err == nil {
+		t.Fatal("buildSingBoxOutbound() expected unsupported vmess transport error")
+	}
+	if _, err := buildSingBoxOutbound("vless://11111111-1111-1111-1111-111111111111@proxy.example.com:443?type=quic"); err == nil {
+		t.Fatal("buildSingBoxOutbound() expected unsupported vless transport error")
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsUnsafeVLESSSecurity(t *testing.T) {
+	for _, security := range []string{"xtls", "unknown"} {
+		raw := "vless://11111111-1111-1111-1111-111111111111@proxy.example.com:443?security=" + security
+		if _, err := buildSingBoxOutbound(raw); err == nil {
+			t.Fatalf("buildSingBoxOutbound(%s) expected unsupported security error", security)
+		}
+	}
+}
+
+func TestBuildSingBoxOutboundRejectsMissingURLPort(t *testing.T) {
+	cases := []string{
+		"vless://11111111-1111-1111-1111-111111111111@proxy.example.com?security=tls",
+		"trojan://secret@proxy.example.com?type=ws",
+		"ss://YWVzLTEyOC1nY206c2VjcmV0@proxy.example.com",
+	}
+	for _, raw := range cases {
+		if _, err := buildSingBoxOutbound(raw); err == nil {
+			t.Fatalf("buildSingBoxOutbound(%s) expected missing port error", raw)
+		}
+	}
+}

--- a/internal/adapter/provider/proxy_check.go
+++ b/internal/adapter/provider/proxy_check.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type ProxyConnectivityResult struct {
+	OK         bool   `json:"ok"`
+	OutboundIP string `json:"outboundIP,omitempty"`
+	DurationMS int64  `json:"durationMs"`
+	Error      string `json:"error,omitempty"`
+}
+
+func TestProxyConnectivity(ctx context.Context, rawProxy string) ProxyConnectivityResult {
+	started := time.Now()
+	result := ProxyConnectivityResult{OK: false}
+	resolvedProxy, err := resolveProviderProxyURL(rawProxy)
+	if err != nil {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = err.Error()
+		return result
+	}
+	proxyURL, err := url.Parse(resolvedProxy)
+	if err != nil || proxyURL.Scheme == "" || proxyURL.Host == "" {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = "invalid provider proxy URL"
+		return result
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = http.ProxyURL(proxyURL)
+	client := &http.Client{Transport: transport, Timeout: 15 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.ipify.org?format=json", nil)
+	if err != nil {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = err.Error()
+		return result
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = sanitizeProxyCheckError(err)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = fmt.Sprintf("probe returned HTTP %d", resp.StatusCode)
+		return result
+	}
+	var body struct {
+		IP string `json:"ip"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		result.DurationMS = time.Since(started).Milliseconds()
+		result.Error = "probe returned an invalid response"
+		return result
+	}
+	result.DurationMS = time.Since(started).Milliseconds()
+	result.OK = strings.TrimSpace(body.IP) != ""
+	result.OutboundIP = strings.TrimSpace(body.IP)
+	if !result.OK {
+		result.Error = "probe returned an empty outbound IP"
+	}
+	return result
+}
+
+func sanitizeProxyCheckError(err error) string {
+	message := err.Error()
+	if len(message) > 300 {
+		message = message[:300] + "..."
+	}
+	return message
+}

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	adapterprovider "github.com/awsl-project/maxx/internal/adapter/provider"
 	"github.com/awsl-project/maxx/internal/adapter/provider/bedrock"
 	"github.com/awsl-project/maxx/internal/adapter/provider/zai"
 	maxxctx "github.com/awsl-project/maxx/internal/context"
@@ -123,6 +124,8 @@ func (h *AdminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleSettings(w, r, parts)
 	case "proxy-status":
 		h.handleProxyStatus(w, r)
+	case "proxy-check":
+		h.handleProxyCheck(w, r)
 	case "provider-stats":
 		h.handleProviderStats(w, r)
 	case "cooldowns":
@@ -1644,6 +1647,33 @@ func (h *AdminHandler) handleSettings(w http.ResponseWriter, r *http.Request, pa
 	default:
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 	}
+}
+
+func (h *AdminHandler) handleProxyCheck(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	var body struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.URL) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "proxy URL required"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+	result := adapterprovider.TestProxyConnectivity(ctx, body.URL)
+	status := http.StatusOK
+	if !result.OK {
+		status = http.StatusBadGateway
+	}
+	writeJSON(w, status, result)
 }
 
 // Proxy status handler

--- a/internal/handler/admin_proxy_check_test.go
+++ b/internal/handler/admin_proxy_check_test.go
@@ -1,0 +1,32 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleProxyCheckRejectsEmptyURL(t *testing.T) {
+	handler := NewAdminHandler(nil, nil, "")
+	req := httptest.NewRequest(http.MethodPost, "/admin/proxy-check", strings.NewReader(`{"url":""}`))
+	rec := httptest.NewRecorder()
+
+	handler.handleProxyCheck(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}
+
+func TestHandleProxyCheckRequiresPost(t *testing.T) {
+	handler := NewAdminHandler(nil, nil, "")
+	req := httptest.NewRequest(http.MethodGet, "/admin/proxy-check", nil)
+	rec := httptest.NewRecorder()
+
+	handler.handleProxyCheck(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -27,6 +27,7 @@ import type {
   ProxyRequestCleanupFailedResult,
   ProxyUpstreamAttempt,
   ProxyStatus,
+  ProxyConnectivityResult,
   ProviderStats,
   CursorPaginationParams,
   CursorPaginationResult,
@@ -694,6 +695,11 @@ export class HttpTransport implements Transport {
   async getPublicProxyStatus(): Promise<ProxyStatus> {
     const { data } = await this.client.get<ProxyStatus>('/proxy-status');
     return this.expectObject<ProxyStatus>(data, '/proxy-status');
+  }
+
+  async checkOutboundProxy(url: string, signal?: AbortSignal): Promise<ProxyConnectivityResult> {
+    const { data } = await this.adminClient.post<ProxyConnectivityResult>('/proxy-check', { url }, { signal });
+    return this.expectObject<ProxyConnectivityResult>(data, '/admin/proxy-check');
   }
 
   // ===== System API =====

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -61,6 +61,7 @@ export type {
   ProxyRequestErrorStats,
   ProxyRequestCleanupFailedResult,
   ProxyRequestStatus,
+  ProxyConnectivityResult,
   ProxyUpstreamAttempt,
   ProxyUpstreamAttemptStatus,
   RequestInfo,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -27,6 +27,7 @@ import type {
   CursorPaginationParams,
   CursorPaginationResult,
   ProxyStatus,
+  ProxyConnectivityResult,
   ProviderStats,
   WSMessageType,
   EventCallback,
@@ -211,6 +212,7 @@ export interface Transport {
   // ===== Proxy Status API =====
   getProxyStatus(): Promise<ProxyStatus>;
   getPublicProxyStatus(): Promise<ProxyStatus>;
+  checkOutboundProxy(url: string, signal?: AbortSignal): Promise<ProxyConnectivityResult>;
 
   // ===== System API =====
   restartServer(): Promise<void>;

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -834,6 +834,13 @@ export interface ProxyStatus {
   commit: string;
 }
 
+export interface ProxyConnectivityResult {
+  ok: boolean;
+  outboundIP?: string;
+  durationMs: number;
+  error?: string;
+}
+
 // ===== Provider Stats =====
 
 export interface ProviderStats {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2282,9 +2282,15 @@
     "empty": "No proxies yet. Add one to bind providers to it.",
     "name": "Name",
     "url": "Proxy URL",
+    "placeholder": "socks5h://127.0.0.1:10808 or vless://...",
     "preview": "Preview",
-    "hint": "Supported schemes: http, https, socks5, socks5h. Passwords are masked in the UI preview.",
+    "check": "Test connection",
+    "checking": "Testing",
+    "checkSuccess": "Connection works. Outbound IP: {{ip}}. Took {{duration}}ms.",
+    "checkError": "Connection unavailable: {{error}}",
+    "checkFailed": "Failed to test proxy connection.",
+    "hint": "Supported schemes: http, https, socks5, socks5h, plus vmess, vless, trojan, and ss node links. Node links run through Maxx's bundled or configured sing-box. Passwords are masked in the UI preview.",
     "saveFailed": "Failed to save proxy settings.",
-    "invalidURL": "Proxy URL must start with http://, https://, socks5://, or socks5h://."
+    "invalidURL": "Proxy URL must start with http://, https://, socks5://, socks5h://, vmess://, vless://, trojan://, or ss://."
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2278,9 +2278,15 @@
     "empty": "还没有代理。新增后可以绑定到 provider。",
     "name": "名称",
     "url": "代理 URL",
+    "placeholder": "socks5h://127.0.0.1:10808 或 vless://...",
     "preview": "预览",
-    "hint": "支持协议：http、https、socks5、socks5h。UI 预览会遮蔽密码。",
+    "check": "测试连接",
+    "checking": "测试中",
+    "checkSuccess": "连接可用，出口 IP：{{ip}}，耗时 {{duration}}ms。",
+    "checkError": "连接不可用：{{error}}",
+    "checkFailed": "测试代理连接失败。",
+    "hint": "支持协议：http、https、socks5、socks5h，也可直接填 vmess、vless、trojan、ss 节点链接；节点链接会通过 Maxx 内置或配置的 sing-box 运行，UI 预览会遮蔽密码。",
     "saveFailed": "保存代理设置失败。",
-    "invalidURL": "代理 URL 必须以 http://、https://、socks5:// 或 socks5h:// 开头。"
+    "invalidURL": "代理 URL 必须以 http://、https://、socks5://、socks5h://、vmess://、vless://、trojan:// 或 ss:// 开头。"
   }
 }

--- a/web/src/pages/proxies/index.tsx
+++ b/web/src/pages/proxies/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Network, Plus, Save, Trash2 } from 'lucide-react';
+import { Loader2, Network, PlugZap, Plus, Save, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { PageHeader } from '@/components/layout/page-header';
 import {
@@ -13,6 +13,7 @@ import {
   Switch,
 } from '@/components/ui';
 import { useSettings, useUpdateSetting } from '@/hooks/queries';
+import { getTransport, type ProxyConnectivityResult } from '@/lib/transport';
 import {
   OUTBOUND_PROXIES_SETTING_KEY,
   isSupportedProxyURL,
@@ -26,6 +27,11 @@ function newProxy(): OutboundProxyDefinition {
   return { id: crypto.randomUUID(), name: 'Proxy', url: 'http://127.0.0.1:7890' };
 }
 
+type ProxyCheckState =
+  | { status: 'checking'; url: string }
+  | ({ status: 'success'; url: string } & ProxyConnectivityResult)
+  | ({ status: 'error'; url: string } & ProxyConnectivityResult);
+
 export function ProxiesPage() {
   const { t } = useTranslation();
   const { data: settings } = useSettings();
@@ -37,10 +43,49 @@ export function ProxiesPage() {
   const [items, setItems] = useState<OutboundProxyDefinition[] | null>(null);
   const proxies = items ?? saved;
   const [error, setError] = useState<string | null>(null);
+  const [checks, setChecks] = useState<Record<string, ProxyCheckState>>({});
   const dirty = items !== null;
 
   const update = (id: string, patch: Partial<OutboundProxyDefinition>) => {
     setItems(proxies.map((item) => (item.id === id ? { ...item, ...patch } : item)));
+    if (patch.url !== undefined) {
+      setChecks((current) => {
+        const next = { ...current };
+        delete next[id];
+        return next;
+      });
+    }
+  };
+
+  const checkProxy = async (proxy: OutboundProxyDefinition) => {
+    const requestURL = proxy.url;
+    if (!isSupportedProxyURL(requestURL)) {
+      setChecks((current) => ({
+        ...current,
+        [proxy.id]: { status: 'error', url: requestURL, ok: false, durationMs: 0, error: t('proxies.invalidURL') },
+      }));
+      return;
+    }
+    setChecks((current) => ({ ...current, [proxy.id]: { status: 'checking', url: requestURL } }));
+    try {
+      const result = await getTransport().checkOutboundProxy(requestURL);
+      setChecks((current) => {
+        if (current[proxy.id]?.url !== requestURL) return current;
+        return {
+          ...current,
+          [proxy.id]: { ...result, url: requestURL, status: result.ok ? 'success' : 'error' },
+        };
+      });
+    } catch (err) {
+      const message = err instanceof Error && err.message ? err.message : t('proxies.checkFailed');
+      setChecks((current) => {
+        if (current[proxy.id]?.url !== requestURL) return current;
+        return {
+          ...current,
+          [proxy.id]: { status: 'error', url: requestURL, ok: false, durationMs: 0, error: message },
+        };
+      });
+    }
   };
 
   const save = async () => {
@@ -88,11 +133,13 @@ export function ProxiesPage() {
               {proxies.length === 0 ? (
                 <p className="text-sm text-muted-foreground">{t('proxies.empty')}</p>
               ) : null}
-              {proxies.map((proxy) => (
+              {proxies.map((proxy) => {
+                const check = checks[proxy.id];
+                return (
                 <div
                   key={proxy.id}
                   data-testid="proxy-row"
-                  className="grid gap-3 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-[1fr_2fr_auto_auto] md:items-end"
+                  className="grid gap-3 rounded-xl border border-border bg-muted/20 p-4 md:grid-cols-[1fr_2fr_auto_auto_auto] md:items-end"
                 >
                   <div className="space-y-2">
                     <Label htmlFor={`proxy-name-${proxy.id}`}>{t('proxies.name')}</Label>
@@ -108,7 +155,7 @@ export function ProxiesPage() {
                       id={`proxy-url-${proxy.id}`}
                       value={proxy.url}
                       onChange={(e) => update(proxy.id, { url: e.target.value })}
-                      placeholder="http://127.0.0.1:7890"
+                      placeholder={t('proxies.placeholder')}
                     />
                   </div>
                   <div className="flex items-center gap-2 pb-2">
@@ -121,6 +168,15 @@ export function ProxiesPage() {
                     </span>
                   </div>
                   <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={check?.status === 'checking' || proxy.disabled || !proxy.url.trim()}
+                    onClick={() => void checkProxy(proxy)}
+                  >
+                    {check?.status === 'checking' ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
+                    {check?.status === 'checking' ? t('proxies.checking') : t('proxies.check')}
+                  </Button>
+                  <Button
                     variant="ghost"
                     size="sm"
                     onClick={() => setItems(proxies.filter((item) => item.id !== proxy.id))}
@@ -128,11 +184,24 @@ export function ProxiesPage() {
                     <Trash2 size={14} />
                     {t('common.delete')}
                   </Button>
-                  <p className="md:col-span-4 text-xs text-muted-foreground">
-                    {t('proxies.preview')}: {maskProxyURL(proxy.url)}
-                  </p>
+                  <div className="md:col-span-5 space-y-1 text-xs">
+                    <p className="text-muted-foreground">
+                      {t('proxies.preview')}: {maskProxyURL(proxy.url)}
+                    </p>
+                    {check?.status === 'success' ? (
+                      <p className="text-emerald-600">
+                        {t('proxies.checkSuccess', { ip: check.outboundIP, duration: check.durationMs })}
+                      </p>
+                    ) : null}
+                    {check?.status === 'error' ? (
+                      <p className="text-destructive">
+                        {t('proxies.checkError', { error: check.error || t('proxies.checkFailed') })}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
-              ))}
+                );
+              })}
               {error ? <p className="text-sm text-destructive">{error}</p> : null}
               <p className="text-xs text-muted-foreground">{t('proxies.hint')}</p>
             </CardContent>

--- a/web/src/pages/proxies/utils/proxy-settings.test.ts
+++ b/web/src/pages/proxies/utils/proxy-settings.test.ts
@@ -14,14 +14,29 @@ describe('proxy-settings', () => {
   });
 
   it('validates supported proxy schemes', () => {
+    const completeVMess = btoa(JSON.stringify({
+      add: 'example.com',
+      port: '443',
+      id: '11111111-1111-1111-1111-111111111111',
+    }));
+    const incompleteVMess = btoa(JSON.stringify({ add: 'example.com' }));
     expect(isSupportedProxyURL('http://127.0.0.1:7890')).toBe(true);
     expect(isSupportedProxyURL('https://proxy.example:443')).toBe(true);
     expect(isSupportedProxyURL('socks5://127.0.0.1:7891')).toBe(true);
     expect(isSupportedProxyURL('socks5h://proxy.example:1080')).toBe(true);
+    expect(isSupportedProxyURL(`vmess://${completeVMess}`)).toBe(true);
+    expect(isSupportedProxyURL(`vmess://${incompleteVMess}`)).toBe(false);
+    expect(isSupportedProxyURL('vless://11111111-1111-1111-1111-111111111111@example.com:443?security=tls')).toBe(true);
+    expect(isSupportedProxyURL('trojan://secret@example.com:443')).toBe(true);
+    expect(isSupportedProxyURL('ss://YWVzLTEyOC1nY206c2VjcmV0@example.com:8388')).toBe(true);
     expect(isSupportedProxyURL('127.0.0.1:7890')).toBe(false);
   });
 
   it('masks proxy credentials in previews', () => {
     expect(maskProxyURL('http://user:pass@127.0.0.1:7890/')).toBe('http://***:***@127.0.0.1:7890/');
+    expect(maskProxyURL('vmess://eyJhZGQiOiJleGFtcGxlLmNvbSJ9')).toBe('vmess://***');
+    expect(maskProxyURL('vless://secret@example.com:443?security=tls')).toBe('vless://***');
+    expect(maskProxyURL('trojan://secret@example.com:443')).toBe('trojan://***');
+    expect(maskProxyURL('ss://YWVzLTEyOC1nY206c2VjcmV0@example.com:8388')).toBe('ss://***');
   });
 });

--- a/web/src/pages/proxies/utils/proxy-settings.ts
+++ b/web/src/pages/proxies/utils/proxy-settings.ts
@@ -37,6 +37,10 @@ export function proxyLabel(proxy: OutboundProxyDefinition): string {
 }
 
 export function maskProxyURL(raw: string): string {
+  const scheme = getProxyScheme(raw);
+  if (['vmess', 'vless', 'trojan', 'ss'].includes(scheme)) {
+    return `${scheme}://***`;
+  }
   try {
     const url = new URL(raw);
     if (url.username || url.password) {
@@ -49,9 +53,71 @@ export function maskProxyURL(raw: string): string {
   }
 }
 
-export function isSupportedProxyURL(raw: string): boolean {
+function getProxyScheme(raw: string): string {
+  const trimmed = raw.trim();
+  const separator = trimmed.indexOf('://');
+  if (separator <= 0) return '';
+  return trimmed.slice(0, separator).toLowerCase();
+}
+
+function validPort(value: string | null): boolean {
+  if (!value || !/^\d+$/.test(value)) return false;
+  const port = Number(value);
+  return port > 0 && port <= 65535;
+}
+
+function decodeBase64Loose(value: string): string | null {
+  const normalized = value.trim().replace(/-/g, '+').replace(/_/g, '/');
+  if (!normalized) return null;
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4);
   try {
-    const url = new URL(raw.trim());
+    return atob(padded);
+  } catch {
+    return null;
+  }
+}
+
+function isSupportedVMessURL(raw: string): boolean {
+  const decoded = decodeBase64Loose(raw.slice('vmess://'.length));
+  if (!decoded) return false;
+  try {
+    const payload = JSON.parse(decoded) as { add?: unknown; port?: unknown; id?: unknown };
+    return (
+      typeof payload.add === 'string' &&
+      payload.add.trim() !== '' &&
+      typeof payload.id === 'string' &&
+      payload.id.trim() !== '' &&
+      validPort(String(payload.port ?? ''))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isSupportedURLNode(raw: string, scheme: 'vless' | 'trojan' | 'ss'): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== `${scheme}:` || !url.hostname || !validPort(url.port)) return false;
+    if (scheme === 'ss') {
+      const user = url.username ? `${url.username}${url.password ? `:${url.password}` : ''}` : '';
+      if (!user) return false;
+      if (url.password) return true;
+      const decoded = decodeBase64Loose(user);
+      return !!decoded && decoded.includes(':');
+    }
+    return !!url.username;
+  } catch {
+    return false;
+  }
+}
+
+export function isSupportedProxyURL(raw: string): boolean {
+  const trimmed = raw.trim();
+  const scheme = getProxyScheme(trimmed);
+  if (scheme === 'vmess') return isSupportedVMessURL(trimmed);
+  if (scheme === 'vless' || scheme === 'trojan' || scheme === 'ss') return isSupportedURLNode(trimmed, scheme);
+  try {
+    const url = new URL(trimmed);
     return ['http:', 'https:', 'socks5:', 'socks5h:'].includes(url.protocol) && !!url.host;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- allow managed outbound proxies to store vmess, vless, trojan, and ss node links from v2rayN-style configs
- resolve node links at provider runtime by launching a local sing-box mixed inbound and routing provider traffic through the generated socks5h endpoint
- bundle sing-box into the official Docker image and verify the downloaded archive with fixed SHA-256 checksums
- add an admin proxy connectivity check that probes `https://api.ipify.org?format=json` through the same runtime path and shows outbound IP or failure reason in the proxy UI
- update proxy management validation, placeholder text, i18n copy, and node-link preview masking

## Implementation notes
- Existing `http`, `https`, `socks5`, and `socks5h` proxy URLs continue to pass through unchanged.
- Node links are parsed into sing-box outbound config at runtime; Maxx does not implement the proxy protocol stack directly.
- The managed local listener binds to `127.0.0.1`, waits for readiness, cleans up temp configs on exit, singleflights concurrent startup for the same node link, and caps active managed node proxies.
- Official Docker images include `/app/bin/sing-box`, so Docker deployments do not require the operator to install sing-box manually.
- Non-Docker deployments can place `sing-box` next to the `maxx` binary, under `./bin/sing-box`, set `MAXX_SING_BOX_PATH`, or rely on `PATH`.
- If no sing-box binary is available, provider setup and the connectivity check fail closed with an explicit error instead of silently going direct.
- Unsupported VLESS security and non-supported transports are rejected instead of producing incomplete configs; URL-form node links must include explicit ports.

## Validation
- `git diff --check`
- `go test ./internal/adapter/provider ./internal/router ./internal/handler`
- `pnpm -C web test -- proxy-settings.test.ts`
- `pnpm -C web typecheck`
- `pnpm -C web build`

## Manual probe
- Parsed the provided vmess/ws/tls node shape and verified DNS/TCP/TLS reachability from the current host.
- Verified the provided VMess node through the new `/admin/proxy-check` path with a local sing-box runtime; result: outbound IP `8.210.108.58`.