### PR TITLE
fix(requests): clean upstream error records precisely

### DIFF
--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1181,8 +1181,9 @@ func parseProxyRequestFilter(r *http.Request) (*repository.ProxyRequestFilter, e
 	startTimeStr := r.URL.Query().Get("startTime")
 	endTimeStr := r.URL.Query().Get("endTime")
 	errorModeStr := r.URL.Query().Get("errorMode")
+	errorContainsValues := r.URL.Query()["errorContains"]
 
-	if providerIDStr == "" && statusStr == "" && apiTokenIDStr == "" && projectIDStr == "" && startTimeStr == "" && endTimeStr == "" && errorModeStr == "" {
+	if providerIDStr == "" && statusStr == "" && apiTokenIDStr == "" && projectIDStr == "" && startTimeStr == "" && endTimeStr == "" && errorModeStr == "" && len(errorContainsValues) == 0 {
 		return nil, nil
 	}
 
@@ -1235,6 +1236,15 @@ func parseProxyRequestFilter(r *http.Request) (*repository.ProxyRequestFilter, e
 		default:
 			return nil, errors.New("invalid errorMode")
 		}
+	}
+	for _, value := range errorContainsValues {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			filter.ErrorContainsAny = append(filter.ErrorContainsAny, value)
+		}
+	}
+	if len(filter.ErrorContainsAny) == 1 {
+		filter.ErrorContains = &filter.ErrorContainsAny[0]
 	}
 	return filter, nil
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -125,14 +125,16 @@ type SessionKey struct {
 
 // ProxyRequestFilter 请求列表过滤条件
 type ProxyRequestFilter struct {
-	TenantID   *uint64 // Tenant ID，nil 表示不过滤
-	ProviderID *uint64 // Provider ID，nil 表示不过滤
-	Status     *string // 状态，nil 表示不过滤
-	APITokenID *uint64 // API Token ID，nil 表示不过滤
-	ProjectID  *uint64 // Project ID，nil 表示不过滤
-	StartTime  *time.Time
-	EndTime    *time.Time
-	ErrorMode  ProxyRequestErrorMode // 错误请求过滤模式
+	TenantID         *uint64 // Tenant ID，nil 表示不过滤
+	ProviderID       *uint64 // Provider ID，nil 表示不过滤
+	Status           *string // 状态，nil 表示不过滤
+	APITokenID       *uint64 // API Token ID，nil 表示不过滤
+	ProjectID        *uint64 // Project ID，nil 表示不过滤
+	StartTime        *time.Time
+	EndTime          *time.Time
+	ErrorMode        ProxyRequestErrorMode // 错误请求过滤模式
+	ErrorContains    *string               // Error substring filter，nil 表示不过滤
+	ErrorContainsAny []string              // Error substring OR filter，nil 表示不过滤
 }
 
 type ProxyRequestErrorMode string

--- a/internal/repository/sqlite/proxy_request.go
+++ b/internal/repository/sqlite/proxy_request.go
@@ -23,6 +23,13 @@ var activeProxyRequestStatuses = []string{"PENDING", "IN_PROGRESS"}
 
 var proxyRequestErrorStatuses = []string{"FAILED", "REJECTED"}
 
+func escapeLikePattern(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `%`, `\%`)
+	value = strings.ReplaceAll(value, `_`, `\_`)
+	return value
+}
+
 func cloneProxyRequestFilter(filter *repository.ProxyRequestFilter) *repository.ProxyRequestFilter {
 	if filter == nil {
 		return &repository.ProxyRequestFilter{}
@@ -77,9 +84,29 @@ func applyProxyRequestBaseFilter(query *gorm.DB, filter *repository.ProxyRequest
 
 func applyProxyRequestCleanupFailedFilter(query *gorm.DB, filter *repository.ProxyRequestFilter) *gorm.DB {
 	query = applyProxyRequestBaseFilter(query, filter)
-	return query.
+	query = query.
 		Where("status NOT IN ?", activeProxyRequestStatuses).
 		Where("status IN ? OR status_code >= ?", proxyRequestErrorStatuses, 400)
+	if filter != nil {
+		needles := append([]string{}, filter.ErrorContainsAny...)
+		if len(needles) == 0 && filter.ErrorContains != nil {
+			needles = append(needles, *filter.ErrorContains)
+		}
+		conditions := make([]string, 0, len(needles))
+		args := make([]any, 0, len(needles))
+		for _, needle := range needles {
+			needle = strings.TrimSpace(needle)
+			if needle == "" {
+				continue
+			}
+			conditions = append(conditions, "LOWER(error) LIKE ? ESCAPE '\\'")
+			args = append(args, "%"+escapeLikePattern(strings.ToLower(needle))+"%")
+		}
+		if len(conditions) > 0 {
+			query = query.Where("("+strings.Join(conditions, " OR ")+")", args...)
+		}
+	}
+	return query
 }
 
 func proxyRequestTrendBucketSize(startMs, endMs int64) int64 {

--- a/internal/repository/sqlite/proxy_request_test.go
+++ b/internal/repository/sqlite/proxy_request_test.go
@@ -1286,6 +1286,81 @@ func TestProxyRequestDeleteFailedWithFilterDeletesAttemptsAndPreservesNonErrors(
 	}
 }
 
+func TestProxyRequestDeleteFailedWithFilterMatchesErrorContains(t *testing.T) {
+	db, err := NewDBWithDSN("sqlite://:memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewProxyRequestRepository(db)
+	attemptRepo := NewProxyUpstreamAttemptRepository(db)
+
+	upstreamNeedle := "failed to connect to upstream: upstream error"
+	disconnectNeedle := "client disconnected: context canceled"
+	instanceNeedle := "Instance no longer alive"
+	literalWildcardNeedle := "100%_upstream"
+	matching := buildTestProxyRequest("FAILED", 201)
+	matching.StatusCode = 500
+	matching.Error = "proxy failed: failed to connect to upstream: upstream error"
+	disconnectMatching := buildTestProxyRequest("FAILED", 205)
+	disconnectMatching.StatusCode = 499
+	disconnectMatching.Error = "stream closed: client disconnected: context canceled"
+	instanceMatching := buildTestProxyRequest("FAILED", 206)
+	instanceMatching.StatusCode = 500
+	instanceMatching.Error = "proxy failed: Instance no longer alive"
+	wildcardLiteralMatching := buildTestProxyRequest("FAILED", 207)
+	wildcardLiteralMatching.StatusCode = 500
+	wildcardLiteralMatching.Error = "proxy failed: 100%_upstream"
+	wildcardWouldMatchIfUnescaped := buildTestProxyRequest("FAILED", 208)
+	wildcardWouldMatchIfUnescaped.StatusCode = 500
+	wildcardWouldMatchIfUnescaped.Error = "proxy failed: 100xxupstream"
+	nonMatching := buildTestProxyRequest("FAILED", 202)
+	nonMatching.StatusCode = 500
+	nonMatching.Error = "provider returned: invalid api key"
+	activeMatching := buildTestProxyRequest("IN_PROGRESS", 203)
+	activeMatching.StatusCode = 500
+	activeMatching.Error = upstreamNeedle
+	successMatching := buildTestProxyRequest("COMPLETED", 204)
+	successMatching.StatusCode = 200
+	successMatching.Error = upstreamNeedle
+
+	for _, req := range []*domain.ProxyRequest{matching, disconnectMatching, instanceMatching, wildcardLiteralMatching, wildcardWouldMatchIfUnescaped, nonMatching, activeMatching, successMatching} {
+		if err := repo.Create(req); err != nil {
+			t.Fatalf("create request %s: %v", req.RequestID, err)
+		}
+		seedAttemptForRequest(t, attemptRepo, db, req.ID, time.Now())
+	}
+
+	filter := &repository.ProxyRequestFilter{ErrorContainsAny: []string{upstreamNeedle, disconnectNeedle, instanceNeedle, literalWildcardNeedle}}
+	candidateCount, err := repo.CountFailedWithFilter(1, filter)
+	if err != nil {
+		t.Fatalf("CountFailedWithFilter: %v", err)
+	}
+	if candidateCount != 4 {
+		t.Fatalf("cleanup candidate count = %d, want 4", candidateCount)
+	}
+
+	deletedRequests, deletedAttempts, err := repo.DeleteFailedWithFilter(1, filter)
+	if err != nil {
+		t.Fatalf("DeleteFailedWithFilter: %v", err)
+	}
+	if deletedRequests != 4 || deletedAttempts != 4 {
+		t.Fatalf("deleted requests/attempts = %d/%d, want 4/4", deletedRequests, deletedAttempts)
+	}
+
+	for _, req := range []*domain.ProxyRequest{matching, disconnectMatching, instanceMatching, wildcardLiteralMatching} {
+		if _, err := repo.GetByID(1, req.ID); err == nil {
+			t.Fatalf("matching failed request %d still exists after cleanup", req.ID)
+		}
+	}
+	for _, req := range []*domain.ProxyRequest{wildcardWouldMatchIfUnescaped, nonMatching, activeMatching, successMatching} {
+		if _, err := repo.GetByID(req.TenantID, req.ID); err != nil {
+			t.Fatalf("request %d (%s) should be preserved: %v", req.ID, req.Status, err)
+		}
+	}
+}
+
 func TestProxyRequestRepositoryReassignAPITokenID(t *testing.T) {
 	db, err := NewDBWithDSN("sqlite://:memory:")
 	if err != nil {

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -805,6 +805,8 @@ export interface CursorPaginationParams {
   endTime?: string;
   /** 错误请求过滤模式 */
   errorMode?: ProxyRequestErrorMode;
+  /** 按错误信息子串过滤 */
+  errorContains?: string | string[];
 }
 
 /** 游标分页响应 */

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -472,8 +472,11 @@
     },
     "cleanupFailed": {
       "action": "Clean failed records",
+      "noisyErrorsAction": "Clean noisy errors",
       "title": "Clean failed request records?",
+      "noisyErrorsTitle": "Clean noisy error records?",
       "description": "This will delete {{count}} failed/error request records matching the current filters and their upstream attempts. Successful and active requests are not deleted.",
+      "noisyErrorsDescription": "This will delete {{count}} failed/error request records matching the current filters whose error contains one of: {{errors}}. Their upstream attempts are deleted too. Other failed records, successful records, and active requests are not deleted.",
       "confirm": "Clean failed records",
       "cleaning": "Cleaning..."
     }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -471,8 +471,11 @@
     },
     "cleanupFailed": {
       "action": "清理失败记录",
+      "noisyErrorsAction": "清理连接噪音错误",
       "title": "清理失败请求记录？",
+      "noisyErrorsTitle": "清理连接噪音错误请求记录？",
       "description": "将删除当前筛选条件下 {{count}} 条失败/错误请求记录，并同步删除对应 upstream attempts。成功请求和活跃请求不会被删除。",
+      "noisyErrorsDescription": "将删除当前筛选条件下错误信息包含以下任一内容的 {{count}} 条失败/错误请求记录：{{errors}}，并同步删除对应 upstream attempts。其他失败记录、成功请求和活跃请求不会被删除。",
       "confirm": "清理失败记录",
       "cleaning": "清理中..."
     }

--- a/web/src/pages/requests/column-settings.tsx
+++ b/web/src/pages/requests/column-settings.tsx
@@ -152,14 +152,15 @@ export function RequestsColumnSettings({ prefs, availability, onChange }: Column
   return (
     <Popover>
       <PopoverTrigger
+        aria-label={t('requests.columns.action')}
+        title={t('requests.columns.action')}
         className={cn(
-          'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+          'flex size-8 items-center justify-center rounded-lg text-sm font-medium transition-all',
           'bg-muted/50 hover:bg-muted border border-border/50 hover:border-border',
           'text-muted-foreground hover:text-foreground',
         )}
       >
         <Columns3 size={14} />
-        <span>{t('requests.columns.action')}</span>
       </PopoverTrigger>
       <PopoverContent align="end" className="w-72 p-3 gap-2">
         <div className="flex items-center justify-between gap-2 px-1">

--- a/web/src/pages/requests/index.tsx
+++ b/web/src/pages/requests/index.tsx
@@ -132,6 +132,13 @@ const REQUEST_TOKEN_FILTER_STORAGE_KEY = 'maxx-requests-token-filter';
 const REQUEST_PROJECT_FILTER_STORAGE_KEY = 'maxx-requests-project-filter';
 const REQUESTS_VIRTUALIZE_THRESHOLD = 40;
 const DEFAULT_DESKTOP_ROW_HEIGHT = 38;
+const CLEANUP_ERROR_TEXTS = [
+  'failed to connect to upstream: upstream error',
+  'client disconnected: context canceled',
+  'Instance no longer alive',
+];
+
+type CleanupFailedKind = 'all' | 'upstreamError';
 
 function ProtocolBadge({
   request,
@@ -347,6 +354,7 @@ export function RequestsPage() {
   const [errorMode, setErrorMode] = useState<ProxyRequestErrorMode>('all');
   const [errorStatsOpen, setErrorStatsOpen] = useState(false);
   const [cleanupFailedOpen, setCleanupFailedOpen] = useState(false);
+  const [cleanupFailedKind, setCleanupFailedKind] = useState<CleanupFailedKind>('all');
   const [startDate, setStartDate] = useState<Date | undefined>(undefined);
   const [endDate, setEndDate] = useState<Date | undefined>(undefined);
 
@@ -424,10 +432,20 @@ export function RequestsPage() {
     selectedStatus,
   ]);
 
+  const upstreamErrorCleanupParams = useMemo<CursorPaginationParams>(
+    () => ({
+      ...cleanupFailedCountParams,
+      errorContains: CLEANUP_ERROR_TEXTS,
+    }),
+    [cleanupFailedCountParams],
+  );
+
   const { data: failedCount, refetch: refetchFailedCount } = useCleanupFailedProxyRequestsCount(
     cleanupFailedCountParams,
     requestsQueryEnabled,
   );
+  const { data: upstreamErrorFailedCount, refetch: refetchUpstreamErrorFailedCount } =
+    useCleanupFailedProxyRequestsCount(upstreamErrorCleanupParams, requestsQueryEnabled);
   const cleanupFailedRequests = useCleanupFailedProxyRequests();
 
   // Check if API Token auth is enabled
@@ -593,13 +611,21 @@ export function RequestsPage() {
     errorStatsOpen && requestsQueryEnabled,
   );
 
+  const handleOpenCleanupFailedDialog = (kind: CleanupFailedKind) => {
+    setCleanupFailedKind(kind);
+    setCleanupFailedOpen(true);
+  };
+
   const handleCleanupFailedRequests = () => {
-    cleanupFailedRequests.mutate(cleanupFailedCountParams, {
+    const params =
+      cleanupFailedKind === 'upstreamError' ? upstreamErrorCleanupParams : cleanupFailedCountParams;
+    cleanupFailedRequests.mutate(params, {
       onSuccess: () => {
         setCleanupFailedOpen(false);
         void refetch();
         void refetchCount();
         void refetchFailedCount();
+        void refetchUpstreamErrorFailedCount();
       },
     });
   };
@@ -838,6 +864,7 @@ export function RequestsPage() {
     refetch();
     refetchCount();
     refetchFailedCount();
+    refetchUpstreamErrorFailedCount();
   };
 
   // 过滤模式变化时重置滚动
@@ -980,14 +1007,29 @@ export function RequestsPage() {
           variant="destructive"
           size="sm"
           disabled={(failedCount ?? 0) === 0 || cleanupFailedRequests.isPending}
-          onClick={() => setCleanupFailedOpen(true)}
+          onClick={() => handleOpenCleanupFailedDialog('all')}
         >
-          {cleanupFailedRequests.isPending ? (
+          {cleanupFailedRequests.isPending && cleanupFailedKind === 'all' ? (
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
           ) : (
             <Trash2 className="mr-2 h-4 w-4" />
           )}
           {t('requests.cleanupFailed.action')}
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          disabled={(upstreamErrorFailedCount ?? 0) === 0 || cleanupFailedRequests.isPending}
+          onClick={() => handleOpenCleanupFailedDialog('upstreamError')}
+          title={CLEANUP_ERROR_TEXTS.join('\n')}
+        >
+          {cleanupFailedRequests.isPending && cleanupFailedKind === 'upstreamError' ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Trash2 className="mr-2 h-4 w-4" />
+          )}
+          {t('requests.cleanupFailed.noisyErrorsAction')}
         </Button>
         <TimeRangeFilter
           startDate={startDate}
@@ -1005,15 +1047,16 @@ export function RequestsPage() {
         <button
           onClick={handleRefresh}
           disabled={isFetching || waitingFilterValidation}
+          aria-label={t('requests.refresh')}
+          title={t('requests.refresh')}
           className={cn(
-            'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+            'flex size-8 items-center justify-center rounded-lg text-sm font-medium transition-all',
             'bg-muted/50 hover:bg-muted border border-border/50 hover:border-border',
             'text-muted-foreground hover:text-foreground',
             (isFetching || waitingFilterValidation) && 'opacity-50 cursor-not-allowed',
           )}
         >
           <RefreshCw size={14} className={isFetching ? 'animate-spin' : ''} />
-          <span>{t('requests.refresh')}</span>
         </button>
       </PageHeader>
 
@@ -1029,10 +1072,17 @@ export function RequestsPage() {
         <AlertDialogContent className="border-destructive/30 bg-card shadow-2xl">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-foreground">
-              {t('requests.cleanupFailed.title')}
+              {cleanupFailedKind === 'upstreamError'
+                ? t('requests.cleanupFailed.noisyErrorsTitle')
+                : t('requests.cleanupFailed.title')}
             </AlertDialogTitle>
             <AlertDialogDescription className="text-foreground/90">
-              {t('requests.cleanupFailed.description', { count: failedCount ?? 0 })}
+              {cleanupFailedKind === 'upstreamError'
+                ? t('requests.cleanupFailed.noisyErrorsDescription', {
+                    count: upstreamErrorFailedCount ?? 0,
+                    errors: CLEANUP_ERROR_TEXTS.join(' / '),
+                  })
+                : t('requests.cleanupFailed.description', { count: failedCount ?? 0 })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -1040,7 +1090,12 @@ export function RequestsPage() {
               {t('common.cancel')}
             </AlertDialogCancel>
             <AlertDialogAction
-              disabled={cleanupFailedRequests.isPending || (failedCount ?? 0) === 0}
+              disabled={
+                cleanupFailedRequests.isPending ||
+                (cleanupFailedKind === 'upstreamError'
+                  ? (upstreamErrorFailedCount ?? 0) === 0
+                  : (failedCount ?? 0) === 0)
+              }
               onClick={handleCleanupFailedRequests}
             >
               {cleanupFailedRequests.isPending


### PR DESCRIPTION
## Summary
- add a Requests tab shortcut to clean noisy connection/runtime failures only
- match failed records whose error contains any of:
  - `failed to connect to upstream: upstream error`
  - `client disconnected: context canceled`
  - `Instance no longer alive`
- thread a narrow multi-value `errorContains` cleanup filter through failed-cleanup count/delete endpoints
- escape SQL LIKE wildcards so cleanup text is treated literally, not as a pattern
- preserve successful, active, and unrelated failed records while deleting matched upstream attempts with matched requests
- make the Requests tab column display/order and refresh actions icon-only, keeping aria-label/title text for accessibility

## Validation
- `git diff --check`
- `go test ./internal/repository/sqlite -run 'DeleteFailedWithFilter|escapeLikePattern' -count=1`
- `go test ./internal/handler -run 'ProxyRequests|CleanupFailed' -count=1`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- real backend + Vite web slow Playwright recording; verified both target buttons have empty visible text and accessible labels