### PR TITLE
fix(external-models): group manual models by route type

### DIFF
--- a/internal/handler/models.go
+++ b/internal/handler/models.go
@@ -117,6 +117,12 @@ func (h *ModelsHandler) collectModelNamesForUserAgent(tenantID uint64, userAgent
 }
 
 func (h *ModelsHandler) collectAvailableModelNames(tenantID uint64, clientType domain.ClientType, projectID, providerID, apiTokenID uint64, userAgent string) ([]string, error) {
+	if models, enabled, err := h.collectConfiguredExternalModelClientTypeList(clientType); err != nil {
+		return nil, err
+	} else if enabled {
+		return sortedModelNames(models), nil
+	}
+
 	candidates, err := h.collectCandidateModelNames(tenantID, userAgent)
 	if err != nil {
 		return nil, err
@@ -344,7 +350,7 @@ func isProviderModelExposed(provider *domain.Provider, model string) bool {
 }
 
 func (h *ModelsHandler) collectConfiguredExternalModelRouteGroups(tenantID uint64, clientType domain.ClientType, projectID, providerID uint64) ([]modelRouteGroup, bool, error) {
-	if h == nil || h.settingsRepo == nil || h.router == nil {
+	if h == nil || h.settingsRepo == nil {
 		return nil, false, nil
 	}
 	enabledValue, err := h.settingsRepo.Get(domain.SettingKeyExternalModelListEnabled)
@@ -357,6 +363,32 @@ func (h *ModelsHandler) collectConfiguredExternalModelRouteGroups(tenantID uint6
 	value, err := h.settingsRepo.Get(domain.SettingKeyExternalModelList)
 	if err != nil {
 		return nil, false, err
+	}
+	clientTypeModels, hasClientTypes := parseExternalModelClientTypeSetting(value)
+	if hasClientTypes {
+		groups := make([]modelRouteGroup, 0, len(clientTypeModels))
+		for groupClientType, models := range clientTypeModels {
+			if clientType != "" && groupClientType != clientType {
+				continue
+			}
+			if providerID != 0 || projectID != 0 {
+				continue
+			}
+			normalizedModels := normalizeExternalModelList(models)
+			sort.Strings(normalizedModels)
+			if len(normalizedModels) == 0 {
+				continue
+			}
+			groups = append(groups, modelRouteGroup{
+				ClientType: groupClientType,
+				Models:     normalizedModels,
+			})
+		}
+		sort.Slice(groups, func(i, j int) bool { return groups[i].ClientType < groups[j].ClientType })
+		return groups, true, nil
+	}
+	if h.router == nil {
+		return nil, false, nil
 	}
 	routeModels, categorized := parseExternalModelRouteSetting(value)
 	if !categorized {
@@ -404,6 +436,32 @@ func (h *ModelsHandler) collectConfiguredExternalModelRouteGroups(tenantID uint6
 	return groups, true, nil
 }
 
+func (h *ModelsHandler) collectConfiguredExternalModelClientTypeList(clientType domain.ClientType) (map[string]struct{}, bool, error) {
+	result := make(map[string]struct{})
+	if h == nil || h.settingsRepo == nil || clientType == "" {
+		return result, false, nil
+	}
+	enabledValue, err := h.settingsRepo.Get(domain.SettingKeyExternalModelListEnabled)
+	if err != nil {
+		return nil, false, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(enabledValue), "true") {
+		return result, false, nil
+	}
+	value, err := h.settingsRepo.Get(domain.SettingKeyExternalModelList)
+	if err != nil {
+		return nil, false, err
+	}
+	clientTypeModels, categorized := parseExternalModelClientTypeSetting(value)
+	if !categorized {
+		return result, false, nil
+	}
+	for _, name := range clientTypeModels[clientType] {
+		addModelName(result, name)
+	}
+	return result, true, nil
+}
+
 func (h *ModelsHandler) collectConfiguredExternalModelList() (map[string]struct{}, bool, error) {
 	result := make(map[string]struct{})
 	if h == nil || h.settingsRepo == nil {
@@ -425,6 +483,36 @@ func (h *ModelsHandler) collectConfiguredExternalModelList() (map[string]struct{
 		addModelName(result, name)
 	}
 	return result, true, nil
+}
+
+func parseExternalModelClientTypeSetting(value string) (map[domain.ClientType][]string, bool) {
+	trimmed := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmed, "{") {
+		return nil, false
+	}
+	var categorized struct {
+		ClientTypes map[string][]string `json:"clientTypes"`
+	}
+	if json.Unmarshal([]byte(trimmed), &categorized) != nil || len(categorized.ClientTypes) == 0 {
+		return nil, false
+	}
+	result := make(map[domain.ClientType][]string, len(categorized.ClientTypes))
+	valid := map[domain.ClientType]struct{}{
+		domain.ClientTypeOpenAI: {},
+		domain.ClientTypeCodex:  {},
+		domain.ClientTypeClaude: {},
+		domain.ClientTypeGemini: {},
+	}
+	for key, models := range categorized.ClientTypes {
+		clientType := domain.ClientType(strings.TrimSpace(key))
+		if _, ok := valid[clientType]; !ok {
+			continue
+		}
+		if normalized := normalizeExternalModelList(models); len(normalized) > 0 {
+			result[clientType] = normalized
+		}
+	}
+	return result, true
 }
 
 func parseExternalModelRouteSetting(value string) (map[uint64][]string, bool) {
@@ -462,11 +550,15 @@ func parseExternalModelListSetting(value string) []string {
 	}
 	if strings.HasPrefix(trimmed, "{") {
 		var categorized struct {
+			ClientTypes   map[string][]string `json:"clientTypes"`
 			Routes        map[string][]string `json:"routes"`
 			Uncategorized []string            `json:"uncategorized"`
 		}
 		if json.Unmarshal([]byte(trimmed), &categorized) == nil {
 			values := make([]string, 0, len(categorized.Uncategorized))
+			for _, models := range categorized.ClientTypes {
+				values = append(values, models...)
+			}
 			for _, models := range categorized.Routes {
 				values = append(values, models...)
 			}

--- a/internal/handler/models_availability_test.go
+++ b/internal/handler/models_availability_test.go
@@ -296,8 +296,8 @@ func TestAvailableModelRouteGroupsUseCategorizedExternalModelList(t *testing.T) 
 	handler.SetSettingsRepository(&selfServiceSettingsRepo{values: map[string]string{
 		domain.SettingKeyExternalModelListEnabled: "true",
 		domain.SettingKeyExternalModelList: `{
-			"version": 1,
-			"routes": {"21": ["user-manual-fill-demo", "glm-4.5"]},
+			"version": 2,
+			"clientTypes": {"openai": ["user-manual-fill-demo", "glm-4.5"], "claude": ["claude-manual"]},
 			"uncategorized": ["manual-custom-model"]
 		}`,
 	}})
@@ -307,10 +307,10 @@ func TestAvailableModelRouteGroupsUseCategorizedExternalModelList(t *testing.T) 
 		t.Fatalf("collectAvailableModelRouteGroups: %v", err)
 	}
 	if len(groups) != 1 {
-		t.Fatalf("groups = %#v, want one manual route group", groups)
+		t.Fatalf("groups = %#v, want one manual route type group", groups)
 	}
-	if groups[0].RouteID != 21 || groups[0].ProviderName != "manual-openai" {
-		t.Fatalf("group = %#v, want route 21 provider manual-openai", groups[0])
+	if groups[0].RouteID != 0 || groups[0].ProviderName != "" || groups[0].ClientType != domain.ClientTypeOpenAI {
+		t.Fatalf("group = %#v, want openai route type without provider split", groups[0])
 	}
 	want := []string{"glm-4.5", "user-manual-fill-demo"}
 	if len(groups[0].Models) != len(want) {
@@ -319,6 +319,19 @@ func TestAvailableModelRouteGroupsUseCategorizedExternalModelList(t *testing.T) 
 	for i := range want {
 		if groups[0].Models[i] != want[i] {
 			t.Fatalf("models = %#v, want %#v", groups[0].Models, want)
+		}
+	}
+
+	names, err := handler.collectAvailableModelNames(1, domain.ClientTypeOpenAI, 0, 0, 0, "")
+	if err != nil {
+		t.Fatalf("collectAvailableModelNames: %v", err)
+	}
+	if len(names) != len(want) {
+		t.Fatalf("names = %#v, want %#v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("names = %#v, want %#v", names, want)
 		}
 	}
 }

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -415,14 +415,15 @@ func (h *SelfServiceHandler) collectUserPanelAvailableModelRouteGroups(tenantID,
 	}
 
 	groups := make([]modelRouteGroup, 0)
-	seen := make(map[uint64]int)
+	seen := make(map[string]int)
 	for _, clientType := range h.userPanelModelClientTypes() {
 		clientGroups, err := h.modelsHandler.collectAvailableModelRouteGroups(tenantID, clientType, 0, 0, apiTokenID, "")
 		if err != nil {
 			return nil, err
 		}
 		for _, group := range clientGroups {
-			if idx, ok := seen[group.RouteID]; ok {
+			groupKey := fmt.Sprintf("%s:%d", group.ClientType, group.RouteID)
+			if idx, ok := seen[groupKey]; ok {
 				merged := make(map[string]struct{}, len(groups[idx].Models)+len(group.Models))
 				for _, model := range groups[idx].Models {
 					merged[model] = struct{}{}
@@ -433,7 +434,7 @@ func (h *SelfServiceHandler) collectUserPanelAvailableModelRouteGroups(tenantID,
 				groups[idx].Models = sortedModelNames(merged)
 				continue
 			}
-			seen[group.RouteID] = len(groups)
+			seen[groupKey] = len(groups)
 			groups = append(groups, group)
 		}
 	}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -2282,17 +2282,20 @@
     "title": "External Models",
     "description": "Manage the model names exposed to external clients and the user console.",
     "editorTitle": "Public model list",
-    "editorDesc": "Enter externally exposed model names by route group. Use one model per line, or paste comma-separated names.",
+    "editorDesc": "Enter model names by route type.",
     "placeholder": "gpt-5\nclaude-sonnet-4\ngemini-2.5-pro",
-    "saveHint": "This remains the original admin External Models tab entry point; no other tab gets a model-name editor.",
     "modelCount": "{{count}} models",
     "globalScope": "Global",
     "uncategorizedTitle": "Uncategorized models",
-    "uncategorizedDesc": "Temporarily holds model names that are not assigned to a specific route group yet; they are still saved into the external model list.",
     "groupPlaceholder": "Example:\ngpt-4o-public\nglm-4.5",
     "noRoutes": "No enabled routes are available. You can still put model names in the uncategorized section.",
     "uncategorizedPlaceholder": "Example:\nmanual-custom-model",
-    "saveFormatHint": "Saved categories are written into the external model list; /v1/models reads model names from every category."
+    "routeTypes": {
+      "openai": "OpenAI route",
+      "codex": "Codex route",
+      "claude": "Claude route",
+      "gemini": "Gemini route"
+    }
   },
   "proxies": {
     "title": "Proxies",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -2278,17 +2278,20 @@
     "title": "外部模型",
     "description": "管理暴露给外部客户端和用户控制台的模型名。",
     "editorTitle": "公开模型列表",
-    "editorDesc": "按路由分类填写对外暴露的模型名；每个分类每行一个模型，也可以粘贴逗号分隔的模型名。",
+    "editorDesc": "按路由类型填写模型名。",
     "placeholder": "gpt-5\nclaude-sonnet-4\ngemini-2.5-pro",
-    "saveHint": "这里仍是管理员后台 External Models tab 的原维护入口；不会在其他 tab 新增填写入口。",
     "modelCount": "{{count}} 个模型",
     "globalScope": "全局",
     "uncategorizedTitle": "未分类模型",
-    "uncategorizedDesc": "用于暂存还没归到具体路由分类的模型名；保存后仍会进入外部模型列表。",
     "groupPlaceholder": "例如：\ngpt-4o-public\nglm-4.5",
     "noRoutes": "当前没有已启用路由。仍可先把模型名填到未分类区域。",
     "uncategorizedPlaceholder": "例如：\nmanual-custom-model",
-    "saveFormatHint": "保存时会按分类写入外部模型列表；/v1/models 会读取所有分类中的模型名。"
+    "routeTypes": {
+      "openai": "OpenAI 路由",
+      "codex": "Codex 路由",
+      "claude": "Claude 路由",
+      "gemini": "Gemini 路由"
+    }
   },
   "proxies": {
     "title": "代理",

--- a/web/src/pages/external-models/index.tsx
+++ b/web/src/pages/external-models/index.tsx
@@ -5,31 +5,24 @@ import { useTranslation } from 'react-i18next';
 import { PageHeader } from '@/components/layout/page-header';
 import { Badge, Button, Card, CardContent, CardHeader, CardTitle } from '@/components/ui';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  settingsKeys,
-  useProjects,
-  useProviders,
-  useRoutes,
-  useSettings,
-  useUpdateSetting,
-} from '@/hooks/queries';
-import type { Project, Provider, Route } from '@/lib/transport/types';
+import { settingsKeys, useRoutes, useSettings, useUpdateSetting } from '@/hooks/queries';
+import type { ClientType, Route } from '@/lib/transport/types';
 
 const EXTERNAL_MODEL_LIST_SETTING_KEY = 'external_model_list';
 const UNCATEGORIZED_KEY = '__uncategorized__';
 
 type CategorizedExternalModelListSetting = {
   version?: number;
+  clientTypes?: Partial<Record<ClientType, string[]>>;
   routes?: Record<string, string[]>;
   uncategorized?: string[];
 };
 
 type RouteGroup = {
-  key: string;
-  route: Route;
-  provider: Provider;
-  project?: Project;
+  key: ClientType;
 };
+
+const ROUTE_GROUP_ORDER: ClientType[] = ['openai', 'codex', 'claude', 'gemini'];
 
 function parseModelText(value: string) {
   return Array.from(
@@ -42,7 +35,7 @@ function parseModelText(value: string) {
   ).sort((a, b) => a.localeCompare(b));
 }
 
-function parseStoredExternalModels(value: string): Record<string, string> {
+function parseStoredExternalModels(value: string, routes: Route[] = []): Record<string, string> {
   const trimmed = value.trim();
   if (!trimmed) return { [UNCATEGORIZED_KEY]: '' };
 
@@ -54,9 +47,24 @@ function parseStoredExternalModels(value: string): Record<string, string> {
     if (parsed && typeof parsed === 'object') {
       const setting = parsed as CategorizedExternalModelListSetting;
       const next: Record<string, string> = {};
-      for (const [routeID, models] of Object.entries(setting.routes ?? {})) {
-        next[routeID] = parseModelText(Array.isArray(models) ? models.join('\n') : '').join('\n');
+      for (const clientType of ROUTE_GROUP_ORDER) {
+        const models = setting.clientTypes?.[clientType];
+        if (Array.isArray(models)) {
+          next[clientType] = parseModelText(models.join('\n')).join('\n');
+        }
       }
+
+      const routeClientTypeByID = new Map(
+        routes.map((route) => [String(route.id), route.clientType]),
+      );
+      for (const [routeID, models] of Object.entries(setting.routes ?? {})) {
+        const clientType = routeClientTypeByID.get(routeID);
+        if (!clientType) continue;
+        next[clientType] = parseModelText(
+          [next[clientType] ?? '', ...(Array.isArray(models) ? models : [])].join('\n'),
+        ).join('\n');
+      }
+
       next[UNCATEGORIZED_KEY] = parseModelText((setting.uncategorized ?? []).join('\n')).join('\n');
       return next;
     }
@@ -67,42 +75,20 @@ function parseStoredExternalModels(value: string): Record<string, string> {
   return { [UNCATEGORIZED_KEY]: parseModelText(trimmed).join('\n') };
 }
 
-function buildRouteGroups({
-  routes,
-  providers,
-  projects,
-}: {
-  routes: Route[];
-  providers: Provider[];
-  projects: Project[];
-}): RouteGroup[] {
-  const providerByID = new Map(providers.map((provider) => [provider.id, provider]));
-  const projectByID = new Map(projects.map((project) => [project.id, project]));
-
-  return routes
-    .filter((route) => route.isEnabled)
-    .sort((a, b) => {
-      if (a.projectID !== b.projectID) return a.projectID - b.projectID;
-      if (a.clientType !== b.clientType) return a.clientType.localeCompare(b.clientType);
-      return a.position - b.position;
-    })
-    .flatMap((route) => {
-      const provider = providerByID.get(route.providerID);
-      if (!provider) return [];
-      return [
-        {
-          key: String(route.id),
-          route,
-          provider,
-          project: route.projectID ? projectByID.get(route.projectID) : undefined,
-        },
-      ];
-    });
+function buildRouteGroups(routes: Route[]): RouteGroup[] {
+  const enabledClientTypes = new Set(
+    routes.filter((route) => route.isEnabled).map((route) => route.clientType),
+  );
+  return ROUTE_GROUP_ORDER.filter((clientType) => enabledClientTypes.has(clientType)).map(
+    (key) => ({
+      key,
+    }),
+  );
 }
 
 function normalizeDraftForSave(draft: Record<string, string>, groups: RouteGroup[]) {
   const routes: Record<string, string[]> = {};
-  const usedKeys = new Set(groups.map((group) => group.key));
+  const usedKeys = new Set<string>(groups.map((group) => group.key));
 
   for (const group of groups) {
     const models = parseModelText(draft[group.key] ?? '');
@@ -118,8 +104,8 @@ function normalizeDraftForSave(draft: Record<string, string>, groups: RouteGroup
 
   return JSON.stringify(
     {
-      version: 1,
-      routes,
+      version: 2,
+      clientTypes: routes,
       uncategorized,
     },
     null,
@@ -139,17 +125,12 @@ export function ExternalModelsPage() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { data: settings, isLoading } = useSettings();
-  const { data: providers = [] } = useProviders();
   const { data: routes = [] } = useRoutes();
-  const { data: projects = [] } = useProjects();
   const updateSetting = useUpdateSetting();
   const storedList = settings?.[EXTERNAL_MODEL_LIST_SETTING_KEY] ?? '';
-  const routeGroups = useMemo(
-    () => buildRouteGroups({ routes, providers, projects }),
-    [routes, providers, projects],
-  );
+  const routeGroups = useMemo(() => buildRouteGroups(routes), [routes]);
   const [draft, setDraft] = useState<Record<string, string>>(() =>
-    parseStoredExternalModels(storedList),
+    parseStoredExternalModels(storedList, routes),
   );
   const [saved, setSaved] = useState(false);
   const normalizedValue = useMemo(
@@ -157,15 +138,15 @@ export function ExternalModelsPage() {
     [draft, routeGroups],
   );
   const storedNormalizedValue = useMemo(() => {
-    const parsed = parseStoredExternalModels(storedList);
+    const parsed = parseStoredExternalModels(storedList, routes);
     return normalizeDraftForSave(parsed, routeGroups);
-  }, [storedList, routeGroups]);
+  }, [storedList, routeGroups, routes]);
   const modelCount = useMemo(() => countModels(draft), [draft]);
   const hasChanges = normalizedValue !== storedNormalizedValue;
 
   useEffect(() => {
-    setDraft(parseStoredExternalModels(storedList));
-  }, [storedList]);
+    setDraft(parseStoredExternalModels(storedList, routes));
+  }, [storedList, routes]);
 
   const setGroupValue = (key: string, value: string) => {
     setDraft((current) => ({ ...current, [key]: value }));
@@ -180,7 +161,7 @@ export function ExternalModelsPage() {
       ...(settings ?? {}),
       [EXTERNAL_MODEL_LIST_SETTING_KEY]: normalizedValue,
     });
-    setDraft(parseStoredExternalModels(normalizedValue));
+    setDraft(parseStoredExternalModels(normalizedValue, routes));
     setSaved(true);
     window.setTimeout(() => setSaved(false), 1600);
   };
@@ -205,10 +186,7 @@ export function ExternalModelsPage() {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4 p-5">
-            <div className="space-y-1">
-              <p className="text-sm text-muted-foreground">{t('externalModels.editorDesc')}</p>
-              <p className="text-xs text-muted-foreground">{t('externalModels.saveHint')}</p>
-            </div>
+            <p className="text-sm text-muted-foreground">{t('externalModels.editorDesc')}</p>
 
             {routeGroups.length > 0 ? (
               <div className="space-y-3">
@@ -222,14 +200,7 @@ export function ExternalModelsPage() {
                       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
                         <div className="min-w-0">
                           <div className="truncate text-sm font-medium text-foreground">
-                            {group.provider.name}
-                          </div>
-                          <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
-                            <span>{group.project?.name ?? t('externalModels.globalScope')}</span>
-                            <span>·</span>
-                            <span>{group.route.clientType}</span>
-                            <span>·</span>
-                            <span>route #{group.route.id}</span>
+                            {t(`externalModels.routeTypes.${group.key}`)}
                           </div>
                         </div>
                         <Badge variant="secondary">
@@ -259,9 +230,6 @@ export function ExternalModelsPage() {
                   <div className="text-sm font-medium text-foreground">
                     {t('externalModels.uncategorizedTitle')}
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {t('externalModels.uncategorizedDesc')}
-                  </p>
                 </div>
                 <Badge variant="outline">
                   {t('externalModels.modelCount', {
@@ -278,8 +246,7 @@ export function ExternalModelsPage() {
               />
             </div>
 
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-xs text-muted-foreground">{t('externalModels.saveFormatHint')}</p>
+            <div className="flex justify-end">
               <Button
                 className="gap-2"
                 onClick={handleSave}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -259,8 +259,7 @@ export function UserPanelPage() {
     if (typeof window === 'undefined') return 'main';
     const params = new URLSearchParams(window.location.search);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined;
+      PerformanceNavigationTiming | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     return resolveUserPanelTab({
       urlTab: params.get('tab'),
@@ -351,8 +350,7 @@ export function UserPanelPage() {
     const urlTab = new URLSearchParams(window.location.search).get('tab');
     const storedTab = window.localStorage.getItem(tabStorageKey);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      | PerformanceNavigationTiming
-      | undefined;
+      PerformanceNavigationTiming | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     setActiveTab(resolveUserPanelTab({ urlTab, storedTab, allowStoredTab }));
   }, [tabStorageKey]);
@@ -655,19 +653,21 @@ export function UserPanelPage() {
                     <div className="mt-3 space-y-3">
                       {modelRouteGroups.map((group) => (
                         <div
-                          key={group.routeID}
+                          key={`${group.clientType}-${group.routeID}`}
                           className="rounded-lg border border-border bg-background p-3"
                         >
                           <div className="flex flex-wrap items-center justify-between gap-2">
                             <div className="min-w-0">
                               <p className="truncate text-sm font-medium text-foreground">
-                                {group.providerName}
+                                {group.providerName ||
+                                  t(`externalModels.routeTypes.${group.clientType}`)}
                               </p>
                               <p className="mt-1 text-xs text-muted-foreground">
                                 {group.projectID > 0
                                   ? t('userPanel.projectRouteScope', { projectID: group.projectID })
                                   : t('userPanel.globalRouteScope')}{' '}
-                                · {group.clientType} · route #{group.routeID}
+                                · {group.clientType}
+                                {group.routeID > 0 ? ` · route #${group.routeID}` : ''}
                               </p>
                             </div>
                             <Badge variant="secondary">


### PR DESCRIPTION
## Summary
- Change the External Models editor from provider/route groups to at most four route-type categories: OpenAI, Codex, Claude, and Gemini.
- Store the manual public model list in `external_model_list.clientTypes` and keep legacy route/category values readable.
- Make `/v1/models` and the user console prefer the matching route-type category, so the user panel no longer splits manual models by provider.

## Validation
- `git diff --check`
- `go test ./internal/handler`
- `pnpm -C web typecheck`
- `pnpm -C web build`

## Demo
- Slow WebM recorded locally: `/home/moltbot/clawd-wechat/tmp/maxx-four-route-models-slow.webm`
