### PR TITLE
fix(provider): include black-box providers in bulk updates

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -540,6 +540,24 @@ type ProviderBulkDeleteResult struct {
 	ModelMappingDeletedCount int      `json:"modelMappingDeletedCount"`
 }
 
+// ProviderBulkUpdateRequest updates selected safe runtime fields without requiring config disclosure.
+type ProviderBulkUpdateRequest struct {
+	IDs                    []uint64   `json:"ids"`
+	UpdateProxy            bool       `json:"updateProxy,omitempty"`
+	ProxyURL               string     `json:"proxyURL,omitempty"`
+	UpdateClientMultiplier bool       `json:"updateClientMultiplier,omitempty"`
+	MultiplierClient       ClientType `json:"multiplierClient,omitempty"`
+	Multiplier             uint64     `json:"multiplier,omitempty"`
+}
+
+// ProviderBulkUpdateResult reports changed and skipped providers.
+type ProviderBulkUpdateResult struct {
+	UpdatedCount int      `json:"updatedCount"`
+	UpdatedIDs   []uint64 `json:"updatedIDs"`
+	NotFoundIDs  []uint64 `json:"notFoundIDs"`
+	Skipped      []string `json:"skipped"`
+}
+
 type Project struct {
 	ID        uint64    `json:"id"`
 	CreatedAt time.Time `json:"createdAt"`

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -95,6 +95,8 @@ func (h *AdminHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "providers":
 		if len(parts) == 3 && parts[2] == "bulk-delete" {
 			h.handleBulkDeleteProviders(w, r)
+		} else if len(parts) == 3 && parts[2] == "bulk-update" {
+			h.handleBulkUpdateProviders(w, r)
 		} else {
 			h.handleProviders(w, r, id)
 		}
@@ -489,6 +491,27 @@ func (h *AdminHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.
 	result, err := h.svc.BulkDeleteProviders(tenantID, req)
 	if err != nil {
 		writeJSON(w, bulkDeleteErrorStatus(err), map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (h *AdminHandler) handleBulkUpdateProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var req domain.ProviderBulkUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	result, err := h.svc.BulkUpdateProviders(maxxctx.GetTenantID(r.Context()), req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -99,6 +99,8 @@ func (h *SelfServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleProviders(w, r, 0)
 		case len(parts) == 3 && parts[2] == "bulk-delete":
 			h.handleBulkDeleteProviders(w, r)
+		case len(parts) == 3 && parts[2] == "bulk-update":
+			h.handleBulkUpdateProviders(w, r)
 		case len(parts) == 3 && parts[2] == "export":
 			h.handleProvidersExport(w, r)
 		case len(parts) == 3 && parts[2] == "import":
@@ -658,6 +660,27 @@ func (h *SelfServiceHandler) handleProjectBySlug(w http.ResponseWriter, r *http.
 		return
 	}
 	writeJSON(w, http.StatusOK, project)
+}
+
+func (h *SelfServiceHandler) handleBulkUpdateProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if !h.requireAdmin(w, r) {
+		return
+	}
+	var req domain.ProviderBulkUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	result, err := h.svc.BulkUpdateProviders(maxxctx.GetTenantID(r.Context()), req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (h *SelfServiceHandler) handleBulkDeleteProviders(w http.ResponseWriter, r *http.Request) {

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -199,6 +199,92 @@ func (s *AdminService) UpdateProvider(tenantID uint64, provider *domain.Provider
 	return nil
 }
 
+func (s *AdminService) BulkUpdateProviders(tenantID uint64, req domain.ProviderBulkUpdateRequest) (*domain.ProviderBulkUpdateResult, error) {
+	if len(req.IDs) == 0 {
+		return nil, fmt.Errorf("ids required")
+	}
+	if !req.UpdateProxy && !req.UpdateClientMultiplier {
+		return nil, fmt.Errorf("no fields selected")
+	}
+
+	seen := make(map[uint64]struct{}, len(req.IDs))
+	result := &domain.ProviderBulkUpdateResult{
+		UpdatedIDs:  []uint64{},
+		NotFoundIDs: []uint64{},
+		Skipped:     []string{},
+	}
+
+	for _, id := range req.IDs {
+		if id == 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		provider, err := s.providerRepo.GetByID(tenantID, id)
+		if err != nil {
+			result.NotFoundIDs = append(result.NotFoundIDs, id)
+			continue
+		}
+
+		changed := false
+		if req.UpdateProxy {
+			if provider.Config == nil {
+				provider.Config = &domain.ProviderConfig{}
+			}
+			provider.Config.ProxyURL = req.ProxyURL
+			changed = true
+		}
+
+		if req.UpdateClientMultiplier {
+			if provider.Config == nil || provider.Config.Custom == nil || !clientTypeSupported(provider.SupportedClientTypes, req.MultiplierClient) {
+				result.Skipped = append(result.Skipped, fmt.Sprintf("%s: multiplier not applicable", provider.Name))
+			} else {
+				if provider.Config.Custom.ClientMultiplier == nil {
+					provider.Config.Custom.ClientMultiplier = map[domain.ClientType]uint64{}
+				}
+				if req.Multiplier == 10000 {
+					delete(provider.Config.Custom.ClientMultiplier, req.MultiplierClient)
+				} else {
+					provider.Config.Custom.ClientMultiplier[req.MultiplierClient] = req.Multiplier
+				}
+				if len(provider.Config.Custom.ClientMultiplier) == 0 {
+					provider.Config.Custom.ClientMultiplier = nil
+				}
+				changed = true
+			}
+		}
+
+		if !changed {
+			continue
+		}
+		if err := s.providerRepo.Update(provider); err != nil {
+			return nil, err
+		}
+		if s.adapterRefresher != nil {
+			s.adapterRefresher.RefreshAdapter(provider)
+		}
+		if err := s.reconcileProviderRouteNative(tenantID, provider); err != nil {
+			log.Printf("[Admin] reconcile provider %d route native flags: %v", provider.ID, err)
+		}
+		result.UpdatedIDs = append(result.UpdatedIDs, provider.ID)
+	}
+
+	result.UpdatedCount = len(result.UpdatedIDs)
+	return result, nil
+}
+
+func clientTypeSupported(clientTypes []domain.ClientType, target domain.ClientType) bool {
+	for _, clientType := range clientTypes {
+		if clientType == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *AdminService) DeleteProvider(tenantID uint64, id uint64) error {
 	// Delete related routes first
 	routes, _ := s.routeRepo.List(tenantID)

--- a/web/src/hooks/queries/index.ts
+++ b/web/src/hooks/queries/index.ts
@@ -14,6 +14,7 @@ export {
   useUpdateProvider,
   useDeleteProvider,
   useBulkDeleteProviders,
+  useBulkUpdateProviders,
   useProviderStats,
   useAllProviderStats,
   useAntigravityQuota,

--- a/web/src/hooks/queries/use-providers.ts
+++ b/web/src/hooks/queries/use-providers.ts
@@ -7,6 +7,7 @@ import {
   getTransport,
   type Provider,
   type CreateProviderData,
+  type ProviderBulkUpdateRequest,
   type ProviderRuntimeModelsPreviewRequest,
   type ProviderModelCheckRequest,
 } from '@/lib/transport';
@@ -108,6 +109,18 @@ export function useUpdateProvider() {
     },
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: providerKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: providerKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: routeKeys.lists() });
+    },
+  });
+}
+
+export function useBulkUpdateProviders() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ProviderBulkUpdateRequest) => getTransport().bulkUpdateProviders(data),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: providerKeys.lists() });
       queryClient.invalidateQueries({ queryKey: routeKeys.lists() });
     },

--- a/web/src/lib/transport/http-transport.ts
+++ b/web/src/lib/transport/http-transport.ts
@@ -10,6 +10,8 @@ import type {
   CreateProviderData,
   ProviderBulkDeleteRequest,
   ProviderBulkDeleteResult,
+  ProviderBulkUpdateRequest,
+  ProviderBulkUpdateResult,
   Project,
   CreateProjectData,
   ProjectArchiveInactiveResult,
@@ -373,6 +375,14 @@ export class HttpTransport implements Transport {
     return result;
   }
 
+  async bulkUpdateProviders(data: ProviderBulkUpdateRequest): Promise<ProviderBulkUpdateResult> {
+    const { data: result } = await this.client.post<ProviderBulkUpdateResult>(
+      '/providers/bulk-update',
+      data,
+    );
+    return result;
+  }
+
   async exportProviders(): Promise<Provider[]> {
     const { data } = await this.client.get<Provider[]>('/providers/export');
     return this.expectArray<Provider>(data, '/providers/export');
@@ -698,7 +708,11 @@ export class HttpTransport implements Transport {
   }
 
   async checkOutboundProxy(url: string, signal?: AbortSignal): Promise<ProxyConnectivityResult> {
-    const { data } = await this.adminClient.post<ProxyConnectivityResult>('/proxy-check', { url }, { signal });
+    const { data } = await this.adminClient.post<ProxyConnectivityResult>(
+      '/proxy-check',
+      { url },
+      { signal },
+    );
     return this.expectObject<ProxyConnectivityResult>(data, '/admin/proxy-check');
   }
 

--- a/web/src/lib/transport/index.ts
+++ b/web/src/lib/transport/index.ts
@@ -24,6 +24,8 @@ export type {
   CreateProviderData,
   ProviderBulkDeleteRequest,
   ProviderBulkDeleteResult,
+  ProviderBulkUpdateRequest,
+  ProviderBulkUpdateResult,
   Project,
   CreateProjectData,
   ProjectArchiveInactiveResult,

--- a/web/src/lib/transport/interface.ts
+++ b/web/src/lib/transport/interface.ts
@@ -8,6 +8,8 @@ import type {
   CreateProviderData,
   ProviderBulkDeleteRequest,
   ProviderBulkDeleteResult,
+  ProviderBulkUpdateRequest,
+  ProviderBulkUpdateResult,
   Project,
   CreateProjectData,
   ProjectArchiveInactiveResult,
@@ -137,6 +139,7 @@ export interface Transport {
   updateProvider(id: number, data: Partial<Provider>): Promise<Provider>;
   deleteProvider(id: number): Promise<void>;
   bulkDeleteProviders(data: ProviderBulkDeleteRequest): Promise<ProviderBulkDeleteResult>;
+  bulkUpdateProviders(data: ProviderBulkUpdateRequest): Promise<ProviderBulkUpdateResult>;
   exportProviders(): Promise<Provider[]>;
   importProviders(providers: Provider[]): Promise<ImportResult>;
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -371,6 +371,22 @@ export interface ProviderBulkDeleteResult {
   modelMappingDeletedCount: number;
 }
 
+export interface ProviderBulkUpdateRequest {
+  ids: number[];
+  updateProxy?: boolean;
+  proxyURL?: string;
+  updateClientMultiplier?: boolean;
+  multiplierClient?: ClientType;
+  multiplier?: number;
+}
+
+export interface ProviderBulkUpdateResult {
+  updatedCount: number;
+  updatedIDs: number[];
+  notFoundIDs: number[];
+  skipped: string[];
+}
+
 export type CreateRouteData = Omit<Route, 'id' | 'createdAt' | 'updatedAt' | 'isNative'>;
 
 export type UpdateRouteData = Partial<CreateRouteData>;
@@ -627,7 +643,12 @@ export interface ResponseInfo {
 }
 
 export type ProxyRequestStatus =
-  'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'CANCELLED' | 'REJECTED';
+  | 'PENDING'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'CANCELLED'
+  | 'REJECTED';
 
 export type ProxyRequestErrorMode = 'all' | 'only' | 'exclude';
 
@@ -716,7 +737,11 @@ export interface ProxyRequest {
 // ===== ProxyUpstreamAttempt =====
 
 export type ProxyUpstreamAttemptStatus =
-  'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
+  | 'PENDING'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'CANCELLED';
 
 export interface ProxyUpstreamAttempt {
   id: number;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -841,10 +841,10 @@
       "multiplierHelper": "Applies to custom providers that support the selected client. 1.00 keeps default pricing.",
       "multiplierClient": "Client type",
       "multiplierValue": "Price multiplier",
-      "multiplierSkipped": "{{name}} was skipped for multiplier because it is not an editable custom provider for that client.",
+      "multiplierSkipped": "{{name}} was skipped for multiplier because it is not a custom provider for that client.",
       "currentProxy": "Proxy: {{proxy}}",
       "currentMultiplier": "{{client}} multiplier: {{multiplier}}×",
-      "noTargets": "No editable providers selected. Black-box providers are skipped.",
+      "noTargets": "No providers selected.",
       "result": "Updated {{count}} providers",
       "submit": "Update"
     }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -838,10 +838,10 @@
       "multiplierHelper": "仅作用于支持所选客户端的 custom provider。1.00 表示使用默认价格。",
       "multiplierClient": "客户端类型",
       "multiplierValue": "价格倍率",
-      "multiplierSkipped": "{{name}} 不是该客户端可更新的 custom provider，已跳过倍率。",
+      "multiplierSkipped": "{{name}} 不是该客户端可用的 custom provider，已跳过倍率。",
       "currentProxy": "代理：{{proxy}}",
       "currentMultiplier": "{{client}} 倍率：{{multiplier}}×",
-      "noTargets": "没有可更新的 provider。黑盒 provider 会被跳过。",
+      "noTargets": "没有选中的 provider。",
       "result": "已更新 {{count}} 个 provider",
       "submit": "更新"
     }

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -21,7 +21,7 @@ import {
   useUpdateSetting,
   useProxyRequestUpdates,
   useCreateProvider,
-  useUpdateProvider,
+  useBulkUpdateProviders,
   useCreateModelMapping,
   useBulkDeleteProviders,
   useRoutes,
@@ -196,7 +196,7 @@ export function ProvidersPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const createProvider = useCreateProvider();
-  const updateProvider = useUpdateProvider();
+  const bulkUpdateProviders = useBulkUpdateProviders();
   const createModelMapping = useCreateModelMapping();
   const bulkDeleteProviders = useBulkDeleteProviders();
   const canManageProviderSettings = user?.role === 'admin';
@@ -334,15 +334,7 @@ export function ProvidersPage() {
     (sum, item) => sum + item.streamingCount,
     0,
   );
-  const bulkProxyUpdateTargets = useMemo(
-    () => selectedProviders.filter((provider) => !provider.blackBox),
-    [selectedProviders],
-  );
-  const bulkProxyUpdateSkipped = useMemo(
-    () =>
-      selectedProviders.filter((provider) => provider.blackBox).map((provider) => provider.name),
-    [selectedProviders],
-  );
+  const bulkProxyUpdateTargets = selectedProviders;
   const bulkUpdateProxyEnabled = bulkUpdateEnabledFields.has('proxy');
   const bulkUpdateMultiplierEnabled = bulkUpdateEnabledFields.has('multiplier');
   const hasBulkUpdateFields = bulkUpdateEnabledFields.size > 0;
@@ -659,74 +651,32 @@ export function ProvidersPage() {
     }
 
     setIsBulkProxyUpdating(true);
-    const skipped = [...bulkProxyUpdateSkipped];
-    const failed: string[] = [];
-    let updated = 0;
 
-    for (const provider of bulkProxyUpdateTargets) {
-      const nextConfig = { ...(provider.config ?? {}) };
-      let shouldUpdateProvider = false;
-      let skippedMultiplier = false;
+    try {
+      const result = await bulkUpdateProviders.mutateAsync({
+        ids: bulkProxyUpdateTargets.map((provider) => provider.id),
+        updateProxy: bulkUpdateProxyEnabled,
+        proxyURL: selectedProxy?.url,
+        updateClientMultiplier: bulkUpdateMultiplierEnabled,
+        multiplierClient: bulkMultiplierClient,
+        multiplier: nextMultiplier,
+      });
+      setIsBulkProxyUpdating(false);
+      setBulkProxyUpdateStatus({ updated: result.updatedCount, skipped: result.skipped });
 
-      if (bulkUpdateProxyEnabled) {
-        nextConfig.proxyURL = selectedProxy?.url;
-        shouldUpdateProvider = true;
+      if (result.skipped.length === 0) {
+        setSelectedProviderIds(new Set());
+        setTimeout(() => {
+          setIsBulkProxyUpdateOpen(false);
+          setBulkProxyUpdateStatus(null);
+        }, 900);
       }
-
-      if (bulkUpdateMultiplierEnabled) {
-        if (
-          provider.config?.custom &&
-          provider.supportedClientTypes.includes(bulkMultiplierClient)
-        ) {
-          const nextClientMultiplier = { ...(provider.config.custom.clientMultiplier ?? {}) };
-          if (nextMultiplier === 10000) {
-            delete nextClientMultiplier[bulkMultiplierClient];
-          } else {
-            nextClientMultiplier[bulkMultiplierClient] = nextMultiplier;
-          }
-          nextConfig.custom = {
-            ...provider.config.custom,
-            clientMultiplier:
-              Object.keys(nextClientMultiplier).length > 0 ? nextClientMultiplier : undefined,
-          };
-          shouldUpdateProvider = true;
-        } else {
-          skippedMultiplier = true;
-        }
-      }
-
-      if (!shouldUpdateProvider) {
-        if (skippedMultiplier) {
-          skipped.push(t('providers.bulkProxyUpdate.multiplierSkipped', { name: provider.name }));
-        }
-        continue;
-      }
-
-      try {
-        await updateProvider.mutateAsync({
-          id: provider.id,
-          data: {
-            config: nextConfig,
-          },
-        });
-        updated += 1;
-        if (skippedMultiplier) {
-          skipped.push(t('providers.bulkProxyUpdate.multiplierSkipped', { name: provider.name }));
-        }
-      } catch (error) {
-        failed.push(`${provider.name}: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    }
-
-    setIsBulkProxyUpdating(false);
-    setBulkProxyUpdateStatus({ updated, skipped: [...skipped, ...failed] });
-
-    if (failed.length === 0) {
-      setSelectedProviderIds(new Set());
-      setTimeout(() => {
-        setIsBulkProxyUpdateOpen(false);
-        setBulkProxyUpdateStatus(null);
-      }, 900);
+    } catch (error) {
+      setIsBulkProxyUpdating(false);
+      setBulkProxyUpdateStatus({
+        updated: 0,
+        skipped: [error instanceof Error ? error.message : String(error)],
+      });
     }
   };
 


### PR DESCRIPTION
## Summary\n- Add a dedicated providers bulk-update API so selected black-box providers can be updated without exposing or round-tripping hidden config\n- Change the Providers bulk update dialog to submit selected IDs to the new endpoint instead of filtering out black-box providers client-side\n- Keep proxy updates and custom-provider client multiplier updates opt-in per field\n- Update copy so black-box providers are no longer described as skipped\n\n## Why\n#887 incorrectly preserved the old editable-provider filter and skipped black-box providers. Updating through regular PUT is unsafe because black-box config is intentionally hidden from the UI/API and could be erased by round-tripping sanitized data.\n\n## Validation\n- go test ./internal/service ./internal/handler\n- git diff --check\n- pnpm -C web typecheck\n- pnpm -C web exec vitest run src/pages/providers/providers-bulk-actions-layout.test.ts src/pages/proxies/utils/proxy-settings.test.ts src/components/layout/app-sidebar/sidebar-renderer.test.ts\n- pnpm -C web build