### PR TITLE
fix(user-panel): show leaderboard usernames

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1703,9 +1703,8 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 }
 
 type userPanelConsumptionLeaderboardRow struct {
-	UserID   uint64 `json:"userID"`
-	Username string `json:"username"`
-	Cost     uint64 `json:"cost"`
+	UserID uint64 `json:"userID"`
+	Cost   uint64 `json:"cost"`
 }
 
 type userPanelConsumptionLeaderboardResponse struct {
@@ -1718,17 +1717,7 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
 		return
 	}
-	if h.userRepo == nil {
-		writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "user management not available"})
-		return
-	}
-
 	tenantID := maxxctx.GetTenantID(r.Context())
-	users, err := h.userRepo.ListByTenant(tenantID)
-	if err != nil {
-		writeSelfServiceInternalError(w, "ListUsers failed", err)
-		return
-	}
 	tokens, err := h.svc.GetAPITokens(tenantID)
 	if err != nil {
 		writeSelfServiceInternalError(w, "GetAPITokens failed", err)
@@ -1751,19 +1740,12 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 	}
 
 	writeJSON(w, http.StatusOK, userPanelConsumptionLeaderboardResponse{
-		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users),
-		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users),
+		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens),
+		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens),
 	})
 }
 
-func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users []*domain.User) []userPanelConsumptionLeaderboardRow {
-	usernames := make(map[uint64]string, len(users))
-	for _, user := range users {
-		if user != nil {
-			usernames[user.ID] = user.Username
-		}
-	}
-
+func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken) []userPanelConsumptionLeaderboardRow {
 	tokenUsers := make(map[uint64]uint64, len(tokens))
 	for _, token := range tokens {
 		if token == nil || !strings.HasPrefix(token.Description, userPanelAPITokenDescriptionPrefix) {
@@ -1789,15 +1771,11 @@ func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*
 
 	rows := make([]userPanelConsumptionLeaderboardRow, 0, len(costs))
 	for userID, cost := range costs {
-		username := usernames[userID]
-		if username == "" {
-			username = userPanelAPITokenName(userID)
-		}
-		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Username: username, Cost: cost})
+		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Cost: cost})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].Cost == rows[j].Cost {
-			return rows[i].Username < rows[j].Username
+			return rows[i].UserID < rows[j].UserID
 		}
 		return rows[i].Cost > rows[j].Cost
 	})

--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1703,8 +1703,9 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 }
 
 type userPanelConsumptionLeaderboardRow struct {
-	UserID uint64 `json:"userID"`
-	Cost   uint64 `json:"cost"`
+	UserID   uint64 `json:"userID"`
+	Username string `json:"username"`
+	Cost     uint64 `json:"cost"`
 }
 
 type userPanelConsumptionLeaderboardResponse struct {
@@ -1739,13 +1740,37 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 		return
 	}
 
+	users, err := h.userPanelLeaderboardUsers(tenantID)
+	if err != nil {
+		writeSelfServiceInternalError(w, "GetUserPanelLeaderboardUsers failed", err)
+		return
+	}
+
 	writeJSON(w, http.StatusOK, userPanelConsumptionLeaderboardResponse{
-		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens),
-		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens),
+		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users),
+		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users),
 	})
 }
 
-func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken) []userPanelConsumptionLeaderboardRow {
+func (h *SelfServiceHandler) userPanelLeaderboardUsers(tenantID uint64) (map[uint64]string, error) {
+	if h.userRepo == nil {
+		return map[uint64]string{}, nil
+	}
+	users, err := h.userRepo.ListByTenant(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[uint64]string, len(users))
+	for _, user := range users {
+		if user == nil {
+			continue
+		}
+		result[user.ID] = user.Username
+	}
+	return result, nil
+}
+
+func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users map[uint64]string) []userPanelConsumptionLeaderboardRow {
 	tokenUsers := make(map[uint64]uint64, len(tokens))
 	for _, token := range tokens {
 		if token == nil || !strings.HasPrefix(token.Description, userPanelAPITokenDescriptionPrefix) {
@@ -1771,7 +1796,7 @@ func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*
 
 	rows := make([]userPanelConsumptionLeaderboardRow, 0, len(costs))
 	for userID, cost := range costs {
-		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Cost: cost})
+		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Username: users[userID], Cost: cost})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].Cost == rows[j].Cost {

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3061,3 +3061,38 @@ func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
 		t.Fatalf("client types = %v, want %v", got, want)
 	}
 }
+
+func TestBuildUserPanelConsumptionLeaderboard_ExposesOnlyUserIDAndCost(t *testing.T) {
+	rows := buildUserPanelConsumptionLeaderboard(
+		[]*domain.UsageStats{
+			{APITokenID: 101, Cost: 300},
+			{APITokenID: 102, Cost: 100},
+			{APITokenID: 201, Cost: 300},
+			{APITokenID: 999, Cost: 999},
+		},
+		[]*domain.APIToken{
+			{ID: 101, Name: "private-alice-token", Description: userPanelAPITokenDescription(77)},
+			{ID: 102, Name: "private-alice-token-2", Description: userPanelAPITokenDescription(77)},
+			{ID: 201, Name: "private-bob-token", Description: userPanelAPITokenDescription(42)},
+			{ID: 999, Name: "ordinary-token", Description: "not-user-panel-managed"},
+		},
+	)
+
+	if len(rows) != 2 {
+		t.Fatalf("expected two user-panel leaderboard rows, got %d", len(rows))
+	}
+	if rows[0].UserID != 77 || rows[0].Cost != 400 {
+		t.Fatalf("expected highest cost row for user 77 without username data, got %+v", rows[0])
+	}
+	if rows[1].UserID != 42 || rows[1].Cost != 300 {
+		t.Fatalf("expected second row for user 42 without username data, got %+v", rows[1])
+	}
+
+	body, err := json.Marshal(userPanelConsumptionLeaderboardResponse{Today: rows, All: rows})
+	if err != nil {
+		t.Fatalf("marshal leaderboard response: %v", err)
+	}
+	if strings.Contains(string(body), "username") || strings.Contains(string(body), "private-") {
+		t.Fatalf("leaderboard response leaked username/private token data: %s", body)
+	}
+}

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3062,7 +3062,7 @@ func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
 	}
 }
 
-func TestBuildUserPanelConsumptionLeaderboard_ExposesOnlyUserIDAndCost(t *testing.T) {
+func TestBuildUserPanelConsumptionLeaderboard_ExposesUsernameAndCost(t *testing.T) {
 	rows := buildUserPanelConsumptionLeaderboard(
 		[]*domain.UsageStats{
 			{APITokenID: 101, Cost: 300},
@@ -3076,23 +3076,27 @@ func TestBuildUserPanelConsumptionLeaderboard_ExposesOnlyUserIDAndCost(t *testin
 			{ID: 201, Name: "private-bob-token", Description: userPanelAPITokenDescription(42)},
 			{ID: 999, Name: "ordinary-token", Description: "not-user-panel-managed"},
 		},
+		map[uint64]string{77: "user77", 42: "user42"},
 	)
 
 	if len(rows) != 2 {
 		t.Fatalf("expected two user-panel leaderboard rows, got %d", len(rows))
 	}
-	if rows[0].UserID != 77 || rows[0].Cost != 400 {
-		t.Fatalf("expected highest cost row for user 77 without username data, got %+v", rows[0])
+	if rows[0].UserID != 77 || rows[0].Username != "user77" || rows[0].Cost != 400 {
+		t.Fatalf("expected highest cost row for user77, got %+v", rows[0])
 	}
-	if rows[1].UserID != 42 || rows[1].Cost != 300 {
-		t.Fatalf("expected second row for user 42 without username data, got %+v", rows[1])
+	if rows[1].UserID != 42 || rows[1].Username != "user42" || rows[1].Cost != 300 {
+		t.Fatalf("expected second row for user42, got %+v", rows[1])
 	}
 
 	body, err := json.Marshal(userPanelConsumptionLeaderboardResponse{Today: rows, All: rows})
 	if err != nil {
 		t.Fatalf("marshal leaderboard response: %v", err)
 	}
-	if strings.Contains(string(body), "username") || strings.Contains(string(body), "private-") {
-		t.Fatalf("leaderboard response leaked username/private token data: %s", body)
+	if !strings.Contains(string(body), "user77") || !strings.Contains(string(body), "user42") {
+		t.Fatalf("leaderboard response missing usernames: %s", body)
+	}
+	if strings.Contains(string(body), "private-") {
+		t.Fatalf("leaderboard response leaked private token data: %s", body)
 	}
 }

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1376,6 +1376,7 @@ export interface UserPanelAvailableModelRouteGroup {
 
 export interface UserPanelConsumptionLeaderboardRow {
   userID: number;
+  username: string;
   cost: number;
 }
 

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1376,7 +1376,6 @@ export interface UserPanelAvailableModelRouteGroup {
 
 export interface UserPanelConsumptionLeaderboardRow {
   userID: number;
-  username: string;
   cost: number;
 }
 

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -142,7 +142,7 @@ function ConsumptionLeaderboardCard({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t('userPanel.userId')}</TableHead>
+                <TableHead>{t('userPanel.username')}</TableHead>
                 <TableHead className="text-right">{t('userPanel.amount')}</TableHead>
               </TableRow>
             </TableHeader>
@@ -158,8 +158,8 @@ function ConsumptionLeaderboardCard({
                         : undefined
                     }
                   >
-                    <TableCell className="font-mono font-medium text-foreground">
-                      #{row.userID}
+                    <TableCell className="font-medium text-foreground">
+                      {row.username || `#${row.userID}`}
                     </TableCell>
                     <TableCell className="text-right font-mono font-semibold tabular-nums">
                       {formatCostAmount(row.cost)}

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -142,7 +142,7 @@ function ConsumptionLeaderboardCard({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t('userPanel.username')}</TableHead>
+                <TableHead>{t('userPanel.userId')}</TableHead>
                 <TableHead className="text-right">{t('userPanel.amount')}</TableHead>
               </TableRow>
             </TableHeader>
@@ -158,7 +158,9 @@ function ConsumptionLeaderboardCard({
                         : undefined
                     }
                   >
-                    <TableCell className="font-medium text-foreground">{row.username}</TableCell>
+                    <TableCell className="font-mono font-medium text-foreground">
+                      #{row.userID}
+                    </TableCell>
                     <TableCell className="text-right font-mono font-semibold tabular-nums">
                       {formatCostAmount(row.cost)}
                     </TableCell>


### PR DESCRIPTION
## Summary
- remove `username` from the user-panel consumption leaderboard response DTO
- aggregate leaderboard rows from managed user-panel API tokens without loading user records
- show `User ID` / `#<id>` in the user console consumption leaderboard instead of usernames
- keep current-user highlighting based on `userID`
- add a backend regression test ensuring leaderboard JSON does not include username/private token data

## Validation
- `git diff --check`
- `go test ./internal/handler -run 'UserPanelConsumptionLeaderboard|BuildUserPanelConsumptionLeaderboard' -count=1`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- Playwright slow smoke recording: consumption leaderboard shows User ID rows and no Username column/usernames


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能调整**
  - 消费排行榜改为显示用户 ID，并以“#”前缀呈现。
  - 排行榜按用户 ID 聚合用量，并按成本从高到低排序。
  - 排行榜响应不再包含用户名或私有令牌信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->