### PR TITLE
feat(provider): bulk update quota checks

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -548,6 +548,8 @@ type ProviderBulkUpdateRequest struct {
 	UpdateClientMultiplier bool       `json:"updateClientMultiplier,omitempty"`
 	MultiplierClient       ClientType `json:"multiplierClient,omitempty"`
 	Multiplier             uint64     `json:"multiplier,omitempty"`
+	UpdateQuotaEnabled     bool       `json:"updateQuotaEnabled,omitempty"`
+	QuotaEnabled           bool       `json:"quotaEnabled,omitempty"`
 }
 
 // ProviderBulkUpdateResult reports changed and skipped providers.

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -203,7 +203,7 @@ func (s *AdminService) BulkUpdateProviders(tenantID uint64, req domain.ProviderB
 	if len(req.IDs) == 0 {
 		return nil, fmt.Errorf("ids required")
 	}
-	if !req.UpdateProxy && !req.UpdateClientMultiplier {
+	if !req.UpdateProxy && !req.UpdateClientMultiplier && !req.UpdateQuotaEnabled {
 		return nil, fmt.Errorf("no fields selected")
 	}
 
@@ -235,6 +235,14 @@ func (s *AdminService) BulkUpdateProviders(tenantID uint64, req domain.ProviderB
 				provider.Config = &domain.ProviderConfig{}
 			}
 			provider.Config.ProxyURL = req.ProxyURL
+			changed = true
+		}
+
+		if req.UpdateQuotaEnabled {
+			if provider.Config == nil {
+				provider.Config = &domain.ProviderConfig{}
+			}
+			provider.Config.QuotaEnabled = req.QuotaEnabled
 			changed = true
 		}
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -378,6 +378,8 @@ export interface ProviderBulkUpdateRequest {
   updateClientMultiplier?: boolean;
   multiplierClient?: ClientType;
   multiplier?: number;
+  updateQuotaEnabled?: boolean;
+  quotaEnabled?: boolean;
 }
 
 export interface ProviderBulkUpdateResult {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -829,7 +829,7 @@
     "bulkProxyUpdate": {
       "open": "Bulk update",
       "title": "Bulk update providers",
-      "description": "Update enabled fields for {{count}} editable provider(s). Fields left off are not changed.",
+      "description": "Update enabled fields for {{count}} selected provider(s). Fields left off are not changed.",
       "selected": "Selected",
       "updatable": "Updatable",
       "multiplierTargets": "Multiplier targets",
@@ -842,8 +842,12 @@
       "multiplierClient": "Client type",
       "multiplierValue": "Price multiplier",
       "multiplierSkipped": "{{name}} was skipped for multiplier because it is not a custom provider for that client.",
+      "quotaLabel": "Update quota check",
+      "quotaHelper": "Toggle whether requests through each selected provider require API token quota.",
+      "quotaValue": "Enable quota check",
       "currentProxy": "Proxy: {{proxy}}",
       "currentMultiplier": "{{client}} multiplier: {{multiplier}}×",
+      "currentQuota": "Quota check: {{status}}",
       "noTargets": "No providers selected.",
       "result": "Updated {{count}} providers",
       "submit": "Update"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -826,7 +826,7 @@
     "bulkProxyUpdate": {
       "open": "批量更新",
       "title": "批量更新提供商",
-      "description": "只更新 {{count}} 个可编辑 provider 中已打开的字段；未打开字段保持原样。",
+      "description": "只更新 {{count}} 个选中 provider 中已打开的字段；未打开字段保持原样。",
       "selected": "已选择",
       "updatable": "可更新",
       "multiplierTargets": "倍率可更新",
@@ -839,8 +839,12 @@
       "multiplierClient": "客户端类型",
       "multiplierValue": "价格倍率",
       "multiplierSkipped": "{{name}} 不是该客户端可用的 custom provider，已跳过倍率。",
+      "quotaLabel": "更新额度检查",
+      "quotaHelper": "批量设置选中 provider 是否要求 API 令牌具备额度。",
+      "quotaValue": "启用额度检查",
       "currentProxy": "代理：{{proxy}}",
       "currentMultiplier": "{{client}} 倍率：{{multiplier}}×",
+      "currentQuota": "额度检查：{{status}}",
       "noTargets": "没有选中的 provider。",
       "result": "已更新 {{count}} 个 provider",
       "submit": "更新"

--- a/web/src/pages/providers/index.tsx
+++ b/web/src/pages/providers/index.tsx
@@ -148,7 +148,7 @@ type ProviderBulkDeletePreviewItem = {
   streamingCount: number;
 };
 
-type BulkUpdateField = 'proxy' | 'multiplier';
+type BulkUpdateField = 'proxy' | 'multiplier' | 'quota';
 
 const BULK_UPDATE_CLIENT_TYPES: ClientType[] = ['claude', 'openai', 'codex', 'gemini'];
 const DEFAULT_BULK_UPDATE_MULTIPLIER = '1.00';
@@ -179,6 +179,7 @@ export function ProvidersPage() {
   const [bulkProxyURL, setBulkProxyURL] = useState('');
   const [bulkMultiplierClient, setBulkMultiplierClient] = useState<ClientType>('claude');
   const [bulkMultiplierValue, setBulkMultiplierValue] = useState(DEFAULT_BULK_UPDATE_MULTIPLIER);
+  const [bulkQuotaEnabled, setBulkQuotaEnabled] = useState(true);
   const [bulkProxyUpdateStatus, setBulkProxyUpdateStatus] = useState<{
     updated: number;
     skipped: string[];
@@ -337,6 +338,7 @@ export function ProvidersPage() {
   const bulkProxyUpdateTargets = selectedProviders;
   const bulkUpdateProxyEnabled = bulkUpdateEnabledFields.has('proxy');
   const bulkUpdateMultiplierEnabled = bulkUpdateEnabledFields.has('multiplier');
+  const bulkUpdateQuotaEnabled = bulkUpdateEnabledFields.has('quota');
   const hasBulkUpdateFields = bulkUpdateEnabledFields.size > 0;
   const bulkMultiplierTargets = useMemo(
     () =>
@@ -618,6 +620,7 @@ export function ProvidersPage() {
       setBulkUpdateEnabledFields(new Set());
       setBulkProxyURL('');
       setBulkMultiplierValue(DEFAULT_BULK_UPDATE_MULTIPLIER);
+      setBulkQuotaEnabled(true);
     }
   };
 
@@ -660,6 +663,8 @@ export function ProvidersPage() {
         updateClientMultiplier: bulkUpdateMultiplierEnabled,
         multiplierClient: bulkMultiplierClient,
         multiplier: nextMultiplier,
+        updateQuotaEnabled: bulkUpdateQuotaEnabled,
+        quotaEnabled: bulkQuotaEnabled,
       });
       setIsBulkProxyUpdating(false);
       setBulkProxyUpdateStatus({ updated: result.updatedCount, skipped: result.skipped });
@@ -1381,6 +1386,38 @@ export function ProvidersPage() {
               )}
             </div>
 
+            <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-medium text-foreground">
+                    {t('providers.bulkProxyUpdate.quotaLabel')}
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {t('providers.bulkProxyUpdate.quotaHelper')}
+                  </p>
+                </div>
+                <Switch
+                  checked={bulkUpdateQuotaEnabled}
+                  onCheckedChange={(checked) => toggleBulkUpdateField('quota', checked)}
+                  disabled={isBulkProxyUpdating}
+                  aria-label={t('providers.bulkProxyUpdate.quotaLabel')}
+                />
+              </div>
+              {bulkUpdateQuotaEnabled && (
+                <div className="flex items-center justify-between rounded-md bg-muted/40 px-3 py-2">
+                  <span className="text-sm text-muted-foreground">
+                    {t('providers.bulkProxyUpdate.quotaValue')}
+                  </span>
+                  <Switch
+                    checked={bulkQuotaEnabled}
+                    onCheckedChange={setBulkQuotaEnabled}
+                    disabled={isBulkProxyUpdating}
+                    aria-label={t('providers.bulkProxyUpdate.quotaValue')}
+                  />
+                </div>
+              )}
+            </div>
+
             <div className="max-h-56 space-y-2 overflow-y-auto rounded-lg border border-border p-3 text-sm">
               {bulkProxyUpdateTargets.map((provider) => (
                 <div key={provider.id} className="rounded-md bg-muted/40 p-2">
@@ -1397,6 +1434,13 @@ export function ProvidersPage() {
                         (provider.config?.custom?.clientMultiplier?.[bulkMultiplierClient] ??
                           10000) / 10000
                       ).toFixed(2),
+                    })}
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {t('providers.bulkProxyUpdate.currentQuota', {
+                      status: provider.config?.quotaEnabled
+                        ? t('common.enabled')
+                        : t('common.disabled'),
                     })}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary\n- Add quota check as an opt-in field in the Providers bulk update dialog\n- Extend provider bulk update payload/service handling with updateQuotaEnabled + quotaEnabled\n- Show current quota-check state in the selected provider preview\n\n## Validation\n- go test ./internal/service ./internal/handler\n- git diff --check\n- pnpm -C web typecheck\n- pnpm -C web exec vitest run src/pages/providers/providers-bulk-actions-layout.test.ts src/pages/proxies/utils/proxy-settings.test.ts src/components/layout/app-sidebar/sidebar-renderer.test.ts\n- pnpm -C web build\n- Playwright smoke recording: /home/moltbot/clawd-wechat/tmp/maxx-provider-bulk-quota-final.webm