### PR TITLE
fix(user-panel): register available model routes endpoint

### DIFF
--- a/internal/handler/self_service_routes.go
+++ b/internal/handler/self_service_routes.go
@@ -21,6 +21,8 @@ var protectedSelfServiceRoutePatterns = []string{
 	"/api/user-panel-token/",
 	"/api/user-panel/models",
 	"/api/user-panel/models/",
+	"/api/user-panel/model-routes",
+	"/api/user-panel/model-routes/",
 	"/api/user-panel/check-in",
 	"/api/user-panel/check-in/",
 	"/api/user-panel/consumption-leaderboard",

--- a/internal/handler/self_service_routes_test.go
+++ b/internal/handler/self_service_routes_test.go
@@ -33,6 +33,28 @@ func TestSelfServiceRoutePatterns_IncludeTrailingSlashVariants(t *testing.T) {
 	}
 }
 
+func TestRegisterSelfServiceRoutes_RegistersUserPanelModelRoutes(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterSelfServiceRoutes(
+		mux,
+		func(h http.Handler) http.Handler { return h },
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+	)
+
+	for _, candidate := range []string{
+		"/api/user-panel/models",
+		"/api/user-panel/models/",
+		"/api/user-panel/model-routes",
+		"/api/user-panel/model-routes/",
+	} {
+		_, registeredPattern := mux.Handler(httptest.NewRequest(http.MethodGet, candidate, nil))
+		if registeredPattern != candidate {
+			t.Fatalf("expected user-panel model route %q to be registered, got %q", candidate, registeredPattern)
+		}
+	}
+}
+
 func TestRegisterSelfServiceRoutes_RegistersProxyStatus(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterSelfServiceRoutes(

--- a/web/src/lib/user-panel-model-routes.test.ts
+++ b/web/src/lib/user-panel-model-routes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { UserPanelAvailableModelRouteGroup } from '@/lib/transport';
+import { visibleUserPanelModelRouteGroups } from './user-panel-model-routes';
+
+function group(routeID: number, models: string[]): UserPanelAvailableModelRouteGroup {
+  return {
+    routeID,
+    providerID: routeID + 100,
+    providerName: `provider-${routeID}`,
+    clientType: 'openai',
+    projectID: 0,
+    models,
+  };
+}
+
+describe('visibleUserPanelModelRouteGroups', () => {
+  it('shows at most four non-empty route groups', () => {
+    const groups = visibleUserPanelModelRouteGroups([
+      group(1, ['a']),
+      group(2, []),
+      group(3, ['b']),
+      group(4, ['c']),
+      group(5, ['d']),
+      group(6, ['e']),
+    ]);
+
+    expect(groups.map((item) => item.routeID)).toEqual([1, 3, 4, 5]);
+  });
+
+  it('shows at most eight models per route and records hidden count', () => {
+    const models = Array.from({ length: 10 }, (_, index) => `model-${index + 1}`);
+    const [result] = visibleUserPanelModelRouteGroups([group(1, models)]);
+
+    expect(result.visibleModels).toEqual(models.slice(0, 8));
+    expect(result.hiddenModelCount).toBe(2);
+  });
+});

--- a/web/src/lib/user-panel-model-routes.ts
+++ b/web/src/lib/user-panel-model-routes.ts
@@ -1,0 +1,19 @@
+import type { UserPanelAvailableModelRouteGroup } from '@/lib/transport';
+
+export type VisibleUserPanelModelRouteGroup = UserPanelAvailableModelRouteGroup & {
+  visibleModels: string[];
+  hiddenModelCount: number;
+};
+
+export function visibleUserPanelModelRouteGroups(
+  groups: UserPanelAvailableModelRouteGroup[],
+): VisibleUserPanelModelRouteGroup[] {
+  return groups
+    .filter((group) => group.models.length > 0)
+    .slice(0, 4)
+    .map((group) => ({
+      ...group,
+      visibleModels: group.models.slice(0, 8),
+      hiddenModelCount: Math.max(group.models.length - 8, 0),
+    }));
+}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -52,9 +52,9 @@ import type {
   UsageStatsFilter,
   UsageStats,
   UserPanelConsumptionLeaderboardRow,
-  UserPanelAvailableModelRouteGroup,
 } from '@/lib/transport';
 import { buildUserPanelEndpointHints } from '@/lib/user-panel-endpoints';
+import { visibleUserPanelModelRouteGroups } from '@/lib/user-panel-model-routes';
 import {
   getUserPanelTabStorageKey,
   resolveUserPanelTab,
@@ -85,16 +85,6 @@ function getLocalDayBounds(now = new Date()) {
     start: start.toISOString(),
     end: now.toISOString(),
   };
-}
-
-function visibleModelRouteGroups(groups: UserPanelAvailableModelRouteGroup[]) {
-  return groups
-    .filter((group) => group.models.length > 0)
-    .map((group) => ({
-      ...group,
-      visibleModels: group.models.slice(0, 8),
-      hiddenModelCount: Math.max(group.models.length - 8, 0),
-    }));
 }
 
 function totalTokens(stats?: UsageStats[]) {
@@ -220,6 +210,7 @@ export function UserPanelPage() {
     enabled: Boolean(user),
   });
   const { data: publicSettings } = usePublicSettings();
+  const externalModelListEnabled = publicSettings?.external_model_list_enabled === 'true';
   const {
     data: availableModels,
     isLoading: availableModelsLoading,
@@ -229,7 +220,7 @@ export function UserPanelPage() {
     data: availableModelRoutes,
     isLoading: availableModelRoutesLoading,
     isError: availableModelRoutesError,
-  } = useUserPanelAvailableModelRoutes(Boolean(user));
+  } = useUserPanelAvailableModelRoutes(Boolean(user) && externalModelListEnabled);
   const {
     data: consumptionLeaderboard,
     isLoading: consumptionLeaderboardLoading,
@@ -259,7 +250,8 @@ export function UserPanelPage() {
     if (typeof window === 'undefined') return 'main';
     const params = new URLSearchParams(window.location.search);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      PerformanceNavigationTiming | undefined;
+      | PerformanceNavigationTiming
+      | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     return resolveUserPanelTab({
       urlTab: params.get('tab'),
@@ -290,7 +282,9 @@ export function UserPanelPage() {
             ? t('userPanel.routeClaude')
             : t('userPanel.routeGemini'),
   }));
-  const modelRouteGroups = visibleModelRouteGroups(availableModelRoutes ?? []);
+  const modelRouteGroups = externalModelListEnabled
+    ? visibleUserPanelModelRouteGroups(availableModelRoutes ?? [])
+    : [];
   const availableModelCount = availableModels?.length ?? 0;
 
   useEffect(() => {
@@ -350,7 +344,8 @@ export function UserPanelPage() {
     const urlTab = new URLSearchParams(window.location.search).get('tab');
     const storedTab = window.localStorage.getItem(tabStorageKey);
     const navigationEntry = window.performance.getEntriesByType('navigation')[0] as
-      PerformanceNavigationTiming | undefined;
+      | PerformanceNavigationTiming
+      | undefined;
     const allowStoredTab = navigationEntry?.type === 'reload';
     setActiveTab(resolveUserPanelTab({ urlTab, storedTab, allowStoredTab }));
   }, [tabStorageKey]);
@@ -643,13 +638,15 @@ export function UserPanelPage() {
                       </Badge>
                     ) : null}
                   </div>
-                  {availableModelsLoading || availableModelRoutesLoading ? (
+                  {availableModelsLoading ||
+                  (externalModelListEnabled && availableModelRoutesLoading) ? (
                     <p className="mt-3 text-sm text-muted-foreground">{t('common.loading')}</p>
-                  ) : availableModelsError || availableModelRoutesError ? (
+                  ) : availableModelsError ||
+                    (externalModelListEnabled && availableModelRoutesError && !availableModels) ? (
                     <p className="mt-3 text-sm text-destructive">
                       {t('userPanel.availableModelsLoadFailed')}
                     </p>
-                  ) : modelRouteGroups.length > 0 ? (
+                  ) : externalModelListEnabled && modelRouteGroups.length > 0 ? (
                     <div className="mt-3 space-y-3">
                       {modelRouteGroups.map((group) => (
                         <div
@@ -657,19 +654,9 @@ export function UserPanelPage() {
                           className="rounded-lg border border-border bg-background p-3"
                         >
                           <div className="flex flex-wrap items-center justify-between gap-2">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-medium text-foreground">
-                                {group.providerName ||
-                                  t(`externalModels.routeTypes.${group.clientType}`)}
-                              </p>
-                              <p className="mt-1 text-xs text-muted-foreground">
-                                {group.projectID > 0
-                                  ? t('userPanel.projectRouteScope', { projectID: group.projectID })
-                                  : t('userPanel.globalRouteScope')}{' '}
-                                · {group.clientType}
-                                {group.routeID > 0 ? ` · route #${group.routeID}` : ''}
-                              </p>
-                            </div>
+                            <p className="truncate text-sm font-medium text-foreground">
+                              {t(`externalModels.routeTypes.${group.clientType}`)}
+                            </p>
                             <Badge variant="secondary">
                               {t('userPanel.availableModelsCount', { count: group.models.length })}
                             </Badge>


### PR DESCRIPTION
## Summary
- register `/api/user-panel/model-routes` and trailing-slash variant with the protected self-service routes
- when `external_model_list_enabled=true`, show at most four route groups in the user console available-model card
- for enabled route groups, display only route type and available model names; provider names, route IDs, and scope details stay out of the user console
- when `external_model_list_enabled=false`, skip route-group loading and show only the flat model-name list
- degrade route-group failures to the flat model list when possible instead of showing a load failure
- add backend route-registration coverage and frontend route-group display-limit coverage

## Validation
- `git diff --check`
- `go test ./internal/handler -run 'SelfServiceRoutePatterns|RegisterSelfServiceRoutes|UserPanel.*Model|AvailableModel' -count=1`
- `pnpm --dir web exec vitest run src/lib/user-panel-model-routes.test.ts`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- Playwright smoke recording:
  - external model list enabled: shows only route type + model names for the first four route groups, without provider/route/scope details
  - external model list disabled: does not request/show route groups; shows flat model names