### PR TITLE
fix(user-panel): include current user in leaderboard

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1719,6 +1719,7 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 		return
 	}
 	tenantID := maxxctx.GetTenantID(r.Context())
+	currentUserID := maxxctx.GetUserID(r.Context())
 	tokens, err := h.svc.GetAPITokens(tenantID)
 	if err != nil {
 		writeSelfServiceInternalError(w, "GetAPITokens failed", err)
@@ -1747,8 +1748,8 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 	}
 
 	writeJSON(w, http.StatusOK, userPanelConsumptionLeaderboardResponse{
-		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users),
-		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users),
+		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users, currentUserID),
+		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users, currentUserID),
 	})
 }
 
@@ -1770,7 +1771,7 @@ func (h *SelfServiceHandler) userPanelLeaderboardUsers(tenantID uint64) (map[uin
 	return result, nil
 }
 
-func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users map[uint64]string) []userPanelConsumptionLeaderboardRow {
+func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users map[uint64]string, currentUserID uint64) []userPanelConsumptionLeaderboardRow {
 	tokenUsers := make(map[uint64]uint64, len(tokens))
 	for _, token := range tokens {
 		if token == nil || !strings.HasPrefix(token.Description, userPanelAPITokenDescriptionPrefix) {
@@ -1792,6 +1793,12 @@ func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*
 			continue
 		}
 		costs[userID] += item.Cost
+	}
+
+	if currentUserID > 0 {
+		if _, ok := costs[currentUserID]; !ok {
+			costs[currentUserID] = 0
+		}
 	}
 
 	rows := make([]userPanelConsumptionLeaderboardRow, 0, len(costs))

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3062,6 +3062,29 @@ func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
 	}
 }
 
+func TestBuildUserPanelConsumptionLeaderboard_IncludesCurrentUserWithoutUsage(t *testing.T) {
+	rows := buildUserPanelConsumptionLeaderboard(
+		[]*domain.UsageStats{
+			{APITokenID: 201, Cost: 300},
+		},
+		[]*domain.APIToken{
+			{ID: 201, Name: "other-user-token", Description: userPanelAPITokenDescription(42)},
+		},
+		map[uint64]string{9: "user9", 42: "user42"},
+		9,
+	)
+
+	if len(rows) != 2 {
+		t.Fatalf("expected current user plus consuming user rows, got %d", len(rows))
+	}
+	if rows[0].UserID != 42 || rows[0].Username != "user42" || rows[0].Cost != 300 {
+		t.Fatalf("expected consuming user first, got %+v", rows[0])
+	}
+	if rows[1].UserID != 9 || rows[1].Username != "user9" || rows[1].Cost != 0 {
+		t.Fatalf("expected current user with zero cost, got %+v", rows[1])
+	}
+}
+
 func TestBuildUserPanelConsumptionLeaderboard_ExposesUsernameAndCost(t *testing.T) {
 	rows := buildUserPanelConsumptionLeaderboard(
 		[]*domain.UsageStats{
@@ -3077,6 +3100,7 @@ func TestBuildUserPanelConsumptionLeaderboard_ExposesUsernameAndCost(t *testing.
 			{ID: 999, Name: "ordinary-token", Description: "not-user-panel-managed"},
 		},
 		map[uint64]string{77: "user77", 42: "user42"},
+		0,
 	)
 
 	if len(rows) != 2 {


### PR DESCRIPTION
## Summary
- keep the logged-in user visible in the user-panel consumption leaderboard even when they have no usage rows yet
- preserve tenant-wide leaderboard aggregation for user-panel managed API tokens
- keep username display and existing current-user highlight behavior by `userID`

## Validation
- `git diff --check`
- `go test ./internal/handler -run 'UserPanelConsumptionLeaderboard|BuildUserPanelConsumptionLeaderboard' -count=1`
- `pnpm -C web typecheck`
- `pnpm -C web build`

## Visual proof
- Real backend + real auth slow webm will be attached in chat after PR creation.
