### PR TITLE
fix(user-panel): show token names in consumption leaderboard

### DIFF
--- a/internal/handler/self_service.go
+++ b/internal/handler/self_service.go
@@ -1703,9 +1703,11 @@ func (h *SelfServiceHandler) handleUserPanelDailyCheckIn(w http.ResponseWriter, 
 }
 
 type userPanelConsumptionLeaderboardRow struct {
-	UserID   uint64 `json:"userID"`
-	Username string `json:"username"`
-	Cost     uint64 `json:"cost"`
+	UserID    uint64 `json:"userID"`
+	TokenID   uint64 `json:"tokenID"`
+	TokenName string `json:"tokenName"`
+	Username  string `json:"username"`
+	Cost      uint64 `json:"cost"`
 }
 
 type userPanelConsumptionLeaderboardResponse struct {
@@ -1741,45 +1743,28 @@ func (h *SelfServiceHandler) handleUserPanelConsumptionLeaderboard(w http.Respon
 		return
 	}
 
-	users, err := h.userPanelLeaderboardUsers(tenantID)
-	if err != nil {
-		writeSelfServiceInternalError(w, "GetUserPanelLeaderboardUsers failed", err)
-		return
-	}
-
 	writeJSON(w, http.StatusOK, userPanelConsumptionLeaderboardResponse{
-		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, users, currentUserID),
-		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, users, currentUserID),
+		Today: buildUserPanelConsumptionLeaderboard(todayStats, tokens, currentUserID),
+		All:   buildUserPanelConsumptionLeaderboard(allStats, tokens, currentUserID),
 	})
 }
 
-func (h *SelfServiceHandler) userPanelLeaderboardUsers(tenantID uint64) (map[uint64]string, error) {
-	if h.userRepo == nil {
-		return map[uint64]string{}, nil
-	}
-	users, err := h.userRepo.ListByTenant(tenantID)
-	if err != nil {
-		return nil, err
-	}
-	result := make(map[uint64]string, len(users))
-	for _, user := range users {
-		if user == nil {
-			continue
-		}
-		result[user.ID] = user.Username
-	}
-	return result, nil
-}
-
-func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, users map[uint64]string, currentUserID uint64) []userPanelConsumptionLeaderboardRow {
+func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*domain.APIToken, currentUserID uint64) []userPanelConsumptionLeaderboardRow {
 	tokenUsers := make(map[uint64]uint64, len(tokens))
+	tokenNames := make(map[uint64]string, len(tokens))
+	var currentUserTokenID uint64
 	for _, token := range tokens {
 		if token == nil || !strings.HasPrefix(token.Description, userPanelAPITokenDescriptionPrefix) {
 			continue
 		}
-		id, err := strconv.ParseUint(strings.TrimPrefix(token.Description, userPanelAPITokenDescriptionPrefix), 10, 64)
-		if err == nil && id > 0 {
-			tokenUsers[token.ID] = id
+		userID, err := strconv.ParseUint(strings.TrimPrefix(token.Description, userPanelAPITokenDescriptionPrefix), 10, 64)
+		if err != nil || userID == 0 {
+			continue
+		}
+		tokenUsers[token.ID] = userID
+		tokenNames[token.ID] = token.Name
+		if currentUserID > 0 && userID == currentUserID && currentUserTokenID == 0 {
+			currentUserTokenID = token.ID
 		}
 	}
 
@@ -1788,26 +1773,25 @@ func buildUserPanelConsumptionLeaderboard(stats []*domain.UsageStats, tokens []*
 		if item == nil {
 			continue
 		}
-		userID := tokenUsers[item.APITokenID]
-		if userID == 0 {
+		if tokenUsers[item.APITokenID] == 0 {
 			continue
 		}
-		costs[userID] += item.Cost
+		costs[item.APITokenID] += item.Cost
 	}
 
-	if currentUserID > 0 {
-		if _, ok := costs[currentUserID]; !ok {
-			costs[currentUserID] = 0
+	if currentUserTokenID > 0 {
+		if _, ok := costs[currentUserTokenID]; !ok {
+			costs[currentUserTokenID] = 0
 		}
 	}
 
 	rows := make([]userPanelConsumptionLeaderboardRow, 0, len(costs))
-	for userID, cost := range costs {
-		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: userID, Username: users[userID], Cost: cost})
+	for tokenID, cost := range costs {
+		rows = append(rows, userPanelConsumptionLeaderboardRow{UserID: tokenUsers[tokenID], TokenID: tokenID, TokenName: tokenNames[tokenID], Cost: cost})
 	}
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].Cost == rows[j].Cost {
-			return rows[i].UserID < rows[j].UserID
+			return rows[i].TokenID < rows[j].TokenID
 		}
 		return rows[i].Cost > rows[j].Cost
 	})

--- a/internal/handler/self_service_test.go
+++ b/internal/handler/self_service_test.go
@@ -3062,30 +3062,30 @@ func TestUserPanelModelClientTypesFollowVisibleRoutes(t *testing.T) {
 	}
 }
 
-func TestBuildUserPanelConsumptionLeaderboard_IncludesCurrentUserWithoutUsage(t *testing.T) {
+func TestBuildUserPanelConsumptionLeaderboard_IncludesCurrentUserTokenWithoutUsage(t *testing.T) {
 	rows := buildUserPanelConsumptionLeaderboard(
 		[]*domain.UsageStats{
 			{APITokenID: 201, Cost: 300},
 		},
 		[]*domain.APIToken{
+			{ID: 101, Name: "current-user-token", Description: userPanelAPITokenDescription(9)},
 			{ID: 201, Name: "other-user-token", Description: userPanelAPITokenDescription(42)},
 		},
-		map[uint64]string{9: "user9", 42: "user42"},
 		9,
 	)
 
 	if len(rows) != 2 {
-		t.Fatalf("expected current user plus consuming user rows, got %d", len(rows))
+		t.Fatalf("expected current token plus consuming token rows, got %d", len(rows))
 	}
-	if rows[0].UserID != 42 || rows[0].Username != "user42" || rows[0].Cost != 300 {
-		t.Fatalf("expected consuming user first, got %+v", rows[0])
+	if rows[0].UserID != 42 || rows[0].TokenID != 201 || rows[0].TokenName != "other-user-token" || rows[0].Cost != 300 {
+		t.Fatalf("expected consuming token first, got %+v", rows[0])
 	}
-	if rows[1].UserID != 9 || rows[1].Username != "user9" || rows[1].Cost != 0 {
-		t.Fatalf("expected current user with zero cost, got %+v", rows[1])
+	if rows[1].UserID != 9 || rows[1].TokenID != 101 || rows[1].TokenName != "current-user-token" || rows[1].Cost != 0 {
+		t.Fatalf("expected current user token with zero cost, got %+v", rows[1])
 	}
 }
 
-func TestBuildUserPanelConsumptionLeaderboard_ExposesUsernameAndCost(t *testing.T) {
+func TestBuildUserPanelConsumptionLeaderboard_ExposesTokenNameAndCost(t *testing.T) {
 	rows := buildUserPanelConsumptionLeaderboard(
 		[]*domain.UsageStats{
 			{APITokenID: 101, Cost: 300},
@@ -3094,33 +3094,35 @@ func TestBuildUserPanelConsumptionLeaderboard_ExposesUsernameAndCost(t *testing.
 			{APITokenID: 999, Cost: 999},
 		},
 		[]*domain.APIToken{
-			{ID: 101, Name: "private-alice-token", Description: userPanelAPITokenDescription(77)},
-			{ID: 102, Name: "private-alice-token-2", Description: userPanelAPITokenDescription(77)},
-			{ID: 201, Name: "private-bob-token", Description: userPanelAPITokenDescription(42)},
+			{ID: 101, Name: "alice-token", Description: userPanelAPITokenDescription(77)},
+			{ID: 102, Name: "alice-token-2", Description: userPanelAPITokenDescription(77)},
+			{ID: 201, Name: "bob-token", Description: userPanelAPITokenDescription(42)},
 			{ID: 999, Name: "ordinary-token", Description: "not-user-panel-managed"},
 		},
-		map[uint64]string{77: "user77", 42: "user42"},
 		0,
 	)
 
-	if len(rows) != 2 {
-		t.Fatalf("expected two user-panel leaderboard rows, got %d", len(rows))
+	if len(rows) != 3 {
+		t.Fatalf("expected three user-panel token leaderboard rows, got %d", len(rows))
 	}
-	if rows[0].UserID != 77 || rows[0].Username != "user77" || rows[0].Cost != 400 {
-		t.Fatalf("expected highest cost row for user77, got %+v", rows[0])
+	if rows[0].UserID != 77 || rows[0].TokenID != 101 || rows[0].TokenName != "alice-token" || rows[0].Cost != 300 {
+		t.Fatalf("expected highest cost row for alice-token, got %+v", rows[0])
 	}
-	if rows[1].UserID != 42 || rows[1].Username != "user42" || rows[1].Cost != 300 {
-		t.Fatalf("expected second row for user42, got %+v", rows[1])
+	if rows[1].UserID != 42 || rows[1].TokenID != 201 || rows[1].TokenName != "bob-token" || rows[1].Cost != 300 {
+		t.Fatalf("expected tie to sort by token id, got %+v", rows[1])
+	}
+	if rows[2].UserID != 77 || rows[2].TokenID != 102 || rows[2].TokenName != "alice-token-2" || rows[2].Cost != 100 {
+		t.Fatalf("expected third row for alice-token-2, got %+v", rows[2])
 	}
 
 	body, err := json.Marshal(userPanelConsumptionLeaderboardResponse{Today: rows, All: rows})
 	if err != nil {
 		t.Fatalf("marshal leaderboard response: %v", err)
 	}
-	if !strings.Contains(string(body), "user77") || !strings.Contains(string(body), "user42") {
-		t.Fatalf("leaderboard response missing usernames: %s", body)
+	if !strings.Contains(string(body), "alice-token") || !strings.Contains(string(body), "bob-token") {
+		t.Fatalf("leaderboard response missing token names: %s", body)
 	}
-	if strings.Contains(string(body), "private-") {
-		t.Fatalf("leaderboard response leaked private token data: %s", body)
+	if strings.Contains(string(body), "ordinary-token") {
+		t.Fatalf("leaderboard response leaked non-user-panel token data: %s", body)
 	}
 }

--- a/web/src/lib/transport/types.ts
+++ b/web/src/lib/transport/types.ts
@@ -1378,7 +1378,9 @@ export interface UserPanelAvailableModelRouteGroup {
 
 export interface UserPanelConsumptionLeaderboardRow {
   userID: number;
-  username: string;
+  tokenID: number;
+  tokenName: string;
+  username?: string;
   cost: number;
 }
 

--- a/web/src/pages/user-panel.tsx
+++ b/web/src/pages/user-panel.tsx
@@ -142,7 +142,7 @@ function ConsumptionLeaderboardCard({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t('userPanel.username')}</TableHead>
+                <TableHead>{t('common.name')}</TableHead>
                 <TableHead className="text-right">{t('userPanel.amount')}</TableHead>
               </TableRow>
             </TableHeader>
@@ -151,7 +151,7 @@ function ConsumptionLeaderboardCard({
                 const isCurrentUser = currentUserID === row.userID;
                 return (
                   <TableRow
-                    key={row.userID}
+                    key={row.tokenID || row.userID}
                     className={
                       isCurrentUser
                         ? 'bg-primary/10 ring-1 ring-inset ring-primary/25 hover:bg-primary/15'
@@ -159,7 +159,7 @@ function ConsumptionLeaderboardCard({
                     }
                   >
                     <TableCell className="font-medium text-foreground">
-                      {row.username || `#${row.userID}`}
+                      {row.tokenName || row.username || `#${row.tokenID || row.userID}`}
                     </TableCell>
                     <TableCell className="text-right font-mono font-semibold tabular-nums">
                       {formatCostAmount(row.cost)}


### PR DESCRIPTION
## Summary
- change the user-panel consumption leaderboard display name from username to token name
- aggregate leaderboard rows by user-panel managed API token instead of folding all of a user's tokens into one row
- keep the current user's token visible with zero cost when it has no usage
- continue excluding non-user-panel-managed tokens from the leaderboard
- use the existing common name label for the leaderboard name column

## Validation
- `git diff --check`
- `go test ./internal/handler -run 'UserPanelConsumptionLeaderboard|BuildUserPanelConsumptionLeaderboard' -count=1`
- `pnpm -C web typecheck`
- `pnpm -C web build`
- real auth-enabled backend + Vite web slow Playwright recording; verified the user-panel consumption tab shows the Name column and token-name rows without the raw i18n key