### PR TITLE
test(proxy): cover claude routes through openai providers

### DIFF
--- a/internal/executor/claude_openai_custom_route_test.go
+++ b/internal/executor/claude_openai_custom_route_test.go
@@ -1,0 +1,114 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/awsl-project/maxx/internal/adapter/provider/custom"
+	"github.com/awsl-project/maxx/internal/converter"
+	"github.com/awsl-project/maxx/internal/domain"
+	"github.com/awsl-project/maxx/internal/flow"
+	"github.com/awsl-project/maxx/internal/router"
+)
+
+func TestDispatchClaudeRouteThroughRealCustomOpenAIProvider(t *testing.T) {
+	var upstreamPath string
+	var upstreamBody map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamPath = r.URL.Path
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("upstream path = %s, want /v1/chat/completions", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
+			t.Fatalf("Authorization = %q, want provider bearer key", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&upstreamBody); err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		if _, ok := upstreamBody["messages"].([]any); !ok {
+			t.Fatalf("upstream body is not OpenAI chat format: %#v", upstreamBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"chatcmpl-real-custom",
+			"object":"chat.completion",
+			"created":1700000000,
+			"model":"gpt-4o-mini",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok from openai custom"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":3,"completion_tokens":5,"total_tokens":8}
+		}`))
+	}))
+	defer upstream.Close()
+
+	provider := &domain.Provider{
+		ID:                   40,
+		TenantID:             domain.DefaultTenantID,
+		Type:                 "custom",
+		Name:                 "openai-format-custom",
+		SupportedClientTypes: []domain.ClientType{domain.ClientTypeOpenAI},
+		Config: &domain.ProviderConfig{Custom: &domain.ProviderConfigCustom{
+			BaseURL: upstream.URL + "/v1",
+			APIKey:  "sk-test",
+		}},
+	}
+	adapter, err := custom.NewAdapter(provider)
+	if err != nil {
+		t.Fatalf("NewAdapter() error = %v", err)
+	}
+
+	requestBody := `{"model":"claude-3-5-sonnet","max_tokens":64,"messages":[{"role":"user","content":"hello"}],"stream":false}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(requestBody)).WithContext(context.Background())
+	c := flow.NewCtx(rec, req)
+	proxyReq := &domain.ProxyRequest{
+		ID:         200,
+		TenantID:   domain.DefaultTenantID,
+		ClientType: domain.ClientTypeClaude,
+		Status:     "IN_PROGRESS",
+		StartTime:  time.Now(),
+	}
+	c.Set(flow.KeyExecutorState, &execState{
+		ctx:                 context.Background(),
+		proxyReq:            proxyReq,
+		tenantID:            domain.DefaultTenantID,
+		clientType:          domain.ClientTypeClaude,
+		requestModel:        "claude-3-5-sonnet",
+		isStream:            false,
+		requestBody:         []byte(requestBody),
+		originalRequestBody: []byte(requestBody),
+		requestHeaders:      http.Header{"Content-Type": []string{"application/json"}},
+		requestURI:          "/v1/messages",
+		routes: []*router.MatchedRoute{{
+			Route:           &domain.Route{ID: 30, TenantID: domain.DefaultTenantID, ProviderID: provider.ID, ClientType: domain.ClientTypeClaude, IsEnabled: true},
+			Provider:        provider,
+			ProviderAdapter: adapter,
+			RetryConfig:     &domain.RetryConfig{MaxRetries: 0, InitialInterval: 0, BackoffRate: 1, MaxInterval: 0},
+		}},
+	})
+
+	e := &Executor{
+		proxyRequestRepo: &recordingProxyRequestRepo{},
+		attemptRepo:      &recordingAttemptRepo{},
+		modelMappingRepo: &stubModelMappingRepo{},
+		settingsRepo:     &stubExecutorSettingsRepo{},
+		converter:        converter.GetGlobalRegistry(),
+	}
+
+	e.dispatch(c)
+
+	if c.Err != nil {
+		t.Fatalf("dispatch returned error: %v", c.Err)
+	}
+	if upstreamPath != "/v1/chat/completions" {
+		t.Fatalf("upstream was not called as OpenAI chat completions, path=%q", upstreamPath)
+	}
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK || !strings.Contains(body, `"type":"message"`) || !strings.Contains(body, `"text":"ok from openai custom"`) {
+		t.Fatalf("client did not receive converted Claude response: status=%d body=%s", rec.Code, body)
+	}
+}

--- a/internal/service/admin_route_native_test.go
+++ b/internal/service/admin_route_native_test.go
@@ -123,6 +123,39 @@ func TestCreateRouteDerivesNativeFromProvider(t *testing.T) {
 	}
 }
 
+func TestCreateRouteAllowsClaudeRouteThroughOpenAIProvider(t *testing.T) {
+	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
+
+	openaiProvider := mustCreateProvider(t, providerRepo, newTestOpenAIOnlyCustomProvider("openai-format-for-claude"))
+	route := &domain.Route{
+		ProviderID: openaiProvider.ID,
+		ClientType: domain.ClientTypeClaude,
+		ProjectID:  0,
+		Position:   1,
+		Weight:     1,
+		IsEnabled:  true,
+		IsNative:   true, // client-submitted value must be ignored; this is a conversion route.
+	}
+
+	if err := svc.CreateRoute(domain.DefaultTenantID, route); err != nil {
+		t.Fatalf("CreateRoute(claude→openai) error = %v", err)
+	}
+	if route.IsNative {
+		t.Fatalf("CreateRoute(claude→openai) IsNative = true, want false")
+	}
+
+	stored, err := routeRepo.GetByID(domain.DefaultTenantID, route.ID)
+	if err != nil {
+		t.Fatalf("GetByID(claude→openai route) error = %v", err)
+	}
+	if stored.ClientType != domain.ClientTypeClaude || stored.ProviderID != openaiProvider.ID {
+		t.Fatalf("stored route = %+v, want Claude route to OpenAI provider", stored)
+	}
+	if stored.IsNative {
+		t.Fatalf("stored claude→openai IsNative = true, want false")
+	}
+}
+
 func TestCreateRouteOverridesClientFalseForCodex(t *testing.T) {
 	svc, providerRepo, routeRepo, _ := setupRouteNativeTestEnv(t)
 


### PR DESCRIPTION
## Summary
- add explicit regression coverage that a Claude route may target an OpenAI-format custom provider as a conversion route
- assert route creation stores it as non-native (`isNative=false`) instead of rejecting it or trusting client-supplied native flags
- add a real custom-provider request proof: Claude `/v1/messages` input is sent to an OpenAI `/v1/chat/completions` upstream and converted back to Claude response format

## Notes
- No special-case endpoint guessing is introduced. The executor already chooses OpenAI when the matched provider only supports OpenAI; this PR pins that intended behavior with route-level and request-level coverage.

## Validation
- `git diff --check`
- `go test ./internal/executor ./internal/service ./internal/converter ./internal/adapter/provider/custom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增集成测试，验证 Claude 请求可通过自定义 OpenAI 兼容提供方完成路由，并正确转换请求与响应格式。
  - 新增路由创建测试，确认 Claude 使用仅支持 OpenAI 的提供方时，会自动采用转换路由。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->